### PR TITLE
test(neon,nextcloud): Fix flaky tests

### DIFF
--- a/packages/neon/neon/test/timer_bloc_test.dart
+++ b/packages/neon/neon/test/timer_bloc_test.dart
@@ -16,7 +16,7 @@ void main() {
       await Future.delayed(duration);
 
       expect(stopwatch.elapsedMilliseconds, greaterThan(duration.inMilliseconds));
-      expect(stopwatch.elapsedMilliseconds, lessThan(duration.inMilliseconds * 1.1));
+      expect(stopwatch.elapsedMilliseconds, lessThan(duration.inMilliseconds * 2));
       expect(TimerBloc().callbacks[duration.inSeconds], contains(callback));
       expect(TimerBloc().timers[duration.inSeconds], isNot(isNull));
     });

--- a/packages/nextcloud/test/webdav_test.dart
+++ b/packages/nextcloud/test/webdav_test.dart
@@ -301,7 +301,7 @@ void main() {
         destination,
         onProgress: progressValues.add,
       );
-      expect(progressValues, [100.0, 100.0]);
+      expect(progressValues, containsAll([100.0, 100.0]));
       expect(destination.readAsBytesSync(), source.readAsBytesSync());
 
       destinationDir.deleteSync(recursive: true);


### PR DESCRIPTION
Since switching to the org these tests are failing quite often because the runners seem to be slower.