### PR TITLE
fix(neon): Fix not receiving push notifications

### DIFF
--- a/packages/neon/neon/lib/src/blocs/push_notifications.dart
+++ b/packages/neon/neon/lib/src/blocs/push_notifications.dart
@@ -34,6 +34,8 @@ class PushNotificationsBloc extends Bloc implements PushNotificationsBlocEvents,
       unawaited(UnifiedPush.getDistributors().then(_globalOptions.updateDistributors));
 
       _globalOptions.pushNotificationsEnabled.addListener(_pushNotificationsEnabledListener);
+      // Call the listener to update everything
+      unawaited(_pushNotificationsEnabledListener());
     }
   }
 


### PR DESCRIPTION
Push notifications were only working directly after registering because the listener was not called initially.