### PR TITLE
fix(tool): Add missing workspace package to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
     labels:
       - "dependencies"
   - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "pub"
     directory: "/packages/app"
     schedule:
       interval: "daily"

--- a/tool/generate-dependabot.sh
+++ b/tool/generate-dependabot.sh
@@ -20,6 +20,7 @@ function add_update() {
 
 add_update github-actions /
 add_update gradle /packages/app/android
+add_update pub /
 for path in $(melos list --relative --parsable); do
   add_update pub "/$path"
 done


### PR DESCRIPTION
Accidentally removed in https://github.com/nextcloud/neon/pull/547