### PR TITLE
fix(neon_files): Fix empty categories

### DIFF
--- a/packages/neon/neon_notes/lib/widgets/category_select.dart
+++ b/packages/neon/neon_notes/lib/widgets/category_select.dart
@@ -14,8 +14,7 @@ class NotesCategorySelect extends StatelessWidget {
 
     categories.sort();
 
-    // After sorting the empty category '' should be at the first place
-    if (categories.isNotEmpty && !categories.first.isNotEmpty) {
+    if (categories.isEmpty) {
       categories.insert(0, '');
     }
   }


### PR DESCRIPTION
The sort already puts the empty string in the beginning. We only need to add the empty category if there are no categories at all.

https://github.com/nextcloud/neon/pull/528