### PR TITLE
feat(tool): Allow all domains in dev container

### DIFF
--- a/tool/Dockerfile.dev
+++ b/tool/Dockerfile.dev
@@ -5,7 +5,7 @@ USER www-data
 
 RUN ./occ maintenance:install --admin-pass admin --admin-email admin@example.com
 RUN ./occ config:system:set allow_local_remote_servers --value=true
-RUN ./occ config:system:set trusted_domains 1 --value=10.0.2.2
+RUN ./occ config:system:set trusted_domains 1 --value="*"
 RUN ./occ app:disable password_policy
 
 RUN OC_PASS="user1" ./occ user:add --password-from-env --display-name "User One" user1


### PR DESCRIPTION
Makes it easier to work with connected device that are not your host machine. Security wise this is fine as the container is only used for development and testing.