### PR TITLE
Feature/dynamite/all of

### DIFF
--- a/packages/dynamite/dynamite/lib/src/builder/resolve_interface.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_interface.dart
@@ -1,0 +1,91 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dynamite/src/builder/resolve_type.dart';
+import 'package:dynamite/src/builder/state.dart';
+import 'package:dynamite/src/helpers/built_value.dart';
+import 'package:dynamite/src/helpers/dart_helpers.dart';
+import 'package:dynamite/src/helpers/dynamite.dart';
+import 'package:dynamite/src/models/open_api.dart';
+import 'package:dynamite/src/models/schema.dart';
+import 'package:dynamite/src/type_result/type_result.dart';
+
+TypeResultObject resolveInterface(
+  final OpenAPI spec,
+  final State state,
+  final String identifier,
+  final Schema schema,
+) {
+  final result = TypeResultObject(
+    '${state.classPrefix}$identifier',
+  );
+
+  if (state.resolvedInterfaces.add(result)) {
+    final className = '${state.classPrefix}$identifier$interfaceSuffix';
+
+    state.output.add(
+      Class((final b) {
+        b
+          ..abstract = true
+          ..modifier = ClassModifier.interface
+          ..name = className
+          ..annotations.add(refer('BuiltValue').call([], {'instantiable': literalFalse}));
+
+        for (final property in schema.properties!.entries) {
+          b.methods.add(
+            Method(
+              (final b) {
+                final propertyName = property.key;
+                final propertySchema = property.value;
+                final result = resolveType(
+                  spec,
+                  state,
+                  '${identifier}_${toDartName(propertyName, uppercaseFirstCharacter: true)}',
+                  propertySchema,
+                  nullable: isDartParameterNullable(
+                    schema.required?.contains(propertyName),
+                    propertySchema,
+                  ),
+                );
+
+                b
+                  ..name = toDartName(propertyName)
+                  ..returns = refer(result.nullableName)
+                  ..type = MethodType.getter
+                  ..docs.addAll(propertySchema.formattedDescription);
+
+                if (toDartName(propertyName) != propertyName) {
+                  b.annotations.add(
+                    refer('BuiltValueField').call([], {
+                      'wireName': literalString(propertyName),
+                    }),
+                  );
+                }
+              },
+            ),
+          );
+        }
+
+        b.methods.addAll([
+          Method(
+            (final b) => b
+              ..returns = refer(className)
+              ..name = 'rebuild'
+              ..requiredParameters.add(
+                Parameter(
+                  (final b) => b
+                    ..name = 'updates'
+                    ..type = refer('void Function(${className}Builder)'),
+                ),
+              ),
+          ),
+          Method(
+            (final b) => b
+              ..returns = refer('${className}Builder')
+              ..name = 'toBuilder',
+          ),
+        ]);
+      }),
+    );
+  }
+
+  return result;
+}

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_object.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_object.dart
@@ -1,17 +1,15 @@
-import 'package:built_collection/built_collection.dart';
-import 'package:code_builder/code_builder.dart';
 import 'package:dynamite/src/builder/header_serializer.dart';
+import 'package:dynamite/src/builder/resolve_interface.dart';
 import 'package:dynamite/src/builder/resolve_type.dart';
 import 'package:dynamite/src/builder/state.dart';
 import 'package:dynamite/src/helpers/built_value.dart';
 import 'package:dynamite/src/helpers/dart_helpers.dart';
-import 'package:dynamite/src/helpers/dynamite.dart';
 import 'package:dynamite/src/helpers/type_result.dart';
 import 'package:dynamite/src/models/open_api.dart';
 import 'package:dynamite/src/models/schema.dart';
 import 'package:dynamite/src/type_result/type_result.dart';
 
-TypeResult resolveObject(
+TypeResultObject resolveObject(
   final OpenAPI spec,
   final State state,
   final String identifier,
@@ -39,49 +37,23 @@ TypeResult resolveObject(
       }
     }
 
-    state.output.add(
+    final interfaceClass = resolveInterface(
+      spec,
+      state,
+      identifier,
+      schema,
+    );
+
+    state.output.addAll([
       buildBuiltClass(
         '${state.classPrefix}$identifier',
-        BuiltList.build((final b) {
-          for (final property in schema.properties!.entries) {
-            b.add(
-              Method(
-                (final b) {
-                  final propertyName = property.key;
-                  final propertySchema = property.value;
-                  final result = resolveType(
-                    spec,
-                    state,
-                    '${identifier}_${toDartName(propertyName, uppercaseFirstCharacter: true)}',
-                    propertySchema,
-                    nullable: isDartParameterNullable(
-                      schema.required?.contains(propertyName),
-                      propertySchema,
-                    ),
-                  );
-
-                  b
-                    ..name = toDartName(propertyName)
-                    ..returns = refer(result.nullableName)
-                    ..type = MethodType.getter
-                    ..docs.addAll(propertySchema.formattedDescription);
-
-                  if (toDartName(propertyName) != propertyName) {
-                    b.annotations.add(
-                      refer('BuiltValueField').call([], {
-                        'wireName': literalString(propertyName),
-                      }),
-                    );
-                  }
-                },
-              ),
-            );
-          }
-        }),
         defaults: defaults,
         customSerializer: isHeader,
+        interfaces: [
+          interfaceClass,
+        ],
       ),
-    );
+    ]);
     if (isHeader) {
       state.output.add(buildHeaderSerializer(state, identifier, spec, schema));
     }

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_type.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_type.dart
@@ -30,6 +30,14 @@ TypeResult resolveType(
       spec.components!.schemas![name]!,
       nullable: nullable,
     );
+  } else if (schema.allOf != null) {
+    result = resolveAllOf(
+      spec,
+      state,
+      identifier,
+      schema,
+      nullable: nullable,
+    );
   } else if (schema.ofs != null) {
     result = resolveOfs(
       spec,

--- a/packages/dynamite/dynamite/lib/src/builder/state.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/state.dart
@@ -12,4 +12,5 @@ class State {
 
   final output = <Spec>[];
   final resolvedTypes = <TypeResult>{};
+  final resolvedInterfaces = <TypeResult>{};
 }

--- a/packages/dynamite/dynamite/lib/src/helpers/built_value.dart
+++ b/packages/dynamite/dynamite/lib/src/helpers/built_value.dart
@@ -1,65 +1,73 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dynamite/src/helpers/dart_helpers.dart';
+import 'package:dynamite/src/type_result/type_result.dart';
+
+const interfaceSuffix = 'Interface';
 
 Spec buildBuiltClass(
-  final String className,
-  final BuiltList<Method> methods, {
+  final String className, {
+  final BuiltList<Method>? methods,
   final Iterable<String>? defaults,
+  final Iterable<TypeResultObject>? interfaces,
   final bool customSerializer = false,
-}) =>
-    Class(
-      (final b) {
-        b
-          ..name = className
-          ..abstract = true
-          ..implements.add(
-            refer(
-              'Built<$className, ${className}Builder>',
-            ),
-          )
-          ..constructors.addAll([
-            builtValueConstructor(className),
-            hiddenConstructor,
-            fromJsonConstructor,
-          ])
-          ..methods.addAll([
-            toJsonMethod,
-            ...methods,
-            buildSerializer(className, isCustom: customSerializer),
-          ]);
+}) {
+  assert((interfaces == null) != (methods == null), 'Either provide an interface or methods.');
 
-        if (defaults != null && defaults.isNotEmpty) {
-          b.methods.add(
-            Method(
-              (final b) => b
-                ..name = '_defaults'
-                ..returns = refer('void')
-                ..static = true
-                ..lambda = true
-                ..annotations.add(
-                  refer('BuiltValueHook').call([], {
-                    'initializeBuilder': literalTrue,
-                  }),
-                )
-                ..requiredParameters.add(
-                  Parameter(
-                    (final b) => b
-                      ..name = 'b'
-                      ..type = refer('${className}Builder'),
-                  ),
-                )
-                ..body = Code(
-                  <String?>[
-                    'b',
-                    ...defaults,
-                  ].join(),
+  return Class(
+    (final b) {
+      b
+        ..name = className
+        ..abstract = true
+        ..implements.addAll([
+          ...?interfaces?.map((final i) => refer('${i.name}$interfaceSuffix')),
+          refer(
+            'Built<$className, ${className}Builder>',
+          ),
+        ])
+        ..constructors.addAll([
+          builtValueConstructor(className),
+          hiddenConstructor,
+          fromJsonConstructor,
+        ])
+        ..methods.addAll([
+          toJsonMethod,
+          ...?methods,
+          buildSerializer(className, isCustom: customSerializer),
+        ]);
+
+      if (defaults != null && defaults.isNotEmpty) {
+        b.methods.add(
+          Method(
+            (final b) => b
+              ..name = '_defaults'
+              ..returns = refer('void')
+              ..static = true
+              ..lambda = true
+              ..annotations.add(
+                refer('BuiltValueHook').call([], {
+                  'initializeBuilder': literalTrue,
+                }),
+              )
+              ..requiredParameters.add(
+                Parameter(
+                  (final b) => b
+                    ..name = 'b'
+                    ..type = refer('${className}Builder'),
                 ),
-            ),
-          );
-        }
-      },
-    );
+              )
+              ..body = Code(
+                <String?>[
+                  'b',
+                  ...defaults,
+                ].join(),
+              ),
+          ),
+        );
+      }
+    },
+  );
+}
 
 Method get toJsonMethod => Method(
       (final b) => b

--- a/packages/neon/neon/lib/src/blocs/user_statuses.dart
+++ b/packages/neon/neon/lib/src/blocs/user_statuses.dart
@@ -16,7 +16,7 @@ abstract class UserStatusesBlocEvents {
 }
 
 abstract class UserStatusesBlocStates {
-  BehaviorSubject<Map<String, Result<UserStatusPublic?>>> get statuses;
+  BehaviorSubject<Map<String, Result<UserStatusPublicInterface?>>> get statuses;
 }
 
 @internal
@@ -39,8 +39,8 @@ class UserStatusesBloc extends InteractiveBloc implements UserStatusesBlocEvents
   }
 
   @override
-  BehaviorSubject<Map<String, Result<UserStatusPublic?>>> statuses =
-      BehaviorSubject<Map<String, Result<UserStatusPublic?>>>();
+  BehaviorSubject<Map<String, Result<UserStatusPublicInterface?>>> statuses =
+      BehaviorSubject<Map<String, Result<UserStatusPublicInterface?>>>();
 
   @override
   Future refresh() async {
@@ -58,7 +58,7 @@ class UserStatusesBloc extends InteractiveBloc implements UserStatusesBlocEvents
     try {
       _updateStatus(username, Result.loading());
 
-      UserStatusPublic? data;
+      UserStatusPublicInterface? data;
 
       if (_account.username == username) {
         var isAway = false;
@@ -71,7 +71,7 @@ class UserStatusesBloc extends InteractiveBloc implements UserStatusesBlocEvents
           final response = await _account.client.userStatus.heartbeat.heartbeat(
             status: isAway ? 'away' : 'online',
           );
-          data = response.ocs.data.public;
+          data = response.ocs.data;
         } catch (e) {
           // 204 is returned if the heartbeat failed because the current status is different. Ignore this and fetch the normal status
           if (e is! DynamiteApiException || e.statusCode != 204) {
@@ -97,9 +97,10 @@ class UserStatusesBloc extends InteractiveBloc implements UserStatusesBlocEvents
     }
   }
 
-  Map<String, Result<UserStatusPublic?>> get _statuses => statuses.valueOrNull ?? <String, Result<UserStatusPublic?>>{};
+  Map<String, Result<UserStatusPublicInterface?>> get _statuses =>
+      statuses.valueOrNull ?? <String, Result<UserStatusPublicInterface?>>{};
 
-  void _updateStatus(final String username, final Result<UserStatusPublic?> result) {
+  void _updateStatus(final String username, final Result<UserStatusPublicInterface?> result) {
     statuses.add({
       ..._statuses,
       username: result,

--- a/packages/neon/neon/lib/src/widgets/user_avatar.dart
+++ b/packages/neon/neon/lib/src/widgets/user_avatar.dart
@@ -85,7 +85,7 @@ class _UserAvatarState extends State<NeonUserAvatar> {
                 ),
               ),
               if (widget.showStatus) ...[
-                ResultBuilder<UserStatusPublic?>(
+                ResultBuilder<UserStatusPublicInterface?>(
                   stream: _userStatusBloc.statuses.mapNotNull((final statuses) => statuses[widget.username]),
                   builder: _userStatusIconBuilder,
                 ),
@@ -95,7 +95,7 @@ class _UserAvatarState extends State<NeonUserAvatar> {
         },
       );
 
-  Widget _userStatusIconBuilder(final BuildContext context, final Result<UserStatusPublic?> result) {
+  Widget _userStatusIconBuilder(final BuildContext context, final Result<UserStatusPublicInterface?> result) {
     final hasEmoji = result.data?.icon != null;
     final scaledSize = size / (hasEmoji ? 2 : 2.5);
 

--- a/packages/nextcloud/lib/src/api/comments.openapi.dart
+++ b/packages/nextcloud/lib/src/api/comments.openapi.dart
@@ -110,8 +110,18 @@ class CommentsNotificationsClient {
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CommentsNotificationsNotificationsViewHeadersInterface {
+  String? get location;
+  CommentsNotificationsNotificationsViewHeadersInterface rebuild(
+    final void Function(CommentsNotificationsNotificationsViewHeadersInterfaceBuilder) updates,
+  );
+  CommentsNotificationsNotificationsViewHeadersInterfaceBuilder toBuilder();
+}
+
 abstract class CommentsNotificationsNotificationsViewHeaders
     implements
+        CommentsNotificationsNotificationsViewHeadersInterface,
         Built<CommentsNotificationsNotificationsViewHeaders, CommentsNotificationsNotificationsViewHeadersBuilder> {
   factory CommentsNotificationsNotificationsViewHeaders([
     final void Function(CommentsNotificationsNotificationsViewHeadersBuilder)? b,
@@ -129,7 +139,6 @@ abstract class CommentsNotificationsNotificationsViewHeaders
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String? get location;
   @BuiltValueSerializer(custom: true)
   static Serializer<CommentsNotificationsNotificationsViewHeaders> get serializer =>
       _$CommentsNotificationsNotificationsViewHeadersSerializer();
@@ -178,8 +187,17 @@ class _$CommentsNotificationsNotificationsViewHeadersSerializer
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CommentsCapabilities_FilesInterface {
+  bool get comments;
+  CommentsCapabilities_FilesInterface rebuild(final void Function(CommentsCapabilities_FilesInterfaceBuilder) updates);
+  CommentsCapabilities_FilesInterfaceBuilder toBuilder();
+}
+
 abstract class CommentsCapabilities_Files
-    implements Built<CommentsCapabilities_Files, CommentsCapabilities_FilesBuilder> {
+    implements
+        CommentsCapabilities_FilesInterface,
+        Built<CommentsCapabilities_Files, CommentsCapabilities_FilesBuilder> {
   factory CommentsCapabilities_Files([final void Function(CommentsCapabilities_FilesBuilder)? b]) =
       _$CommentsCapabilities_Files;
 
@@ -195,11 +213,18 @@ abstract class CommentsCapabilities_Files
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get comments;
   static Serializer<CommentsCapabilities_Files> get serializer => _$commentsCapabilitiesFilesSerializer;
 }
 
-abstract class CommentsCapabilities implements Built<CommentsCapabilities, CommentsCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CommentsCapabilitiesInterface {
+  CommentsCapabilities_Files get files;
+  CommentsCapabilitiesInterface rebuild(final void Function(CommentsCapabilitiesInterfaceBuilder) updates);
+  CommentsCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class CommentsCapabilities
+    implements CommentsCapabilitiesInterface, Built<CommentsCapabilities, CommentsCapabilitiesBuilder> {
   factory CommentsCapabilities([final void Function(CommentsCapabilitiesBuilder)? b]) = _$CommentsCapabilities;
 
   // coverage:ignore-start
@@ -214,7 +239,6 @@ abstract class CommentsCapabilities implements Built<CommentsCapabilities, Comme
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CommentsCapabilities_Files get files;
   static Serializer<CommentsCapabilities> get serializer => _$commentsCapabilitiesSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/comments.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/comments.openapi.g.dart
@@ -86,6 +86,13 @@ class _$CommentsCapabilitiesSerializer implements StructuredSerializer<CommentsC
   }
 }
 
+abstract mixin class CommentsNotificationsNotificationsViewHeadersInterfaceBuilder {
+  void replace(CommentsNotificationsNotificationsViewHeadersInterface other);
+  void update(void Function(CommentsNotificationsNotificationsViewHeadersInterfaceBuilder) updates);
+  String? get location;
+  set location(String? location);
+}
+
 class _$CommentsNotificationsNotificationsViewHeaders extends CommentsNotificationsNotificationsViewHeaders {
   @override
   final String? location;
@@ -128,12 +135,13 @@ class _$CommentsNotificationsNotificationsViewHeaders extends CommentsNotificati
 
 class CommentsNotificationsNotificationsViewHeadersBuilder
     implements
-        Builder<CommentsNotificationsNotificationsViewHeaders, CommentsNotificationsNotificationsViewHeadersBuilder> {
+        Builder<CommentsNotificationsNotificationsViewHeaders, CommentsNotificationsNotificationsViewHeadersBuilder>,
+        CommentsNotificationsNotificationsViewHeadersInterfaceBuilder {
   _$CommentsNotificationsNotificationsViewHeaders? _$v;
 
   String? _location;
   String? get location => _$this._location;
-  set location(String? location) => _$this._location = location;
+  set location(covariant String? location) => _$this._location = location;
 
   CommentsNotificationsNotificationsViewHeadersBuilder();
 
@@ -147,7 +155,7 @@ class CommentsNotificationsNotificationsViewHeadersBuilder
   }
 
   @override
-  void replace(CommentsNotificationsNotificationsViewHeaders other) {
+  void replace(covariant CommentsNotificationsNotificationsViewHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CommentsNotificationsNotificationsViewHeaders;
   }
@@ -165,6 +173,13 @@ class CommentsNotificationsNotificationsViewHeadersBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CommentsCapabilities_FilesInterfaceBuilder {
+  void replace(CommentsCapabilities_FilesInterface other);
+  void update(void Function(CommentsCapabilities_FilesInterfaceBuilder) updates);
+  bool? get comments;
+  set comments(bool? comments);
 }
 
 class _$CommentsCapabilities_Files extends CommentsCapabilities_Files {
@@ -206,12 +221,14 @@ class _$CommentsCapabilities_Files extends CommentsCapabilities_Files {
 }
 
 class CommentsCapabilities_FilesBuilder
-    implements Builder<CommentsCapabilities_Files, CommentsCapabilities_FilesBuilder> {
+    implements
+        Builder<CommentsCapabilities_Files, CommentsCapabilities_FilesBuilder>,
+        CommentsCapabilities_FilesInterfaceBuilder {
   _$CommentsCapabilities_Files? _$v;
 
   bool? _comments;
   bool? get comments => _$this._comments;
-  set comments(bool? comments) => _$this._comments = comments;
+  set comments(covariant bool? comments) => _$this._comments = comments;
 
   CommentsCapabilities_FilesBuilder();
 
@@ -225,7 +242,7 @@ class CommentsCapabilities_FilesBuilder
   }
 
   @override
-  void replace(CommentsCapabilities_Files other) {
+  void replace(covariant CommentsCapabilities_Files other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CommentsCapabilities_Files;
   }
@@ -245,6 +262,13 @@ class CommentsCapabilities_FilesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CommentsCapabilitiesInterfaceBuilder {
+  void replace(CommentsCapabilitiesInterface other);
+  void update(void Function(CommentsCapabilitiesInterfaceBuilder) updates);
+  CommentsCapabilities_FilesBuilder get files;
+  set files(CommentsCapabilities_FilesBuilder? files);
 }
 
 class _$CommentsCapabilities extends CommentsCapabilities {
@@ -285,12 +309,13 @@ class _$CommentsCapabilities extends CommentsCapabilities {
   }
 }
 
-class CommentsCapabilitiesBuilder implements Builder<CommentsCapabilities, CommentsCapabilitiesBuilder> {
+class CommentsCapabilitiesBuilder
+    implements Builder<CommentsCapabilities, CommentsCapabilitiesBuilder>, CommentsCapabilitiesInterfaceBuilder {
   _$CommentsCapabilities? _$v;
 
   CommentsCapabilities_FilesBuilder? _files;
   CommentsCapabilities_FilesBuilder get files => _$this._files ??= CommentsCapabilities_FilesBuilder();
-  set files(CommentsCapabilities_FilesBuilder? files) => _$this._files = files;
+  set files(covariant CommentsCapabilities_FilesBuilder? files) => _$this._files = files;
 
   CommentsCapabilitiesBuilder();
 
@@ -304,7 +329,7 @@ class CommentsCapabilitiesBuilder implements Builder<CommentsCapabilities, Comme
   }
 
   @override
-  void replace(CommentsCapabilities other) {
+  void replace(covariant CommentsCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CommentsCapabilities;
   }

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -2056,7 +2056,21 @@ class CoreWipeClient {
   }
 }
 
-abstract class CoreStatus implements Built<CoreStatus, CoreStatusBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreStatusInterface {
+  bool get installed;
+  bool get maintenance;
+  bool get needsDbUpgrade;
+  String get version;
+  String get versionstring;
+  String get edition;
+  String get productname;
+  bool get extendedSupport;
+  CoreStatusInterface rebuild(final void Function(CoreStatusInterfaceBuilder) updates);
+  CoreStatusInterfaceBuilder toBuilder();
+}
+
+abstract class CoreStatus implements CoreStatusInterface, Built<CoreStatus, CoreStatusBuilder> {
   factory CoreStatus([final void Function(CoreStatusBuilder)? b]) = _$CoreStatus;
 
   // coverage:ignore-start
@@ -2070,18 +2084,21 @@ abstract class CoreStatus implements Built<CoreStatus, CoreStatusBuilder> {
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get installed;
-  bool get maintenance;
-  bool get needsDbUpgrade;
-  String get version;
-  String get versionstring;
-  String get edition;
-  String get productname;
-  bool get extendedSupport;
   static Serializer<CoreStatus> get serializer => _$coreStatusSerializer;
 }
 
-abstract class CoreOCSMeta implements Built<CoreOCSMeta, CoreOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  CoreOCSMetaInterface rebuild(final void Function(CoreOCSMetaInterfaceBuilder) updates);
+  CoreOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class CoreOCSMeta implements CoreOCSMetaInterface, Built<CoreOCSMeta, CoreOCSMetaBuilder> {
   factory CoreOCSMeta([final void Function(CoreOCSMetaBuilder)? b]) = _$CoreOCSMeta;
 
   // coverage:ignore-start
@@ -2095,16 +2112,21 @@ abstract class CoreOCSMeta implements Built<CoreOCSMeta, CoreOCSMetaBuilder> {
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<CoreOCSMeta> get serializer => _$coreOCSMetaSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataInterface {
+  String get apppassword;
+  CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
 }
 
 abstract class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data
     implements
+        CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data,
             CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data([
@@ -2123,13 +2145,23 @@ abstract class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get apppassword;
   static Serializer<CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreAppPasswordGetAppPasswordResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data get data;
+  CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs
     implements
+        CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsInterface,
         Built<CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs,
             CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder> {
   factory CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs([
@@ -2148,14 +2180,22 @@ abstract class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs> get serializer =>
       _$coreAppPasswordGetAppPasswordResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreAppPasswordGetAppPasswordResponse200ApplicationJsonInterface {
+  CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs get ocs;
+  CoreAppPasswordGetAppPasswordResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreAppPasswordGetAppPasswordResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreAppPasswordGetAppPasswordResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreAppPasswordGetAppPasswordResponse200ApplicationJson
     implements
+        CoreAppPasswordGetAppPasswordResponse200ApplicationJsonInterface,
         Built<CoreAppPasswordGetAppPasswordResponse200ApplicationJson,
             CoreAppPasswordGetAppPasswordResponse200ApplicationJsonBuilder> {
   factory CoreAppPasswordGetAppPasswordResponse200ApplicationJson([
@@ -2174,13 +2214,22 @@ abstract class CoreAppPasswordGetAppPasswordResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreAppPasswordGetAppPasswordResponse200ApplicationJson> get serializer =>
       _$coreAppPasswordGetAppPasswordResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataInterface {
+  String get apppassword;
+  CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data
     implements
+        CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data,
             CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data([
@@ -2201,13 +2250,23 @@ abstract class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Da
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get apppassword;
   static Serializer<CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreAppPasswordRotateAppPasswordResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data get data;
+  CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs
     implements
+        CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsInterface,
         Built<CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs,
             CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder> {
   factory CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs([
@@ -2226,14 +2285,22 @@ abstract class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs> get serializer =>
       _$coreAppPasswordRotateAppPasswordResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonInterface {
+  CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs get ocs;
+  CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson
     implements
+        CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonInterface,
         Built<CoreAppPasswordRotateAppPasswordResponse200ApplicationJson,
             CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonBuilder> {
   factory CoreAppPasswordRotateAppPasswordResponse200ApplicationJson([
@@ -2252,13 +2319,23 @@ abstract class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreAppPasswordRotateAppPasswordResponse200ApplicationJson> get serializer =>
       _$coreAppPasswordRotateAppPasswordResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  JsonObject get data;
+  CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs
     implements
+        CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsInterface,
         Built<CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs,
             CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder> {
   factory CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs([
@@ -2277,14 +2354,22 @@ abstract class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  JsonObject get data;
   static Serializer<CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs> get serializer =>
       _$coreAppPasswordDeleteAppPasswordResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonInterface {
+  CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs get ocs;
+  CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson
     implements
+        CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonInterface,
         Built<CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson,
             CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonBuilder> {
   factory CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson([
@@ -2303,12 +2388,25 @@ abstract class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson> get serializer =>
       _$coreAppPasswordDeleteAppPasswordResponse200ApplicationJsonSerializer;
 }
 
-abstract class CoreAutocompleteResult implements Built<CoreAutocompleteResult, CoreAutocompleteResultBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreAutocompleteResultInterface {
+  String get id;
+  String get label;
+  String get icon;
+  String get source;
+  String get status;
+  String get subline;
+  String get shareWithDisplayNameUnique;
+  CoreAutocompleteResultInterface rebuild(final void Function(CoreAutocompleteResultInterfaceBuilder) updates);
+  CoreAutocompleteResultInterfaceBuilder toBuilder();
+}
+
+abstract class CoreAutocompleteResult
+    implements CoreAutocompleteResultInterface, Built<CoreAutocompleteResult, CoreAutocompleteResultBuilder> {
   factory CoreAutocompleteResult([final void Function(CoreAutocompleteResultBuilder)? b]) = _$CoreAutocompleteResult;
 
   // coverage:ignore-start
@@ -2323,18 +2421,22 @@ abstract class CoreAutocompleteResult implements Built<CoreAutocompleteResult, C
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  String get label;
-  String get icon;
-  String get source;
-  String get status;
-  String get subline;
-  String get shareWithDisplayNameUnique;
   static Serializer<CoreAutocompleteResult> get serializer => _$coreAutocompleteResultSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreAutoCompleteGetResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  BuiltList<CoreAutocompleteResult> get data;
+  CoreAutoCompleteGetResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreAutoCompleteGetResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreAutoCompleteGetResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class CoreAutoCompleteGetResponse200ApplicationJson_Ocs
     implements
+        CoreAutoCompleteGetResponse200ApplicationJson_OcsInterface,
         Built<CoreAutoCompleteGetResponse200ApplicationJson_Ocs,
             CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder> {
   factory CoreAutoCompleteGetResponse200ApplicationJson_Ocs([
@@ -2353,14 +2455,22 @@ abstract class CoreAutoCompleteGetResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  BuiltList<CoreAutocompleteResult> get data;
   static Serializer<CoreAutoCompleteGetResponse200ApplicationJson_Ocs> get serializer =>
       _$coreAutoCompleteGetResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreAutoCompleteGetResponse200ApplicationJsonInterface {
+  CoreAutoCompleteGetResponse200ApplicationJson_Ocs get ocs;
+  CoreAutoCompleteGetResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreAutoCompleteGetResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreAutoCompleteGetResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreAutoCompleteGetResponse200ApplicationJson
     implements
+        CoreAutoCompleteGetResponse200ApplicationJsonInterface,
         Built<CoreAutoCompleteGetResponse200ApplicationJson, CoreAutoCompleteGetResponse200ApplicationJsonBuilder> {
   factory CoreAutoCompleteGetResponse200ApplicationJson([
     final void Function(CoreAutoCompleteGetResponse200ApplicationJsonBuilder)? b,
@@ -2378,13 +2488,24 @@ abstract class CoreAutoCompleteGetResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreAutoCompleteGetResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreAutoCompleteGetResponse200ApplicationJson> get serializer =>
       _$coreAutoCompleteGetResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreAvatarAvatarGetAvatarDarkHeadersInterface {
+  @BuiltValueField(wireName: 'x-nc-iscustomavatar')
+  int? get xNcIscustomavatar;
+  CoreAvatarAvatarGetAvatarDarkHeadersInterface rebuild(
+    final void Function(CoreAvatarAvatarGetAvatarDarkHeadersInterfaceBuilder) updates,
+  );
+  CoreAvatarAvatarGetAvatarDarkHeadersInterfaceBuilder toBuilder();
+}
+
 abstract class CoreAvatarAvatarGetAvatarDarkHeaders
-    implements Built<CoreAvatarAvatarGetAvatarDarkHeaders, CoreAvatarAvatarGetAvatarDarkHeadersBuilder> {
+    implements
+        CoreAvatarAvatarGetAvatarDarkHeadersInterface,
+        Built<CoreAvatarAvatarGetAvatarDarkHeaders, CoreAvatarAvatarGetAvatarDarkHeadersBuilder> {
   factory CoreAvatarAvatarGetAvatarDarkHeaders([final void Function(CoreAvatarAvatarGetAvatarDarkHeadersBuilder)? b]) =
       _$CoreAvatarAvatarGetAvatarDarkHeaders;
 
@@ -2400,8 +2521,6 @@ abstract class CoreAvatarAvatarGetAvatarDarkHeaders
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'x-nc-iscustomavatar')
-  int? get xNcIscustomavatar;
   @BuiltValueSerializer(custom: true)
   static Serializer<CoreAvatarAvatarGetAvatarDarkHeaders> get serializer =>
       _$CoreAvatarAvatarGetAvatarDarkHeadersSerializer();
@@ -2447,8 +2566,20 @@ class _$CoreAvatarAvatarGetAvatarDarkHeadersSerializer
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreAvatarAvatarGetAvatarHeadersInterface {
+  @BuiltValueField(wireName: 'x-nc-iscustomavatar')
+  int? get xNcIscustomavatar;
+  CoreAvatarAvatarGetAvatarHeadersInterface rebuild(
+    final void Function(CoreAvatarAvatarGetAvatarHeadersInterfaceBuilder) updates,
+  );
+  CoreAvatarAvatarGetAvatarHeadersInterfaceBuilder toBuilder();
+}
+
 abstract class CoreAvatarAvatarGetAvatarHeaders
-    implements Built<CoreAvatarAvatarGetAvatarHeaders, CoreAvatarAvatarGetAvatarHeadersBuilder> {
+    implements
+        CoreAvatarAvatarGetAvatarHeadersInterface,
+        Built<CoreAvatarAvatarGetAvatarHeaders, CoreAvatarAvatarGetAvatarHeadersBuilder> {
   factory CoreAvatarAvatarGetAvatarHeaders([final void Function(CoreAvatarAvatarGetAvatarHeadersBuilder)? b]) =
       _$CoreAvatarAvatarGetAvatarHeaders;
 
@@ -2464,8 +2595,6 @@ abstract class CoreAvatarAvatarGetAvatarHeaders
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'x-nc-iscustomavatar')
-  int? get xNcIscustomavatar;
   @BuiltValueSerializer(custom: true)
   static Serializer<CoreAvatarAvatarGetAvatarHeaders> get serializer => _$CoreAvatarAvatarGetAvatarHeadersSerializer();
 }
@@ -2509,8 +2638,19 @@ class _$CoreAvatarAvatarGetAvatarHeadersSerializer implements StructuredSerializ
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreLoginFlowV2CredentialsInterface {
+  String get server;
+  String get loginName;
+  String get appPassword;
+  CoreLoginFlowV2CredentialsInterface rebuild(final void Function(CoreLoginFlowV2CredentialsInterfaceBuilder) updates);
+  CoreLoginFlowV2CredentialsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreLoginFlowV2Credentials
-    implements Built<CoreLoginFlowV2Credentials, CoreLoginFlowV2CredentialsBuilder> {
+    implements
+        CoreLoginFlowV2CredentialsInterface,
+        Built<CoreLoginFlowV2Credentials, CoreLoginFlowV2CredentialsBuilder> {
   factory CoreLoginFlowV2Credentials([final void Function(CoreLoginFlowV2CredentialsBuilder)? b]) =
       _$CoreLoginFlowV2Credentials;
 
@@ -2526,13 +2666,19 @@ abstract class CoreLoginFlowV2Credentials
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get server;
-  String get loginName;
-  String get appPassword;
   static Serializer<CoreLoginFlowV2Credentials> get serializer => _$coreLoginFlowV2CredentialsSerializer;
 }
 
-abstract class CoreLoginFlowV2_Poll implements Built<CoreLoginFlowV2_Poll, CoreLoginFlowV2_PollBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreLoginFlowV2_PollInterface {
+  String get token;
+  String get endpoint;
+  CoreLoginFlowV2_PollInterface rebuild(final void Function(CoreLoginFlowV2_PollInterfaceBuilder) updates);
+  CoreLoginFlowV2_PollInterfaceBuilder toBuilder();
+}
+
+abstract class CoreLoginFlowV2_Poll
+    implements CoreLoginFlowV2_PollInterface, Built<CoreLoginFlowV2_Poll, CoreLoginFlowV2_PollBuilder> {
   factory CoreLoginFlowV2_Poll([final void Function(CoreLoginFlowV2_PollBuilder)? b]) = _$CoreLoginFlowV2_Poll;
 
   // coverage:ignore-start
@@ -2547,12 +2693,18 @@ abstract class CoreLoginFlowV2_Poll implements Built<CoreLoginFlowV2_Poll, CoreL
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get token;
-  String get endpoint;
   static Serializer<CoreLoginFlowV2_Poll> get serializer => _$coreLoginFlowV2PollSerializer;
 }
 
-abstract class CoreLoginFlowV2 implements Built<CoreLoginFlowV2, CoreLoginFlowV2Builder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreLoginFlowV2Interface {
+  CoreLoginFlowV2_Poll get poll;
+  String get login;
+  CoreLoginFlowV2Interface rebuild(final void Function(CoreLoginFlowV2InterfaceBuilder) updates);
+  CoreLoginFlowV2InterfaceBuilder toBuilder();
+}
+
+abstract class CoreLoginFlowV2 implements CoreLoginFlowV2Interface, Built<CoreLoginFlowV2, CoreLoginFlowV2Builder> {
   factory CoreLoginFlowV2([final void Function(CoreLoginFlowV2Builder)? b]) = _$CoreLoginFlowV2;
 
   // coverage:ignore-start
@@ -2567,13 +2719,26 @@ abstract class CoreLoginFlowV2 implements Built<CoreLoginFlowV2, CoreLoginFlowV2
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreLoginFlowV2_Poll get poll;
-  String get login;
   static Serializer<CoreLoginFlowV2> get serializer => _$coreLoginFlowV2Serializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreOpenGraphObject_OpenGraphObjectInterface {
+  String get id;
+  String get name;
+  String? get description;
+  String? get thumb;
+  String get link;
+  CoreOpenGraphObject_OpenGraphObjectInterface rebuild(
+    final void Function(CoreOpenGraphObject_OpenGraphObjectInterfaceBuilder) updates,
+  );
+  CoreOpenGraphObject_OpenGraphObjectInterfaceBuilder toBuilder();
+}
+
 abstract class CoreOpenGraphObject_OpenGraphObject
-    implements Built<CoreOpenGraphObject_OpenGraphObject, CoreOpenGraphObject_OpenGraphObjectBuilder> {
+    implements
+        CoreOpenGraphObject_OpenGraphObjectInterface,
+        Built<CoreOpenGraphObject_OpenGraphObject, CoreOpenGraphObject_OpenGraphObjectBuilder> {
   factory CoreOpenGraphObject_OpenGraphObject([final void Function(CoreOpenGraphObject_OpenGraphObjectBuilder)? b]) =
       _$CoreOpenGraphObject_OpenGraphObject;
 
@@ -2589,16 +2754,22 @@ abstract class CoreOpenGraphObject_OpenGraphObject
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  String get name;
-  String? get description;
-  String? get thumb;
-  String get link;
   static Serializer<CoreOpenGraphObject_OpenGraphObject> get serializer =>
       _$coreOpenGraphObjectOpenGraphObjectSerializer;
 }
 
-abstract class CoreOpenGraphObject implements Built<CoreOpenGraphObject, CoreOpenGraphObjectBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreOpenGraphObjectInterface {
+  String get richObjectType;
+  BuiltMap<String, JsonObject> get richObject;
+  CoreOpenGraphObject_OpenGraphObject get openGraphObject;
+  bool get accessible;
+  CoreOpenGraphObjectInterface rebuild(final void Function(CoreOpenGraphObjectInterfaceBuilder) updates);
+  CoreOpenGraphObjectInterfaceBuilder toBuilder();
+}
+
+abstract class CoreOpenGraphObject
+    implements CoreOpenGraphObjectInterface, Built<CoreOpenGraphObject, CoreOpenGraphObjectBuilder> {
   factory CoreOpenGraphObject([final void Function(CoreOpenGraphObjectBuilder)? b]) = _$CoreOpenGraphObject;
 
   // coverage:ignore-start
@@ -2613,14 +2784,19 @@ abstract class CoreOpenGraphObject implements Built<CoreOpenGraphObject, CoreOpe
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get richObjectType;
-  BuiltMap<String, JsonObject> get richObject;
-  CoreOpenGraphObject_OpenGraphObject get openGraphObject;
-  bool get accessible;
   static Serializer<CoreOpenGraphObject> get serializer => _$coreOpenGraphObjectSerializer;
 }
 
-abstract class CoreCollection implements Built<CoreCollection, CoreCollectionBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollectionInterface {
+  int get id;
+  String get name;
+  BuiltList<CoreOpenGraphObject> get resources;
+  CoreCollectionInterface rebuild(final void Function(CoreCollectionInterfaceBuilder) updates);
+  CoreCollectionInterfaceBuilder toBuilder();
+}
+
+abstract class CoreCollection implements CoreCollectionInterface, Built<CoreCollection, CoreCollectionBuilder> {
   factory CoreCollection([final void Function(CoreCollectionBuilder)? b]) = _$CoreCollection;
 
   // coverage:ignore-start
@@ -2635,14 +2811,23 @@ abstract class CoreCollection implements Built<CoreCollection, CoreCollectionBui
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int get id;
-  String get name;
-  BuiltList<CoreOpenGraphObject> get resources;
   static Serializer<CoreCollection> get serializer => _$coreCollectionSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  BuiltList<CoreCollection> get data;
+  CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsInterfaceBuilder)
+        updates,
+  );
+  CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs
     implements
+        CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsInterface,
         Built<CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs,
             CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder> {
   factory CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs([
@@ -2663,14 +2848,22 @@ abstract class CoreCollaborationResourcesSearchCollectionsResponse200Application
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  BuiltList<CoreCollection> get data;
   static Serializer<CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs> get serializer =>
       _$coreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonInterface {
+  CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs get ocs;
+  CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson
     implements
+        CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonInterface,
         Built<CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson,
             CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonBuilder> {
   factory CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson([
@@ -2691,13 +2884,23 @@ abstract class CoreCollaborationResourcesSearchCollectionsResponse200Application
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson> get serializer =>
       _$coreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreCollection get data;
+  CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs
     implements
+        CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsInterface,
         Built<CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs,
             CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder> {
   factory CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs([
@@ -2718,14 +2921,22 @@ abstract class CoreCollaborationResourcesListCollectionResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreCollection get data;
   static Serializer<CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs> get serializer =>
       _$coreCollaborationResourcesListCollectionResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesListCollectionResponse200ApplicationJsonInterface {
+  CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs get ocs;
+  CoreCollaborationResourcesListCollectionResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreCollaborationResourcesListCollectionResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreCollaborationResourcesListCollectionResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesListCollectionResponse200ApplicationJson
     implements
+        CoreCollaborationResourcesListCollectionResponse200ApplicationJsonInterface,
         Built<CoreCollaborationResourcesListCollectionResponse200ApplicationJson,
             CoreCollaborationResourcesListCollectionResponse200ApplicationJsonBuilder> {
   factory CoreCollaborationResourcesListCollectionResponse200ApplicationJson([
@@ -2746,13 +2957,24 @@ abstract class CoreCollaborationResourcesListCollectionResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreCollaborationResourcesListCollectionResponse200ApplicationJson> get serializer =>
       _$coreCollaborationResourcesListCollectionResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreCollection get data;
+  CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsInterfaceBuilder)
+        updates,
+  );
+  CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs
     implements
+        CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsInterface,
         Built<CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs,
             CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder> {
   factory CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs([
@@ -2773,14 +2995,22 @@ abstract class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJ
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreCollection get data;
   static Serializer<CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs> get serializer =>
       _$coreCollaborationResourcesRenameCollectionResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonInterface {
+  CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs get ocs;
+  CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson
     implements
+        CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonInterface,
         Built<CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson,
             CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonBuilder> {
   factory CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson([
@@ -2801,13 +3031,23 @@ abstract class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJ
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson> get serializer =>
       _$coreCollaborationResourcesRenameCollectionResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreCollection get data;
+  CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs
     implements
+        CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsInterface,
         Built<CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs,
             CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder> {
   factory CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs([
@@ -2828,14 +3068,22 @@ abstract class CoreCollaborationResourcesAddResourceResponse200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreCollection get data;
   static Serializer<CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs> get serializer =>
       _$coreCollaborationResourcesAddResourceResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesAddResourceResponse200ApplicationJsonInterface {
+  CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs get ocs;
+  CoreCollaborationResourcesAddResourceResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreCollaborationResourcesAddResourceResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreCollaborationResourcesAddResourceResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesAddResourceResponse200ApplicationJson
     implements
+        CoreCollaborationResourcesAddResourceResponse200ApplicationJsonInterface,
         Built<CoreCollaborationResourcesAddResourceResponse200ApplicationJson,
             CoreCollaborationResourcesAddResourceResponse200ApplicationJsonBuilder> {
   factory CoreCollaborationResourcesAddResourceResponse200ApplicationJson([
@@ -2854,13 +3102,23 @@ abstract class CoreCollaborationResourcesAddResourceResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreCollaborationResourcesAddResourceResponse200ApplicationJson> get serializer =>
       _$coreCollaborationResourcesAddResourceResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreCollection get data;
+  CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs
     implements
+        CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsInterface,
         Built<CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs,
             CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder> {
   factory CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs([
@@ -2881,14 +3139,22 @@ abstract class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreCollection get data;
   static Serializer<CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs> get serializer =>
       _$coreCollaborationResourcesRemoveResourceResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonInterface {
+  CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs get ocs;
+  CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson
     implements
+        CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonInterface,
         Built<CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson,
             CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonBuilder> {
   factory CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson([
@@ -2909,13 +3175,25 @@ abstract class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson> get serializer =>
       _$coreCollaborationResourcesRemoveResourceResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  BuiltList<CoreCollection> get data;
+  CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(
+      CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsInterfaceBuilder,
+    ) updates,
+  );
+  CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs
     implements
+        CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsInterface,
         Built<CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs,
             CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder> {
   factory CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs([
@@ -2936,14 +3214,23 @@ abstract class CoreCollaborationResourcesGetCollectionsByResourceResponse200Appl
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  BuiltList<CoreCollection> get data;
   static Serializer<CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs> get serializer =>
       _$coreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonInterface {
+  CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs get ocs;
+  CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonInterfaceBuilder)
+        updates,
+  );
+  CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson
     implements
+        CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonInterface,
         Built<CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson,
             CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonBuilder> {
   factory CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson([
@@ -2964,13 +3251,25 @@ abstract class CoreCollaborationResourcesGetCollectionsByResourceResponse200Appl
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson> get serializer =>
       _$coreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreCollection get data;
+  CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(
+      CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsInterfaceBuilder,
+    ) updates,
+  );
+  CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs
     implements
+        CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsInterface,
         Built<CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs,
             CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder> {
   factory CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs([
@@ -2991,14 +3290,23 @@ abstract class CoreCollaborationResourcesCreateCollectionOnResourceResponse200Ap
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreCollection get data;
   static Serializer<CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs>
       get serializer => _$coreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonInterface {
+  CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs get ocs;
+  CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonInterfaceBuilder)
+        updates,
+  );
+  CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson
     implements
+        CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonInterface,
         Built<CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson,
             CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonBuilder> {
   factory CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson([
@@ -3019,12 +3327,22 @@ abstract class CoreCollaborationResourcesCreateCollectionOnResourceResponse200Ap
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson> get serializer =>
       _$coreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonSerializer;
 }
 
-abstract class CoreContactsAction implements Built<CoreContactsAction, CoreContactsActionBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreContactsActionInterface {
+  String get title;
+  String get icon;
+  String get hyperlink;
+  String get appId;
+  CoreContactsActionInterface rebuild(final void Function(CoreContactsActionInterfaceBuilder) updates);
+  CoreContactsActionInterfaceBuilder toBuilder();
+}
+
+abstract class CoreContactsAction
+    implements CoreContactsActionInterface, Built<CoreContactsAction, CoreContactsActionBuilder> {
   factory CoreContactsAction([final void Function(CoreContactsActionBuilder)? b]) = _$CoreContactsAction;
 
   // coverage:ignore-start
@@ -3039,15 +3357,23 @@ abstract class CoreContactsAction implements Built<CoreContactsAction, CoreConta
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get title;
-  String get icon;
-  String get hyperlink;
-  String get appId;
   static Serializer<CoreContactsAction> get serializer => _$coreContactsActionSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataInterface {
+  String get userId;
+  String get displayName;
+  BuiltList<CoreContactsAction> get actions;
+  CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
 }
 
 abstract class CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data
     implements
+        CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data,
             CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data([
@@ -3066,15 +3392,23 @@ abstract class CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get userId;
-  String get displayName;
-  BuiltList<CoreContactsAction> get actions;
   static Serializer<CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreHoverCardGetUserResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreHoverCardGetUserResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data get data;
+  CoreHoverCardGetUserResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreHoverCardGetUserResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreHoverCardGetUserResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreHoverCardGetUserResponse200ApplicationJson_Ocs
     implements
+        CoreHoverCardGetUserResponse200ApplicationJson_OcsInterface,
         Built<CoreHoverCardGetUserResponse200ApplicationJson_Ocs,
             CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder> {
   factory CoreHoverCardGetUserResponse200ApplicationJson_Ocs([
@@ -3093,14 +3427,22 @@ abstract class CoreHoverCardGetUserResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreHoverCardGetUserResponse200ApplicationJson_Ocs> get serializer =>
       _$coreHoverCardGetUserResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreHoverCardGetUserResponse200ApplicationJsonInterface {
+  CoreHoverCardGetUserResponse200ApplicationJson_Ocs get ocs;
+  CoreHoverCardGetUserResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreHoverCardGetUserResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreHoverCardGetUserResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreHoverCardGetUserResponse200ApplicationJson
     implements
+        CoreHoverCardGetUserResponse200ApplicationJsonInterface,
         Built<CoreHoverCardGetUserResponse200ApplicationJson, CoreHoverCardGetUserResponse200ApplicationJsonBuilder> {
   factory CoreHoverCardGetUserResponse200ApplicationJson([
     final void Function(CoreHoverCardGetUserResponse200ApplicationJsonBuilder)? b,
@@ -3118,7 +3460,6 @@ abstract class CoreHoverCardGetUserResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreHoverCardGetUserResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreHoverCardGetUserResponse200ApplicationJson> get serializer =>
       _$coreHoverCardGetUserResponse200ApplicationJsonSerializer;
 }
@@ -3179,7 +3520,23 @@ class _$CoreNavigationEntry_OrderSerializer implements PrimitiveSerializer<CoreN
   }
 }
 
-abstract class CoreNavigationEntry implements Built<CoreNavigationEntry, CoreNavigationEntryBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreNavigationEntryInterface {
+  String get id;
+  CoreNavigationEntry_Order get order;
+  String get href;
+  String get icon;
+  String get type;
+  String get name;
+  bool get active;
+  String get classes;
+  int get unread;
+  CoreNavigationEntryInterface rebuild(final void Function(CoreNavigationEntryInterfaceBuilder) updates);
+  CoreNavigationEntryInterfaceBuilder toBuilder();
+}
+
+abstract class CoreNavigationEntry
+    implements CoreNavigationEntryInterface, Built<CoreNavigationEntry, CoreNavigationEntryBuilder> {
   factory CoreNavigationEntry([final void Function(CoreNavigationEntryBuilder)? b]) = _$CoreNavigationEntry;
 
   // coverage:ignore-start
@@ -3194,20 +3551,22 @@ abstract class CoreNavigationEntry implements Built<CoreNavigationEntry, CoreNav
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  CoreNavigationEntry_Order get order;
-  String get href;
-  String get icon;
-  String get type;
-  String get name;
-  bool get active;
-  String get classes;
-  int get unread;
   static Serializer<CoreNavigationEntry> get serializer => _$coreNavigationEntrySerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  BuiltList<CoreNavigationEntry> get data;
+  CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs
     implements
+        CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsInterface,
         Built<CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs,
             CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder> {
   factory CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs([
@@ -3226,14 +3585,22 @@ abstract class CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  BuiltList<CoreNavigationEntry> get data;
   static Serializer<CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs> get serializer =>
       _$coreNavigationGetAppsNavigationResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreNavigationGetAppsNavigationResponse200ApplicationJsonInterface {
+  CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs get ocs;
+  CoreNavigationGetAppsNavigationResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreNavigationGetAppsNavigationResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreNavigationGetAppsNavigationResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreNavigationGetAppsNavigationResponse200ApplicationJson
     implements
+        CoreNavigationGetAppsNavigationResponse200ApplicationJsonInterface,
         Built<CoreNavigationGetAppsNavigationResponse200ApplicationJson,
             CoreNavigationGetAppsNavigationResponse200ApplicationJsonBuilder> {
   factory CoreNavigationGetAppsNavigationResponse200ApplicationJson([
@@ -3252,13 +3619,23 @@ abstract class CoreNavigationGetAppsNavigationResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreNavigationGetAppsNavigationResponse200ApplicationJson> get serializer =>
       _$coreNavigationGetAppsNavigationResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  BuiltList<CoreNavigationEntry> get data;
+  CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs
     implements
+        CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsInterface,
         Built<CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs,
             CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder> {
   factory CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs([
@@ -3277,14 +3654,22 @@ abstract class CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  BuiltList<CoreNavigationEntry> get data;
   static Serializer<CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs> get serializer =>
       _$coreNavigationGetSettingsNavigationResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreNavigationGetSettingsNavigationResponse200ApplicationJsonInterface {
+  CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs get ocs;
+  CoreNavigationGetSettingsNavigationResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreNavigationGetSettingsNavigationResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreNavigationGetSettingsNavigationResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreNavigationGetSettingsNavigationResponse200ApplicationJson
     implements
+        CoreNavigationGetSettingsNavigationResponse200ApplicationJsonInterface,
         Built<CoreNavigationGetSettingsNavigationResponse200ApplicationJson,
             CoreNavigationGetSettingsNavigationResponse200ApplicationJsonBuilder> {
   factory CoreNavigationGetSettingsNavigationResponse200ApplicationJson([
@@ -3303,13 +3688,27 @@ abstract class CoreNavigationGetSettingsNavigationResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreNavigationGetSettingsNavigationResponse200ApplicationJson> get serializer =>
       _$coreNavigationGetSettingsNavigationResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionInterface {
+  int get major;
+  int get minor;
+  int get micro;
+  String get string;
+  String get edition;
+  bool get extendedSupport;
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionInterface rebuild(
+    final void Function(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionInterfaceBuilder) updates,
+  );
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionInterfaceBuilder toBuilder();
+}
+
 abstract class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version
     implements
+        CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionInterface,
         Built<CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version,
             CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder> {
   factory CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version([
@@ -3328,18 +3727,23 @@ abstract class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int get major;
-  int get minor;
-  int get micro;
-  String get string;
-  String get edition;
-  bool get extendedSupport;
   static Serializer<CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version> get serializer =>
       _$coreOcsGetCapabilitiesResponse200ApplicationJsonOcsDataVersionSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreCommentsCapabilities_FilesInterface {
+  bool get comments;
+  CoreCommentsCapabilities_FilesInterface rebuild(
+    final void Function(CoreCommentsCapabilities_FilesInterfaceBuilder) updates,
+  );
+  CoreCommentsCapabilities_FilesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreCommentsCapabilities_Files
-    implements Built<CoreCommentsCapabilities_Files, CoreCommentsCapabilities_FilesBuilder> {
+    implements
+        CoreCommentsCapabilities_FilesInterface,
+        Built<CoreCommentsCapabilities_Files, CoreCommentsCapabilities_FilesBuilder> {
   factory CoreCommentsCapabilities_Files([final void Function(CoreCommentsCapabilities_FilesBuilder)? b]) =
       _$CoreCommentsCapabilities_Files;
 
@@ -3355,11 +3759,18 @@ abstract class CoreCommentsCapabilities_Files
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get comments;
   static Serializer<CoreCommentsCapabilities_Files> get serializer => _$coreCommentsCapabilitiesFilesSerializer;
 }
 
-abstract class CoreCommentsCapabilities implements Built<CoreCommentsCapabilities, CoreCommentsCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreCommentsCapabilitiesInterface {
+  CoreCommentsCapabilities_Files get files;
+  CoreCommentsCapabilitiesInterface rebuild(final void Function(CoreCommentsCapabilitiesInterfaceBuilder) updates);
+  CoreCommentsCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class CoreCommentsCapabilities
+    implements CoreCommentsCapabilitiesInterface, Built<CoreCommentsCapabilities, CoreCommentsCapabilitiesBuilder> {
   factory CoreCommentsCapabilities([final void Function(CoreCommentsCapabilitiesBuilder)? b]) =
       _$CoreCommentsCapabilities;
 
@@ -3375,11 +3786,19 @@ abstract class CoreCommentsCapabilities implements Built<CoreCommentsCapabilitie
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreCommentsCapabilities_Files get files;
   static Serializer<CoreCommentsCapabilities> get serializer => _$coreCommentsCapabilitiesSerializer;
 }
 
-abstract class CoreDavCapabilities_Dav implements Built<CoreDavCapabilities_Dav, CoreDavCapabilities_DavBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreDavCapabilities_DavInterface {
+  String get chunking;
+  String? get bulkupload;
+  CoreDavCapabilities_DavInterface rebuild(final void Function(CoreDavCapabilities_DavInterfaceBuilder) updates);
+  CoreDavCapabilities_DavInterfaceBuilder toBuilder();
+}
+
+abstract class CoreDavCapabilities_Dav
+    implements CoreDavCapabilities_DavInterface, Built<CoreDavCapabilities_Dav, CoreDavCapabilities_DavBuilder> {
   factory CoreDavCapabilities_Dav([final void Function(CoreDavCapabilities_DavBuilder)? b]) = _$CoreDavCapabilities_Dav;
 
   // coverage:ignore-start
@@ -3394,12 +3813,18 @@ abstract class CoreDavCapabilities_Dav implements Built<CoreDavCapabilities_Dav,
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get chunking;
-  String? get bulkupload;
   static Serializer<CoreDavCapabilities_Dav> get serializer => _$coreDavCapabilitiesDavSerializer;
 }
 
-abstract class CoreDavCapabilities implements Built<CoreDavCapabilities, CoreDavCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreDavCapabilitiesInterface {
+  CoreDavCapabilities_Dav get dav;
+  CoreDavCapabilitiesInterface rebuild(final void Function(CoreDavCapabilitiesInterfaceBuilder) updates);
+  CoreDavCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class CoreDavCapabilities
+    implements CoreDavCapabilitiesInterface, Built<CoreDavCapabilities, CoreDavCapabilitiesBuilder> {
   factory CoreDavCapabilities([final void Function(CoreDavCapabilitiesBuilder)? b]) = _$CoreDavCapabilities;
 
   // coverage:ignore-start
@@ -3414,12 +3839,24 @@ abstract class CoreDavCapabilities implements Built<CoreDavCapabilities, CoreDav
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreDavCapabilities_Dav get dav;
   static Serializer<CoreDavCapabilities> get serializer => _$coreDavCapabilitiesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesCapabilities_Files_DirectEditingInterface {
+  String get url;
+  String get etag;
+  bool get supportsFileId;
+  CoreFilesCapabilities_Files_DirectEditingInterface rebuild(
+    final void Function(CoreFilesCapabilities_Files_DirectEditingInterfaceBuilder) updates,
+  );
+  CoreFilesCapabilities_Files_DirectEditingInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesCapabilities_Files_DirectEditing
-    implements Built<CoreFilesCapabilities_Files_DirectEditing, CoreFilesCapabilities_Files_DirectEditingBuilder> {
+    implements
+        CoreFilesCapabilities_Files_DirectEditingInterface,
+        Built<CoreFilesCapabilities_Files_DirectEditing, CoreFilesCapabilities_Files_DirectEditingBuilder> {
   factory CoreFilesCapabilities_Files_DirectEditing([
     final void Function(CoreFilesCapabilities_Files_DirectEditingBuilder)? b,
   ]) = _$CoreFilesCapabilities_Files_DirectEditing;
@@ -3436,15 +3873,26 @@ abstract class CoreFilesCapabilities_Files_DirectEditing
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get url;
-  String get etag;
-  bool get supportsFileId;
   static Serializer<CoreFilesCapabilities_Files_DirectEditing> get serializer =>
       _$coreFilesCapabilitiesFilesDirectEditingSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesCapabilities_FilesInterface {
+  bool get bigfilechunking;
+  @BuiltValueField(wireName: 'blacklisted_files')
+  BuiltList<JsonObject> get blacklistedFiles;
+  CoreFilesCapabilities_Files_DirectEditing get directEditing;
+  CoreFilesCapabilities_FilesInterface rebuild(
+    final void Function(CoreFilesCapabilities_FilesInterfaceBuilder) updates,
+  );
+  CoreFilesCapabilities_FilesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesCapabilities_Files
-    implements Built<CoreFilesCapabilities_Files, CoreFilesCapabilities_FilesBuilder> {
+    implements
+        CoreFilesCapabilities_FilesInterface,
+        Built<CoreFilesCapabilities_Files, CoreFilesCapabilities_FilesBuilder> {
   factory CoreFilesCapabilities_Files([final void Function(CoreFilesCapabilities_FilesBuilder)? b]) =
       _$CoreFilesCapabilities_Files;
 
@@ -3460,14 +3908,18 @@ abstract class CoreFilesCapabilities_Files
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get bigfilechunking;
-  @BuiltValueField(wireName: 'blacklisted_files')
-  BuiltList<JsonObject> get blacklistedFiles;
-  CoreFilesCapabilities_Files_DirectEditing get directEditing;
   static Serializer<CoreFilesCapabilities_Files> get serializer => _$coreFilesCapabilitiesFilesSerializer;
 }
 
-abstract class CoreFilesCapabilities implements Built<CoreFilesCapabilities, CoreFilesCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesCapabilitiesInterface {
+  CoreFilesCapabilities_Files get files;
+  CoreFilesCapabilitiesInterface rebuild(final void Function(CoreFilesCapabilitiesInterfaceBuilder) updates);
+  CoreFilesCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class CoreFilesCapabilities
+    implements CoreFilesCapabilitiesInterface, Built<CoreFilesCapabilities, CoreFilesCapabilitiesBuilder> {
   factory CoreFilesCapabilities([final void Function(CoreFilesCapabilitiesBuilder)? b]) = _$CoreFilesCapabilities;
 
   // coverage:ignore-start
@@ -3482,12 +3934,22 @@ abstract class CoreFilesCapabilities implements Built<CoreFilesCapabilities, Cor
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreFilesCapabilities_Files get files;
   static Serializer<CoreFilesCapabilities> get serializer => _$coreFilesCapabilitiesSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_Public_PasswordInterface {
+  bool get enforced;
+  bool get askForOptionalPassword;
+  CoreFilesSharingCapabilities_FilesSharing_Public_PasswordInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder toBuilder();
 }
 
 abstract class CoreFilesSharingCapabilities_FilesSharing_Public_Password
     implements
+        CoreFilesSharingCapabilities_FilesSharing_Public_PasswordInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Public_Password,
             CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Public_Password([
@@ -3506,14 +3968,24 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Public_Password
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enforced;
-  bool get askForOptionalPassword;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Public_Password> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingPublicPasswordSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface {
+  bool get enabled;
+  int? get days;
+  bool? get enforced;
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate
     implements
+        CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate,
             CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate([
@@ -3532,15 +4004,24 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  int? get days;
-  bool? get enforced;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingPublicExpireDateSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface {
+  bool get enabled;
+  int? get days;
+  bool? get enforced;
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
     implements
+        CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal,
             CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal([
@@ -3561,15 +4042,24 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateIntern
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  int? get days;
-  bool? get enforced;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingPublicExpireDateInternalSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface {
+  bool get enabled;
+  int? get days;
+  bool? get enforced;
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
     implements
+        CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote,
             CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote([
@@ -3588,15 +4078,36 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  int? get days;
-  bool? get enforced;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingPublicExpireDateRemoteSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_PublicInterface {
+  bool get enabled;
+  CoreFilesSharingCapabilities_FilesSharing_Public_Password? get password;
+  @BuiltValueField(wireName: 'multiple_links')
+  bool? get multipleLinks;
+  @BuiltValueField(wireName: 'expire_date')
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate? get expireDate;
+  @BuiltValueField(wireName: 'expire_date_internal')
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal? get expireDateInternal;
+  @BuiltValueField(wireName: 'expire_date_remote')
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote? get expireDateRemote;
+  @BuiltValueField(wireName: 'send_mail')
+  bool? get sendMail;
+  bool? get upload;
+  @BuiltValueField(wireName: 'upload_files_drop')
+  bool? get uploadFilesDrop;
+  CoreFilesSharingCapabilities_FilesSharing_PublicInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_Public
     implements
+        CoreFilesSharingCapabilities_FilesSharing_PublicInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Public,
             CoreFilesSharingCapabilities_FilesSharing_PublicBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Public([
@@ -3615,27 +4126,22 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Public
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  CoreFilesSharingCapabilities_FilesSharing_Public_Password? get password;
-  @BuiltValueField(wireName: 'multiple_links')
-  bool? get multipleLinks;
-  @BuiltValueField(wireName: 'expire_date')
-  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate? get expireDate;
-  @BuiltValueField(wireName: 'expire_date_internal')
-  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal? get expireDateInternal;
-  @BuiltValueField(wireName: 'expire_date_remote')
-  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote? get expireDateRemote;
-  @BuiltValueField(wireName: 'send_mail')
-  bool? get sendMail;
-  bool? get upload;
-  @BuiltValueField(wireName: 'upload_files_drop')
-  bool? get uploadFilesDrop;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Public> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingPublicSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateInterface {
+  bool get enabled;
+  CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate
     implements
+        CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate,
             CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate([
@@ -3654,13 +4160,25 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingUserExpireDateSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_UserInterface {
+  @BuiltValueField(wireName: 'send_mail')
+  bool get sendMail;
+  @BuiltValueField(wireName: 'expire_date')
+  CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate? get expireDate;
+  CoreFilesSharingCapabilities_FilesSharing_UserInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_UserInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_UserInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_User
     implements
+        CoreFilesSharingCapabilities_FilesSharing_UserInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_User, CoreFilesSharingCapabilities_FilesSharing_UserBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_User([
     final void Function(CoreFilesSharingCapabilities_FilesSharing_UserBuilder)? b,
@@ -3678,16 +4196,22 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_User
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'send_mail')
-  bool get sendMail;
-  @BuiltValueField(wireName: 'expire_date')
-  CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate? get expireDate;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_User> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingUserSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface {
+  bool get enabled;
+  CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate
     implements
+        CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate,
             CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate([
@@ -3706,13 +4230,24 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingGroupExpireDateSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_GroupInterface {
+  bool get enabled;
+  @BuiltValueField(wireName: 'expire_date')
+  CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate? get expireDate;
+  CoreFilesSharingCapabilities_FilesSharing_GroupInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_Group
     implements
+        CoreFilesSharingCapabilities_FilesSharing_GroupInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Group, CoreFilesSharingCapabilities_FilesSharing_GroupBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Group([
     final void Function(CoreFilesSharingCapabilities_FilesSharing_GroupBuilder)? b,
@@ -3730,15 +4265,22 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Group
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  @BuiltValueField(wireName: 'expire_date')
-  CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate? get expireDate;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Group> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingGroupSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface {
+  bool get enabled;
+  CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate
     implements
+        CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate,
             CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate([
@@ -3757,13 +4299,23 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingFederationExpireDateSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface {
+  bool get enabled;
+  CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder)
+        updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported
     implements
+        CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported,
             CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported([
@@ -3784,13 +4336,27 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSu
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingFederationExpireDateSupportedSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_FederationInterface {
+  bool get outgoing;
+  bool get incoming;
+  @BuiltValueField(wireName: 'expire_date')
+  CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate get expireDate;
+  @BuiltValueField(wireName: 'expire_date_supported')
+  CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported get expireDateSupported;
+  CoreFilesSharingCapabilities_FilesSharing_FederationInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_Federation
     implements
+        CoreFilesSharingCapabilities_FilesSharing_FederationInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Federation,
             CoreFilesSharingCapabilities_FilesSharing_FederationBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Federation([
@@ -3809,18 +4375,25 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Federation
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get outgoing;
-  bool get incoming;
-  @BuiltValueField(wireName: 'expire_date')
-  CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate get expireDate;
-  @BuiltValueField(wireName: 'expire_date_supported')
-  CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported get expireDateSupported;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Federation> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingFederationSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharing_ShareeInterface {
+  @BuiltValueField(wireName: 'query_lookup_default')
+  bool get queryLookupDefault;
+  @BuiltValueField(wireName: 'always_show_unique')
+  bool get alwaysShowUnique;
+  CoreFilesSharingCapabilities_FilesSharing_ShareeInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing_Sharee
     implements
+        CoreFilesSharingCapabilities_FilesSharing_ShareeInterface,
         Built<CoreFilesSharingCapabilities_FilesSharing_Sharee,
             CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing_Sharee([
@@ -3839,16 +4412,34 @@ abstract class CoreFilesSharingCapabilities_FilesSharing_Sharee
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'query_lookup_default')
-  bool get queryLookupDefault;
-  @BuiltValueField(wireName: 'always_show_unique')
-  bool get alwaysShowUnique;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing_Sharee> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingShareeSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilities_FilesSharingInterface {
+  @BuiltValueField(wireName: 'api_enabled')
+  bool get apiEnabled;
+  CoreFilesSharingCapabilities_FilesSharing_Public get public;
+  CoreFilesSharingCapabilities_FilesSharing_User get user;
+  bool get resharing;
+  @BuiltValueField(wireName: 'group_sharing')
+  bool? get groupSharing;
+  CoreFilesSharingCapabilities_FilesSharing_Group? get group;
+  @BuiltValueField(wireName: 'default_permissions')
+  int? get defaultPermissions;
+  CoreFilesSharingCapabilities_FilesSharing_Federation get federation;
+  CoreFilesSharingCapabilities_FilesSharing_Sharee get sharee;
+  CoreFilesSharingCapabilities_FilesSharingInterface rebuild(
+    final void Function(CoreFilesSharingCapabilities_FilesSharingInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilities_FilesSharingInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities_FilesSharing
-    implements Built<CoreFilesSharingCapabilities_FilesSharing, CoreFilesSharingCapabilities_FilesSharingBuilder> {
+    implements
+        CoreFilesSharingCapabilities_FilesSharingInterface,
+        Built<CoreFilesSharingCapabilities_FilesSharing, CoreFilesSharingCapabilities_FilesSharingBuilder> {
   factory CoreFilesSharingCapabilities_FilesSharing([
     final void Function(CoreFilesSharingCapabilities_FilesSharingBuilder)? b,
   ]) = _$CoreFilesSharingCapabilities_FilesSharing;
@@ -3865,24 +4456,24 @@ abstract class CoreFilesSharingCapabilities_FilesSharing
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'api_enabled')
-  bool get apiEnabled;
-  CoreFilesSharingCapabilities_FilesSharing_Public get public;
-  CoreFilesSharingCapabilities_FilesSharing_User get user;
-  bool get resharing;
-  @BuiltValueField(wireName: 'group_sharing')
-  bool? get groupSharing;
-  CoreFilesSharingCapabilities_FilesSharing_Group? get group;
-  @BuiltValueField(wireName: 'default_permissions')
-  int? get defaultPermissions;
-  CoreFilesSharingCapabilities_FilesSharing_Federation get federation;
-  CoreFilesSharingCapabilities_FilesSharing_Sharee get sharee;
   static Serializer<CoreFilesSharingCapabilities_FilesSharing> get serializer =>
       _$coreFilesSharingCapabilitiesFilesSharingSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesSharingCapabilitiesInterface {
+  @BuiltValueField(wireName: 'files_sharing')
+  CoreFilesSharingCapabilities_FilesSharing get filesSharing;
+  CoreFilesSharingCapabilitiesInterface rebuild(
+    final void Function(CoreFilesSharingCapabilitiesInterfaceBuilder) updates,
+  );
+  CoreFilesSharingCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesSharingCapabilities
-    implements Built<CoreFilesSharingCapabilities, CoreFilesSharingCapabilitiesBuilder> {
+    implements
+        CoreFilesSharingCapabilitiesInterface,
+        Built<CoreFilesSharingCapabilities, CoreFilesSharingCapabilitiesBuilder> {
   factory CoreFilesSharingCapabilities([final void Function(CoreFilesSharingCapabilitiesBuilder)? b]) =
       _$CoreFilesSharingCapabilities;
 
@@ -3898,13 +4489,22 @@ abstract class CoreFilesSharingCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'files_sharing')
-  CoreFilesSharingCapabilities_FilesSharing get filesSharing;
   static Serializer<CoreFilesSharingCapabilities> get serializer => _$coreFilesSharingCapabilitiesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesTrashbinCapabilities_FilesInterface {
+  bool get undelete;
+  CoreFilesTrashbinCapabilities_FilesInterface rebuild(
+    final void Function(CoreFilesTrashbinCapabilities_FilesInterfaceBuilder) updates,
+  );
+  CoreFilesTrashbinCapabilities_FilesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesTrashbinCapabilities_Files
-    implements Built<CoreFilesTrashbinCapabilities_Files, CoreFilesTrashbinCapabilities_FilesBuilder> {
+    implements
+        CoreFilesTrashbinCapabilities_FilesInterface,
+        Built<CoreFilesTrashbinCapabilities_Files, CoreFilesTrashbinCapabilities_FilesBuilder> {
   factory CoreFilesTrashbinCapabilities_Files([final void Function(CoreFilesTrashbinCapabilities_FilesBuilder)? b]) =
       _$CoreFilesTrashbinCapabilities_Files;
 
@@ -3920,13 +4520,23 @@ abstract class CoreFilesTrashbinCapabilities_Files
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get undelete;
   static Serializer<CoreFilesTrashbinCapabilities_Files> get serializer =>
       _$coreFilesTrashbinCapabilitiesFilesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesTrashbinCapabilitiesInterface {
+  CoreFilesTrashbinCapabilities_Files get files;
+  CoreFilesTrashbinCapabilitiesInterface rebuild(
+    final void Function(CoreFilesTrashbinCapabilitiesInterfaceBuilder) updates,
+  );
+  CoreFilesTrashbinCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesTrashbinCapabilities
-    implements Built<CoreFilesTrashbinCapabilities, CoreFilesTrashbinCapabilitiesBuilder> {
+    implements
+        CoreFilesTrashbinCapabilitiesInterface,
+        Built<CoreFilesTrashbinCapabilities, CoreFilesTrashbinCapabilitiesBuilder> {
   factory CoreFilesTrashbinCapabilities([final void Function(CoreFilesTrashbinCapabilitiesBuilder)? b]) =
       _$CoreFilesTrashbinCapabilities;
 
@@ -3942,12 +4552,26 @@ abstract class CoreFilesTrashbinCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreFilesTrashbinCapabilities_Files get files;
   static Serializer<CoreFilesTrashbinCapabilities> get serializer => _$coreFilesTrashbinCapabilitiesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesVersionsCapabilities_FilesInterface {
+  bool get versioning;
+  @BuiltValueField(wireName: 'version_labeling')
+  bool get versionLabeling;
+  @BuiltValueField(wireName: 'version_deletion')
+  bool get versionDeletion;
+  CoreFilesVersionsCapabilities_FilesInterface rebuild(
+    final void Function(CoreFilesVersionsCapabilities_FilesInterfaceBuilder) updates,
+  );
+  CoreFilesVersionsCapabilities_FilesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesVersionsCapabilities_Files
-    implements Built<CoreFilesVersionsCapabilities_Files, CoreFilesVersionsCapabilities_FilesBuilder> {
+    implements
+        CoreFilesVersionsCapabilities_FilesInterface,
+        Built<CoreFilesVersionsCapabilities_Files, CoreFilesVersionsCapabilities_FilesBuilder> {
   factory CoreFilesVersionsCapabilities_Files([final void Function(CoreFilesVersionsCapabilities_FilesBuilder)? b]) =
       _$CoreFilesVersionsCapabilities_Files;
 
@@ -3963,17 +4587,23 @@ abstract class CoreFilesVersionsCapabilities_Files
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get versioning;
-  @BuiltValueField(wireName: 'version_labeling')
-  bool get versionLabeling;
-  @BuiltValueField(wireName: 'version_deletion')
-  bool get versionDeletion;
   static Serializer<CoreFilesVersionsCapabilities_Files> get serializer =>
       _$coreFilesVersionsCapabilitiesFilesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreFilesVersionsCapabilitiesInterface {
+  CoreFilesVersionsCapabilities_Files get files;
+  CoreFilesVersionsCapabilitiesInterface rebuild(
+    final void Function(CoreFilesVersionsCapabilitiesInterfaceBuilder) updates,
+  );
+  CoreFilesVersionsCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreFilesVersionsCapabilities
-    implements Built<CoreFilesVersionsCapabilities, CoreFilesVersionsCapabilitiesBuilder> {
+    implements
+        CoreFilesVersionsCapabilitiesInterface,
+        Built<CoreFilesVersionsCapabilities, CoreFilesVersionsCapabilitiesBuilder> {
   factory CoreFilesVersionsCapabilities([final void Function(CoreFilesVersionsCapabilitiesBuilder)? b]) =
       _$CoreFilesVersionsCapabilities;
 
@@ -3989,12 +4619,24 @@ abstract class CoreFilesVersionsCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreFilesVersionsCapabilities_Files get files;
   static Serializer<CoreFilesVersionsCapabilities> get serializer => _$coreFilesVersionsCapabilitiesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreNotesCapabilities_NotesInterface {
+  @BuiltValueField(wireName: 'api_version')
+  BuiltList<String>? get apiVersion;
+  String? get version;
+  CoreNotesCapabilities_NotesInterface rebuild(
+    final void Function(CoreNotesCapabilities_NotesInterfaceBuilder) updates,
+  );
+  CoreNotesCapabilities_NotesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreNotesCapabilities_Notes
-    implements Built<CoreNotesCapabilities_Notes, CoreNotesCapabilities_NotesBuilder> {
+    implements
+        CoreNotesCapabilities_NotesInterface,
+        Built<CoreNotesCapabilities_Notes, CoreNotesCapabilities_NotesBuilder> {
   factory CoreNotesCapabilities_Notes([final void Function(CoreNotesCapabilities_NotesBuilder)? b]) =
       _$CoreNotesCapabilities_Notes;
 
@@ -4010,13 +4652,18 @@ abstract class CoreNotesCapabilities_Notes
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'api_version')
-  BuiltList<String>? get apiVersion;
-  String? get version;
   static Serializer<CoreNotesCapabilities_Notes> get serializer => _$coreNotesCapabilitiesNotesSerializer;
 }
 
-abstract class CoreNotesCapabilities implements Built<CoreNotesCapabilities, CoreNotesCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreNotesCapabilitiesInterface {
+  CoreNotesCapabilities_Notes get notes;
+  CoreNotesCapabilitiesInterface rebuild(final void Function(CoreNotesCapabilitiesInterfaceBuilder) updates);
+  CoreNotesCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class CoreNotesCapabilities
+    implements CoreNotesCapabilitiesInterface, Built<CoreNotesCapabilities, CoreNotesCapabilitiesBuilder> {
   factory CoreNotesCapabilities([final void Function(CoreNotesCapabilitiesBuilder)? b]) = _$CoreNotesCapabilities;
 
   // coverage:ignore-start
@@ -4031,12 +4678,26 @@ abstract class CoreNotesCapabilities implements Built<CoreNotesCapabilities, Cor
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreNotesCapabilities_Notes get notes;
   static Serializer<CoreNotesCapabilities> get serializer => _$coreNotesCapabilitiesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreNotificationsCapabilities_NotificationsInterface {
+  @BuiltValueField(wireName: 'ocs-endpoints')
+  BuiltList<String>? get ocsEndpoints;
+  BuiltList<String>? get push;
+  @BuiltValueField(wireName: 'admin-notifications')
+  BuiltList<String>? get adminNotifications;
+  CoreNotificationsCapabilities_NotificationsInterface rebuild(
+    final void Function(CoreNotificationsCapabilities_NotificationsInterfaceBuilder) updates,
+  );
+  CoreNotificationsCapabilities_NotificationsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreNotificationsCapabilities_Notifications
-    implements Built<CoreNotificationsCapabilities_Notifications, CoreNotificationsCapabilities_NotificationsBuilder> {
+    implements
+        CoreNotificationsCapabilities_NotificationsInterface,
+        Built<CoreNotificationsCapabilities_Notifications, CoreNotificationsCapabilities_NotificationsBuilder> {
   factory CoreNotificationsCapabilities_Notifications([
     final void Function(CoreNotificationsCapabilities_NotificationsBuilder)? b,
   ]) = _$CoreNotificationsCapabilities_Notifications;
@@ -4053,17 +4714,23 @@ abstract class CoreNotificationsCapabilities_Notifications
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'ocs-endpoints')
-  BuiltList<String>? get ocsEndpoints;
-  BuiltList<String>? get push;
-  @BuiltValueField(wireName: 'admin-notifications')
-  BuiltList<String>? get adminNotifications;
   static Serializer<CoreNotificationsCapabilities_Notifications> get serializer =>
       _$coreNotificationsCapabilitiesNotificationsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreNotificationsCapabilitiesInterface {
+  CoreNotificationsCapabilities_Notifications get notifications;
+  CoreNotificationsCapabilitiesInterface rebuild(
+    final void Function(CoreNotificationsCapabilitiesInterfaceBuilder) updates,
+  );
+  CoreNotificationsCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreNotificationsCapabilities
-    implements Built<CoreNotificationsCapabilities, CoreNotificationsCapabilitiesBuilder> {
+    implements
+        CoreNotificationsCapabilitiesInterface,
+        Built<CoreNotificationsCapabilities, CoreNotificationsCapabilitiesBuilder> {
   factory CoreNotificationsCapabilities([final void Function(CoreNotificationsCapabilitiesBuilder)? b]) =
       _$CoreNotificationsCapabilities;
 
@@ -4079,12 +4746,27 @@ abstract class CoreNotificationsCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreNotificationsCapabilities_Notifications get notifications;
   static Serializer<CoreNotificationsCapabilities> get serializer => _$coreNotificationsCapabilitiesSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreProvisioningApiCapabilities_ProvisioningApiInterface {
+  String get version;
+  @BuiltValueField(wireName: 'AccountPropertyScopesVersion')
+  int get accountPropertyScopesVersion;
+  @BuiltValueField(wireName: 'AccountPropertyScopesFederatedEnabled')
+  bool get accountPropertyScopesFederatedEnabled;
+  @BuiltValueField(wireName: 'AccountPropertyScopesPublishedEnabled')
+  bool get accountPropertyScopesPublishedEnabled;
+  CoreProvisioningApiCapabilities_ProvisioningApiInterface rebuild(
+    final void Function(CoreProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder) updates,
+  );
+  CoreProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder toBuilder();
 }
 
 abstract class CoreProvisioningApiCapabilities_ProvisioningApi
     implements
+        CoreProvisioningApiCapabilities_ProvisioningApiInterface,
         Built<CoreProvisioningApiCapabilities_ProvisioningApi, CoreProvisioningApiCapabilities_ProvisioningApiBuilder> {
   factory CoreProvisioningApiCapabilities_ProvisioningApi([
     final void Function(CoreProvisioningApiCapabilities_ProvisioningApiBuilder)? b,
@@ -4102,19 +4784,24 @@ abstract class CoreProvisioningApiCapabilities_ProvisioningApi
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get version;
-  @BuiltValueField(wireName: 'AccountPropertyScopesVersion')
-  int get accountPropertyScopesVersion;
-  @BuiltValueField(wireName: 'AccountPropertyScopesFederatedEnabled')
-  bool get accountPropertyScopesFederatedEnabled;
-  @BuiltValueField(wireName: 'AccountPropertyScopesPublishedEnabled')
-  bool get accountPropertyScopesPublishedEnabled;
   static Serializer<CoreProvisioningApiCapabilities_ProvisioningApi> get serializer =>
       _$coreProvisioningApiCapabilitiesProvisioningApiSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreProvisioningApiCapabilitiesInterface {
+  @BuiltValueField(wireName: 'provisioning_api')
+  CoreProvisioningApiCapabilities_ProvisioningApi get provisioningApi;
+  CoreProvisioningApiCapabilitiesInterface rebuild(
+    final void Function(CoreProvisioningApiCapabilitiesInterfaceBuilder) updates,
+  );
+  CoreProvisioningApiCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreProvisioningApiCapabilities
-    implements Built<CoreProvisioningApiCapabilities, CoreProvisioningApiCapabilitiesBuilder> {
+    implements
+        CoreProvisioningApiCapabilitiesInterface,
+        Built<CoreProvisioningApiCapabilities, CoreProvisioningApiCapabilitiesBuilder> {
   factory CoreProvisioningApiCapabilities([final void Function(CoreProvisioningApiCapabilitiesBuilder)? b]) =
       _$CoreProvisioningApiCapabilities;
 
@@ -4130,13 +4817,21 @@ abstract class CoreProvisioningApiCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'provisioning_api')
-  CoreProvisioningApiCapabilities_ProvisioningApi get provisioningApi;
   static Serializer<CoreProvisioningApiCapabilities> get serializer => _$coreProvisioningApiCapabilitiesSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterface {
+  bool get enabled;
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterface rebuild(
+    final void Function(CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder) updates,
+  );
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder toBuilder();
 }
 
 abstract class CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop
     implements
+        CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterface,
         Built<CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop,
             CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder> {
   factory CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop([
@@ -4157,13 +4852,23 @@ abstract class CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesD
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop> get serializer =>
       _$coreSharebymailCapabilitiesFilesSharingSharebymailUploadFilesDropSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterface {
+  bool get enabled;
+  bool get enforced;
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterface rebuild(
+    final void Function(CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterfaceBuilder) updates,
+  );
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterfaceBuilder toBuilder();
+}
+
 abstract class CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password
     implements
+        CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterface,
         Built<CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password,
             CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder> {
   factory CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password([
@@ -4182,14 +4887,23 @@ abstract class CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  bool get enforced;
   static Serializer<CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password> get serializer =>
       _$coreSharebymailCapabilitiesFilesSharingSharebymailPasswordSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterface {
+  bool get enabled;
+  bool get enforced;
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterface rebuild(
+    final void Function(CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder) updates,
+  );
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder toBuilder();
+}
+
 abstract class CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate
     implements
+        CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterface,
         Built<CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate,
             CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder> {
   factory CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate([
@@ -4208,14 +4922,29 @@ abstract class CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  bool get enforced;
   static Serializer<CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate> get serializer =>
       _$coreSharebymailCapabilitiesFilesSharingSharebymailExpireDateSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreSharebymailCapabilities_FilesSharing_SharebymailInterface {
+  bool get enabled;
+  @BuiltValueField(wireName: 'send_password_by_mail')
+  bool get sendPasswordByMail;
+  @BuiltValueField(wireName: 'upload_files_drop')
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop get uploadFilesDrop;
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password get password;
+  @BuiltValueField(wireName: 'expire_date')
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate get expireDate;
+  CoreSharebymailCapabilities_FilesSharing_SharebymailInterface rebuild(
+    final void Function(CoreSharebymailCapabilities_FilesSharing_SharebymailInterfaceBuilder) updates,
+  );
+  CoreSharebymailCapabilities_FilesSharing_SharebymailInterfaceBuilder toBuilder();
+}
+
 abstract class CoreSharebymailCapabilities_FilesSharing_Sharebymail
     implements
+        CoreSharebymailCapabilities_FilesSharing_SharebymailInterface,
         Built<CoreSharebymailCapabilities_FilesSharing_Sharebymail,
             CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder> {
   factory CoreSharebymailCapabilities_FilesSharing_Sharebymail([
@@ -4234,20 +4963,23 @@ abstract class CoreSharebymailCapabilities_FilesSharing_Sharebymail
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  @BuiltValueField(wireName: 'send_password_by_mail')
-  bool get sendPasswordByMail;
-  @BuiltValueField(wireName: 'upload_files_drop')
-  CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop get uploadFilesDrop;
-  CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password get password;
-  @BuiltValueField(wireName: 'expire_date')
-  CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate get expireDate;
   static Serializer<CoreSharebymailCapabilities_FilesSharing_Sharebymail> get serializer =>
       _$coreSharebymailCapabilitiesFilesSharingSharebymailSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreSharebymailCapabilities_FilesSharingInterface {
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail get sharebymail;
+  CoreSharebymailCapabilities_FilesSharingInterface rebuild(
+    final void Function(CoreSharebymailCapabilities_FilesSharingInterfaceBuilder) updates,
+  );
+  CoreSharebymailCapabilities_FilesSharingInterfaceBuilder toBuilder();
+}
+
 abstract class CoreSharebymailCapabilities_FilesSharing
-    implements Built<CoreSharebymailCapabilities_FilesSharing, CoreSharebymailCapabilities_FilesSharingBuilder> {
+    implements
+        CoreSharebymailCapabilities_FilesSharingInterface,
+        Built<CoreSharebymailCapabilities_FilesSharing, CoreSharebymailCapabilities_FilesSharingBuilder> {
   factory CoreSharebymailCapabilities_FilesSharing([
     final void Function(CoreSharebymailCapabilities_FilesSharingBuilder)? b,
   ]) = _$CoreSharebymailCapabilities_FilesSharing;
@@ -4264,13 +4996,24 @@ abstract class CoreSharebymailCapabilities_FilesSharing
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreSharebymailCapabilities_FilesSharing_Sharebymail get sharebymail;
   static Serializer<CoreSharebymailCapabilities_FilesSharing> get serializer =>
       _$coreSharebymailCapabilitiesFilesSharingSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreSharebymailCapabilitiesInterface {
+  @BuiltValueField(wireName: 'files_sharing')
+  CoreSharebymailCapabilities_FilesSharing get filesSharing;
+  CoreSharebymailCapabilitiesInterface rebuild(
+    final void Function(CoreSharebymailCapabilitiesInterfaceBuilder) updates,
+  );
+  CoreSharebymailCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreSharebymailCapabilities
-    implements Built<CoreSharebymailCapabilities, CoreSharebymailCapabilitiesBuilder> {
+    implements
+        CoreSharebymailCapabilitiesInterface,
+        Built<CoreSharebymailCapabilities, CoreSharebymailCapabilitiesBuilder> {
   factory CoreSharebymailCapabilities([final void Function(CoreSharebymailCapabilitiesBuilder)? b]) =
       _$CoreSharebymailCapabilities;
 
@@ -4286,29 +5029,11 @@ abstract class CoreSharebymailCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'files_sharing')
-  CoreSharebymailCapabilities_FilesSharing get filesSharing;
   static Serializer<CoreSharebymailCapabilities> get serializer => _$coreSharebymailCapabilitiesSerializer;
 }
 
-abstract class CoreThemingPublicCapabilities_Theming
-    implements Built<CoreThemingPublicCapabilities_Theming, CoreThemingPublicCapabilities_ThemingBuilder> {
-  factory CoreThemingPublicCapabilities_Theming([
-    final void Function(CoreThemingPublicCapabilities_ThemingBuilder)? b,
-  ]) = _$CoreThemingPublicCapabilities_Theming;
-
-  // coverage:ignore-start
-  const CoreThemingPublicCapabilities_Theming._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory CoreThemingPublicCapabilities_Theming.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class CoreThemingPublicCapabilities_ThemingInterface {
   String get name;
   String get url;
   String get slogan;
@@ -4329,12 +5054,49 @@ abstract class CoreThemingPublicCapabilities_Theming
   bool get backgroundDefault;
   String get logoheader;
   String get favicon;
+  CoreThemingPublicCapabilities_ThemingInterface rebuild(
+    final void Function(CoreThemingPublicCapabilities_ThemingInterfaceBuilder) updates,
+  );
+  CoreThemingPublicCapabilities_ThemingInterfaceBuilder toBuilder();
+}
+
+abstract class CoreThemingPublicCapabilities_Theming
+    implements
+        CoreThemingPublicCapabilities_ThemingInterface,
+        Built<CoreThemingPublicCapabilities_Theming, CoreThemingPublicCapabilities_ThemingBuilder> {
+  factory CoreThemingPublicCapabilities_Theming([
+    final void Function(CoreThemingPublicCapabilities_ThemingBuilder)? b,
+  ]) = _$CoreThemingPublicCapabilities_Theming;
+
+  // coverage:ignore-start
+  const CoreThemingPublicCapabilities_Theming._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory CoreThemingPublicCapabilities_Theming.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<CoreThemingPublicCapabilities_Theming> get serializer =>
       _$coreThemingPublicCapabilitiesThemingSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreThemingPublicCapabilitiesInterface {
+  CoreThemingPublicCapabilities_Theming get theming;
+  CoreThemingPublicCapabilitiesInterface rebuild(
+    final void Function(CoreThemingPublicCapabilitiesInterfaceBuilder) updates,
+  );
+  CoreThemingPublicCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreThemingPublicCapabilities
-    implements Built<CoreThemingPublicCapabilities, CoreThemingPublicCapabilitiesBuilder> {
+    implements
+        CoreThemingPublicCapabilitiesInterface,
+        Built<CoreThemingPublicCapabilities, CoreThemingPublicCapabilitiesBuilder> {
   factory CoreThemingPublicCapabilities([final void Function(CoreThemingPublicCapabilitiesBuilder)? b]) =
       _$CoreThemingPublicCapabilities;
 
@@ -4350,12 +5112,25 @@ abstract class CoreThemingPublicCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreThemingPublicCapabilities_Theming get theming;
   static Serializer<CoreThemingPublicCapabilities> get serializer => _$coreThemingPublicCapabilitiesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreUserStatusCapabilities_UserStatusInterface {
+  bool get enabled;
+  bool get restore;
+  @BuiltValueField(wireName: 'supports_emoji')
+  bool get supportsEmoji;
+  CoreUserStatusCapabilities_UserStatusInterface rebuild(
+    final void Function(CoreUserStatusCapabilities_UserStatusInterfaceBuilder) updates,
+  );
+  CoreUserStatusCapabilities_UserStatusInterfaceBuilder toBuilder();
+}
+
 abstract class CoreUserStatusCapabilities_UserStatus
-    implements Built<CoreUserStatusCapabilities_UserStatus, CoreUserStatusCapabilities_UserStatusBuilder> {
+    implements
+        CoreUserStatusCapabilities_UserStatusInterface,
+        Built<CoreUserStatusCapabilities_UserStatus, CoreUserStatusCapabilities_UserStatusBuilder> {
   factory CoreUserStatusCapabilities_UserStatus([
     final void Function(CoreUserStatusCapabilities_UserStatusBuilder)? b,
   ]) = _$CoreUserStatusCapabilities_UserStatus;
@@ -4372,16 +5147,22 @@ abstract class CoreUserStatusCapabilities_UserStatus
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  bool get restore;
-  @BuiltValueField(wireName: 'supports_emoji')
-  bool get supportsEmoji;
   static Serializer<CoreUserStatusCapabilities_UserStatus> get serializer =>
       _$coreUserStatusCapabilitiesUserStatusSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreUserStatusCapabilitiesInterface {
+  @BuiltValueField(wireName: 'user_status')
+  CoreUserStatusCapabilities_UserStatus get userStatus;
+  CoreUserStatusCapabilitiesInterface rebuild(final void Function(CoreUserStatusCapabilitiesInterfaceBuilder) updates);
+  CoreUserStatusCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreUserStatusCapabilities
-    implements Built<CoreUserStatusCapabilities, CoreUserStatusCapabilitiesBuilder> {
+    implements
+        CoreUserStatusCapabilitiesInterface,
+        Built<CoreUserStatusCapabilities, CoreUserStatusCapabilitiesBuilder> {
   factory CoreUserStatusCapabilities([final void Function(CoreUserStatusCapabilitiesBuilder)? b]) =
       _$CoreUserStatusCapabilities;
 
@@ -4397,13 +5178,22 @@ abstract class CoreUserStatusCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'user_status')
-  CoreUserStatusCapabilities_UserStatus get userStatus;
   static Serializer<CoreUserStatusCapabilities> get serializer => _$coreUserStatusCapabilitiesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreWeatherStatusCapabilities_WeatherStatusInterface {
+  bool get enabled;
+  CoreWeatherStatusCapabilities_WeatherStatusInterface rebuild(
+    final void Function(CoreWeatherStatusCapabilities_WeatherStatusInterfaceBuilder) updates,
+  );
+  CoreWeatherStatusCapabilities_WeatherStatusInterfaceBuilder toBuilder();
+}
+
 abstract class CoreWeatherStatusCapabilities_WeatherStatus
-    implements Built<CoreWeatherStatusCapabilities_WeatherStatus, CoreWeatherStatusCapabilities_WeatherStatusBuilder> {
+    implements
+        CoreWeatherStatusCapabilities_WeatherStatusInterface,
+        Built<CoreWeatherStatusCapabilities_WeatherStatus, CoreWeatherStatusCapabilities_WeatherStatusBuilder> {
   factory CoreWeatherStatusCapabilities_WeatherStatus([
     final void Function(CoreWeatherStatusCapabilities_WeatherStatusBuilder)? b,
   ]) = _$CoreWeatherStatusCapabilities_WeatherStatus;
@@ -4420,13 +5210,24 @@ abstract class CoreWeatherStatusCapabilities_WeatherStatus
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<CoreWeatherStatusCapabilities_WeatherStatus> get serializer =>
       _$coreWeatherStatusCapabilitiesWeatherStatusSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreWeatherStatusCapabilitiesInterface {
+  @BuiltValueField(wireName: 'weather_status')
+  CoreWeatherStatusCapabilities_WeatherStatus get weatherStatus;
+  CoreWeatherStatusCapabilitiesInterface rebuild(
+    final void Function(CoreWeatherStatusCapabilitiesInterfaceBuilder) updates,
+  );
+  CoreWeatherStatusCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreWeatherStatusCapabilities
-    implements Built<CoreWeatherStatusCapabilities, CoreWeatherStatusCapabilitiesBuilder> {
+    implements
+        CoreWeatherStatusCapabilitiesInterface,
+        Built<CoreWeatherStatusCapabilities, CoreWeatherStatusCapabilitiesBuilder> {
   factory CoreWeatherStatusCapabilities([final void Function(CoreWeatherStatusCapabilitiesBuilder)? b]) =
       _$CoreWeatherStatusCapabilities;
 
@@ -4442,8 +5243,6 @@ abstract class CoreWeatherStatusCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'weather_status')
-  CoreWeatherStatusCapabilities_WeatherStatus get weatherStatus;
   static Serializer<CoreWeatherStatusCapabilities> get serializer => _$coreWeatherStatusCapabilitiesSerializer;
 }
 
@@ -4626,8 +5425,19 @@ class _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_CapabilitiesSe
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataInterface {
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version get version;
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Capabilities get capabilities;
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data
     implements
+        CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data,
             CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data([
@@ -4646,14 +5456,23 @@ abstract class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version get version;
-  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Capabilities get capabilities;
   static Serializer<CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreOcsGetCapabilitiesResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data get data;
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs
     implements
+        CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsInterface,
         Built<CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs,
             CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder> {
   factory CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs([
@@ -4672,14 +5491,22 @@ abstract class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs> get serializer =>
       _$coreOcsGetCapabilitiesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreOcsGetCapabilitiesResponse200ApplicationJsonInterface {
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs get ocs;
+  CoreOcsGetCapabilitiesResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreOcsGetCapabilitiesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreOcsGetCapabilitiesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreOcsGetCapabilitiesResponse200ApplicationJson
     implements
+        CoreOcsGetCapabilitiesResponse200ApplicationJsonInterface,
         Built<CoreOcsGetCapabilitiesResponse200ApplicationJson,
             CoreOcsGetCapabilitiesResponse200ApplicationJsonBuilder> {
   factory CoreOcsGetCapabilitiesResponse200ApplicationJson([
@@ -4698,13 +5525,23 @@ abstract class CoreOcsGetCapabilitiesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreOcsGetCapabilitiesResponse200ApplicationJson> get serializer =>
       _$coreOcsGetCapabilitiesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  JsonObject get data;
+  CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs
     implements
+        CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsInterface,
         Built<CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs,
             CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder> {
   factory CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs([
@@ -4723,14 +5560,22 @@ abstract class CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  JsonObject get data;
   static Serializer<CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs> get serializer =>
       _$coreProfileApiSetVisibilityResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreProfileApiSetVisibilityResponse200ApplicationJsonInterface {
+  CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs get ocs;
+  CoreProfileApiSetVisibilityResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreProfileApiSetVisibilityResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreProfileApiSetVisibilityResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreProfileApiSetVisibilityResponse200ApplicationJson
     implements
+        CoreProfileApiSetVisibilityResponse200ApplicationJsonInterface,
         Built<CoreProfileApiSetVisibilityResponse200ApplicationJson,
             CoreProfileApiSetVisibilityResponse200ApplicationJsonBuilder> {
   factory CoreProfileApiSetVisibilityResponse200ApplicationJson([
@@ -4749,12 +5594,21 @@ abstract class CoreProfileApiSetVisibilityResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreProfileApiSetVisibilityResponse200ApplicationJson> get serializer =>
       _$coreProfileApiSetVisibilityResponse200ApplicationJsonSerializer;
 }
 
-abstract class CoreReference implements Built<CoreReference, CoreReferenceBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceInterface {
+  String get richObjectType;
+  BuiltMap<String, JsonObject> get richObject;
+  CoreOpenGraphObject get openGraphObject;
+  bool get accessible;
+  CoreReferenceInterface rebuild(final void Function(CoreReferenceInterfaceBuilder) updates);
+  CoreReferenceInterfaceBuilder toBuilder();
+}
+
+abstract class CoreReference implements CoreReferenceInterface, Built<CoreReference, CoreReferenceBuilder> {
   factory CoreReference([final void Function(CoreReferenceBuilder)? b]) = _$CoreReference;
 
   // coverage:ignore-start
@@ -4769,15 +5623,21 @@ abstract class CoreReference implements Built<CoreReference, CoreReferenceBuilde
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get richObjectType;
-  BuiltMap<String, JsonObject> get richObject;
-  CoreOpenGraphObject get openGraphObject;
-  bool get accessible;
   static Serializer<CoreReference> get serializer => _$coreReferenceSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltMap<String, CoreReference> get references;
+  CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
 }
 
 abstract class CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data
     implements
+        CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data,
             CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data([
@@ -4796,13 +5656,23 @@ abstract class CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltMap<String, CoreReference> get references;
   static Serializer<CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreReferenceApiResolveOneResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiResolveOneResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data get data;
+  CoreReferenceApiResolveOneResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreReferenceApiResolveOneResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreReferenceApiResolveOneResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs
     implements
+        CoreReferenceApiResolveOneResponse200ApplicationJson_OcsInterface,
         Built<CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs,
             CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder> {
   factory CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs([
@@ -4821,14 +5691,22 @@ abstract class CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs> get serializer =>
       _$coreReferenceApiResolveOneResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiResolveOneResponse200ApplicationJsonInterface {
+  CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs get ocs;
+  CoreReferenceApiResolveOneResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreReferenceApiResolveOneResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreReferenceApiResolveOneResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiResolveOneResponse200ApplicationJson
     implements
+        CoreReferenceApiResolveOneResponse200ApplicationJsonInterface,
         Built<CoreReferenceApiResolveOneResponse200ApplicationJson,
             CoreReferenceApiResolveOneResponse200ApplicationJsonBuilder> {
   factory CoreReferenceApiResolveOneResponse200ApplicationJson([
@@ -4847,7 +5725,6 @@ abstract class CoreReferenceApiResolveOneResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreReferenceApiResolveOneResponse200ApplicationJson> get serializer =>
       _$coreReferenceApiResolveOneResponse200ApplicationJsonSerializer;
 }
@@ -4925,8 +5802,18 @@ class _$CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data_ReferencesSer
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltMap<String, CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data_References> get references;
+  CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data
     implements
+        CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data,
             CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data([
@@ -4945,13 +5832,23 @@ abstract class CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltMap<String, CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data_References> get references;
   static Serializer<CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreReferenceApiResolveResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiResolveResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data get data;
+  CoreReferenceApiResolveResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreReferenceApiResolveResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreReferenceApiResolveResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiResolveResponse200ApplicationJson_Ocs
     implements
+        CoreReferenceApiResolveResponse200ApplicationJson_OcsInterface,
         Built<CoreReferenceApiResolveResponse200ApplicationJson_Ocs,
             CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder> {
   factory CoreReferenceApiResolveResponse200ApplicationJson_Ocs([
@@ -4970,14 +5867,22 @@ abstract class CoreReferenceApiResolveResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreReferenceApiResolveResponse200ApplicationJson_Ocs> get serializer =>
       _$coreReferenceApiResolveResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiResolveResponse200ApplicationJsonInterface {
+  CoreReferenceApiResolveResponse200ApplicationJson_Ocs get ocs;
+  CoreReferenceApiResolveResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreReferenceApiResolveResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreReferenceApiResolveResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiResolveResponse200ApplicationJson
     implements
+        CoreReferenceApiResolveResponse200ApplicationJsonInterface,
         Built<CoreReferenceApiResolveResponse200ApplicationJson,
             CoreReferenceApiResolveResponse200ApplicationJsonBuilder> {
   factory CoreReferenceApiResolveResponse200ApplicationJson([
@@ -4996,7 +5901,6 @@ abstract class CoreReferenceApiResolveResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreReferenceApiResolveResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreReferenceApiResolveResponse200ApplicationJson> get serializer =>
       _$coreReferenceApiResolveResponse200ApplicationJsonSerializer;
 }
@@ -5074,8 +5978,18 @@ class _$CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data_ReferencesSer
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltMap<String, CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data_References> get references;
+  CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data
     implements
+        CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data,
             CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data([
@@ -5094,13 +6008,23 @@ abstract class CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltMap<String, CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data_References> get references;
   static Serializer<CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreReferenceApiExtractResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiExtractResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data get data;
+  CoreReferenceApiExtractResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreReferenceApiExtractResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreReferenceApiExtractResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiExtractResponse200ApplicationJson_Ocs
     implements
+        CoreReferenceApiExtractResponse200ApplicationJson_OcsInterface,
         Built<CoreReferenceApiExtractResponse200ApplicationJson_Ocs,
             CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder> {
   factory CoreReferenceApiExtractResponse200ApplicationJson_Ocs([
@@ -5119,14 +6043,22 @@ abstract class CoreReferenceApiExtractResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreReferenceApiExtractResponse200ApplicationJson_Ocs> get serializer =>
       _$coreReferenceApiExtractResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiExtractResponse200ApplicationJsonInterface {
+  CoreReferenceApiExtractResponse200ApplicationJson_Ocs get ocs;
+  CoreReferenceApiExtractResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreReferenceApiExtractResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreReferenceApiExtractResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiExtractResponse200ApplicationJson
     implements
+        CoreReferenceApiExtractResponse200ApplicationJsonInterface,
         Built<CoreReferenceApiExtractResponse200ApplicationJson,
             CoreReferenceApiExtractResponse200ApplicationJsonBuilder> {
   factory CoreReferenceApiExtractResponse200ApplicationJson([
@@ -5145,12 +6077,25 @@ abstract class CoreReferenceApiExtractResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreReferenceApiExtractResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreReferenceApiExtractResponse200ApplicationJson> get serializer =>
       _$coreReferenceApiExtractResponse200ApplicationJsonSerializer;
 }
 
-abstract class CoreReferenceProvider implements Built<CoreReferenceProvider, CoreReferenceProviderBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceProviderInterface {
+  String get id;
+  String get title;
+  @BuiltValueField(wireName: 'icon_url')
+  String get iconUrl;
+  int get order;
+  @BuiltValueField(wireName: 'search_providers_ids')
+  BuiltList<String>? get searchProvidersIds;
+  CoreReferenceProviderInterface rebuild(final void Function(CoreReferenceProviderInterfaceBuilder) updates);
+  CoreReferenceProviderInterfaceBuilder toBuilder();
+}
+
+abstract class CoreReferenceProvider
+    implements CoreReferenceProviderInterface, Built<CoreReferenceProvider, CoreReferenceProviderBuilder> {
   factory CoreReferenceProvider([final void Function(CoreReferenceProviderBuilder)? b]) = _$CoreReferenceProvider;
 
   // coverage:ignore-start
@@ -5165,18 +6110,22 @@ abstract class CoreReferenceProvider implements Built<CoreReferenceProvider, Cor
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  String get title;
-  @BuiltValueField(wireName: 'icon_url')
-  String get iconUrl;
-  int get order;
-  @BuiltValueField(wireName: 'search_providers_ids')
-  BuiltList<String>? get searchProvidersIds;
   static Serializer<CoreReferenceProvider> get serializer => _$coreReferenceProviderSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  BuiltList<CoreReferenceProvider> get data;
+  CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs
     implements
+        CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsInterface,
         Built<CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs,
             CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder> {
   factory CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs([
@@ -5195,14 +6144,22 @@ abstract class CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  BuiltList<CoreReferenceProvider> get data;
   static Serializer<CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs> get serializer =>
       _$coreReferenceApiGetProvidersInfoResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonInterface {
+  CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs get ocs;
+  CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiGetProvidersInfoResponse200ApplicationJson
     implements
+        CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonInterface,
         Built<CoreReferenceApiGetProvidersInfoResponse200ApplicationJson,
             CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonBuilder> {
   factory CoreReferenceApiGetProvidersInfoResponse200ApplicationJson([
@@ -5221,13 +6178,22 @@ abstract class CoreReferenceApiGetProvidersInfoResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreReferenceApiGetProvidersInfoResponse200ApplicationJson> get serializer =>
       _$coreReferenceApiGetProvidersInfoResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataInterface {
+  bool get success;
+  CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data
     implements
+        CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data,
             CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data([
@@ -5246,13 +6212,23 @@ abstract class CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
   static Serializer<CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreReferenceApiTouchProviderResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data get data;
+  CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs
     implements
+        CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsInterface,
         Built<CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs,
             CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder> {
   factory CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs([
@@ -5271,14 +6247,22 @@ abstract class CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs> get serializer =>
       _$coreReferenceApiTouchProviderResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreReferenceApiTouchProviderResponse200ApplicationJsonInterface {
+  CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs get ocs;
+  CoreReferenceApiTouchProviderResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreReferenceApiTouchProviderResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreReferenceApiTouchProviderResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreReferenceApiTouchProviderResponse200ApplicationJson
     implements
+        CoreReferenceApiTouchProviderResponse200ApplicationJsonInterface,
         Built<CoreReferenceApiTouchProviderResponse200ApplicationJson,
             CoreReferenceApiTouchProviderResponse200ApplicationJsonBuilder> {
   factory CoreReferenceApiTouchProviderResponse200ApplicationJson([
@@ -5297,13 +6281,25 @@ abstract class CoreReferenceApiTouchProviderResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreReferenceApiTouchProviderResponse200ApplicationJson> get serializer =>
       _$coreReferenceApiTouchProviderResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesInterface {
+  String get id;
+  String get name;
+  String get description;
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesInterface rebuild(
+    final void Function(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesInterfaceBuilder)
+        updates,
+  );
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types
     implements
+        CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesInterface,
         Built<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types,
             CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesBuilder> {
   factory CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types([
@@ -5324,15 +6320,22 @@ abstract class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  String get name;
-  String get description;
   static Serializer<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types> get serializer =>
       _$coreTextProcessingApiTaskTypesResponse200ApplicationJsonOcsDataTypesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types> get types;
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data
     implements
+        CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data,
             CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data([
@@ -5351,13 +6354,23 @@ abstract class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types> get types;
   static Serializer<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreTextProcessingApiTaskTypesResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data get data;
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs
     implements
+        CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsInterface,
         Built<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs,
             CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder> {
   factory CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs([
@@ -5376,14 +6389,22 @@ abstract class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs> get serializer =>
       _$coreTextProcessingApiTaskTypesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiTaskTypesResponse200ApplicationJsonInterface {
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs get ocs;
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreTextProcessingApiTaskTypesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiTaskTypesResponse200ApplicationJson
     implements
+        CoreTextProcessingApiTaskTypesResponse200ApplicationJsonInterface,
         Built<CoreTextProcessingApiTaskTypesResponse200ApplicationJson,
             CoreTextProcessingApiTaskTypesResponse200ApplicationJsonBuilder> {
   factory CoreTextProcessingApiTaskTypesResponse200ApplicationJson([
@@ -5402,12 +6423,26 @@ abstract class CoreTextProcessingApiTaskTypesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreTextProcessingApiTaskTypesResponse200ApplicationJson> get serializer =>
       _$coreTextProcessingApiTaskTypesResponse200ApplicationJsonSerializer;
 }
 
-abstract class CoreTextProcessingTask implements Built<CoreTextProcessingTask, CoreTextProcessingTaskBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingTaskInterface {
+  int? get id;
+  String get type;
+  int get status;
+  String? get userId;
+  String get appId;
+  String get input;
+  String? get output;
+  String get identifier;
+  CoreTextProcessingTaskInterface rebuild(final void Function(CoreTextProcessingTaskInterfaceBuilder) updates);
+  CoreTextProcessingTaskInterfaceBuilder toBuilder();
+}
+
+abstract class CoreTextProcessingTask
+    implements CoreTextProcessingTaskInterface, Built<CoreTextProcessingTask, CoreTextProcessingTaskBuilder> {
   factory CoreTextProcessingTask([final void Function(CoreTextProcessingTaskBuilder)? b]) = _$CoreTextProcessingTask;
 
   // coverage:ignore-start
@@ -5422,19 +6457,21 @@ abstract class CoreTextProcessingTask implements Built<CoreTextProcessingTask, C
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int? get id;
-  String get type;
-  int get status;
-  String? get userId;
-  String get appId;
-  String get input;
-  String? get output;
-  String get identifier;
   static Serializer<CoreTextProcessingTask> get serializer => _$coreTextProcessingTaskSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataInterface {
+  CoreTextProcessingTask get task;
+  CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
 }
 
 abstract class CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data
     implements
+        CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data,
             CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data([
@@ -5453,13 +6490,23 @@ abstract class CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreTextProcessingTask get task;
   static Serializer<CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreTextProcessingApiScheduleResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data get data;
+  CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs
     implements
+        CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsInterface,
         Built<CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs,
             CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder> {
   factory CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs([
@@ -5478,14 +6525,22 @@ abstract class CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs> get serializer =>
       _$coreTextProcessingApiScheduleResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiScheduleResponse200ApplicationJsonInterface {
+  CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs get ocs;
+  CoreTextProcessingApiScheduleResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreTextProcessingApiScheduleResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiScheduleResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiScheduleResponse200ApplicationJson
     implements
+        CoreTextProcessingApiScheduleResponse200ApplicationJsonInterface,
         Built<CoreTextProcessingApiScheduleResponse200ApplicationJson,
             CoreTextProcessingApiScheduleResponse200ApplicationJsonBuilder> {
   factory CoreTextProcessingApiScheduleResponse200ApplicationJson([
@@ -5504,13 +6559,22 @@ abstract class CoreTextProcessingApiScheduleResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreTextProcessingApiScheduleResponse200ApplicationJson> get serializer =>
       _$coreTextProcessingApiScheduleResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataInterface {
+  CoreTextProcessingTask get task;
+  CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data
     implements
+        CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data,
             CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data([
@@ -5529,13 +6593,23 @@ abstract class CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreTextProcessingTask get task;
   static Serializer<CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreTextProcessingApiGetTaskResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data get data;
+  CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs
     implements
+        CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsInterface,
         Built<CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs,
             CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder> {
   factory CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs([
@@ -5554,14 +6628,22 @@ abstract class CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs> get serializer =>
       _$coreTextProcessingApiGetTaskResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiGetTaskResponse200ApplicationJsonInterface {
+  CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs get ocs;
+  CoreTextProcessingApiGetTaskResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreTextProcessingApiGetTaskResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiGetTaskResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiGetTaskResponse200ApplicationJson
     implements
+        CoreTextProcessingApiGetTaskResponse200ApplicationJsonInterface,
         Built<CoreTextProcessingApiGetTaskResponse200ApplicationJson,
             CoreTextProcessingApiGetTaskResponse200ApplicationJsonBuilder> {
   factory CoreTextProcessingApiGetTaskResponse200ApplicationJson([
@@ -5580,13 +6662,22 @@ abstract class CoreTextProcessingApiGetTaskResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreTextProcessingApiGetTaskResponse200ApplicationJson> get serializer =>
       _$coreTextProcessingApiGetTaskResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataInterface {
+  CoreTextProcessingTask get task;
+  CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data
     implements
+        CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data,
             CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data([
@@ -5607,13 +6698,23 @@ abstract class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Dat
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreTextProcessingTask get task;
   static Serializer<CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreTextProcessingApiDeleteTaskResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data get data;
+  CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs
     implements
+        CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsInterface,
         Built<CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs,
             CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder> {
   factory CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs([
@@ -5632,14 +6733,22 @@ abstract class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs> get serializer =>
       _$coreTextProcessingApiDeleteTaskResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonInterface {
+  CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs get ocs;
+  CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson
     implements
+        CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonInterface,
         Built<CoreTextProcessingApiDeleteTaskResponse200ApplicationJson,
             CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonBuilder> {
   factory CoreTextProcessingApiDeleteTaskResponse200ApplicationJson([
@@ -5658,13 +6767,22 @@ abstract class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreTextProcessingApiDeleteTaskResponse200ApplicationJson> get serializer =>
       _$coreTextProcessingApiDeleteTaskResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<CoreTextProcessingTask> get tasks;
+  CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data
     implements
+        CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data,
             CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data([
@@ -5685,13 +6803,23 @@ abstract class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<CoreTextProcessingTask> get tasks;
   static Serializer<CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreTextProcessingApiListTasksByAppResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data get data;
+  CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs
     implements
+        CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsInterface,
         Built<CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs,
             CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder> {
   factory CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs([
@@ -5710,14 +6838,22 @@ abstract class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs> get serializer =>
       _$coreTextProcessingApiListTasksByAppResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonInterface {
+  CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs get ocs;
+  CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson
     implements
+        CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonInterface,
         Built<CoreTextProcessingApiListTasksByAppResponse200ApplicationJson,
             CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonBuilder> {
   factory CoreTextProcessingApiListTasksByAppResponse200ApplicationJson([
@@ -5736,13 +6872,26 @@ abstract class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreTextProcessingApiListTasksByAppResponse200ApplicationJson> get serializer =>
       _$coreTextProcessingApiListTasksByAppResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesInterface {
+  String get from;
+  String get fromLabel;
+  String get to;
+  String get toLabel;
+  CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesInterface rebuild(
+    final void Function(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesInterfaceBuilder)
+        updates,
+  );
+  CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages
     implements
+        CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesInterface,
         Built<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages,
             CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesBuilder> {
   factory CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages([
@@ -5763,16 +6912,23 @@ abstract class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_La
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get from;
-  String get fromLabel;
-  String get to;
-  String get toLabel;
   static Serializer<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages> get serializer =>
       _$coreTranslationApiLanguagesResponse200ApplicationJsonOcsDataLanguagesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages> get languages;
+  bool get languageDetection;
+  CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data
     implements
+        CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data,
             CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data([
@@ -5791,14 +6947,23 @@ abstract class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages> get languages;
-  bool get languageDetection;
   static Serializer<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreTranslationApiLanguagesResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTranslationApiLanguagesResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data get data;
+  CoreTranslationApiLanguagesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreTranslationApiLanguagesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreTranslationApiLanguagesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs
     implements
+        CoreTranslationApiLanguagesResponse200ApplicationJson_OcsInterface,
         Built<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs,
             CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder> {
   factory CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs([
@@ -5817,14 +6982,22 @@ abstract class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs> get serializer =>
       _$coreTranslationApiLanguagesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTranslationApiLanguagesResponse200ApplicationJsonInterface {
+  CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs get ocs;
+  CoreTranslationApiLanguagesResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreTranslationApiLanguagesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreTranslationApiLanguagesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTranslationApiLanguagesResponse200ApplicationJson
     implements
+        CoreTranslationApiLanguagesResponse200ApplicationJsonInterface,
         Built<CoreTranslationApiLanguagesResponse200ApplicationJson,
             CoreTranslationApiLanguagesResponse200ApplicationJsonBuilder> {
   factory CoreTranslationApiLanguagesResponse200ApplicationJson([
@@ -5843,13 +7016,23 @@ abstract class CoreTranslationApiLanguagesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreTranslationApiLanguagesResponse200ApplicationJson> get serializer =>
       _$coreTranslationApiLanguagesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataInterface {
+  String get text;
+  String? get from;
+  CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data
     implements
+        CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data,
             CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data([
@@ -5868,14 +7051,23 @@ abstract class CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get text;
-  String? get from;
   static Serializer<CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreTranslationApiTranslateResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTranslationApiTranslateResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data get data;
+  CoreTranslationApiTranslateResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreTranslationApiTranslateResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreTranslationApiTranslateResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTranslationApiTranslateResponse200ApplicationJson_Ocs
     implements
+        CoreTranslationApiTranslateResponse200ApplicationJson_OcsInterface,
         Built<CoreTranslationApiTranslateResponse200ApplicationJson_Ocs,
             CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder> {
   factory CoreTranslationApiTranslateResponse200ApplicationJson_Ocs([
@@ -5894,14 +7086,22 @@ abstract class CoreTranslationApiTranslateResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreTranslationApiTranslateResponse200ApplicationJson_Ocs> get serializer =>
       _$coreTranslationApiTranslateResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreTranslationApiTranslateResponse200ApplicationJsonInterface {
+  CoreTranslationApiTranslateResponse200ApplicationJson_Ocs get ocs;
+  CoreTranslationApiTranslateResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreTranslationApiTranslateResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreTranslationApiTranslateResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreTranslationApiTranslateResponse200ApplicationJson
     implements
+        CoreTranslationApiTranslateResponse200ApplicationJsonInterface,
         Built<CoreTranslationApiTranslateResponse200ApplicationJson,
             CoreTranslationApiTranslateResponse200ApplicationJsonBuilder> {
   factory CoreTranslationApiTranslateResponse200ApplicationJson([
@@ -5920,12 +7120,21 @@ abstract class CoreTranslationApiTranslateResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreTranslationApiTranslateResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreTranslationApiTranslateResponse200ApplicationJson> get serializer =>
       _$coreTranslationApiTranslateResponse200ApplicationJsonSerializer;
 }
 
-abstract class CoreUnifiedSearchProvider implements Built<CoreUnifiedSearchProvider, CoreUnifiedSearchProviderBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreUnifiedSearchProviderInterface {
+  String get id;
+  String get name;
+  int get order;
+  CoreUnifiedSearchProviderInterface rebuild(final void Function(CoreUnifiedSearchProviderInterfaceBuilder) updates);
+  CoreUnifiedSearchProviderInterfaceBuilder toBuilder();
+}
+
+abstract class CoreUnifiedSearchProvider
+    implements CoreUnifiedSearchProviderInterface, Built<CoreUnifiedSearchProvider, CoreUnifiedSearchProviderBuilder> {
   factory CoreUnifiedSearchProvider([final void Function(CoreUnifiedSearchProviderBuilder)? b]) =
       _$CoreUnifiedSearchProvider;
 
@@ -5941,14 +7150,22 @@ abstract class CoreUnifiedSearchProvider implements Built<CoreUnifiedSearchProvi
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  String get name;
-  int get order;
   static Serializer<CoreUnifiedSearchProvider> get serializer => _$coreUnifiedSearchProviderSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  BuiltList<CoreUnifiedSearchProvider> get data;
+  CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs
     implements
+        CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsInterface,
         Built<CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs,
             CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder> {
   factory CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs([
@@ -5967,14 +7184,22 @@ abstract class CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  BuiltList<CoreUnifiedSearchProvider> get data;
   static Serializer<CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs> get serializer =>
       _$coreUnifiedSearchGetProvidersResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreUnifiedSearchGetProvidersResponse200ApplicationJsonInterface {
+  CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs get ocs;
+  CoreUnifiedSearchGetProvidersResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreUnifiedSearchGetProvidersResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreUnifiedSearchGetProvidersResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreUnifiedSearchGetProvidersResponse200ApplicationJson
     implements
+        CoreUnifiedSearchGetProvidersResponse200ApplicationJsonInterface,
         Built<CoreUnifiedSearchGetProvidersResponse200ApplicationJson,
             CoreUnifiedSearchGetProvidersResponse200ApplicationJsonBuilder> {
   factory CoreUnifiedSearchGetProvidersResponse200ApplicationJson([
@@ -5993,7 +7218,6 @@ abstract class CoreUnifiedSearchGetProvidersResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreUnifiedSearchGetProvidersResponse200ApplicationJson> get serializer =>
       _$coreUnifiedSearchGetProvidersResponse200ApplicationJsonSerializer;
 }
@@ -6055,8 +7279,25 @@ class _$CoreUnifiedSearchSearchCursorSerializer implements PrimitiveSerializer<C
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreUnifiedSearchResultEntryInterface {
+  String get thumbnailUrl;
+  String get title;
+  String get subline;
+  String get resourceUrl;
+  String get icon;
+  bool get rounded;
+  BuiltList<String> get attributes;
+  CoreUnifiedSearchResultEntryInterface rebuild(
+    final void Function(CoreUnifiedSearchResultEntryInterfaceBuilder) updates,
+  );
+  CoreUnifiedSearchResultEntryInterfaceBuilder toBuilder();
+}
+
 abstract class CoreUnifiedSearchResultEntry
-    implements Built<CoreUnifiedSearchResultEntry, CoreUnifiedSearchResultEntryBuilder> {
+    implements
+        CoreUnifiedSearchResultEntryInterface,
+        Built<CoreUnifiedSearchResultEntry, CoreUnifiedSearchResultEntryBuilder> {
   factory CoreUnifiedSearchResultEntry([final void Function(CoreUnifiedSearchResultEntryBuilder)? b]) =
       _$CoreUnifiedSearchResultEntry;
 
@@ -6072,13 +7313,6 @@ abstract class CoreUnifiedSearchResultEntry
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get thumbnailUrl;
-  String get title;
-  String get subline;
-  String get resourceUrl;
-  String get icon;
-  bool get rounded;
-  BuiltList<String> get attributes;
   static Serializer<CoreUnifiedSearchResultEntry> get serializer => _$coreUnifiedSearchResultEntrySerializer;
 }
 
@@ -6139,7 +7373,18 @@ class _$CoreUnifiedSearchResult_CursorSerializer implements PrimitiveSerializer<
   }
 }
 
-abstract class CoreUnifiedSearchResult implements Built<CoreUnifiedSearchResult, CoreUnifiedSearchResultBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class CoreUnifiedSearchResultInterface {
+  String get name;
+  bool get isPaginated;
+  BuiltList<CoreUnifiedSearchResultEntry> get entries;
+  CoreUnifiedSearchResult_Cursor? get cursor;
+  CoreUnifiedSearchResultInterface rebuild(final void Function(CoreUnifiedSearchResultInterfaceBuilder) updates);
+  CoreUnifiedSearchResultInterfaceBuilder toBuilder();
+}
+
+abstract class CoreUnifiedSearchResult
+    implements CoreUnifiedSearchResultInterface, Built<CoreUnifiedSearchResult, CoreUnifiedSearchResultBuilder> {
   factory CoreUnifiedSearchResult([final void Function(CoreUnifiedSearchResultBuilder)? b]) = _$CoreUnifiedSearchResult;
 
   // coverage:ignore-start
@@ -6154,15 +7399,22 @@ abstract class CoreUnifiedSearchResult implements Built<CoreUnifiedSearchResult,
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get name;
-  bool get isPaginated;
-  BuiltList<CoreUnifiedSearchResultEntry> get entries;
-  CoreUnifiedSearchResult_Cursor? get cursor;
   static Serializer<CoreUnifiedSearchResult> get serializer => _$coreUnifiedSearchResultSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class CoreUnifiedSearchSearchResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreUnifiedSearchResult get data;
+  CoreUnifiedSearchSearchResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreUnifiedSearchSearchResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreUnifiedSearchSearchResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs
     implements
+        CoreUnifiedSearchSearchResponse200ApplicationJson_OcsInterface,
         Built<CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs,
             CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder> {
   factory CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs([
@@ -6181,14 +7433,22 @@ abstract class CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreUnifiedSearchResult get data;
   static Serializer<CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs> get serializer =>
       _$coreUnifiedSearchSearchResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreUnifiedSearchSearchResponse200ApplicationJsonInterface {
+  CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs get ocs;
+  CoreUnifiedSearchSearchResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreUnifiedSearchSearchResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreUnifiedSearchSearchResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreUnifiedSearchSearchResponse200ApplicationJson
     implements
+        CoreUnifiedSearchSearchResponse200ApplicationJsonInterface,
         Built<CoreUnifiedSearchSearchResponse200ApplicationJson,
             CoreUnifiedSearchSearchResponse200ApplicationJsonBuilder> {
   factory CoreUnifiedSearchSearchResponse200ApplicationJson([
@@ -6207,13 +7467,23 @@ abstract class CoreUnifiedSearchSearchResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreUnifiedSearchSearchResponse200ApplicationJson> get serializer =>
       _$coreUnifiedSearchSearchResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewInterface {
+  BuiltList<String> get regular;
+  BuiltList<String> get admin;
+  CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewInterface rebuild(
+    final void Function(CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder) updates,
+  );
+  CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder toBuilder();
+}
+
 abstract class CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew
     implements
+        CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewInterface,
         Built<CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew,
             CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder> {
   factory CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew([
@@ -6232,14 +7502,25 @@ abstract class CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String> get regular;
-  BuiltList<String> get admin;
   static Serializer<CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew> get serializer =>
       _$coreWhatsNewGetResponse200ApplicationJsonOcsDataWhatsNewSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataInterface {
+  String get changelogURL;
+  String get product;
+  String get version;
+  CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew? get whatsNew;
+  CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data
     implements
+        CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataInterface,
         Built<CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data,
             CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder> {
   factory CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data([
@@ -6258,16 +7539,23 @@ abstract class CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get changelogURL;
-  String get product;
-  String get version;
-  CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew? get whatsNew;
   static Serializer<CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$coreWhatsNewGetResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreWhatsNewGetResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data get data;
+  CoreWhatsNewGetResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreWhatsNewGetResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreWhatsNewGetResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreWhatsNewGetResponse200ApplicationJson_Ocs
     implements
+        CoreWhatsNewGetResponse200ApplicationJson_OcsInterface,
         Built<CoreWhatsNewGetResponse200ApplicationJson_Ocs, CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder> {
   factory CoreWhatsNewGetResponse200ApplicationJson_Ocs([
     final void Function(CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder)? b,
@@ -6285,14 +7573,23 @@ abstract class CoreWhatsNewGetResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<CoreWhatsNewGetResponse200ApplicationJson_Ocs> get serializer =>
       _$coreWhatsNewGetResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreWhatsNewGetResponse200ApplicationJsonInterface {
+  CoreWhatsNewGetResponse200ApplicationJson_Ocs get ocs;
+  CoreWhatsNewGetResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreWhatsNewGetResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreWhatsNewGetResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreWhatsNewGetResponse200ApplicationJson
-    implements Built<CoreWhatsNewGetResponse200ApplicationJson, CoreWhatsNewGetResponse200ApplicationJsonBuilder> {
+    implements
+        CoreWhatsNewGetResponse200ApplicationJsonInterface,
+        Built<CoreWhatsNewGetResponse200ApplicationJson, CoreWhatsNewGetResponse200ApplicationJsonBuilder> {
   factory CoreWhatsNewGetResponse200ApplicationJson([
     final void Function(CoreWhatsNewGetResponse200ApplicationJsonBuilder)? b,
   ]) = _$CoreWhatsNewGetResponse200ApplicationJson;
@@ -6309,13 +7606,23 @@ abstract class CoreWhatsNewGetResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreWhatsNewGetResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreWhatsNewGetResponse200ApplicationJson> get serializer =>
       _$coreWhatsNewGetResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreWhatsNewDismissResponse200ApplicationJson_OcsInterface {
+  CoreOCSMeta get meta;
+  JsonObject get data;
+  CoreWhatsNewDismissResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(CoreWhatsNewDismissResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  CoreWhatsNewDismissResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class CoreWhatsNewDismissResponse200ApplicationJson_Ocs
     implements
+        CoreWhatsNewDismissResponse200ApplicationJson_OcsInterface,
         Built<CoreWhatsNewDismissResponse200ApplicationJson_Ocs,
             CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder> {
   factory CoreWhatsNewDismissResponse200ApplicationJson_Ocs([
@@ -6334,14 +7641,22 @@ abstract class CoreWhatsNewDismissResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreOCSMeta get meta;
-  JsonObject get data;
   static Serializer<CoreWhatsNewDismissResponse200ApplicationJson_Ocs> get serializer =>
       _$coreWhatsNewDismissResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreWhatsNewDismissResponse200ApplicationJsonInterface {
+  CoreWhatsNewDismissResponse200ApplicationJson_Ocs get ocs;
+  CoreWhatsNewDismissResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreWhatsNewDismissResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreWhatsNewDismissResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreWhatsNewDismissResponse200ApplicationJson
     implements
+        CoreWhatsNewDismissResponse200ApplicationJsonInterface,
         Built<CoreWhatsNewDismissResponse200ApplicationJson, CoreWhatsNewDismissResponse200ApplicationJsonBuilder> {
   factory CoreWhatsNewDismissResponse200ApplicationJson([
     final void Function(CoreWhatsNewDismissResponse200ApplicationJsonBuilder)? b,
@@ -6359,13 +7674,23 @@ abstract class CoreWhatsNewDismissResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  CoreWhatsNewDismissResponse200ApplicationJson_Ocs get ocs;
   static Serializer<CoreWhatsNewDismissResponse200ApplicationJson> get serializer =>
       _$coreWhatsNewDismissResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class CoreWipeCheckWipeResponse200ApplicationJsonInterface {
+  bool get wipe;
+  CoreWipeCheckWipeResponse200ApplicationJsonInterface rebuild(
+    final void Function(CoreWipeCheckWipeResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  CoreWipeCheckWipeResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class CoreWipeCheckWipeResponse200ApplicationJson
-    implements Built<CoreWipeCheckWipeResponse200ApplicationJson, CoreWipeCheckWipeResponse200ApplicationJsonBuilder> {
+    implements
+        CoreWipeCheckWipeResponse200ApplicationJsonInterface,
+        Built<CoreWipeCheckWipeResponse200ApplicationJson, CoreWipeCheckWipeResponse200ApplicationJsonBuilder> {
   factory CoreWipeCheckWipeResponse200ApplicationJson([
     final void Function(CoreWipeCheckWipeResponse200ApplicationJsonBuilder)? b,
   ]) = _$CoreWipeCheckWipeResponse200ApplicationJson;
@@ -6382,7 +7707,6 @@ abstract class CoreWipeCheckWipeResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get wipe;
   static Serializer<CoreWipeCheckWipeResponse200ApplicationJson> get serializer =>
       _$coreWipeCheckWipeResponse200ApplicationJsonSerializer;
 }

--- a/packages/nextcloud/lib/src/api/core.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.g.dart
@@ -7894,6 +7894,34 @@ class _$CoreWipeCheckWipeResponse200ApplicationJsonSerializer
   }
 }
 
+abstract mixin class CoreStatusInterfaceBuilder {
+  void replace(CoreStatusInterface other);
+  void update(void Function(CoreStatusInterfaceBuilder) updates);
+  bool? get installed;
+  set installed(bool? installed);
+
+  bool? get maintenance;
+  set maintenance(bool? maintenance);
+
+  bool? get needsDbUpgrade;
+  set needsDbUpgrade(bool? needsDbUpgrade);
+
+  String? get version;
+  set version(String? version);
+
+  String? get versionstring;
+  set versionstring(String? versionstring);
+
+  String? get edition;
+  set edition(String? edition);
+
+  String? get productname;
+  set productname(String? productname);
+
+  bool? get extendedSupport;
+  set extendedSupport(bool? extendedSupport);
+}
+
 class _$CoreStatus extends CoreStatus {
   @override
   final bool installed;
@@ -7984,40 +8012,40 @@ class _$CoreStatus extends CoreStatus {
   }
 }
 
-class CoreStatusBuilder implements Builder<CoreStatus, CoreStatusBuilder> {
+class CoreStatusBuilder implements Builder<CoreStatus, CoreStatusBuilder>, CoreStatusInterfaceBuilder {
   _$CoreStatus? _$v;
 
   bool? _installed;
   bool? get installed => _$this._installed;
-  set installed(bool? installed) => _$this._installed = installed;
+  set installed(covariant bool? installed) => _$this._installed = installed;
 
   bool? _maintenance;
   bool? get maintenance => _$this._maintenance;
-  set maintenance(bool? maintenance) => _$this._maintenance = maintenance;
+  set maintenance(covariant bool? maintenance) => _$this._maintenance = maintenance;
 
   bool? _needsDbUpgrade;
   bool? get needsDbUpgrade => _$this._needsDbUpgrade;
-  set needsDbUpgrade(bool? needsDbUpgrade) => _$this._needsDbUpgrade = needsDbUpgrade;
+  set needsDbUpgrade(covariant bool? needsDbUpgrade) => _$this._needsDbUpgrade = needsDbUpgrade;
 
   String? _version;
   String? get version => _$this._version;
-  set version(String? version) => _$this._version = version;
+  set version(covariant String? version) => _$this._version = version;
 
   String? _versionstring;
   String? get versionstring => _$this._versionstring;
-  set versionstring(String? versionstring) => _$this._versionstring = versionstring;
+  set versionstring(covariant String? versionstring) => _$this._versionstring = versionstring;
 
   String? _edition;
   String? get edition => _$this._edition;
-  set edition(String? edition) => _$this._edition = edition;
+  set edition(covariant String? edition) => _$this._edition = edition;
 
   String? _productname;
   String? get productname => _$this._productname;
-  set productname(String? productname) => _$this._productname = productname;
+  set productname(covariant String? productname) => _$this._productname = productname;
 
   bool? _extendedSupport;
   bool? get extendedSupport => _$this._extendedSupport;
-  set extendedSupport(bool? extendedSupport) => _$this._extendedSupport = extendedSupport;
+  set extendedSupport(covariant bool? extendedSupport) => _$this._extendedSupport = extendedSupport;
 
   CoreStatusBuilder();
 
@@ -8038,7 +8066,7 @@ class CoreStatusBuilder implements Builder<CoreStatus, CoreStatusBuilder> {
   }
 
   @override
-  void replace(CoreStatus other) {
+  void replace(covariant CoreStatus other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreStatus;
   }
@@ -8065,6 +8093,25 @@ class CoreStatusBuilder implements Builder<CoreStatus, CoreStatusBuilder> {
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreOCSMetaInterfaceBuilder {
+  void replace(CoreOCSMetaInterface other);
+  void update(void Function(CoreOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
 }
 
 class _$CoreOCSMeta extends CoreOCSMeta {
@@ -8129,28 +8176,28 @@ class _$CoreOCSMeta extends CoreOCSMeta {
   }
 }
 
-class CoreOCSMetaBuilder implements Builder<CoreOCSMeta, CoreOCSMetaBuilder> {
+class CoreOCSMetaBuilder implements Builder<CoreOCSMeta, CoreOCSMetaBuilder>, CoreOCSMetaInterfaceBuilder {
   _$CoreOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   CoreOCSMetaBuilder();
 
@@ -8168,7 +8215,7 @@ class CoreOCSMetaBuilder implements Builder<CoreOCSMeta, CoreOCSMetaBuilder> {
   }
 
   @override
-  void replace(CoreOCSMeta other) {
+  void replace(covariant CoreOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreOCSMeta;
   }
@@ -8192,6 +8239,13 @@ class CoreOCSMetaBuilder implements Builder<CoreOCSMeta, CoreOCSMetaBuilder> {
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get apppassword;
+  set apppassword(String? apppassword);
 }
 
 class _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data
@@ -8243,12 +8297,13 @@ class _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data
 class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data,
-            CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _apppassword;
   String? get apppassword => _$this._apppassword;
-  set apppassword(String? apppassword) => _$this._apppassword = apppassword;
+  set apppassword(covariant String? apppassword) => _$this._apppassword = apppassword;
 
   CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -8262,7 +8317,7 @@ class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_Data;
   }
@@ -8283,6 +8338,16 @@ class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs
@@ -8340,17 +8405,19 @@ class _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs
 class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs,
-            CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder> {
+            CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder>,
+        CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder();
 
@@ -8365,7 +8432,7 @@ class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson_Ocs;
   }
@@ -8399,6 +8466,13 @@ class CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAppPasswordGetAppPasswordResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreAppPasswordGetAppPasswordResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreAppPasswordGetAppPasswordResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson
@@ -8447,13 +8521,14 @@ class _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson
 class CoreAppPasswordGetAppPasswordResponse200ApplicationJsonBuilder
     implements
         Builder<CoreAppPasswordGetAppPasswordResponse200ApplicationJson,
-            CoreAppPasswordGetAppPasswordResponse200ApplicationJsonBuilder> {
+            CoreAppPasswordGetAppPasswordResponse200ApplicationJsonBuilder>,
+        CoreAppPasswordGetAppPasswordResponse200ApplicationJsonInterfaceBuilder {
   _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson? _$v;
 
   CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreAppPasswordGetAppPasswordResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreAppPasswordGetAppPasswordResponse200ApplicationJsonBuilder();
 
@@ -8467,7 +8542,7 @@ class CoreAppPasswordGetAppPasswordResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreAppPasswordGetAppPasswordResponse200ApplicationJson other) {
+  void replace(covariant CoreAppPasswordGetAppPasswordResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAppPasswordGetAppPasswordResponse200ApplicationJson;
   }
@@ -8498,6 +8573,14 @@ class CoreAppPasswordGetAppPasswordResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get apppassword;
+  set apppassword(String? apppassword);
 }
 
 class _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data
@@ -8549,12 +8632,13 @@ class _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data
 class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data,
-            CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _apppassword;
   String? get apppassword => _$this._apppassword;
-  set apppassword(String? apppassword) => _$this._apppassword = apppassword;
+  set apppassword(covariant String? apppassword) => _$this._apppassword = apppassword;
 
   CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -8568,7 +8652,7 @@ class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_Data;
   }
@@ -8589,6 +8673,16 @@ class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs
@@ -8648,17 +8742,19 @@ class _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs
 class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs,
-            CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder> {
+            CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder>,
+        CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder();
 
@@ -8673,7 +8769,7 @@ class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_Ocs;
   }
@@ -8707,6 +8803,13 @@ class CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson
@@ -8755,13 +8858,14 @@ class _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson
 class CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonBuilder
     implements
         Builder<CoreAppPasswordRotateAppPasswordResponse200ApplicationJson,
-            CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonBuilder> {
+            CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonBuilder>,
+        CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonInterfaceBuilder {
   _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson? _$v;
 
   CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreAppPasswordRotateAppPasswordResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonBuilder();
 
@@ -8775,7 +8879,7 @@ class CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreAppPasswordRotateAppPasswordResponse200ApplicationJson other) {
+  void replace(covariant CoreAppPasswordRotateAppPasswordResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAppPasswordRotateAppPasswordResponse200ApplicationJson;
   }
@@ -8806,6 +8910,16 @@ class CoreAppPasswordRotateAppPasswordResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs
@@ -8865,16 +8979,17 @@ class _$CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs
 class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs,
-            CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder> {
+            CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder>,
+        CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder();
 
@@ -8889,7 +9004,7 @@ class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_Ocs;
   }
@@ -8924,6 +9039,13 @@ class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson
@@ -8972,13 +9094,14 @@ class _$CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson
 class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonBuilder
     implements
         Builder<CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson,
-            CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonBuilder> {
+            CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonBuilder>,
+        CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonInterfaceBuilder {
   _$CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson? _$v;
 
   CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonBuilder();
 
@@ -8992,7 +9115,7 @@ class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson other) {
+  void replace(covariant CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAppPasswordDeleteAppPasswordResponse200ApplicationJson;
   }
@@ -9023,6 +9146,31 @@ class CoreAppPasswordDeleteAppPasswordResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAutocompleteResultInterfaceBuilder {
+  void replace(CoreAutocompleteResultInterface other);
+  void update(void Function(CoreAutocompleteResultInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get label;
+  set label(String? label);
+
+  String? get icon;
+  set icon(String? icon);
+
+  String? get source;
+  set source(String? source);
+
+  String? get status;
+  set status(String? status);
+
+  String? get subline;
+  set subline(String? subline);
+
+  String? get shareWithDisplayNameUnique;
+  set shareWithDisplayNameUnique(String? shareWithDisplayNameUnique);
 }
 
 class _$CoreAutocompleteResult extends CoreAutocompleteResult {
@@ -9111,36 +9259,37 @@ class _$CoreAutocompleteResult extends CoreAutocompleteResult {
   }
 }
 
-class CoreAutocompleteResultBuilder implements Builder<CoreAutocompleteResult, CoreAutocompleteResultBuilder> {
+class CoreAutocompleteResultBuilder
+    implements Builder<CoreAutocompleteResult, CoreAutocompleteResultBuilder>, CoreAutocompleteResultInterfaceBuilder {
   _$CoreAutocompleteResult? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _label;
   String? get label => _$this._label;
-  set label(String? label) => _$this._label = label;
+  set label(covariant String? label) => _$this._label = label;
 
   String? _icon;
   String? get icon => _$this._icon;
-  set icon(String? icon) => _$this._icon = icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
 
   String? _source;
   String? get source => _$this._source;
-  set source(String? source) => _$this._source = source;
+  set source(covariant String? source) => _$this._source = source;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   String? _subline;
   String? get subline => _$this._subline;
-  set subline(String? subline) => _$this._subline = subline;
+  set subline(covariant String? subline) => _$this._subline = subline;
 
   String? _shareWithDisplayNameUnique;
   String? get shareWithDisplayNameUnique => _$this._shareWithDisplayNameUnique;
-  set shareWithDisplayNameUnique(String? shareWithDisplayNameUnique) =>
+  set shareWithDisplayNameUnique(covariant String? shareWithDisplayNameUnique) =>
       _$this._shareWithDisplayNameUnique = shareWithDisplayNameUnique;
 
   CoreAutocompleteResultBuilder();
@@ -9161,7 +9310,7 @@ class CoreAutocompleteResultBuilder implements Builder<CoreAutocompleteResult, C
   }
 
   @override
-  void replace(CoreAutocompleteResult other) {
+  void replace(covariant CoreAutocompleteResult other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAutocompleteResult;
   }
@@ -9188,6 +9337,16 @@ class CoreAutocompleteResultBuilder implements Builder<CoreAutocompleteResult, C
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAutoCompleteGetResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreAutoCompleteGetResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreAutoCompleteGetResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  ListBuilder<CoreAutocompleteResult> get data;
+  set data(ListBuilder<CoreAutocompleteResult>? data);
 }
 
 class _$CoreAutoCompleteGetResponse200ApplicationJson_Ocs extends CoreAutoCompleteGetResponse200ApplicationJson_Ocs {
@@ -9241,16 +9400,17 @@ class _$CoreAutoCompleteGetResponse200ApplicationJson_Ocs extends CoreAutoComple
 class CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreAutoCompleteGetResponse200ApplicationJson_Ocs,
-            CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder> {
+            CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder>,
+        CoreAutoCompleteGetResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreAutoCompleteGetResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<CoreAutocompleteResult>? _data;
   ListBuilder<CoreAutocompleteResult> get data => _$this._data ??= ListBuilder<CoreAutocompleteResult>();
-  set data(ListBuilder<CoreAutocompleteResult>? data) => _$this._data = data;
+  set data(covariant ListBuilder<CoreAutocompleteResult>? data) => _$this._data = data;
 
   CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder();
 
@@ -9265,7 +9425,7 @@ class CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreAutoCompleteGetResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreAutoCompleteGetResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAutoCompleteGetResponse200ApplicationJson_Ocs;
   }
@@ -9298,6 +9458,13 @@ class CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAutoCompleteGetResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreAutoCompleteGetResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreAutoCompleteGetResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreAutoCompleteGetResponse200ApplicationJson extends CoreAutoCompleteGetResponse200ApplicationJson {
@@ -9343,13 +9510,14 @@ class _$CoreAutoCompleteGetResponse200ApplicationJson extends CoreAutoCompleteGe
 
 class CoreAutoCompleteGetResponse200ApplicationJsonBuilder
     implements
-        Builder<CoreAutoCompleteGetResponse200ApplicationJson, CoreAutoCompleteGetResponse200ApplicationJsonBuilder> {
+        Builder<CoreAutoCompleteGetResponse200ApplicationJson, CoreAutoCompleteGetResponse200ApplicationJsonBuilder>,
+        CoreAutoCompleteGetResponse200ApplicationJsonInterfaceBuilder {
   _$CoreAutoCompleteGetResponse200ApplicationJson? _$v;
 
   CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreAutoCompleteGetResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreAutoCompleteGetResponse200ApplicationJsonBuilder();
 
@@ -9363,7 +9531,7 @@ class CoreAutoCompleteGetResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreAutoCompleteGetResponse200ApplicationJson other) {
+  void replace(covariant CoreAutoCompleteGetResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAutoCompleteGetResponse200ApplicationJson;
   }
@@ -9393,6 +9561,13 @@ class CoreAutoCompleteGetResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAvatarAvatarGetAvatarDarkHeadersInterfaceBuilder {
+  void replace(CoreAvatarAvatarGetAvatarDarkHeadersInterface other);
+  void update(void Function(CoreAvatarAvatarGetAvatarDarkHeadersInterfaceBuilder) updates);
+  int? get xNcIscustomavatar;
+  set xNcIscustomavatar(int? xNcIscustomavatar);
 }
 
 class _$CoreAvatarAvatarGetAvatarDarkHeaders extends CoreAvatarAvatarGetAvatarDarkHeaders {
@@ -9436,12 +9611,14 @@ class _$CoreAvatarAvatarGetAvatarDarkHeaders extends CoreAvatarAvatarGetAvatarDa
 }
 
 class CoreAvatarAvatarGetAvatarDarkHeadersBuilder
-    implements Builder<CoreAvatarAvatarGetAvatarDarkHeaders, CoreAvatarAvatarGetAvatarDarkHeadersBuilder> {
+    implements
+        Builder<CoreAvatarAvatarGetAvatarDarkHeaders, CoreAvatarAvatarGetAvatarDarkHeadersBuilder>,
+        CoreAvatarAvatarGetAvatarDarkHeadersInterfaceBuilder {
   _$CoreAvatarAvatarGetAvatarDarkHeaders? _$v;
 
   int? _xNcIscustomavatar;
   int? get xNcIscustomavatar => _$this._xNcIscustomavatar;
-  set xNcIscustomavatar(int? xNcIscustomavatar) => _$this._xNcIscustomavatar = xNcIscustomavatar;
+  set xNcIscustomavatar(covariant int? xNcIscustomavatar) => _$this._xNcIscustomavatar = xNcIscustomavatar;
 
   CoreAvatarAvatarGetAvatarDarkHeadersBuilder();
 
@@ -9455,7 +9632,7 @@ class CoreAvatarAvatarGetAvatarDarkHeadersBuilder
   }
 
   @override
-  void replace(CoreAvatarAvatarGetAvatarDarkHeaders other) {
+  void replace(covariant CoreAvatarAvatarGetAvatarDarkHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAvatarAvatarGetAvatarDarkHeaders;
   }
@@ -9473,6 +9650,13 @@ class CoreAvatarAvatarGetAvatarDarkHeadersBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreAvatarAvatarGetAvatarHeadersInterfaceBuilder {
+  void replace(CoreAvatarAvatarGetAvatarHeadersInterface other);
+  void update(void Function(CoreAvatarAvatarGetAvatarHeadersInterfaceBuilder) updates);
+  int? get xNcIscustomavatar;
+  set xNcIscustomavatar(int? xNcIscustomavatar);
 }
 
 class _$CoreAvatarAvatarGetAvatarHeaders extends CoreAvatarAvatarGetAvatarHeaders {
@@ -9514,12 +9698,14 @@ class _$CoreAvatarAvatarGetAvatarHeaders extends CoreAvatarAvatarGetAvatarHeader
 }
 
 class CoreAvatarAvatarGetAvatarHeadersBuilder
-    implements Builder<CoreAvatarAvatarGetAvatarHeaders, CoreAvatarAvatarGetAvatarHeadersBuilder> {
+    implements
+        Builder<CoreAvatarAvatarGetAvatarHeaders, CoreAvatarAvatarGetAvatarHeadersBuilder>,
+        CoreAvatarAvatarGetAvatarHeadersInterfaceBuilder {
   _$CoreAvatarAvatarGetAvatarHeaders? _$v;
 
   int? _xNcIscustomavatar;
   int? get xNcIscustomavatar => _$this._xNcIscustomavatar;
-  set xNcIscustomavatar(int? xNcIscustomavatar) => _$this._xNcIscustomavatar = xNcIscustomavatar;
+  set xNcIscustomavatar(covariant int? xNcIscustomavatar) => _$this._xNcIscustomavatar = xNcIscustomavatar;
 
   CoreAvatarAvatarGetAvatarHeadersBuilder();
 
@@ -9533,7 +9719,7 @@ class CoreAvatarAvatarGetAvatarHeadersBuilder
   }
 
   @override
-  void replace(CoreAvatarAvatarGetAvatarHeaders other) {
+  void replace(covariant CoreAvatarAvatarGetAvatarHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreAvatarAvatarGetAvatarHeaders;
   }
@@ -9551,6 +9737,19 @@ class CoreAvatarAvatarGetAvatarHeadersBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreLoginFlowV2CredentialsInterfaceBuilder {
+  void replace(CoreLoginFlowV2CredentialsInterface other);
+  void update(void Function(CoreLoginFlowV2CredentialsInterfaceBuilder) updates);
+  String? get server;
+  set server(String? server);
+
+  String? get loginName;
+  set loginName(String? loginName);
+
+  String? get appPassword;
+  set appPassword(String? appPassword);
 }
 
 class _$CoreLoginFlowV2Credentials extends CoreLoginFlowV2Credentials {
@@ -9608,20 +9807,22 @@ class _$CoreLoginFlowV2Credentials extends CoreLoginFlowV2Credentials {
 }
 
 class CoreLoginFlowV2CredentialsBuilder
-    implements Builder<CoreLoginFlowV2Credentials, CoreLoginFlowV2CredentialsBuilder> {
+    implements
+        Builder<CoreLoginFlowV2Credentials, CoreLoginFlowV2CredentialsBuilder>,
+        CoreLoginFlowV2CredentialsInterfaceBuilder {
   _$CoreLoginFlowV2Credentials? _$v;
 
   String? _server;
   String? get server => _$this._server;
-  set server(String? server) => _$this._server = server;
+  set server(covariant String? server) => _$this._server = server;
 
   String? _loginName;
   String? get loginName => _$this._loginName;
-  set loginName(String? loginName) => _$this._loginName = loginName;
+  set loginName(covariant String? loginName) => _$this._loginName = loginName;
 
   String? _appPassword;
   String? get appPassword => _$this._appPassword;
-  set appPassword(String? appPassword) => _$this._appPassword = appPassword;
+  set appPassword(covariant String? appPassword) => _$this._appPassword = appPassword;
 
   CoreLoginFlowV2CredentialsBuilder();
 
@@ -9637,7 +9838,7 @@ class CoreLoginFlowV2CredentialsBuilder
   }
 
   @override
-  void replace(CoreLoginFlowV2Credentials other) {
+  void replace(covariant CoreLoginFlowV2Credentials other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreLoginFlowV2Credentials;
   }
@@ -9660,6 +9861,16 @@ class CoreLoginFlowV2CredentialsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreLoginFlowV2_PollInterfaceBuilder {
+  void replace(CoreLoginFlowV2_PollInterface other);
+  void update(void Function(CoreLoginFlowV2_PollInterfaceBuilder) updates);
+  String? get token;
+  set token(String? token);
+
+  String? get endpoint;
+  set endpoint(String? endpoint);
 }
 
 class _$CoreLoginFlowV2_Poll extends CoreLoginFlowV2_Poll {
@@ -9707,16 +9918,17 @@ class _$CoreLoginFlowV2_Poll extends CoreLoginFlowV2_Poll {
   }
 }
 
-class CoreLoginFlowV2_PollBuilder implements Builder<CoreLoginFlowV2_Poll, CoreLoginFlowV2_PollBuilder> {
+class CoreLoginFlowV2_PollBuilder
+    implements Builder<CoreLoginFlowV2_Poll, CoreLoginFlowV2_PollBuilder>, CoreLoginFlowV2_PollInterfaceBuilder {
   _$CoreLoginFlowV2_Poll? _$v;
 
   String? _token;
   String? get token => _$this._token;
-  set token(String? token) => _$this._token = token;
+  set token(covariant String? token) => _$this._token = token;
 
   String? _endpoint;
   String? get endpoint => _$this._endpoint;
-  set endpoint(String? endpoint) => _$this._endpoint = endpoint;
+  set endpoint(covariant String? endpoint) => _$this._endpoint = endpoint;
 
   CoreLoginFlowV2_PollBuilder();
 
@@ -9731,7 +9943,7 @@ class CoreLoginFlowV2_PollBuilder implements Builder<CoreLoginFlowV2_Poll, CoreL
   }
 
   @override
-  void replace(CoreLoginFlowV2_Poll other) {
+  void replace(covariant CoreLoginFlowV2_Poll other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreLoginFlowV2_Poll;
   }
@@ -9752,6 +9964,16 @@ class CoreLoginFlowV2_PollBuilder implements Builder<CoreLoginFlowV2_Poll, CoreL
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreLoginFlowV2InterfaceBuilder {
+  void replace(CoreLoginFlowV2Interface other);
+  void update(void Function(CoreLoginFlowV2InterfaceBuilder) updates);
+  CoreLoginFlowV2_PollBuilder get poll;
+  set poll(CoreLoginFlowV2_PollBuilder? poll);
+
+  String? get login;
+  set login(String? login);
 }
 
 class _$CoreLoginFlowV2 extends CoreLoginFlowV2 {
@@ -9798,16 +10020,17 @@ class _$CoreLoginFlowV2 extends CoreLoginFlowV2 {
   }
 }
 
-class CoreLoginFlowV2Builder implements Builder<CoreLoginFlowV2, CoreLoginFlowV2Builder> {
+class CoreLoginFlowV2Builder
+    implements Builder<CoreLoginFlowV2, CoreLoginFlowV2Builder>, CoreLoginFlowV2InterfaceBuilder {
   _$CoreLoginFlowV2? _$v;
 
   CoreLoginFlowV2_PollBuilder? _poll;
   CoreLoginFlowV2_PollBuilder get poll => _$this._poll ??= CoreLoginFlowV2_PollBuilder();
-  set poll(CoreLoginFlowV2_PollBuilder? poll) => _$this._poll = poll;
+  set poll(covariant CoreLoginFlowV2_PollBuilder? poll) => _$this._poll = poll;
 
   String? _login;
   String? get login => _$this._login;
-  set login(String? login) => _$this._login = login;
+  set login(covariant String? login) => _$this._login = login;
 
   CoreLoginFlowV2Builder();
 
@@ -9822,7 +10045,7 @@ class CoreLoginFlowV2Builder implements Builder<CoreLoginFlowV2, CoreLoginFlowV2
   }
 
   @override
-  void replace(CoreLoginFlowV2 other) {
+  void replace(covariant CoreLoginFlowV2 other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreLoginFlowV2;
   }
@@ -9854,6 +10077,25 @@ class CoreLoginFlowV2Builder implements Builder<CoreLoginFlowV2, CoreLoginFlowV2
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreOpenGraphObject_OpenGraphObjectInterfaceBuilder {
+  void replace(CoreOpenGraphObject_OpenGraphObjectInterface other);
+  void update(void Function(CoreOpenGraphObject_OpenGraphObjectInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get name;
+  set name(String? name);
+
+  String? get description;
+  set description(String? description);
+
+  String? get thumb;
+  set thumb(String? thumb);
+
+  String? get link;
+  set link(String? link);
 }
 
 class _$CoreOpenGraphObject_OpenGraphObject extends CoreOpenGraphObject_OpenGraphObject {
@@ -9922,28 +10164,30 @@ class _$CoreOpenGraphObject_OpenGraphObject extends CoreOpenGraphObject_OpenGrap
 }
 
 class CoreOpenGraphObject_OpenGraphObjectBuilder
-    implements Builder<CoreOpenGraphObject_OpenGraphObject, CoreOpenGraphObject_OpenGraphObjectBuilder> {
+    implements
+        Builder<CoreOpenGraphObject_OpenGraphObject, CoreOpenGraphObject_OpenGraphObjectBuilder>,
+        CoreOpenGraphObject_OpenGraphObjectInterfaceBuilder {
   _$CoreOpenGraphObject_OpenGraphObject? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   String? _description;
   String? get description => _$this._description;
-  set description(String? description) => _$this._description = description;
+  set description(covariant String? description) => _$this._description = description;
 
   String? _thumb;
   String? get thumb => _$this._thumb;
-  set thumb(String? thumb) => _$this._thumb = thumb;
+  set thumb(covariant String? thumb) => _$this._thumb = thumb;
 
   String? _link;
   String? get link => _$this._link;
-  set link(String? link) => _$this._link = link;
+  set link(covariant String? link) => _$this._link = link;
 
   CoreOpenGraphObject_OpenGraphObjectBuilder();
 
@@ -9961,7 +10205,7 @@ class CoreOpenGraphObject_OpenGraphObjectBuilder
   }
 
   @override
-  void replace(CoreOpenGraphObject_OpenGraphObject other) {
+  void replace(covariant CoreOpenGraphObject_OpenGraphObject other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreOpenGraphObject_OpenGraphObject;
   }
@@ -9985,6 +10229,22 @@ class CoreOpenGraphObject_OpenGraphObjectBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreOpenGraphObjectInterfaceBuilder {
+  void replace(CoreOpenGraphObjectInterface other);
+  void update(void Function(CoreOpenGraphObjectInterfaceBuilder) updates);
+  String? get richObjectType;
+  set richObjectType(String? richObjectType);
+
+  MapBuilder<String, JsonObject> get richObject;
+  set richObject(MapBuilder<String, JsonObject>? richObject);
+
+  CoreOpenGraphObject_OpenGraphObjectBuilder get openGraphObject;
+  set openGraphObject(CoreOpenGraphObject_OpenGraphObjectBuilder? openGraphObject);
+
+  bool? get accessible;
+  set accessible(bool? accessible);
 }
 
 class _$CoreOpenGraphObject extends CoreOpenGraphObject {
@@ -10048,26 +10308,27 @@ class _$CoreOpenGraphObject extends CoreOpenGraphObject {
   }
 }
 
-class CoreOpenGraphObjectBuilder implements Builder<CoreOpenGraphObject, CoreOpenGraphObjectBuilder> {
+class CoreOpenGraphObjectBuilder
+    implements Builder<CoreOpenGraphObject, CoreOpenGraphObjectBuilder>, CoreOpenGraphObjectInterfaceBuilder {
   _$CoreOpenGraphObject? _$v;
 
   String? _richObjectType;
   String? get richObjectType => _$this._richObjectType;
-  set richObjectType(String? richObjectType) => _$this._richObjectType = richObjectType;
+  set richObjectType(covariant String? richObjectType) => _$this._richObjectType = richObjectType;
 
   MapBuilder<String, JsonObject>? _richObject;
   MapBuilder<String, JsonObject> get richObject => _$this._richObject ??= MapBuilder<String, JsonObject>();
-  set richObject(MapBuilder<String, JsonObject>? richObject) => _$this._richObject = richObject;
+  set richObject(covariant MapBuilder<String, JsonObject>? richObject) => _$this._richObject = richObject;
 
   CoreOpenGraphObject_OpenGraphObjectBuilder? _openGraphObject;
   CoreOpenGraphObject_OpenGraphObjectBuilder get openGraphObject =>
       _$this._openGraphObject ??= CoreOpenGraphObject_OpenGraphObjectBuilder();
-  set openGraphObject(CoreOpenGraphObject_OpenGraphObjectBuilder? openGraphObject) =>
+  set openGraphObject(covariant CoreOpenGraphObject_OpenGraphObjectBuilder? openGraphObject) =>
       _$this._openGraphObject = openGraphObject;
 
   bool? _accessible;
   bool? get accessible => _$this._accessible;
-  set accessible(bool? accessible) => _$this._accessible = accessible;
+  set accessible(covariant bool? accessible) => _$this._accessible = accessible;
 
   CoreOpenGraphObjectBuilder();
 
@@ -10084,7 +10345,7 @@ class CoreOpenGraphObjectBuilder implements Builder<CoreOpenGraphObject, CoreOpe
   }
 
   @override
-  void replace(CoreOpenGraphObject other) {
+  void replace(covariant CoreOpenGraphObject other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreOpenGraphObject;
   }
@@ -10122,6 +10383,19 @@ class CoreOpenGraphObjectBuilder implements Builder<CoreOpenGraphObject, CoreOpe
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollectionInterfaceBuilder {
+  void replace(CoreCollectionInterface other);
+  void update(void Function(CoreCollectionInterfaceBuilder) updates);
+  int? get id;
+  set id(int? id);
+
+  String? get name;
+  set name(String? name);
+
+  ListBuilder<CoreOpenGraphObject> get resources;
+  set resources(ListBuilder<CoreOpenGraphObject>? resources);
 }
 
 class _$CoreCollection extends CoreCollection {
@@ -10173,20 +10447,20 @@ class _$CoreCollection extends CoreCollection {
   }
 }
 
-class CoreCollectionBuilder implements Builder<CoreCollection, CoreCollectionBuilder> {
+class CoreCollectionBuilder implements Builder<CoreCollection, CoreCollectionBuilder>, CoreCollectionInterfaceBuilder {
   _$CoreCollection? _$v;
 
   int? _id;
   int? get id => _$this._id;
-  set id(int? id) => _$this._id = id;
+  set id(covariant int? id) => _$this._id = id;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   ListBuilder<CoreOpenGraphObject>? _resources;
   ListBuilder<CoreOpenGraphObject> get resources => _$this._resources ??= ListBuilder<CoreOpenGraphObject>();
-  set resources(ListBuilder<CoreOpenGraphObject>? resources) => _$this._resources = resources;
+  set resources(covariant ListBuilder<CoreOpenGraphObject>? resources) => _$this._resources = resources;
 
   CoreCollectionBuilder();
 
@@ -10202,7 +10476,7 @@ class CoreCollectionBuilder implements Builder<CoreCollection, CoreCollectionBui
   }
 
   @override
-  void replace(CoreCollection other) {
+  void replace(covariant CoreCollection other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollection;
   }
@@ -10236,6 +10510,17 @@ class CoreCollectionBuilder implements Builder<CoreCollection, CoreCollectionBui
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  ListBuilder<CoreCollection> get data;
+  set data(ListBuilder<CoreCollection>? data);
 }
 
 class _$CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs
@@ -10296,16 +10581,17 @@ class _$CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Oc
 class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs,
-            CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder> {
+            CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder>,
+        CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<CoreCollection>? _data;
   ListBuilder<CoreCollection> get data => _$this._data ??= ListBuilder<CoreCollection>();
-  set data(ListBuilder<CoreCollection>? data) => _$this._data = data;
+  set data(covariant ListBuilder<CoreCollection>? data) => _$this._data = data;
 
   CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder();
 
@@ -10320,7 +10606,7 @@ class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsB
   }
 
   @override
-  void replace(CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_Ocs;
   }
@@ -10356,6 +10642,14 @@ class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsB
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson
@@ -10406,13 +10700,15 @@ class _$CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson
 class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonBuilder
     implements
         Builder<CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson,
-            CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonBuilder> {
+            CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonBuilder>,
+        CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonInterfaceBuilder {
   _$CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson? _$v;
 
   CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonBuilder();
 
@@ -10426,7 +10722,7 @@ class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonBuild
   }
 
   @override
-  void replace(CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson other) {
+  void replace(covariant CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJson;
   }
@@ -10457,6 +10753,17 @@ class CoreCollaborationResourcesSearchCollectionsResponse200ApplicationJsonBuild
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreCollectionBuilder get data;
+  set data(CoreCollectionBuilder? data);
 }
 
 class _$CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs
@@ -10516,16 +10823,17 @@ class _$CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs
 class CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs,
-            CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder> {
+            CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder>,
+        CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreCollectionBuilder? _data;
   CoreCollectionBuilder get data => _$this._data ??= CoreCollectionBuilder();
-  set data(CoreCollectionBuilder? data) => _$this._data = data;
+  set data(covariant CoreCollectionBuilder? data) => _$this._data = data;
 
   CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder();
 
@@ -10540,7 +10848,7 @@ class CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuil
   }
 
   @override
-  void replace(CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesListCollectionResponse200ApplicationJson_Ocs;
   }
@@ -10575,6 +10883,14 @@ class CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesListCollectionResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreCollaborationResourcesListCollectionResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesListCollectionResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreCollaborationResourcesListCollectionResponse200ApplicationJson
@@ -10625,13 +10941,15 @@ class _$CoreCollaborationResourcesListCollectionResponse200ApplicationJson
 class CoreCollaborationResourcesListCollectionResponse200ApplicationJsonBuilder
     implements
         Builder<CoreCollaborationResourcesListCollectionResponse200ApplicationJson,
-            CoreCollaborationResourcesListCollectionResponse200ApplicationJsonBuilder> {
+            CoreCollaborationResourcesListCollectionResponse200ApplicationJsonBuilder>,
+        CoreCollaborationResourcesListCollectionResponse200ApplicationJsonInterfaceBuilder {
   _$CoreCollaborationResourcesListCollectionResponse200ApplicationJson? _$v;
 
   CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreCollaborationResourcesListCollectionResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   CoreCollaborationResourcesListCollectionResponse200ApplicationJsonBuilder();
 
@@ -10645,7 +10963,7 @@ class CoreCollaborationResourcesListCollectionResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreCollaborationResourcesListCollectionResponse200ApplicationJson other) {
+  void replace(covariant CoreCollaborationResourcesListCollectionResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesListCollectionResponse200ApplicationJson;
   }
@@ -10676,6 +10994,17 @@ class CoreCollaborationResourcesListCollectionResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreCollectionBuilder get data;
+  set data(CoreCollectionBuilder? data);
 }
 
 class _$CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs
@@ -10735,16 +11064,17 @@ class _$CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs
 class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs,
-            CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder> {
+            CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder>,
+        CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreCollectionBuilder? _data;
   CoreCollectionBuilder get data => _$this._data ??= CoreCollectionBuilder();
-  set data(CoreCollectionBuilder? data) => _$this._data = data;
+  set data(covariant CoreCollectionBuilder? data) => _$this._data = data;
 
   CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder();
 
@@ -10759,7 +11089,7 @@ class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBu
   }
 
   @override
-  void replace(CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_Ocs;
   }
@@ -10794,6 +11124,14 @@ class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBu
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson
@@ -10844,13 +11182,15 @@ class _$CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson
 class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonBuilder
     implements
         Builder<CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson,
-            CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonBuilder> {
+            CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonBuilder>,
+        CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonInterfaceBuilder {
   _$CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson? _$v;
 
   CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonBuilder();
 
@@ -10864,7 +11204,7 @@ class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonBuilde
   }
 
   @override
-  void replace(CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson other) {
+  void replace(covariant CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesRenameCollectionResponse200ApplicationJson;
   }
@@ -10895,6 +11235,17 @@ class CoreCollaborationResourcesRenameCollectionResponse200ApplicationJsonBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreCollectionBuilder get data;
+  set data(CoreCollectionBuilder? data);
 }
 
 class _$CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs
@@ -10954,16 +11305,17 @@ class _$CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs
 class CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs,
-            CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder> {
+            CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder>,
+        CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreCollectionBuilder? _data;
   CoreCollectionBuilder get data => _$this._data ??= CoreCollectionBuilder();
-  set data(CoreCollectionBuilder? data) => _$this._data = data;
+  set data(covariant CoreCollectionBuilder? data) => _$this._data = data;
 
   CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder();
 
@@ -10978,7 +11330,7 @@ class CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesAddResourceResponse200ApplicationJson_Ocs;
   }
@@ -11013,6 +11365,13 @@ class CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesAddResourceResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreCollaborationResourcesAddResourceResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreCollaborationResourcesAddResourceResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreCollaborationResourcesAddResourceResponse200ApplicationJson
@@ -11063,13 +11422,15 @@ class _$CoreCollaborationResourcesAddResourceResponse200ApplicationJson
 class CoreCollaborationResourcesAddResourceResponse200ApplicationJsonBuilder
     implements
         Builder<CoreCollaborationResourcesAddResourceResponse200ApplicationJson,
-            CoreCollaborationResourcesAddResourceResponse200ApplicationJsonBuilder> {
+            CoreCollaborationResourcesAddResourceResponse200ApplicationJsonBuilder>,
+        CoreCollaborationResourcesAddResourceResponse200ApplicationJsonInterfaceBuilder {
   _$CoreCollaborationResourcesAddResourceResponse200ApplicationJson? _$v;
 
   CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreCollaborationResourcesAddResourceResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   CoreCollaborationResourcesAddResourceResponse200ApplicationJsonBuilder();
 
@@ -11083,7 +11444,7 @@ class CoreCollaborationResourcesAddResourceResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreCollaborationResourcesAddResourceResponse200ApplicationJson other) {
+  void replace(covariant CoreCollaborationResourcesAddResourceResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesAddResourceResponse200ApplicationJson;
   }
@@ -11114,6 +11475,17 @@ class CoreCollaborationResourcesAddResourceResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreCollectionBuilder get data;
+  set data(CoreCollectionBuilder? data);
 }
 
 class _$CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs
@@ -11173,16 +11545,17 @@ class _$CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs
 class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs,
-            CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder> {
+            CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder>,
+        CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreCollectionBuilder? _data;
   CoreCollectionBuilder get data => _$this._data ??= CoreCollectionBuilder();
-  set data(CoreCollectionBuilder? data) => _$this._data = data;
+  set data(covariant CoreCollectionBuilder? data) => _$this._data = data;
 
   CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder();
 
@@ -11197,7 +11570,7 @@ class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuil
   }
 
   @override
-  void replace(CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_Ocs;
   }
@@ -11232,6 +11605,14 @@ class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson
@@ -11282,13 +11663,15 @@ class _$CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson
 class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonBuilder
     implements
         Builder<CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson,
-            CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonBuilder> {
+            CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonBuilder>,
+        CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonInterfaceBuilder {
   _$CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson? _$v;
 
   CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonBuilder();
 
@@ -11302,7 +11685,7 @@ class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson other) {
+  void replace(covariant CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesRemoveResourceResponse200ApplicationJson;
   }
@@ -11333,6 +11716,18 @@ class CoreCollaborationResourcesRemoveResourceResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsInterfaceBuilder)
+          updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  ListBuilder<CoreCollection> get data;
+  set data(ListBuilder<CoreCollection>? data);
 }
 
 class _$CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs
@@ -11397,16 +11792,17 @@ class _$CoreCollaborationResourcesGetCollectionsByResourceResponse200Application
 class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs,
-            CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder> {
+            CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder>,
+        CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<CoreCollection>? _data;
   ListBuilder<CoreCollection> get data => _$this._data ??= ListBuilder<CoreCollection>();
-  set data(ListBuilder<CoreCollection>? data) => _$this._data = data;
+  set data(covariant ListBuilder<CoreCollection>? data) => _$this._data = data;
 
   CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder();
 
@@ -11421,7 +11817,7 @@ class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJs
   }
 
   @override
-  void replace(CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_Ocs;
   }
@@ -11459,6 +11855,15 @@ class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJs
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonInterfaceBuilder)
+          updates);
+  CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson
@@ -11510,13 +11915,14 @@ class _$CoreCollaborationResourcesGetCollectionsByResourceResponse200Application
 class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonBuilder
     implements
         Builder<CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson,
-            CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonBuilder> {
+            CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonBuilder>,
+        CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonInterfaceBuilder {
   _$CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson? _$v;
 
   CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder? ocs) =>
+  set ocs(covariant CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson_OcsBuilder? ocs) =>
       _$this._ocs = ocs;
 
   CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJsonBuilder();
@@ -11531,7 +11937,7 @@ class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJs
   }
 
   @override
-  void replace(CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson other) {
+  void replace(covariant CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJson;
   }
@@ -11566,6 +11972,18 @@ class CoreCollaborationResourcesGetCollectionsByResourceResponse200ApplicationJs
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsInterfaceBuilder)
+          updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreCollectionBuilder get data;
+  set data(CoreCollectionBuilder? data);
 }
 
 class _$CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs
@@ -11630,16 +12048,17 @@ class _$CoreCollaborationResourcesCreateCollectionOnResourceResponse200Applicati
 class CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs,
-            CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder> {
+            CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder>,
+        CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreCollectionBuilder? _data;
   CoreCollectionBuilder get data => _$this._data ??= CoreCollectionBuilder();
-  set data(CoreCollectionBuilder? data) => _$this._data = data;
+  set data(covariant CoreCollectionBuilder? data) => _$this._data = data;
 
   CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder();
 
@@ -11654,7 +12073,7 @@ class CoreCollaborationResourcesCreateCollectionOnResourceResponse200Application
   }
 
   @override
-  void replace(CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_Ocs;
   }
@@ -11693,6 +12112,15 @@ class CoreCollaborationResourcesCreateCollectionOnResourceResponse200Application
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonInterfaceBuilder)
+          updates);
+  CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson
@@ -11747,13 +12175,14 @@ class _$CoreCollaborationResourcesCreateCollectionOnResourceResponse200Applicati
 class CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonBuilder
     implements
         Builder<CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson,
-            CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonBuilder> {
+            CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonBuilder>,
+        CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonInterfaceBuilder {
   _$CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson? _$v;
 
   CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder? ocs) =>
+  set ocs(covariant CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson_OcsBuilder? ocs) =>
       _$this._ocs = ocs;
 
   CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJsonBuilder();
@@ -11768,7 +12197,7 @@ class CoreCollaborationResourcesCreateCollectionOnResourceResponse200Application
   }
 
   @override
-  void replace(CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson other) {
+  void replace(covariant CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCollaborationResourcesCreateCollectionOnResourceResponse200ApplicationJson;
   }
@@ -11803,6 +12232,22 @@ class CoreCollaborationResourcesCreateCollectionOnResourceResponse200Application
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreContactsActionInterfaceBuilder {
+  void replace(CoreContactsActionInterface other);
+  void update(void Function(CoreContactsActionInterfaceBuilder) updates);
+  String? get title;
+  set title(String? title);
+
+  String? get icon;
+  set icon(String? icon);
+
+  String? get hyperlink;
+  set hyperlink(String? hyperlink);
+
+  String? get appId;
+  set appId(String? appId);
 }
 
 class _$CoreContactsAction extends CoreContactsAction {
@@ -11865,24 +12310,25 @@ class _$CoreContactsAction extends CoreContactsAction {
   }
 }
 
-class CoreContactsActionBuilder implements Builder<CoreContactsAction, CoreContactsActionBuilder> {
+class CoreContactsActionBuilder
+    implements Builder<CoreContactsAction, CoreContactsActionBuilder>, CoreContactsActionInterfaceBuilder {
   _$CoreContactsAction? _$v;
 
   String? _title;
   String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
+  set title(covariant String? title) => _$this._title = title;
 
   String? _icon;
   String? get icon => _$this._icon;
-  set icon(String? icon) => _$this._icon = icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
 
   String? _hyperlink;
   String? get hyperlink => _$this._hyperlink;
-  set hyperlink(String? hyperlink) => _$this._hyperlink = hyperlink;
+  set hyperlink(covariant String? hyperlink) => _$this._hyperlink = hyperlink;
 
   String? _appId;
   String? get appId => _$this._appId;
-  set appId(String? appId) => _$this._appId = appId;
+  set appId(covariant String? appId) => _$this._appId = appId;
 
   CoreContactsActionBuilder();
 
@@ -11899,7 +12345,7 @@ class CoreContactsActionBuilder implements Builder<CoreContactsAction, CoreConta
   }
 
   @override
-  void replace(CoreContactsAction other) {
+  void replace(covariant CoreContactsAction other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreContactsAction;
   }
@@ -11922,6 +12368,19 @@ class CoreContactsActionBuilder implements Builder<CoreContactsAction, CoreConta
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get userId;
+  set userId(String? userId);
+
+  String? get displayName;
+  set displayName(String? displayName);
+
+  ListBuilder<CoreContactsAction> get actions;
+  set actions(ListBuilder<CoreContactsAction>? actions);
 }
 
 class _$CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data
@@ -11988,20 +12447,21 @@ class _$CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data
 class CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data,
-            CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _userId;
   String? get userId => _$this._userId;
-  set userId(String? userId) => _$this._userId = userId;
+  set userId(covariant String? userId) => _$this._userId = userId;
 
   String? _displayName;
   String? get displayName => _$this._displayName;
-  set displayName(String? displayName) => _$this._displayName = displayName;
+  set displayName(covariant String? displayName) => _$this._displayName = displayName;
 
   ListBuilder<CoreContactsAction>? _actions;
   ListBuilder<CoreContactsAction> get actions => _$this._actions ??= ListBuilder<CoreContactsAction>();
-  set actions(ListBuilder<CoreContactsAction>? actions) => _$this._actions = actions;
+  set actions(covariant ListBuilder<CoreContactsAction>? actions) => _$this._actions = actions;
 
   CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -12017,7 +12477,7 @@ class CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreHoverCardGetUserResponse200ApplicationJson_Ocs_Data;
   }
@@ -12054,6 +12514,16 @@ class CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreHoverCardGetUserResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreHoverCardGetUserResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreHoverCardGetUserResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreHoverCardGetUserResponse200ApplicationJson_Ocs extends CoreHoverCardGetUserResponse200ApplicationJson_Ocs {
@@ -12107,17 +12577,18 @@ class _$CoreHoverCardGetUserResponse200ApplicationJson_Ocs extends CoreHoverCard
 class CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreHoverCardGetUserResponse200ApplicationJson_Ocs,
-            CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder> {
+            CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder>,
+        CoreHoverCardGetUserResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreHoverCardGetUserResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreHoverCardGetUserResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder();
 
@@ -12132,7 +12603,7 @@ class CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreHoverCardGetUserResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreHoverCardGetUserResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreHoverCardGetUserResponse200ApplicationJson_Ocs;
   }
@@ -12165,6 +12636,13 @@ class CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreHoverCardGetUserResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreHoverCardGetUserResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreHoverCardGetUserResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreHoverCardGetUserResponse200ApplicationJson extends CoreHoverCardGetUserResponse200ApplicationJson {
@@ -12210,13 +12688,14 @@ class _$CoreHoverCardGetUserResponse200ApplicationJson extends CoreHoverCardGetU
 
 class CoreHoverCardGetUserResponse200ApplicationJsonBuilder
     implements
-        Builder<CoreHoverCardGetUserResponse200ApplicationJson, CoreHoverCardGetUserResponse200ApplicationJsonBuilder> {
+        Builder<CoreHoverCardGetUserResponse200ApplicationJson, CoreHoverCardGetUserResponse200ApplicationJsonBuilder>,
+        CoreHoverCardGetUserResponse200ApplicationJsonInterfaceBuilder {
   _$CoreHoverCardGetUserResponse200ApplicationJson? _$v;
 
   CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreHoverCardGetUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreHoverCardGetUserResponse200ApplicationJsonBuilder();
 
@@ -12230,7 +12709,7 @@ class CoreHoverCardGetUserResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreHoverCardGetUserResponse200ApplicationJson other) {
+  void replace(covariant CoreHoverCardGetUserResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreHoverCardGetUserResponse200ApplicationJson;
   }
@@ -12364,6 +12843,37 @@ class CoreNavigationEntry_OrderBuilder implements Builder<CoreNavigationEntry_Or
   }
 }
 
+abstract mixin class CoreNavigationEntryInterfaceBuilder {
+  void replace(CoreNavigationEntryInterface other);
+  void update(void Function(CoreNavigationEntryInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  CoreNavigationEntry_OrderBuilder get order;
+  set order(CoreNavigationEntry_OrderBuilder? order);
+
+  String? get href;
+  set href(String? href);
+
+  String? get icon;
+  set icon(String? icon);
+
+  String? get type;
+  set type(String? type);
+
+  String? get name;
+  set name(String? name);
+
+  bool? get active;
+  set active(bool? active);
+
+  String? get classes;
+  set classes(String? classes);
+
+  int? get unread;
+  set unread(int? unread);
+}
+
 class _$CoreNavigationEntry extends CoreNavigationEntry {
   @override
   final String id;
@@ -12463,44 +12973,45 @@ class _$CoreNavigationEntry extends CoreNavigationEntry {
   }
 }
 
-class CoreNavigationEntryBuilder implements Builder<CoreNavigationEntry, CoreNavigationEntryBuilder> {
+class CoreNavigationEntryBuilder
+    implements Builder<CoreNavigationEntry, CoreNavigationEntryBuilder>, CoreNavigationEntryInterfaceBuilder {
   _$CoreNavigationEntry? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   CoreNavigationEntry_OrderBuilder? _order;
   CoreNavigationEntry_OrderBuilder get order => _$this._order ??= CoreNavigationEntry_OrderBuilder();
-  set order(CoreNavigationEntry_OrderBuilder? order) => _$this._order = order;
+  set order(covariant CoreNavigationEntry_OrderBuilder? order) => _$this._order = order;
 
   String? _href;
   String? get href => _$this._href;
-  set href(String? href) => _$this._href = href;
+  set href(covariant String? href) => _$this._href = href;
 
   String? _icon;
   String? get icon => _$this._icon;
-  set icon(String? icon) => _$this._icon = icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
 
   String? _type;
   String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
+  set type(covariant String? type) => _$this._type = type;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   bool? _active;
   bool? get active => _$this._active;
-  set active(bool? active) => _$this._active = active;
+  set active(covariant bool? active) => _$this._active = active;
 
   String? _classes;
   String? get classes => _$this._classes;
-  set classes(String? classes) => _$this._classes = classes;
+  set classes(covariant String? classes) => _$this._classes = classes;
 
   int? _unread;
   int? get unread => _$this._unread;
-  set unread(int? unread) => _$this._unread = unread;
+  set unread(covariant int? unread) => _$this._unread = unread;
 
   CoreNavigationEntryBuilder();
 
@@ -12522,7 +13033,7 @@ class CoreNavigationEntryBuilder implements Builder<CoreNavigationEntry, CoreNav
   }
 
   @override
-  void replace(CoreNavigationEntry other) {
+  void replace(covariant CoreNavigationEntry other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreNavigationEntry;
   }
@@ -12562,6 +13073,16 @@ class CoreNavigationEntryBuilder implements Builder<CoreNavigationEntry, CoreNav
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  ListBuilder<CoreNavigationEntry> get data;
+  set data(ListBuilder<CoreNavigationEntry>? data);
 }
 
 class _$CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs
@@ -12621,16 +13142,17 @@ class _$CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs
 class CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs,
-            CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder> {
+            CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder>,
+        CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<CoreNavigationEntry>? _data;
   ListBuilder<CoreNavigationEntry> get data => _$this._data ??= ListBuilder<CoreNavigationEntry>();
-  set data(ListBuilder<CoreNavigationEntry>? data) => _$this._data = data;
+  set data(covariant ListBuilder<CoreNavigationEntry>? data) => _$this._data = data;
 
   CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder();
 
@@ -12645,7 +13167,7 @@ class CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreNavigationGetAppsNavigationResponse200ApplicationJson_Ocs;
   }
@@ -12679,6 +13201,13 @@ class CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreNavigationGetAppsNavigationResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreNavigationGetAppsNavigationResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreNavigationGetAppsNavigationResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreNavigationGetAppsNavigationResponse200ApplicationJson
@@ -12727,13 +13256,14 @@ class _$CoreNavigationGetAppsNavigationResponse200ApplicationJson
 class CoreNavigationGetAppsNavigationResponse200ApplicationJsonBuilder
     implements
         Builder<CoreNavigationGetAppsNavigationResponse200ApplicationJson,
-            CoreNavigationGetAppsNavigationResponse200ApplicationJsonBuilder> {
+            CoreNavigationGetAppsNavigationResponse200ApplicationJsonBuilder>,
+        CoreNavigationGetAppsNavigationResponse200ApplicationJsonInterfaceBuilder {
   _$CoreNavigationGetAppsNavigationResponse200ApplicationJson? _$v;
 
   CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreNavigationGetAppsNavigationResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreNavigationGetAppsNavigationResponse200ApplicationJsonBuilder();
 
@@ -12747,7 +13277,7 @@ class CoreNavigationGetAppsNavigationResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreNavigationGetAppsNavigationResponse200ApplicationJson other) {
+  void replace(covariant CoreNavigationGetAppsNavigationResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreNavigationGetAppsNavigationResponse200ApplicationJson;
   }
@@ -12778,6 +13308,16 @@ class CoreNavigationGetAppsNavigationResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  ListBuilder<CoreNavigationEntry> get data;
+  set data(ListBuilder<CoreNavigationEntry>? data);
 }
 
 class _$CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs
@@ -12837,16 +13377,17 @@ class _$CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs
 class CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs,
-            CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder> {
+            CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder>,
+        CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<CoreNavigationEntry>? _data;
   ListBuilder<CoreNavigationEntry> get data => _$this._data ??= ListBuilder<CoreNavigationEntry>();
-  set data(ListBuilder<CoreNavigationEntry>? data) => _$this._data = data;
+  set data(covariant ListBuilder<CoreNavigationEntry>? data) => _$this._data = data;
 
   CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder();
 
@@ -12861,7 +13402,7 @@ class CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreNavigationGetSettingsNavigationResponse200ApplicationJson_Ocs;
   }
@@ -12895,6 +13436,13 @@ class CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreNavigationGetSettingsNavigationResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreNavigationGetSettingsNavigationResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreNavigationGetSettingsNavigationResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreNavigationGetSettingsNavigationResponse200ApplicationJson
@@ -12944,13 +13492,14 @@ class _$CoreNavigationGetSettingsNavigationResponse200ApplicationJson
 class CoreNavigationGetSettingsNavigationResponse200ApplicationJsonBuilder
     implements
         Builder<CoreNavigationGetSettingsNavigationResponse200ApplicationJson,
-            CoreNavigationGetSettingsNavigationResponse200ApplicationJsonBuilder> {
+            CoreNavigationGetSettingsNavigationResponse200ApplicationJsonBuilder>,
+        CoreNavigationGetSettingsNavigationResponse200ApplicationJsonInterfaceBuilder {
   _$CoreNavigationGetSettingsNavigationResponse200ApplicationJson? _$v;
 
   CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreNavigationGetSettingsNavigationResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreNavigationGetSettingsNavigationResponse200ApplicationJsonBuilder();
 
@@ -12964,7 +13513,7 @@ class CoreNavigationGetSettingsNavigationResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreNavigationGetSettingsNavigationResponse200ApplicationJson other) {
+  void replace(covariant CoreNavigationGetSettingsNavigationResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreNavigationGetSettingsNavigationResponse200ApplicationJson;
   }
@@ -12995,6 +13544,28 @@ class CoreNavigationGetSettingsNavigationResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionInterfaceBuilder {
+  void replace(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionInterface other);
+  void update(void Function(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionInterfaceBuilder) updates);
+  int? get major;
+  set major(int? major);
+
+  int? get minor;
+  set minor(int? minor);
+
+  int? get micro;
+  set micro(int? micro);
+
+  String? get string;
+  set string(String? string);
+
+  String? get edition;
+  set edition(String? edition);
+
+  bool? get extendedSupport;
+  set extendedSupport(bool? extendedSupport);
 }
 
 class _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version
@@ -13088,32 +13659,33 @@ class _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version
 class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder
     implements
         Builder<CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version,
-            CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder> {
+            CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder>,
+        CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionInterfaceBuilder {
   _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version? _$v;
 
   int? _major;
   int? get major => _$this._major;
-  set major(int? major) => _$this._major = major;
+  set major(covariant int? major) => _$this._major = major;
 
   int? _minor;
   int? get minor => _$this._minor;
-  set minor(int? minor) => _$this._minor = minor;
+  set minor(covariant int? minor) => _$this._minor = minor;
 
   int? _micro;
   int? get micro => _$this._micro;
-  set micro(int? micro) => _$this._micro = micro;
+  set micro(covariant int? micro) => _$this._micro = micro;
 
   String? _string;
   String? get string => _$this._string;
-  set string(String? string) => _$this._string = string;
+  set string(covariant String? string) => _$this._string = string;
 
   String? _edition;
   String? get edition => _$this._edition;
-  set edition(String? edition) => _$this._edition = edition;
+  set edition(covariant String? edition) => _$this._edition = edition;
 
   bool? _extendedSupport;
   bool? get extendedSupport => _$this._extendedSupport;
-  set extendedSupport(bool? extendedSupport) => _$this._extendedSupport = extendedSupport;
+  set extendedSupport(covariant bool? extendedSupport) => _$this._extendedSupport = extendedSupport;
 
   CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder();
 
@@ -13132,7 +13704,7 @@ class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder
   }
 
   @override
-  void replace(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version other) {
+  void replace(covariant CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_Version;
   }
@@ -13163,6 +13735,13 @@ class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCommentsCapabilities_FilesInterfaceBuilder {
+  void replace(CoreCommentsCapabilities_FilesInterface other);
+  void update(void Function(CoreCommentsCapabilities_FilesInterfaceBuilder) updates);
+  bool? get comments;
+  set comments(bool? comments);
 }
 
 class _$CoreCommentsCapabilities_Files extends CoreCommentsCapabilities_Files {
@@ -13204,12 +13783,14 @@ class _$CoreCommentsCapabilities_Files extends CoreCommentsCapabilities_Files {
 }
 
 class CoreCommentsCapabilities_FilesBuilder
-    implements Builder<CoreCommentsCapabilities_Files, CoreCommentsCapabilities_FilesBuilder> {
+    implements
+        Builder<CoreCommentsCapabilities_Files, CoreCommentsCapabilities_FilesBuilder>,
+        CoreCommentsCapabilities_FilesInterfaceBuilder {
   _$CoreCommentsCapabilities_Files? _$v;
 
   bool? _comments;
   bool? get comments => _$this._comments;
-  set comments(bool? comments) => _$this._comments = comments;
+  set comments(covariant bool? comments) => _$this._comments = comments;
 
   CoreCommentsCapabilities_FilesBuilder();
 
@@ -13223,7 +13804,7 @@ class CoreCommentsCapabilities_FilesBuilder
   }
 
   @override
-  void replace(CoreCommentsCapabilities_Files other) {
+  void replace(covariant CoreCommentsCapabilities_Files other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCommentsCapabilities_Files;
   }
@@ -13243,6 +13824,13 @@ class CoreCommentsCapabilities_FilesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreCommentsCapabilitiesInterfaceBuilder {
+  void replace(CoreCommentsCapabilitiesInterface other);
+  void update(void Function(CoreCommentsCapabilitiesInterfaceBuilder) updates);
+  CoreCommentsCapabilities_FilesBuilder get files;
+  set files(CoreCommentsCapabilities_FilesBuilder? files);
 }
 
 class _$CoreCommentsCapabilities extends CoreCommentsCapabilities {
@@ -13283,12 +13871,15 @@ class _$CoreCommentsCapabilities extends CoreCommentsCapabilities {
   }
 }
 
-class CoreCommentsCapabilitiesBuilder implements Builder<CoreCommentsCapabilities, CoreCommentsCapabilitiesBuilder> {
+class CoreCommentsCapabilitiesBuilder
+    implements
+        Builder<CoreCommentsCapabilities, CoreCommentsCapabilitiesBuilder>,
+        CoreCommentsCapabilitiesInterfaceBuilder {
   _$CoreCommentsCapabilities? _$v;
 
   CoreCommentsCapabilities_FilesBuilder? _files;
   CoreCommentsCapabilities_FilesBuilder get files => _$this._files ??= CoreCommentsCapabilities_FilesBuilder();
-  set files(CoreCommentsCapabilities_FilesBuilder? files) => _$this._files = files;
+  set files(covariant CoreCommentsCapabilities_FilesBuilder? files) => _$this._files = files;
 
   CoreCommentsCapabilitiesBuilder();
 
@@ -13302,7 +13893,7 @@ class CoreCommentsCapabilitiesBuilder implements Builder<CoreCommentsCapabilitie
   }
 
   @override
-  void replace(CoreCommentsCapabilities other) {
+  void replace(covariant CoreCommentsCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreCommentsCapabilities;
   }
@@ -13332,6 +13923,16 @@ class CoreCommentsCapabilitiesBuilder implements Builder<CoreCommentsCapabilitie
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreDavCapabilities_DavInterfaceBuilder {
+  void replace(CoreDavCapabilities_DavInterface other);
+  void update(void Function(CoreDavCapabilities_DavInterfaceBuilder) updates);
+  String? get chunking;
+  set chunking(String? chunking);
+
+  String? get bulkupload;
+  set bulkupload(String? bulkupload);
 }
 
 class _$CoreDavCapabilities_Dav extends CoreDavCapabilities_Dav {
@@ -13378,16 +13979,19 @@ class _$CoreDavCapabilities_Dav extends CoreDavCapabilities_Dav {
   }
 }
 
-class CoreDavCapabilities_DavBuilder implements Builder<CoreDavCapabilities_Dav, CoreDavCapabilities_DavBuilder> {
+class CoreDavCapabilities_DavBuilder
+    implements
+        Builder<CoreDavCapabilities_Dav, CoreDavCapabilities_DavBuilder>,
+        CoreDavCapabilities_DavInterfaceBuilder {
   _$CoreDavCapabilities_Dav? _$v;
 
   String? _chunking;
   String? get chunking => _$this._chunking;
-  set chunking(String? chunking) => _$this._chunking = chunking;
+  set chunking(covariant String? chunking) => _$this._chunking = chunking;
 
   String? _bulkupload;
   String? get bulkupload => _$this._bulkupload;
-  set bulkupload(String? bulkupload) => _$this._bulkupload = bulkupload;
+  set bulkupload(covariant String? bulkupload) => _$this._bulkupload = bulkupload;
 
   CoreDavCapabilities_DavBuilder();
 
@@ -13402,7 +14006,7 @@ class CoreDavCapabilities_DavBuilder implements Builder<CoreDavCapabilities_Dav,
   }
 
   @override
-  void replace(CoreDavCapabilities_Dav other) {
+  void replace(covariant CoreDavCapabilities_Dav other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreDavCapabilities_Dav;
   }
@@ -13423,6 +14027,13 @@ class CoreDavCapabilities_DavBuilder implements Builder<CoreDavCapabilities_Dav,
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreDavCapabilitiesInterfaceBuilder {
+  void replace(CoreDavCapabilitiesInterface other);
+  void update(void Function(CoreDavCapabilitiesInterfaceBuilder) updates);
+  CoreDavCapabilities_DavBuilder get dav;
+  set dav(CoreDavCapabilities_DavBuilder? dav);
 }
 
 class _$CoreDavCapabilities extends CoreDavCapabilities {
@@ -13463,12 +14074,13 @@ class _$CoreDavCapabilities extends CoreDavCapabilities {
   }
 }
 
-class CoreDavCapabilitiesBuilder implements Builder<CoreDavCapabilities, CoreDavCapabilitiesBuilder> {
+class CoreDavCapabilitiesBuilder
+    implements Builder<CoreDavCapabilities, CoreDavCapabilitiesBuilder>, CoreDavCapabilitiesInterfaceBuilder {
   _$CoreDavCapabilities? _$v;
 
   CoreDavCapabilities_DavBuilder? _dav;
   CoreDavCapabilities_DavBuilder get dav => _$this._dav ??= CoreDavCapabilities_DavBuilder();
-  set dav(CoreDavCapabilities_DavBuilder? dav) => _$this._dav = dav;
+  set dav(covariant CoreDavCapabilities_DavBuilder? dav) => _$this._dav = dav;
 
   CoreDavCapabilitiesBuilder();
 
@@ -13482,7 +14094,7 @@ class CoreDavCapabilitiesBuilder implements Builder<CoreDavCapabilities, CoreDav
   }
 
   @override
-  void replace(CoreDavCapabilities other) {
+  void replace(covariant CoreDavCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreDavCapabilities;
   }
@@ -13512,6 +14124,19 @@ class CoreDavCapabilitiesBuilder implements Builder<CoreDavCapabilities, CoreDav
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesCapabilities_Files_DirectEditingInterfaceBuilder {
+  void replace(CoreFilesCapabilities_Files_DirectEditingInterface other);
+  void update(void Function(CoreFilesCapabilities_Files_DirectEditingInterfaceBuilder) updates);
+  String? get url;
+  set url(String? url);
+
+  String? get etag;
+  set etag(String? etag);
+
+  bool? get supportsFileId;
+  set supportsFileId(bool? supportsFileId);
 }
 
 class _$CoreFilesCapabilities_Files_DirectEditing extends CoreFilesCapabilities_Files_DirectEditing {
@@ -13573,20 +14198,22 @@ class _$CoreFilesCapabilities_Files_DirectEditing extends CoreFilesCapabilities_
 }
 
 class CoreFilesCapabilities_Files_DirectEditingBuilder
-    implements Builder<CoreFilesCapabilities_Files_DirectEditing, CoreFilesCapabilities_Files_DirectEditingBuilder> {
+    implements
+        Builder<CoreFilesCapabilities_Files_DirectEditing, CoreFilesCapabilities_Files_DirectEditingBuilder>,
+        CoreFilesCapabilities_Files_DirectEditingInterfaceBuilder {
   _$CoreFilesCapabilities_Files_DirectEditing? _$v;
 
   String? _url;
   String? get url => _$this._url;
-  set url(String? url) => _$this._url = url;
+  set url(covariant String? url) => _$this._url = url;
 
   String? _etag;
   String? get etag => _$this._etag;
-  set etag(String? etag) => _$this._etag = etag;
+  set etag(covariant String? etag) => _$this._etag = etag;
 
   bool? _supportsFileId;
   bool? get supportsFileId => _$this._supportsFileId;
-  set supportsFileId(bool? supportsFileId) => _$this._supportsFileId = supportsFileId;
+  set supportsFileId(covariant bool? supportsFileId) => _$this._supportsFileId = supportsFileId;
 
   CoreFilesCapabilities_Files_DirectEditingBuilder();
 
@@ -13602,7 +14229,7 @@ class CoreFilesCapabilities_Files_DirectEditingBuilder
   }
 
   @override
-  void replace(CoreFilesCapabilities_Files_DirectEditing other) {
+  void replace(covariant CoreFilesCapabilities_Files_DirectEditing other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesCapabilities_Files_DirectEditing;
   }
@@ -13625,6 +14252,19 @@ class CoreFilesCapabilities_Files_DirectEditingBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesCapabilities_FilesInterfaceBuilder {
+  void replace(CoreFilesCapabilities_FilesInterface other);
+  void update(void Function(CoreFilesCapabilities_FilesInterfaceBuilder) updates);
+  bool? get bigfilechunking;
+  set bigfilechunking(bool? bigfilechunking);
+
+  ListBuilder<JsonObject> get blacklistedFiles;
+  set blacklistedFiles(ListBuilder<JsonObject>? blacklistedFiles);
+
+  CoreFilesCapabilities_Files_DirectEditingBuilder get directEditing;
+  set directEditing(CoreFilesCapabilities_Files_DirectEditingBuilder? directEditing);
 }
 
 class _$CoreFilesCapabilities_Files extends CoreFilesCapabilities_Files {
@@ -13683,21 +14323,24 @@ class _$CoreFilesCapabilities_Files extends CoreFilesCapabilities_Files {
 }
 
 class CoreFilesCapabilities_FilesBuilder
-    implements Builder<CoreFilesCapabilities_Files, CoreFilesCapabilities_FilesBuilder> {
+    implements
+        Builder<CoreFilesCapabilities_Files, CoreFilesCapabilities_FilesBuilder>,
+        CoreFilesCapabilities_FilesInterfaceBuilder {
   _$CoreFilesCapabilities_Files? _$v;
 
   bool? _bigfilechunking;
   bool? get bigfilechunking => _$this._bigfilechunking;
-  set bigfilechunking(bool? bigfilechunking) => _$this._bigfilechunking = bigfilechunking;
+  set bigfilechunking(covariant bool? bigfilechunking) => _$this._bigfilechunking = bigfilechunking;
 
   ListBuilder<JsonObject>? _blacklistedFiles;
   ListBuilder<JsonObject> get blacklistedFiles => _$this._blacklistedFiles ??= ListBuilder<JsonObject>();
-  set blacklistedFiles(ListBuilder<JsonObject>? blacklistedFiles) => _$this._blacklistedFiles = blacklistedFiles;
+  set blacklistedFiles(covariant ListBuilder<JsonObject>? blacklistedFiles) =>
+      _$this._blacklistedFiles = blacklistedFiles;
 
   CoreFilesCapabilities_Files_DirectEditingBuilder? _directEditing;
   CoreFilesCapabilities_Files_DirectEditingBuilder get directEditing =>
       _$this._directEditing ??= CoreFilesCapabilities_Files_DirectEditingBuilder();
-  set directEditing(CoreFilesCapabilities_Files_DirectEditingBuilder? directEditing) =>
+  set directEditing(covariant CoreFilesCapabilities_Files_DirectEditingBuilder? directEditing) =>
       _$this._directEditing = directEditing;
 
   CoreFilesCapabilities_FilesBuilder();
@@ -13714,7 +14357,7 @@ class CoreFilesCapabilities_FilesBuilder
   }
 
   @override
-  void replace(CoreFilesCapabilities_Files other) {
+  void replace(covariant CoreFilesCapabilities_Files other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesCapabilities_Files;
   }
@@ -13751,6 +14394,13 @@ class CoreFilesCapabilities_FilesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesCapabilitiesInterfaceBuilder {
+  void replace(CoreFilesCapabilitiesInterface other);
+  void update(void Function(CoreFilesCapabilitiesInterfaceBuilder) updates);
+  CoreFilesCapabilities_FilesBuilder get files;
+  set files(CoreFilesCapabilities_FilesBuilder? files);
 }
 
 class _$CoreFilesCapabilities extends CoreFilesCapabilities {
@@ -13791,12 +14441,13 @@ class _$CoreFilesCapabilities extends CoreFilesCapabilities {
   }
 }
 
-class CoreFilesCapabilitiesBuilder implements Builder<CoreFilesCapabilities, CoreFilesCapabilitiesBuilder> {
+class CoreFilesCapabilitiesBuilder
+    implements Builder<CoreFilesCapabilities, CoreFilesCapabilitiesBuilder>, CoreFilesCapabilitiesInterfaceBuilder {
   _$CoreFilesCapabilities? _$v;
 
   CoreFilesCapabilities_FilesBuilder? _files;
   CoreFilesCapabilities_FilesBuilder get files => _$this._files ??= CoreFilesCapabilities_FilesBuilder();
-  set files(CoreFilesCapabilities_FilesBuilder? files) => _$this._files = files;
+  set files(covariant CoreFilesCapabilities_FilesBuilder? files) => _$this._files = files;
 
   CoreFilesCapabilitiesBuilder();
 
@@ -13810,7 +14461,7 @@ class CoreFilesCapabilitiesBuilder implements Builder<CoreFilesCapabilities, Cor
   }
 
   @override
-  void replace(CoreFilesCapabilities other) {
+  void replace(covariant CoreFilesCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesCapabilities;
   }
@@ -13840,6 +14491,16 @@ class CoreFilesCapabilitiesBuilder implements Builder<CoreFilesCapabilities, Cor
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_Public_PasswordInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder) updates);
+  bool? get enforced;
+  set enforced(bool? enforced);
+
+  bool? get askForOptionalPassword;
+  set askForOptionalPassword(bool? askForOptionalPassword);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Public_Password
@@ -13900,16 +14561,18 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Public_Password
 class CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Public_Password,
-            CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Public_Password? _$v;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   bool? _askForOptionalPassword;
   bool? get askForOptionalPassword => _$this._askForOptionalPassword;
-  set askForOptionalPassword(bool? askForOptionalPassword) => _$this._askForOptionalPassword = askForOptionalPassword;
+  set askForOptionalPassword(covariant bool? askForOptionalPassword) =>
+      _$this._askForOptionalPassword = askForOptionalPassword;
 
   CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder();
 
@@ -13924,7 +14587,7 @@ class CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Public_Password other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Public_Password other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Public_Password;
   }
@@ -13947,6 +14610,19 @@ class CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  int? get days;
+  set days(int? days);
+
+  bool? get enforced;
+  set enforced(bool? enforced);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate
@@ -14009,20 +14685,21 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate
 class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate,
-            CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   int? _days;
   int? get days => _$this._days;
-  set days(int? days) => _$this._days = days;
+  set days(covariant int? days) => _$this._days = days;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder();
 
@@ -14038,7 +14715,7 @@ class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDate;
   }
@@ -14061,6 +14738,20 @@ class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface other);
+  void update(
+      void Function(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  int? get days;
+  set days(int? days);
+
+  bool? get enforced;
+  set enforced(bool? enforced);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
@@ -14124,20 +14815,21 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
 class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal,
-            CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   int? _days;
   int? get days => _$this._days;
-  set days(int? days) => _$this._days = days;
+  set days(covariant int? days) => _$this._days = days;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder();
 
@@ -14153,7 +14845,7 @@ class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal;
   }
@@ -14176,6 +14868,19 @@ class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  int? get days;
+  set days(int? days);
+
+  bool? get enforced;
+  set enforced(bool? enforced);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
@@ -14239,20 +14944,21 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
 class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote,
-            CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   int? _days;
   int? get days => _$this._days;
-  set days(int? days) => _$this._days = days;
+  set days(covariant int? days) => _$this._days = days;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder();
 
@@ -14268,7 +14974,7 @@ class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote;
   }
@@ -14291,6 +14997,38 @@ class CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_PublicInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder get password;
+  set password(CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder? password);
+
+  bool? get multipleLinks;
+  set multipleLinks(bool? multipleLinks);
+
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder get expireDate;
+  set expireDate(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder? expireDate);
+
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder get expireDateInternal;
+  set expireDateInternal(
+      CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder? expireDateInternal);
+
+  CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder get expireDateRemote;
+  set expireDateRemote(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder? expireDateRemote);
+
+  bool? get sendMail;
+  set sendMail(bool? sendMail);
+
+  bool? get upload;
+  set upload(bool? upload);
+
+  bool? get uploadFilesDrop;
+  set uploadFilesDrop(bool? uploadFilesDrop);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Public extends CoreFilesSharingCapabilities_FilesSharing_Public {
@@ -14390,53 +15128,55 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Public extends CoreFilesSharin
 class CoreFilesSharingCapabilities_FilesSharing_PublicBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Public,
-            CoreFilesSharingCapabilities_FilesSharing_PublicBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_PublicBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Public? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder? _password;
   CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder get password =>
       _$this._password ??= CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder();
-  set password(CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder? password) =>
+  set password(covariant CoreFilesSharingCapabilities_FilesSharing_Public_PasswordBuilder? password) =>
       _$this._password = password;
 
   bool? _multipleLinks;
   bool? get multipleLinks => _$this._multipleLinks;
-  set multipleLinks(bool? multipleLinks) => _$this._multipleLinks = multipleLinks;
+  set multipleLinks(covariant bool? multipleLinks) => _$this._multipleLinks = multipleLinks;
 
   CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder? _expireDate;
   CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder get expireDate =>
       _$this._expireDate ??= CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder();
-  set expireDate(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder? expireDate) =>
+  set expireDate(covariant CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
   CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder? _expireDateInternal;
   CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder get expireDateInternal =>
       _$this._expireDateInternal ??= CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder();
   set expireDateInternal(
-          CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder? expireDateInternal) =>
+          covariant CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder? expireDateInternal) =>
       _$this._expireDateInternal = expireDateInternal;
 
   CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder? _expireDateRemote;
   CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder get expireDateRemote =>
       _$this._expireDateRemote ??= CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder();
-  set expireDateRemote(CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder? expireDateRemote) =>
+  set expireDateRemote(
+          covariant CoreFilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder? expireDateRemote) =>
       _$this._expireDateRemote = expireDateRemote;
 
   bool? _sendMail;
   bool? get sendMail => _$this._sendMail;
-  set sendMail(bool? sendMail) => _$this._sendMail = sendMail;
+  set sendMail(covariant bool? sendMail) => _$this._sendMail = sendMail;
 
   bool? _upload;
   bool? get upload => _$this._upload;
-  set upload(bool? upload) => _$this._upload = upload;
+  set upload(covariant bool? upload) => _$this._upload = upload;
 
   bool? _uploadFilesDrop;
   bool? get uploadFilesDrop => _$this._uploadFilesDrop;
-  set uploadFilesDrop(bool? uploadFilesDrop) => _$this._uploadFilesDrop = uploadFilesDrop;
+  set uploadFilesDrop(covariant bool? uploadFilesDrop) => _$this._uploadFilesDrop = uploadFilesDrop;
 
   CoreFilesSharingCapabilities_FilesSharing_PublicBuilder();
 
@@ -14458,7 +15198,7 @@ class CoreFilesSharingCapabilities_FilesSharing_PublicBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Public other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Public other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Public;
   }
@@ -14509,6 +15249,13 @@ class CoreFilesSharingCapabilities_FilesSharing_PublicBuilder
   }
 }
 
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+}
+
 class _$CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate
     extends CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate {
   @override
@@ -14557,12 +15304,13 @@ class _$CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate
 class CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate,
-            CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder();
 
@@ -14576,7 +15324,7 @@ class CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_User_ExpireDate;
   }
@@ -14597,6 +15345,16 @@ class CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_UserInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_UserInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_UserInterfaceBuilder) updates);
+  bool? get sendMail;
+  set sendMail(bool? sendMail);
+
+  CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder get expireDate;
+  set expireDate(CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder? expireDate);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_User extends CoreFilesSharingCapabilities_FilesSharing_User {
@@ -14650,17 +15408,18 @@ class _$CoreFilesSharingCapabilities_FilesSharing_User extends CoreFilesSharingC
 
 class CoreFilesSharingCapabilities_FilesSharing_UserBuilder
     implements
-        Builder<CoreFilesSharingCapabilities_FilesSharing_User, CoreFilesSharingCapabilities_FilesSharing_UserBuilder> {
+        Builder<CoreFilesSharingCapabilities_FilesSharing_User, CoreFilesSharingCapabilities_FilesSharing_UserBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_UserInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_User? _$v;
 
   bool? _sendMail;
   bool? get sendMail => _$this._sendMail;
-  set sendMail(bool? sendMail) => _$this._sendMail = sendMail;
+  set sendMail(covariant bool? sendMail) => _$this._sendMail = sendMail;
 
   CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder? _expireDate;
   CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder get expireDate =>
       _$this._expireDate ??= CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder();
-  set expireDate(CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder? expireDate) =>
+  set expireDate(covariant CoreFilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
   CoreFilesSharingCapabilities_FilesSharing_UserBuilder();
@@ -14676,7 +15435,7 @@ class CoreFilesSharingCapabilities_FilesSharing_UserBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_User other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_User other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_User;
   }
@@ -14711,6 +15470,13 @@ class CoreFilesSharingCapabilities_FilesSharing_UserBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate
@@ -14761,12 +15527,13 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate
 class CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate,
-            CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder();
 
@@ -14780,7 +15547,7 @@ class CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDate;
   }
@@ -14801,6 +15568,16 @@ class CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_GroupInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder get expireDate;
+  set expireDate(CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder? expireDate);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Group extends CoreFilesSharingCapabilities_FilesSharing_Group {
@@ -14855,17 +15632,18 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Group extends CoreFilesSharing
 class CoreFilesSharingCapabilities_FilesSharing_GroupBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Group,
-            CoreFilesSharingCapabilities_FilesSharing_GroupBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_GroupBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Group? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder? _expireDate;
   CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder get expireDate =>
       _$this._expireDate ??= CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder();
-  set expireDate(CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder? expireDate) =>
+  set expireDate(covariant CoreFilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
   CoreFilesSharingCapabilities_FilesSharing_GroupBuilder();
@@ -14881,7 +15659,7 @@ class CoreFilesSharingCapabilities_FilesSharing_GroupBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Group other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Group other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Group;
   }
@@ -14916,6 +15694,13 @@ class CoreFilesSharingCapabilities_FilesSharing_GroupBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate
@@ -14966,12 +15751,13 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate
 class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate,
-            CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder();
 
@@ -14985,7 +15771,7 @@ class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDate;
   }
@@ -15006,6 +15792,14 @@ class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface other);
+  void update(
+      void Function(CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported
@@ -15057,12 +15851,13 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported
 class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported,
-            CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder();
 
@@ -15076,7 +15871,7 @@ class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBu
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported;
   }
@@ -15097,6 +15892,23 @@ class CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBu
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_FederationInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder) updates);
+  bool? get outgoing;
+  set outgoing(bool? outgoing);
+
+  bool? get incoming;
+  set incoming(bool? incoming);
+
+  CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder get expireDate;
+  set expireDate(CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder? expireDate);
+
+  CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder get expireDateSupported;
+  set expireDateSupported(
+      CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder? expireDateSupported);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Federation
@@ -15171,28 +15983,30 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Federation
 class CoreFilesSharingCapabilities_FilesSharing_FederationBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Federation,
-            CoreFilesSharingCapabilities_FilesSharing_FederationBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_FederationBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Federation? _$v;
 
   bool? _outgoing;
   bool? get outgoing => _$this._outgoing;
-  set outgoing(bool? outgoing) => _$this._outgoing = outgoing;
+  set outgoing(covariant bool? outgoing) => _$this._outgoing = outgoing;
 
   bool? _incoming;
   bool? get incoming => _$this._incoming;
-  set incoming(bool? incoming) => _$this._incoming = incoming;
+  set incoming(covariant bool? incoming) => _$this._incoming = incoming;
 
   CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder? _expireDate;
   CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder get expireDate =>
       _$this._expireDate ??= CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder();
-  set expireDate(CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder? expireDate) =>
+  set expireDate(covariant CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
   CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder? _expireDateSupported;
   CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder get expireDateSupported =>
       _$this._expireDateSupported ??= CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder();
   set expireDateSupported(
-          CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder? expireDateSupported) =>
+          covariant CoreFilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder?
+              expireDateSupported) =>
       _$this._expireDateSupported = expireDateSupported;
 
   CoreFilesSharingCapabilities_FilesSharing_FederationBuilder();
@@ -15210,7 +16024,7 @@ class CoreFilesSharingCapabilities_FilesSharing_FederationBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Federation other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Federation other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Federation;
   }
@@ -15250,6 +16064,16 @@ class CoreFilesSharingCapabilities_FilesSharing_FederationBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharing_ShareeInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder) updates);
+  bool? get queryLookupDefault;
+  set queryLookupDefault(bool? queryLookupDefault);
+
+  bool? get alwaysShowUnique;
+  set alwaysShowUnique(bool? alwaysShowUnique);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing_Sharee extends CoreFilesSharingCapabilities_FilesSharing_Sharee {
@@ -15309,16 +16133,17 @@ class _$CoreFilesSharingCapabilities_FilesSharing_Sharee extends CoreFilesSharin
 class CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder
     implements
         Builder<CoreFilesSharingCapabilities_FilesSharing_Sharee,
-            CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder> {
+            CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder>,
+        CoreFilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing_Sharee? _$v;
 
   bool? _queryLookupDefault;
   bool? get queryLookupDefault => _$this._queryLookupDefault;
-  set queryLookupDefault(bool? queryLookupDefault) => _$this._queryLookupDefault = queryLookupDefault;
+  set queryLookupDefault(covariant bool? queryLookupDefault) => _$this._queryLookupDefault = queryLookupDefault;
 
   bool? _alwaysShowUnique;
   bool? get alwaysShowUnique => _$this._alwaysShowUnique;
-  set alwaysShowUnique(bool? alwaysShowUnique) => _$this._alwaysShowUnique = alwaysShowUnique;
+  set alwaysShowUnique(covariant bool? alwaysShowUnique) => _$this._alwaysShowUnique = alwaysShowUnique;
 
   CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder();
 
@@ -15333,7 +16158,7 @@ class CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing_Sharee other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing_Sharee other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing_Sharee;
   }
@@ -15356,6 +16181,37 @@ class CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesSharingCapabilities_FilesSharingInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilities_FilesSharingInterface other);
+  void update(void Function(CoreFilesSharingCapabilities_FilesSharingInterfaceBuilder) updates);
+  bool? get apiEnabled;
+  set apiEnabled(bool? apiEnabled);
+
+  CoreFilesSharingCapabilities_FilesSharing_PublicBuilder get public;
+  set public(CoreFilesSharingCapabilities_FilesSharing_PublicBuilder? public);
+
+  CoreFilesSharingCapabilities_FilesSharing_UserBuilder get user;
+  set user(CoreFilesSharingCapabilities_FilesSharing_UserBuilder? user);
+
+  bool? get resharing;
+  set resharing(bool? resharing);
+
+  bool? get groupSharing;
+  set groupSharing(bool? groupSharing);
+
+  CoreFilesSharingCapabilities_FilesSharing_GroupBuilder get group;
+  set group(CoreFilesSharingCapabilities_FilesSharing_GroupBuilder? group);
+
+  int? get defaultPermissions;
+  set defaultPermissions(int? defaultPermissions);
+
+  CoreFilesSharingCapabilities_FilesSharing_FederationBuilder get federation;
+  set federation(CoreFilesSharingCapabilities_FilesSharing_FederationBuilder? federation);
+
+  CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder get sharee;
+  set sharee(CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder? sharee);
 }
 
 class _$CoreFilesSharingCapabilities_FilesSharing extends CoreFilesSharingCapabilities_FilesSharing {
@@ -15458,50 +16314,52 @@ class _$CoreFilesSharingCapabilities_FilesSharing extends CoreFilesSharingCapabi
 }
 
 class CoreFilesSharingCapabilities_FilesSharingBuilder
-    implements Builder<CoreFilesSharingCapabilities_FilesSharing, CoreFilesSharingCapabilities_FilesSharingBuilder> {
+    implements
+        Builder<CoreFilesSharingCapabilities_FilesSharing, CoreFilesSharingCapabilities_FilesSharingBuilder>,
+        CoreFilesSharingCapabilities_FilesSharingInterfaceBuilder {
   _$CoreFilesSharingCapabilities_FilesSharing? _$v;
 
   bool? _apiEnabled;
   bool? get apiEnabled => _$this._apiEnabled;
-  set apiEnabled(bool? apiEnabled) => _$this._apiEnabled = apiEnabled;
+  set apiEnabled(covariant bool? apiEnabled) => _$this._apiEnabled = apiEnabled;
 
   CoreFilesSharingCapabilities_FilesSharing_PublicBuilder? _public;
   CoreFilesSharingCapabilities_FilesSharing_PublicBuilder get public =>
       _$this._public ??= CoreFilesSharingCapabilities_FilesSharing_PublicBuilder();
-  set public(CoreFilesSharingCapabilities_FilesSharing_PublicBuilder? public) => _$this._public = public;
+  set public(covariant CoreFilesSharingCapabilities_FilesSharing_PublicBuilder? public) => _$this._public = public;
 
   CoreFilesSharingCapabilities_FilesSharing_UserBuilder? _user;
   CoreFilesSharingCapabilities_FilesSharing_UserBuilder get user =>
       _$this._user ??= CoreFilesSharingCapabilities_FilesSharing_UserBuilder();
-  set user(CoreFilesSharingCapabilities_FilesSharing_UserBuilder? user) => _$this._user = user;
+  set user(covariant CoreFilesSharingCapabilities_FilesSharing_UserBuilder? user) => _$this._user = user;
 
   bool? _resharing;
   bool? get resharing => _$this._resharing;
-  set resharing(bool? resharing) => _$this._resharing = resharing;
+  set resharing(covariant bool? resharing) => _$this._resharing = resharing;
 
   bool? _groupSharing;
   bool? get groupSharing => _$this._groupSharing;
-  set groupSharing(bool? groupSharing) => _$this._groupSharing = groupSharing;
+  set groupSharing(covariant bool? groupSharing) => _$this._groupSharing = groupSharing;
 
   CoreFilesSharingCapabilities_FilesSharing_GroupBuilder? _group;
   CoreFilesSharingCapabilities_FilesSharing_GroupBuilder get group =>
       _$this._group ??= CoreFilesSharingCapabilities_FilesSharing_GroupBuilder();
-  set group(CoreFilesSharingCapabilities_FilesSharing_GroupBuilder? group) => _$this._group = group;
+  set group(covariant CoreFilesSharingCapabilities_FilesSharing_GroupBuilder? group) => _$this._group = group;
 
   int? _defaultPermissions;
   int? get defaultPermissions => _$this._defaultPermissions;
-  set defaultPermissions(int? defaultPermissions) => _$this._defaultPermissions = defaultPermissions;
+  set defaultPermissions(covariant int? defaultPermissions) => _$this._defaultPermissions = defaultPermissions;
 
   CoreFilesSharingCapabilities_FilesSharing_FederationBuilder? _federation;
   CoreFilesSharingCapabilities_FilesSharing_FederationBuilder get federation =>
       _$this._federation ??= CoreFilesSharingCapabilities_FilesSharing_FederationBuilder();
-  set federation(CoreFilesSharingCapabilities_FilesSharing_FederationBuilder? federation) =>
+  set federation(covariant CoreFilesSharingCapabilities_FilesSharing_FederationBuilder? federation) =>
       _$this._federation = federation;
 
   CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder? _sharee;
   CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder get sharee =>
       _$this._sharee ??= CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder();
-  set sharee(CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder? sharee) => _$this._sharee = sharee;
+  set sharee(covariant CoreFilesSharingCapabilities_FilesSharing_ShareeBuilder? sharee) => _$this._sharee = sharee;
 
   CoreFilesSharingCapabilities_FilesSharingBuilder();
 
@@ -15523,7 +16381,7 @@ class CoreFilesSharingCapabilities_FilesSharingBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities_FilesSharing other) {
+  void replace(covariant CoreFilesSharingCapabilities_FilesSharing other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities_FilesSharing;
   }
@@ -15577,6 +16435,13 @@ class CoreFilesSharingCapabilities_FilesSharingBuilder
   }
 }
 
+abstract mixin class CoreFilesSharingCapabilitiesInterfaceBuilder {
+  void replace(CoreFilesSharingCapabilitiesInterface other);
+  void update(void Function(CoreFilesSharingCapabilitiesInterfaceBuilder) updates);
+  CoreFilesSharingCapabilities_FilesSharingBuilder get filesSharing;
+  set filesSharing(CoreFilesSharingCapabilities_FilesSharingBuilder? filesSharing);
+}
+
 class _$CoreFilesSharingCapabilities extends CoreFilesSharingCapabilities {
   @override
   final CoreFilesSharingCapabilities_FilesSharing filesSharing;
@@ -15616,13 +16481,15 @@ class _$CoreFilesSharingCapabilities extends CoreFilesSharingCapabilities {
 }
 
 class CoreFilesSharingCapabilitiesBuilder
-    implements Builder<CoreFilesSharingCapabilities, CoreFilesSharingCapabilitiesBuilder> {
+    implements
+        Builder<CoreFilesSharingCapabilities, CoreFilesSharingCapabilitiesBuilder>,
+        CoreFilesSharingCapabilitiesInterfaceBuilder {
   _$CoreFilesSharingCapabilities? _$v;
 
   CoreFilesSharingCapabilities_FilesSharingBuilder? _filesSharing;
   CoreFilesSharingCapabilities_FilesSharingBuilder get filesSharing =>
       _$this._filesSharing ??= CoreFilesSharingCapabilities_FilesSharingBuilder();
-  set filesSharing(CoreFilesSharingCapabilities_FilesSharingBuilder? filesSharing) =>
+  set filesSharing(covariant CoreFilesSharingCapabilities_FilesSharingBuilder? filesSharing) =>
       _$this._filesSharing = filesSharing;
 
   CoreFilesSharingCapabilitiesBuilder();
@@ -15637,7 +16504,7 @@ class CoreFilesSharingCapabilitiesBuilder
   }
 
   @override
-  void replace(CoreFilesSharingCapabilities other) {
+  void replace(covariant CoreFilesSharingCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesSharingCapabilities;
   }
@@ -15667,6 +16534,13 @@ class CoreFilesSharingCapabilitiesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesTrashbinCapabilities_FilesInterfaceBuilder {
+  void replace(CoreFilesTrashbinCapabilities_FilesInterface other);
+  void update(void Function(CoreFilesTrashbinCapabilities_FilesInterfaceBuilder) updates);
+  bool? get undelete;
+  set undelete(bool? undelete);
 }
 
 class _$CoreFilesTrashbinCapabilities_Files extends CoreFilesTrashbinCapabilities_Files {
@@ -15708,12 +16582,14 @@ class _$CoreFilesTrashbinCapabilities_Files extends CoreFilesTrashbinCapabilitie
 }
 
 class CoreFilesTrashbinCapabilities_FilesBuilder
-    implements Builder<CoreFilesTrashbinCapabilities_Files, CoreFilesTrashbinCapabilities_FilesBuilder> {
+    implements
+        Builder<CoreFilesTrashbinCapabilities_Files, CoreFilesTrashbinCapabilities_FilesBuilder>,
+        CoreFilesTrashbinCapabilities_FilesInterfaceBuilder {
   _$CoreFilesTrashbinCapabilities_Files? _$v;
 
   bool? _undelete;
   bool? get undelete => _$this._undelete;
-  set undelete(bool? undelete) => _$this._undelete = undelete;
+  set undelete(covariant bool? undelete) => _$this._undelete = undelete;
 
   CoreFilesTrashbinCapabilities_FilesBuilder();
 
@@ -15727,7 +16603,7 @@ class CoreFilesTrashbinCapabilities_FilesBuilder
   }
 
   @override
-  void replace(CoreFilesTrashbinCapabilities_Files other) {
+  void replace(covariant CoreFilesTrashbinCapabilities_Files other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesTrashbinCapabilities_Files;
   }
@@ -15748,6 +16624,13 @@ class CoreFilesTrashbinCapabilities_FilesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesTrashbinCapabilitiesInterfaceBuilder {
+  void replace(CoreFilesTrashbinCapabilitiesInterface other);
+  void update(void Function(CoreFilesTrashbinCapabilitiesInterfaceBuilder) updates);
+  CoreFilesTrashbinCapabilities_FilesBuilder get files;
+  set files(CoreFilesTrashbinCapabilities_FilesBuilder? files);
 }
 
 class _$CoreFilesTrashbinCapabilities extends CoreFilesTrashbinCapabilities {
@@ -15789,13 +16672,15 @@ class _$CoreFilesTrashbinCapabilities extends CoreFilesTrashbinCapabilities {
 }
 
 class CoreFilesTrashbinCapabilitiesBuilder
-    implements Builder<CoreFilesTrashbinCapabilities, CoreFilesTrashbinCapabilitiesBuilder> {
+    implements
+        Builder<CoreFilesTrashbinCapabilities, CoreFilesTrashbinCapabilitiesBuilder>,
+        CoreFilesTrashbinCapabilitiesInterfaceBuilder {
   _$CoreFilesTrashbinCapabilities? _$v;
 
   CoreFilesTrashbinCapabilities_FilesBuilder? _files;
   CoreFilesTrashbinCapabilities_FilesBuilder get files =>
       _$this._files ??= CoreFilesTrashbinCapabilities_FilesBuilder();
-  set files(CoreFilesTrashbinCapabilities_FilesBuilder? files) => _$this._files = files;
+  set files(covariant CoreFilesTrashbinCapabilities_FilesBuilder? files) => _$this._files = files;
 
   CoreFilesTrashbinCapabilitiesBuilder();
 
@@ -15809,7 +16694,7 @@ class CoreFilesTrashbinCapabilitiesBuilder
   }
 
   @override
-  void replace(CoreFilesTrashbinCapabilities other) {
+  void replace(covariant CoreFilesTrashbinCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesTrashbinCapabilities;
   }
@@ -15839,6 +16724,19 @@ class CoreFilesTrashbinCapabilitiesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesVersionsCapabilities_FilesInterfaceBuilder {
+  void replace(CoreFilesVersionsCapabilities_FilesInterface other);
+  void update(void Function(CoreFilesVersionsCapabilities_FilesInterfaceBuilder) updates);
+  bool? get versioning;
+  set versioning(bool? versioning);
+
+  bool? get versionLabeling;
+  set versionLabeling(bool? versionLabeling);
+
+  bool? get versionDeletion;
+  set versionDeletion(bool? versionDeletion);
 }
 
 class _$CoreFilesVersionsCapabilities_Files extends CoreFilesVersionsCapabilities_Files {
@@ -15897,20 +16795,22 @@ class _$CoreFilesVersionsCapabilities_Files extends CoreFilesVersionsCapabilitie
 }
 
 class CoreFilesVersionsCapabilities_FilesBuilder
-    implements Builder<CoreFilesVersionsCapabilities_Files, CoreFilesVersionsCapabilities_FilesBuilder> {
+    implements
+        Builder<CoreFilesVersionsCapabilities_Files, CoreFilesVersionsCapabilities_FilesBuilder>,
+        CoreFilesVersionsCapabilities_FilesInterfaceBuilder {
   _$CoreFilesVersionsCapabilities_Files? _$v;
 
   bool? _versioning;
   bool? get versioning => _$this._versioning;
-  set versioning(bool? versioning) => _$this._versioning = versioning;
+  set versioning(covariant bool? versioning) => _$this._versioning = versioning;
 
   bool? _versionLabeling;
   bool? get versionLabeling => _$this._versionLabeling;
-  set versionLabeling(bool? versionLabeling) => _$this._versionLabeling = versionLabeling;
+  set versionLabeling(covariant bool? versionLabeling) => _$this._versionLabeling = versionLabeling;
 
   bool? _versionDeletion;
   bool? get versionDeletion => _$this._versionDeletion;
-  set versionDeletion(bool? versionDeletion) => _$this._versionDeletion = versionDeletion;
+  set versionDeletion(covariant bool? versionDeletion) => _$this._versionDeletion = versionDeletion;
 
   CoreFilesVersionsCapabilities_FilesBuilder();
 
@@ -15926,7 +16826,7 @@ class CoreFilesVersionsCapabilities_FilesBuilder
   }
 
   @override
-  void replace(CoreFilesVersionsCapabilities_Files other) {
+  void replace(covariant CoreFilesVersionsCapabilities_Files other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesVersionsCapabilities_Files;
   }
@@ -15951,6 +16851,13 @@ class CoreFilesVersionsCapabilities_FilesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreFilesVersionsCapabilitiesInterfaceBuilder {
+  void replace(CoreFilesVersionsCapabilitiesInterface other);
+  void update(void Function(CoreFilesVersionsCapabilitiesInterfaceBuilder) updates);
+  CoreFilesVersionsCapabilities_FilesBuilder get files;
+  set files(CoreFilesVersionsCapabilities_FilesBuilder? files);
 }
 
 class _$CoreFilesVersionsCapabilities extends CoreFilesVersionsCapabilities {
@@ -15992,13 +16899,15 @@ class _$CoreFilesVersionsCapabilities extends CoreFilesVersionsCapabilities {
 }
 
 class CoreFilesVersionsCapabilitiesBuilder
-    implements Builder<CoreFilesVersionsCapabilities, CoreFilesVersionsCapabilitiesBuilder> {
+    implements
+        Builder<CoreFilesVersionsCapabilities, CoreFilesVersionsCapabilitiesBuilder>,
+        CoreFilesVersionsCapabilitiesInterfaceBuilder {
   _$CoreFilesVersionsCapabilities? _$v;
 
   CoreFilesVersionsCapabilities_FilesBuilder? _files;
   CoreFilesVersionsCapabilities_FilesBuilder get files =>
       _$this._files ??= CoreFilesVersionsCapabilities_FilesBuilder();
-  set files(CoreFilesVersionsCapabilities_FilesBuilder? files) => _$this._files = files;
+  set files(covariant CoreFilesVersionsCapabilities_FilesBuilder? files) => _$this._files = files;
 
   CoreFilesVersionsCapabilitiesBuilder();
 
@@ -16012,7 +16921,7 @@ class CoreFilesVersionsCapabilitiesBuilder
   }
 
   @override
-  void replace(CoreFilesVersionsCapabilities other) {
+  void replace(covariant CoreFilesVersionsCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreFilesVersionsCapabilities;
   }
@@ -16042,6 +16951,16 @@ class CoreFilesVersionsCapabilitiesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreNotesCapabilities_NotesInterfaceBuilder {
+  void replace(CoreNotesCapabilities_NotesInterface other);
+  void update(void Function(CoreNotesCapabilities_NotesInterfaceBuilder) updates);
+  ListBuilder<String> get apiVersion;
+  set apiVersion(ListBuilder<String>? apiVersion);
+
+  String? get version;
+  set version(String? version);
 }
 
 class _$CoreNotesCapabilities_Notes extends CoreNotesCapabilities_Notes {
@@ -16087,16 +17006,18 @@ class _$CoreNotesCapabilities_Notes extends CoreNotesCapabilities_Notes {
 }
 
 class CoreNotesCapabilities_NotesBuilder
-    implements Builder<CoreNotesCapabilities_Notes, CoreNotesCapabilities_NotesBuilder> {
+    implements
+        Builder<CoreNotesCapabilities_Notes, CoreNotesCapabilities_NotesBuilder>,
+        CoreNotesCapabilities_NotesInterfaceBuilder {
   _$CoreNotesCapabilities_Notes? _$v;
 
   ListBuilder<String>? _apiVersion;
   ListBuilder<String> get apiVersion => _$this._apiVersion ??= ListBuilder<String>();
-  set apiVersion(ListBuilder<String>? apiVersion) => _$this._apiVersion = apiVersion;
+  set apiVersion(covariant ListBuilder<String>? apiVersion) => _$this._apiVersion = apiVersion;
 
   String? _version;
   String? get version => _$this._version;
-  set version(String? version) => _$this._version = version;
+  set version(covariant String? version) => _$this._version = version;
 
   CoreNotesCapabilities_NotesBuilder();
 
@@ -16111,7 +17032,7 @@ class CoreNotesCapabilities_NotesBuilder
   }
 
   @override
-  void replace(CoreNotesCapabilities_Notes other) {
+  void replace(covariant CoreNotesCapabilities_Notes other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreNotesCapabilities_Notes;
   }
@@ -16141,6 +17062,13 @@ class CoreNotesCapabilities_NotesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreNotesCapabilitiesInterfaceBuilder {
+  void replace(CoreNotesCapabilitiesInterface other);
+  void update(void Function(CoreNotesCapabilitiesInterfaceBuilder) updates);
+  CoreNotesCapabilities_NotesBuilder get notes;
+  set notes(CoreNotesCapabilities_NotesBuilder? notes);
 }
 
 class _$CoreNotesCapabilities extends CoreNotesCapabilities {
@@ -16181,12 +17109,13 @@ class _$CoreNotesCapabilities extends CoreNotesCapabilities {
   }
 }
 
-class CoreNotesCapabilitiesBuilder implements Builder<CoreNotesCapabilities, CoreNotesCapabilitiesBuilder> {
+class CoreNotesCapabilitiesBuilder
+    implements Builder<CoreNotesCapabilities, CoreNotesCapabilitiesBuilder>, CoreNotesCapabilitiesInterfaceBuilder {
   _$CoreNotesCapabilities? _$v;
 
   CoreNotesCapabilities_NotesBuilder? _notes;
   CoreNotesCapabilities_NotesBuilder get notes => _$this._notes ??= CoreNotesCapabilities_NotesBuilder();
-  set notes(CoreNotesCapabilities_NotesBuilder? notes) => _$this._notes = notes;
+  set notes(covariant CoreNotesCapabilities_NotesBuilder? notes) => _$this._notes = notes;
 
   CoreNotesCapabilitiesBuilder();
 
@@ -16200,7 +17129,7 @@ class CoreNotesCapabilitiesBuilder implements Builder<CoreNotesCapabilities, Cor
   }
 
   @override
-  void replace(CoreNotesCapabilities other) {
+  void replace(covariant CoreNotesCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreNotesCapabilities;
   }
@@ -16230,6 +17159,19 @@ class CoreNotesCapabilitiesBuilder implements Builder<CoreNotesCapabilities, Cor
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreNotificationsCapabilities_NotificationsInterfaceBuilder {
+  void replace(CoreNotificationsCapabilities_NotificationsInterface other);
+  void update(void Function(CoreNotificationsCapabilities_NotificationsInterfaceBuilder) updates);
+  ListBuilder<String> get ocsEndpoints;
+  set ocsEndpoints(ListBuilder<String>? ocsEndpoints);
+
+  ListBuilder<String> get push;
+  set push(ListBuilder<String>? push);
+
+  ListBuilder<String> get adminNotifications;
+  set adminNotifications(ListBuilder<String>? adminNotifications);
 }
 
 class _$CoreNotificationsCapabilities_Notifications extends CoreNotificationsCapabilities_Notifications {
@@ -16286,20 +17228,22 @@ class _$CoreNotificationsCapabilities_Notifications extends CoreNotificationsCap
 
 class CoreNotificationsCapabilities_NotificationsBuilder
     implements
-        Builder<CoreNotificationsCapabilities_Notifications, CoreNotificationsCapabilities_NotificationsBuilder> {
+        Builder<CoreNotificationsCapabilities_Notifications, CoreNotificationsCapabilities_NotificationsBuilder>,
+        CoreNotificationsCapabilities_NotificationsInterfaceBuilder {
   _$CoreNotificationsCapabilities_Notifications? _$v;
 
   ListBuilder<String>? _ocsEndpoints;
   ListBuilder<String> get ocsEndpoints => _$this._ocsEndpoints ??= ListBuilder<String>();
-  set ocsEndpoints(ListBuilder<String>? ocsEndpoints) => _$this._ocsEndpoints = ocsEndpoints;
+  set ocsEndpoints(covariant ListBuilder<String>? ocsEndpoints) => _$this._ocsEndpoints = ocsEndpoints;
 
   ListBuilder<String>? _push;
   ListBuilder<String> get push => _$this._push ??= ListBuilder<String>();
-  set push(ListBuilder<String>? push) => _$this._push = push;
+  set push(covariant ListBuilder<String>? push) => _$this._push = push;
 
   ListBuilder<String>? _adminNotifications;
   ListBuilder<String> get adminNotifications => _$this._adminNotifications ??= ListBuilder<String>();
-  set adminNotifications(ListBuilder<String>? adminNotifications) => _$this._adminNotifications = adminNotifications;
+  set adminNotifications(covariant ListBuilder<String>? adminNotifications) =>
+      _$this._adminNotifications = adminNotifications;
 
   CoreNotificationsCapabilities_NotificationsBuilder();
 
@@ -16315,7 +17259,7 @@ class CoreNotificationsCapabilities_NotificationsBuilder
   }
 
   @override
-  void replace(CoreNotificationsCapabilities_Notifications other) {
+  void replace(covariant CoreNotificationsCapabilities_Notifications other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreNotificationsCapabilities_Notifications;
   }
@@ -16353,6 +17297,13 @@ class CoreNotificationsCapabilities_NotificationsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreNotificationsCapabilitiesInterfaceBuilder {
+  void replace(CoreNotificationsCapabilitiesInterface other);
+  void update(void Function(CoreNotificationsCapabilitiesInterfaceBuilder) updates);
+  CoreNotificationsCapabilities_NotificationsBuilder get notifications;
+  set notifications(CoreNotificationsCapabilities_NotificationsBuilder? notifications);
 }
 
 class _$CoreNotificationsCapabilities extends CoreNotificationsCapabilities {
@@ -16395,13 +17346,15 @@ class _$CoreNotificationsCapabilities extends CoreNotificationsCapabilities {
 }
 
 class CoreNotificationsCapabilitiesBuilder
-    implements Builder<CoreNotificationsCapabilities, CoreNotificationsCapabilitiesBuilder> {
+    implements
+        Builder<CoreNotificationsCapabilities, CoreNotificationsCapabilitiesBuilder>,
+        CoreNotificationsCapabilitiesInterfaceBuilder {
   _$CoreNotificationsCapabilities? _$v;
 
   CoreNotificationsCapabilities_NotificationsBuilder? _notifications;
   CoreNotificationsCapabilities_NotificationsBuilder get notifications =>
       _$this._notifications ??= CoreNotificationsCapabilities_NotificationsBuilder();
-  set notifications(CoreNotificationsCapabilities_NotificationsBuilder? notifications) =>
+  set notifications(covariant CoreNotificationsCapabilities_NotificationsBuilder? notifications) =>
       _$this._notifications = notifications;
 
   CoreNotificationsCapabilitiesBuilder();
@@ -16416,7 +17369,7 @@ class CoreNotificationsCapabilitiesBuilder
   }
 
   @override
-  void replace(CoreNotificationsCapabilities other) {
+  void replace(covariant CoreNotificationsCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreNotificationsCapabilities;
   }
@@ -16446,6 +17399,22 @@ class CoreNotificationsCapabilitiesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder {
+  void replace(CoreProvisioningApiCapabilities_ProvisioningApiInterface other);
+  void update(void Function(CoreProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder) updates);
+  String? get version;
+  set version(String? version);
+
+  int? get accountPropertyScopesVersion;
+  set accountPropertyScopesVersion(int? accountPropertyScopesVersion);
+
+  bool? get accountPropertyScopesFederatedEnabled;
+  set accountPropertyScopesFederatedEnabled(bool? accountPropertyScopesFederatedEnabled);
+
+  bool? get accountPropertyScopesPublishedEnabled;
+  set accountPropertyScopesPublishedEnabled(bool? accountPropertyScopesPublishedEnabled);
 }
 
 class _$CoreProvisioningApiCapabilities_ProvisioningApi extends CoreProvisioningApiCapabilities_ProvisioningApi {
@@ -16521,26 +17490,27 @@ class _$CoreProvisioningApiCapabilities_ProvisioningApi extends CoreProvisioning
 class CoreProvisioningApiCapabilities_ProvisioningApiBuilder
     implements
         Builder<CoreProvisioningApiCapabilities_ProvisioningApi,
-            CoreProvisioningApiCapabilities_ProvisioningApiBuilder> {
+            CoreProvisioningApiCapabilities_ProvisioningApiBuilder>,
+        CoreProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder {
   _$CoreProvisioningApiCapabilities_ProvisioningApi? _$v;
 
   String? _version;
   String? get version => _$this._version;
-  set version(String? version) => _$this._version = version;
+  set version(covariant String? version) => _$this._version = version;
 
   int? _accountPropertyScopesVersion;
   int? get accountPropertyScopesVersion => _$this._accountPropertyScopesVersion;
-  set accountPropertyScopesVersion(int? accountPropertyScopesVersion) =>
+  set accountPropertyScopesVersion(covariant int? accountPropertyScopesVersion) =>
       _$this._accountPropertyScopesVersion = accountPropertyScopesVersion;
 
   bool? _accountPropertyScopesFederatedEnabled;
   bool? get accountPropertyScopesFederatedEnabled => _$this._accountPropertyScopesFederatedEnabled;
-  set accountPropertyScopesFederatedEnabled(bool? accountPropertyScopesFederatedEnabled) =>
+  set accountPropertyScopesFederatedEnabled(covariant bool? accountPropertyScopesFederatedEnabled) =>
       _$this._accountPropertyScopesFederatedEnabled = accountPropertyScopesFederatedEnabled;
 
   bool? _accountPropertyScopesPublishedEnabled;
   bool? get accountPropertyScopesPublishedEnabled => _$this._accountPropertyScopesPublishedEnabled;
-  set accountPropertyScopesPublishedEnabled(bool? accountPropertyScopesPublishedEnabled) =>
+  set accountPropertyScopesPublishedEnabled(covariant bool? accountPropertyScopesPublishedEnabled) =>
       _$this._accountPropertyScopesPublishedEnabled = accountPropertyScopesPublishedEnabled;
 
   CoreProvisioningApiCapabilities_ProvisioningApiBuilder();
@@ -16558,7 +17528,7 @@ class CoreProvisioningApiCapabilities_ProvisioningApiBuilder
   }
 
   @override
-  void replace(CoreProvisioningApiCapabilities_ProvisioningApi other) {
+  void replace(covariant CoreProvisioningApiCapabilities_ProvisioningApi other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreProvisioningApiCapabilities_ProvisioningApi;
   }
@@ -16589,6 +17559,13 @@ class CoreProvisioningApiCapabilities_ProvisioningApiBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreProvisioningApiCapabilitiesInterfaceBuilder {
+  void replace(CoreProvisioningApiCapabilitiesInterface other);
+  void update(void Function(CoreProvisioningApiCapabilitiesInterfaceBuilder) updates);
+  CoreProvisioningApiCapabilities_ProvisioningApiBuilder get provisioningApi;
+  set provisioningApi(CoreProvisioningApiCapabilities_ProvisioningApiBuilder? provisioningApi);
 }
 
 class _$CoreProvisioningApiCapabilities extends CoreProvisioningApiCapabilities {
@@ -16631,13 +17608,15 @@ class _$CoreProvisioningApiCapabilities extends CoreProvisioningApiCapabilities 
 }
 
 class CoreProvisioningApiCapabilitiesBuilder
-    implements Builder<CoreProvisioningApiCapabilities, CoreProvisioningApiCapabilitiesBuilder> {
+    implements
+        Builder<CoreProvisioningApiCapabilities, CoreProvisioningApiCapabilitiesBuilder>,
+        CoreProvisioningApiCapabilitiesInterfaceBuilder {
   _$CoreProvisioningApiCapabilities? _$v;
 
   CoreProvisioningApiCapabilities_ProvisioningApiBuilder? _provisioningApi;
   CoreProvisioningApiCapabilities_ProvisioningApiBuilder get provisioningApi =>
       _$this._provisioningApi ??= CoreProvisioningApiCapabilities_ProvisioningApiBuilder();
-  set provisioningApi(CoreProvisioningApiCapabilities_ProvisioningApiBuilder? provisioningApi) =>
+  set provisioningApi(covariant CoreProvisioningApiCapabilities_ProvisioningApiBuilder? provisioningApi) =>
       _$this._provisioningApi = provisioningApi;
 
   CoreProvisioningApiCapabilitiesBuilder();
@@ -16652,7 +17631,7 @@ class CoreProvisioningApiCapabilitiesBuilder
   }
 
   @override
-  void replace(CoreProvisioningApiCapabilities other) {
+  void replace(covariant CoreProvisioningApiCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreProvisioningApiCapabilities;
   }
@@ -16682,6 +17661,14 @@ class CoreProvisioningApiCapabilitiesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder {
+  void replace(CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterface other);
+  void update(
+      void Function(CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
 }
 
 class _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop
@@ -16732,12 +17719,13 @@ class _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop
 class CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder
     implements
         Builder<CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop,
-            CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder> {
+            CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder>,
+        CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder {
   _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder();
 
@@ -16751,7 +17739,7 @@ class CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilde
   }
 
   @override
-  void replace(CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop other) {
+  void replace(covariant CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop;
   }
@@ -16772,6 +17760,16 @@ class CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterfaceBuilder {
+  void replace(CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterface other);
+  void update(void Function(CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  bool? get enforced;
+  set enforced(bool? enforced);
 }
 
 class _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password
@@ -16831,16 +17829,17 @@ class _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password
 class CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder
     implements
         Builder<CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password,
-            CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder> {
+            CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder>,
+        CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterfaceBuilder {
   _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder();
 
@@ -16855,7 +17854,7 @@ class CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder
   }
 
   @override
-  void replace(CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password other) {
+  void replace(covariant CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_Password;
   }
@@ -16878,6 +17877,16 @@ class CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder {
+  void replace(CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterface other);
+  void update(void Function(CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  bool? get enforced;
+  set enforced(bool? enforced);
 }
 
 class _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate
@@ -16937,16 +17946,17 @@ class _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate
 class CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder
     implements
         Builder<CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate,
-            CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder> {
+            CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder>,
+        CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder {
   _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder();
 
@@ -16961,7 +17971,7 @@ class CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder
   }
 
   @override
-  void replace(CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate other) {
+  void replace(covariant CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate;
   }
@@ -16984,6 +17994,25 @@ class CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreSharebymailCapabilities_FilesSharing_SharebymailInterfaceBuilder {
+  void replace(CoreSharebymailCapabilities_FilesSharing_SharebymailInterface other);
+  void update(void Function(CoreSharebymailCapabilities_FilesSharing_SharebymailInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  bool? get sendPasswordByMail;
+  set sendPasswordByMail(bool? sendPasswordByMail);
+
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder get uploadFilesDrop;
+  set uploadFilesDrop(CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder? uploadFilesDrop);
+
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder get password;
+  set password(CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder? password);
+
+  CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder get expireDate;
+  set expireDate(CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder? expireDate);
 }
 
 class _$CoreSharebymailCapabilities_FilesSharing_Sharebymail
@@ -17068,33 +18097,35 @@ class _$CoreSharebymailCapabilities_FilesSharing_Sharebymail
 class CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder
     implements
         Builder<CoreSharebymailCapabilities_FilesSharing_Sharebymail,
-            CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder> {
+            CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder>,
+        CoreSharebymailCapabilities_FilesSharing_SharebymailInterfaceBuilder {
   _$CoreSharebymailCapabilities_FilesSharing_Sharebymail? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   bool? _sendPasswordByMail;
   bool? get sendPasswordByMail => _$this._sendPasswordByMail;
-  set sendPasswordByMail(bool? sendPasswordByMail) => _$this._sendPasswordByMail = sendPasswordByMail;
+  set sendPasswordByMail(covariant bool? sendPasswordByMail) => _$this._sendPasswordByMail = sendPasswordByMail;
 
   CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder? _uploadFilesDrop;
   CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder get uploadFilesDrop =>
       _$this._uploadFilesDrop ??= CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder();
-  set uploadFilesDrop(CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder? uploadFilesDrop) =>
+  set uploadFilesDrop(
+          covariant CoreSharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder? uploadFilesDrop) =>
       _$this._uploadFilesDrop = uploadFilesDrop;
 
   CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder? _password;
   CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder get password =>
       _$this._password ??= CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder();
-  set password(CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder? password) =>
+  set password(covariant CoreSharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder? password) =>
       _$this._password = password;
 
   CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder? _expireDate;
   CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder get expireDate =>
       _$this._expireDate ??= CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder();
-  set expireDate(CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder? expireDate) =>
+  set expireDate(covariant CoreSharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
   CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder();
@@ -17113,7 +18144,7 @@ class CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder
   }
 
   @override
-  void replace(CoreSharebymailCapabilities_FilesSharing_Sharebymail other) {
+  void replace(covariant CoreSharebymailCapabilities_FilesSharing_Sharebymail other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreSharebymailCapabilities_FilesSharing_Sharebymail;
   }
@@ -17156,6 +18187,13 @@ class CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreSharebymailCapabilities_FilesSharingInterfaceBuilder {
+  void replace(CoreSharebymailCapabilities_FilesSharingInterface other);
+  void update(void Function(CoreSharebymailCapabilities_FilesSharingInterfaceBuilder) updates);
+  CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder get sharebymail;
+  set sharebymail(CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder? sharebymail);
 }
 
 class _$CoreSharebymailCapabilities_FilesSharing extends CoreSharebymailCapabilities_FilesSharing {
@@ -17201,13 +18239,15 @@ class _$CoreSharebymailCapabilities_FilesSharing extends CoreSharebymailCapabili
 }
 
 class CoreSharebymailCapabilities_FilesSharingBuilder
-    implements Builder<CoreSharebymailCapabilities_FilesSharing, CoreSharebymailCapabilities_FilesSharingBuilder> {
+    implements
+        Builder<CoreSharebymailCapabilities_FilesSharing, CoreSharebymailCapabilities_FilesSharingBuilder>,
+        CoreSharebymailCapabilities_FilesSharingInterfaceBuilder {
   _$CoreSharebymailCapabilities_FilesSharing? _$v;
 
   CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder? _sharebymail;
   CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder get sharebymail =>
       _$this._sharebymail ??= CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder();
-  set sharebymail(CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder? sharebymail) =>
+  set sharebymail(covariant CoreSharebymailCapabilities_FilesSharing_SharebymailBuilder? sharebymail) =>
       _$this._sharebymail = sharebymail;
 
   CoreSharebymailCapabilities_FilesSharingBuilder();
@@ -17222,7 +18262,7 @@ class CoreSharebymailCapabilities_FilesSharingBuilder
   }
 
   @override
-  void replace(CoreSharebymailCapabilities_FilesSharing other) {
+  void replace(covariant CoreSharebymailCapabilities_FilesSharing other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreSharebymailCapabilities_FilesSharing;
   }
@@ -17252,6 +18292,13 @@ class CoreSharebymailCapabilities_FilesSharingBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreSharebymailCapabilitiesInterfaceBuilder {
+  void replace(CoreSharebymailCapabilitiesInterface other);
+  void update(void Function(CoreSharebymailCapabilitiesInterfaceBuilder) updates);
+  CoreSharebymailCapabilities_FilesSharingBuilder get filesSharing;
+  set filesSharing(CoreSharebymailCapabilities_FilesSharingBuilder? filesSharing);
 }
 
 class _$CoreSharebymailCapabilities extends CoreSharebymailCapabilities {
@@ -17293,13 +18340,15 @@ class _$CoreSharebymailCapabilities extends CoreSharebymailCapabilities {
 }
 
 class CoreSharebymailCapabilitiesBuilder
-    implements Builder<CoreSharebymailCapabilities, CoreSharebymailCapabilitiesBuilder> {
+    implements
+        Builder<CoreSharebymailCapabilities, CoreSharebymailCapabilitiesBuilder>,
+        CoreSharebymailCapabilitiesInterfaceBuilder {
   _$CoreSharebymailCapabilities? _$v;
 
   CoreSharebymailCapabilities_FilesSharingBuilder? _filesSharing;
   CoreSharebymailCapabilities_FilesSharingBuilder get filesSharing =>
       _$this._filesSharing ??= CoreSharebymailCapabilities_FilesSharingBuilder();
-  set filesSharing(CoreSharebymailCapabilities_FilesSharingBuilder? filesSharing) =>
+  set filesSharing(covariant CoreSharebymailCapabilities_FilesSharingBuilder? filesSharing) =>
       _$this._filesSharing = filesSharing;
 
   CoreSharebymailCapabilitiesBuilder();
@@ -17314,7 +18363,7 @@ class CoreSharebymailCapabilitiesBuilder
   }
 
   @override
-  void replace(CoreSharebymailCapabilities other) {
+  void replace(covariant CoreSharebymailCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreSharebymailCapabilities;
   }
@@ -17344,6 +18393,52 @@ class CoreSharebymailCapabilitiesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreThemingPublicCapabilities_ThemingInterfaceBuilder {
+  void replace(CoreThemingPublicCapabilities_ThemingInterface other);
+  void update(void Function(CoreThemingPublicCapabilities_ThemingInterfaceBuilder) updates);
+  String? get name;
+  set name(String? name);
+
+  String? get url;
+  set url(String? url);
+
+  String? get slogan;
+  set slogan(String? slogan);
+
+  String? get color;
+  set color(String? color);
+
+  String? get colorText;
+  set colorText(String? colorText);
+
+  String? get colorElement;
+  set colorElement(String? colorElement);
+
+  String? get colorElementBright;
+  set colorElementBright(String? colorElementBright);
+
+  String? get colorElementDark;
+  set colorElementDark(String? colorElementDark);
+
+  String? get logo;
+  set logo(String? logo);
+
+  String? get background;
+  set background(String? background);
+
+  bool? get backgroundPlain;
+  set backgroundPlain(bool? backgroundPlain);
+
+  bool? get backgroundDefault;
+  set backgroundDefault(bool? backgroundDefault);
+
+  String? get logoheader;
+  set logoheader(String? logoheader);
+
+  String? get favicon;
+  set favicon(String? favicon);
 }
 
 class _$CoreThemingPublicCapabilities_Theming extends CoreThemingPublicCapabilities_Theming {
@@ -17486,64 +18581,66 @@ class _$CoreThemingPublicCapabilities_Theming extends CoreThemingPublicCapabilit
 }
 
 class CoreThemingPublicCapabilities_ThemingBuilder
-    implements Builder<CoreThemingPublicCapabilities_Theming, CoreThemingPublicCapabilities_ThemingBuilder> {
+    implements
+        Builder<CoreThemingPublicCapabilities_Theming, CoreThemingPublicCapabilities_ThemingBuilder>,
+        CoreThemingPublicCapabilities_ThemingInterfaceBuilder {
   _$CoreThemingPublicCapabilities_Theming? _$v;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   String? _url;
   String? get url => _$this._url;
-  set url(String? url) => _$this._url = url;
+  set url(covariant String? url) => _$this._url = url;
 
   String? _slogan;
   String? get slogan => _$this._slogan;
-  set slogan(String? slogan) => _$this._slogan = slogan;
+  set slogan(covariant String? slogan) => _$this._slogan = slogan;
 
   String? _color;
   String? get color => _$this._color;
-  set color(String? color) => _$this._color = color;
+  set color(covariant String? color) => _$this._color = color;
 
   String? _colorText;
   String? get colorText => _$this._colorText;
-  set colorText(String? colorText) => _$this._colorText = colorText;
+  set colorText(covariant String? colorText) => _$this._colorText = colorText;
 
   String? _colorElement;
   String? get colorElement => _$this._colorElement;
-  set colorElement(String? colorElement) => _$this._colorElement = colorElement;
+  set colorElement(covariant String? colorElement) => _$this._colorElement = colorElement;
 
   String? _colorElementBright;
   String? get colorElementBright => _$this._colorElementBright;
-  set colorElementBright(String? colorElementBright) => _$this._colorElementBright = colorElementBright;
+  set colorElementBright(covariant String? colorElementBright) => _$this._colorElementBright = colorElementBright;
 
   String? _colorElementDark;
   String? get colorElementDark => _$this._colorElementDark;
-  set colorElementDark(String? colorElementDark) => _$this._colorElementDark = colorElementDark;
+  set colorElementDark(covariant String? colorElementDark) => _$this._colorElementDark = colorElementDark;
 
   String? _logo;
   String? get logo => _$this._logo;
-  set logo(String? logo) => _$this._logo = logo;
+  set logo(covariant String? logo) => _$this._logo = logo;
 
   String? _background;
   String? get background => _$this._background;
-  set background(String? background) => _$this._background = background;
+  set background(covariant String? background) => _$this._background = background;
 
   bool? _backgroundPlain;
   bool? get backgroundPlain => _$this._backgroundPlain;
-  set backgroundPlain(bool? backgroundPlain) => _$this._backgroundPlain = backgroundPlain;
+  set backgroundPlain(covariant bool? backgroundPlain) => _$this._backgroundPlain = backgroundPlain;
 
   bool? _backgroundDefault;
   bool? get backgroundDefault => _$this._backgroundDefault;
-  set backgroundDefault(bool? backgroundDefault) => _$this._backgroundDefault = backgroundDefault;
+  set backgroundDefault(covariant bool? backgroundDefault) => _$this._backgroundDefault = backgroundDefault;
 
   String? _logoheader;
   String? get logoheader => _$this._logoheader;
-  set logoheader(String? logoheader) => _$this._logoheader = logoheader;
+  set logoheader(covariant String? logoheader) => _$this._logoheader = logoheader;
 
   String? _favicon;
   String? get favicon => _$this._favicon;
-  set favicon(String? favicon) => _$this._favicon = favicon;
+  set favicon(covariant String? favicon) => _$this._favicon = favicon;
 
   CoreThemingPublicCapabilities_ThemingBuilder();
 
@@ -17570,7 +18667,7 @@ class CoreThemingPublicCapabilities_ThemingBuilder
   }
 
   @override
-  void replace(CoreThemingPublicCapabilities_Theming other) {
+  void replace(covariant CoreThemingPublicCapabilities_Theming other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreThemingPublicCapabilities_Theming;
   }
@@ -17614,6 +18711,13 @@ class CoreThemingPublicCapabilities_ThemingBuilder
   }
 }
 
+abstract mixin class CoreThemingPublicCapabilitiesInterfaceBuilder {
+  void replace(CoreThemingPublicCapabilitiesInterface other);
+  void update(void Function(CoreThemingPublicCapabilitiesInterfaceBuilder) updates);
+  CoreThemingPublicCapabilities_ThemingBuilder get theming;
+  set theming(CoreThemingPublicCapabilities_ThemingBuilder? theming);
+}
+
 class _$CoreThemingPublicCapabilities extends CoreThemingPublicCapabilities {
   @override
   final CoreThemingPublicCapabilities_Theming theming;
@@ -17653,13 +18757,15 @@ class _$CoreThemingPublicCapabilities extends CoreThemingPublicCapabilities {
 }
 
 class CoreThemingPublicCapabilitiesBuilder
-    implements Builder<CoreThemingPublicCapabilities, CoreThemingPublicCapabilitiesBuilder> {
+    implements
+        Builder<CoreThemingPublicCapabilities, CoreThemingPublicCapabilitiesBuilder>,
+        CoreThemingPublicCapabilitiesInterfaceBuilder {
   _$CoreThemingPublicCapabilities? _$v;
 
   CoreThemingPublicCapabilities_ThemingBuilder? _theming;
   CoreThemingPublicCapabilities_ThemingBuilder get theming =>
       _$this._theming ??= CoreThemingPublicCapabilities_ThemingBuilder();
-  set theming(CoreThemingPublicCapabilities_ThemingBuilder? theming) => _$this._theming = theming;
+  set theming(covariant CoreThemingPublicCapabilities_ThemingBuilder? theming) => _$this._theming = theming;
 
   CoreThemingPublicCapabilitiesBuilder();
 
@@ -17673,7 +18779,7 @@ class CoreThemingPublicCapabilitiesBuilder
   }
 
   @override
-  void replace(CoreThemingPublicCapabilities other) {
+  void replace(covariant CoreThemingPublicCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreThemingPublicCapabilities;
   }
@@ -17703,6 +18809,19 @@ class CoreThemingPublicCapabilitiesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreUserStatusCapabilities_UserStatusInterfaceBuilder {
+  void replace(CoreUserStatusCapabilities_UserStatusInterface other);
+  void update(void Function(CoreUserStatusCapabilities_UserStatusInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  bool? get restore;
+  set restore(bool? restore);
+
+  bool? get supportsEmoji;
+  set supportsEmoji(bool? supportsEmoji);
 }
 
 class _$CoreUserStatusCapabilities_UserStatus extends CoreUserStatusCapabilities_UserStatus {
@@ -17762,20 +18881,22 @@ class _$CoreUserStatusCapabilities_UserStatus extends CoreUserStatusCapabilities
 }
 
 class CoreUserStatusCapabilities_UserStatusBuilder
-    implements Builder<CoreUserStatusCapabilities_UserStatus, CoreUserStatusCapabilities_UserStatusBuilder> {
+    implements
+        Builder<CoreUserStatusCapabilities_UserStatus, CoreUserStatusCapabilities_UserStatusBuilder>,
+        CoreUserStatusCapabilities_UserStatusInterfaceBuilder {
   _$CoreUserStatusCapabilities_UserStatus? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   bool? _restore;
   bool? get restore => _$this._restore;
-  set restore(bool? restore) => _$this._restore = restore;
+  set restore(covariant bool? restore) => _$this._restore = restore;
 
   bool? _supportsEmoji;
   bool? get supportsEmoji => _$this._supportsEmoji;
-  set supportsEmoji(bool? supportsEmoji) => _$this._supportsEmoji = supportsEmoji;
+  set supportsEmoji(covariant bool? supportsEmoji) => _$this._supportsEmoji = supportsEmoji;
 
   CoreUserStatusCapabilities_UserStatusBuilder();
 
@@ -17791,7 +18912,7 @@ class CoreUserStatusCapabilities_UserStatusBuilder
   }
 
   @override
-  void replace(CoreUserStatusCapabilities_UserStatus other) {
+  void replace(covariant CoreUserStatusCapabilities_UserStatus other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreUserStatusCapabilities_UserStatus;
   }
@@ -17816,6 +18937,13 @@ class CoreUserStatusCapabilities_UserStatusBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreUserStatusCapabilitiesInterfaceBuilder {
+  void replace(CoreUserStatusCapabilitiesInterface other);
+  void update(void Function(CoreUserStatusCapabilitiesInterfaceBuilder) updates);
+  CoreUserStatusCapabilities_UserStatusBuilder get userStatus;
+  set userStatus(CoreUserStatusCapabilities_UserStatusBuilder? userStatus);
 }
 
 class _$CoreUserStatusCapabilities extends CoreUserStatusCapabilities {
@@ -17857,13 +18985,15 @@ class _$CoreUserStatusCapabilities extends CoreUserStatusCapabilities {
 }
 
 class CoreUserStatusCapabilitiesBuilder
-    implements Builder<CoreUserStatusCapabilities, CoreUserStatusCapabilitiesBuilder> {
+    implements
+        Builder<CoreUserStatusCapabilities, CoreUserStatusCapabilitiesBuilder>,
+        CoreUserStatusCapabilitiesInterfaceBuilder {
   _$CoreUserStatusCapabilities? _$v;
 
   CoreUserStatusCapabilities_UserStatusBuilder? _userStatus;
   CoreUserStatusCapabilities_UserStatusBuilder get userStatus =>
       _$this._userStatus ??= CoreUserStatusCapabilities_UserStatusBuilder();
-  set userStatus(CoreUserStatusCapabilities_UserStatusBuilder? userStatus) => _$this._userStatus = userStatus;
+  set userStatus(covariant CoreUserStatusCapabilities_UserStatusBuilder? userStatus) => _$this._userStatus = userStatus;
 
   CoreUserStatusCapabilitiesBuilder();
 
@@ -17877,7 +19007,7 @@ class CoreUserStatusCapabilitiesBuilder
   }
 
   @override
-  void replace(CoreUserStatusCapabilities other) {
+  void replace(covariant CoreUserStatusCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreUserStatusCapabilities;
   }
@@ -17907,6 +19037,13 @@ class CoreUserStatusCapabilitiesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreWeatherStatusCapabilities_WeatherStatusInterfaceBuilder {
+  void replace(CoreWeatherStatusCapabilities_WeatherStatusInterface other);
+  void update(void Function(CoreWeatherStatusCapabilities_WeatherStatusInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
 }
 
 class _$CoreWeatherStatusCapabilities_WeatherStatus extends CoreWeatherStatusCapabilities_WeatherStatus {
@@ -17953,12 +19090,13 @@ class _$CoreWeatherStatusCapabilities_WeatherStatus extends CoreWeatherStatusCap
 
 class CoreWeatherStatusCapabilities_WeatherStatusBuilder
     implements
-        Builder<CoreWeatherStatusCapabilities_WeatherStatus, CoreWeatherStatusCapabilities_WeatherStatusBuilder> {
+        Builder<CoreWeatherStatusCapabilities_WeatherStatus, CoreWeatherStatusCapabilities_WeatherStatusBuilder>,
+        CoreWeatherStatusCapabilities_WeatherStatusInterfaceBuilder {
   _$CoreWeatherStatusCapabilities_WeatherStatus? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   CoreWeatherStatusCapabilities_WeatherStatusBuilder();
 
@@ -17972,7 +19110,7 @@ class CoreWeatherStatusCapabilities_WeatherStatusBuilder
   }
 
   @override
-  void replace(CoreWeatherStatusCapabilities_WeatherStatus other) {
+  void replace(covariant CoreWeatherStatusCapabilities_WeatherStatus other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreWeatherStatusCapabilities_WeatherStatus;
   }
@@ -17993,6 +19131,13 @@ class CoreWeatherStatusCapabilities_WeatherStatusBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreWeatherStatusCapabilitiesInterfaceBuilder {
+  void replace(CoreWeatherStatusCapabilitiesInterface other);
+  void update(void Function(CoreWeatherStatusCapabilitiesInterfaceBuilder) updates);
+  CoreWeatherStatusCapabilities_WeatherStatusBuilder get weatherStatus;
+  set weatherStatus(CoreWeatherStatusCapabilities_WeatherStatusBuilder? weatherStatus);
 }
 
 class _$CoreWeatherStatusCapabilities extends CoreWeatherStatusCapabilities {
@@ -18035,13 +19180,15 @@ class _$CoreWeatherStatusCapabilities extends CoreWeatherStatusCapabilities {
 }
 
 class CoreWeatherStatusCapabilitiesBuilder
-    implements Builder<CoreWeatherStatusCapabilities, CoreWeatherStatusCapabilitiesBuilder> {
+    implements
+        Builder<CoreWeatherStatusCapabilities, CoreWeatherStatusCapabilitiesBuilder>,
+        CoreWeatherStatusCapabilitiesInterfaceBuilder {
   _$CoreWeatherStatusCapabilities? _$v;
 
   CoreWeatherStatusCapabilities_WeatherStatusBuilder? _weatherStatus;
   CoreWeatherStatusCapabilities_WeatherStatusBuilder get weatherStatus =>
       _$this._weatherStatus ??= CoreWeatherStatusCapabilities_WeatherStatusBuilder();
-  set weatherStatus(CoreWeatherStatusCapabilities_WeatherStatusBuilder? weatherStatus) =>
+  set weatherStatus(covariant CoreWeatherStatusCapabilities_WeatherStatusBuilder? weatherStatus) =>
       _$this._weatherStatus = weatherStatus;
 
   CoreWeatherStatusCapabilitiesBuilder();
@@ -18056,7 +19203,7 @@ class CoreWeatherStatusCapabilitiesBuilder
   }
 
   @override
-  void replace(CoreWeatherStatusCapabilities other) {
+  void replace(covariant CoreWeatherStatusCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreWeatherStatusCapabilities;
   }
@@ -18396,6 +19543,16 @@ class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_CapabilitiesBuil
   }
 }
 
+abstract mixin class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder get version;
+  set version(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder? version);
+
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_CapabilitiesBuilder get capabilities;
+  set capabilities(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_CapabilitiesBuilder? capabilities);
+}
+
 class _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data
     extends CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data {
   @override
@@ -18453,19 +19610,21 @@ class _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data
 class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data,
-            CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data? _$v;
 
   CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder? _version;
   CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder get version =>
       _$this._version ??= CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder();
-  set version(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder? version) =>
+  set version(covariant CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_VersionBuilder? version) =>
       _$this._version = version;
 
   CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_CapabilitiesBuilder? _capabilities;
   CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_CapabilitiesBuilder get capabilities =>
       _$this._capabilities ??= CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_CapabilitiesBuilder();
-  set capabilities(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_CapabilitiesBuilder? capabilities) =>
+  set capabilities(
+          covariant CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data_CapabilitiesBuilder? capabilities) =>
       _$this._capabilities = capabilities;
 
   CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder();
@@ -18481,7 +19640,7 @@ class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_Data;
   }
@@ -18516,6 +19675,16 @@ class CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs
@@ -18570,17 +19739,18 @@ class _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs
 class CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs,
-            CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder> {
+            CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder>,
+        CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder();
 
@@ -18595,7 +19765,7 @@ class CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreOcsGetCapabilitiesResponse200ApplicationJson_Ocs;
   }
@@ -18629,6 +19799,13 @@ class CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreOcsGetCapabilitiesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreOcsGetCapabilitiesResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreOcsGetCapabilitiesResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreOcsGetCapabilitiesResponse200ApplicationJson extends CoreOcsGetCapabilitiesResponse200ApplicationJson {
@@ -18676,13 +19853,14 @@ class _$CoreOcsGetCapabilitiesResponse200ApplicationJson extends CoreOcsGetCapab
 class CoreOcsGetCapabilitiesResponse200ApplicationJsonBuilder
     implements
         Builder<CoreOcsGetCapabilitiesResponse200ApplicationJson,
-            CoreOcsGetCapabilitiesResponse200ApplicationJsonBuilder> {
+            CoreOcsGetCapabilitiesResponse200ApplicationJsonBuilder>,
+        CoreOcsGetCapabilitiesResponse200ApplicationJsonInterfaceBuilder {
   _$CoreOcsGetCapabilitiesResponse200ApplicationJson? _$v;
 
   CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreOcsGetCapabilitiesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreOcsGetCapabilitiesResponse200ApplicationJsonBuilder();
 
@@ -18696,7 +19874,7 @@ class CoreOcsGetCapabilitiesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreOcsGetCapabilitiesResponse200ApplicationJson other) {
+  void replace(covariant CoreOcsGetCapabilitiesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreOcsGetCapabilitiesResponse200ApplicationJson;
   }
@@ -18727,6 +19905,16 @@ class CoreOcsGetCapabilitiesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs
@@ -18783,16 +19971,17 @@ class _$CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs
 class CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs,
-            CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder> {
+            CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder>,
+        CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder();
 
@@ -18807,7 +19996,7 @@ class CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreProfileApiSetVisibilityResponse200ApplicationJson_Ocs;
   }
@@ -18842,6 +20031,13 @@ class CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreProfileApiSetVisibilityResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreProfileApiSetVisibilityResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreProfileApiSetVisibilityResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreProfileApiSetVisibilityResponse200ApplicationJson
@@ -18890,13 +20086,14 @@ class _$CoreProfileApiSetVisibilityResponse200ApplicationJson
 class CoreProfileApiSetVisibilityResponse200ApplicationJsonBuilder
     implements
         Builder<CoreProfileApiSetVisibilityResponse200ApplicationJson,
-            CoreProfileApiSetVisibilityResponse200ApplicationJsonBuilder> {
+            CoreProfileApiSetVisibilityResponse200ApplicationJsonBuilder>,
+        CoreProfileApiSetVisibilityResponse200ApplicationJsonInterfaceBuilder {
   _$CoreProfileApiSetVisibilityResponse200ApplicationJson? _$v;
 
   CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreProfileApiSetVisibilityResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreProfileApiSetVisibilityResponse200ApplicationJsonBuilder();
 
@@ -18910,7 +20107,7 @@ class CoreProfileApiSetVisibilityResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreProfileApiSetVisibilityResponse200ApplicationJson other) {
+  void replace(covariant CoreProfileApiSetVisibilityResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreProfileApiSetVisibilityResponse200ApplicationJson;
   }
@@ -18941,6 +20138,22 @@ class CoreProfileApiSetVisibilityResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceInterfaceBuilder {
+  void replace(CoreReferenceInterface other);
+  void update(void Function(CoreReferenceInterfaceBuilder) updates);
+  String? get richObjectType;
+  set richObjectType(String? richObjectType);
+
+  MapBuilder<String, JsonObject> get richObject;
+  set richObject(MapBuilder<String, JsonObject>? richObject);
+
+  CoreOpenGraphObjectBuilder get openGraphObject;
+  set openGraphObject(CoreOpenGraphObjectBuilder? openGraphObject);
+
+  bool? get accessible;
+  set accessible(bool? accessible);
 }
 
 class _$CoreReference extends CoreReference {
@@ -19003,24 +20216,25 @@ class _$CoreReference extends CoreReference {
   }
 }
 
-class CoreReferenceBuilder implements Builder<CoreReference, CoreReferenceBuilder> {
+class CoreReferenceBuilder implements Builder<CoreReference, CoreReferenceBuilder>, CoreReferenceInterfaceBuilder {
   _$CoreReference? _$v;
 
   String? _richObjectType;
   String? get richObjectType => _$this._richObjectType;
-  set richObjectType(String? richObjectType) => _$this._richObjectType = richObjectType;
+  set richObjectType(covariant String? richObjectType) => _$this._richObjectType = richObjectType;
 
   MapBuilder<String, JsonObject>? _richObject;
   MapBuilder<String, JsonObject> get richObject => _$this._richObject ??= MapBuilder<String, JsonObject>();
-  set richObject(MapBuilder<String, JsonObject>? richObject) => _$this._richObject = richObject;
+  set richObject(covariant MapBuilder<String, JsonObject>? richObject) => _$this._richObject = richObject;
 
   CoreOpenGraphObjectBuilder? _openGraphObject;
   CoreOpenGraphObjectBuilder get openGraphObject => _$this._openGraphObject ??= CoreOpenGraphObjectBuilder();
-  set openGraphObject(CoreOpenGraphObjectBuilder? openGraphObject) => _$this._openGraphObject = openGraphObject;
+  set openGraphObject(covariant CoreOpenGraphObjectBuilder? openGraphObject) =>
+      _$this._openGraphObject = openGraphObject;
 
   bool? _accessible;
   bool? get accessible => _$this._accessible;
-  set accessible(bool? accessible) => _$this._accessible = accessible;
+  set accessible(covariant bool? accessible) => _$this._accessible = accessible;
 
   CoreReferenceBuilder();
 
@@ -19037,7 +20251,7 @@ class CoreReferenceBuilder implements Builder<CoreReference, CoreReferenceBuilde
   }
 
   @override
-  void replace(CoreReference other) {
+  void replace(covariant CoreReference other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReference;
   }
@@ -19074,6 +20288,13 @@ class CoreReferenceBuilder implements Builder<CoreReference, CoreReferenceBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  MapBuilder<String, CoreReference> get references;
+  set references(MapBuilder<String, CoreReference>? references);
 }
 
 class _$CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data
@@ -19124,12 +20345,13 @@ class _$CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data
 class CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data,
-            CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data? _$v;
 
   MapBuilder<String, CoreReference>? _references;
   MapBuilder<String, CoreReference> get references => _$this._references ??= MapBuilder<String, CoreReference>();
-  set references(MapBuilder<String, CoreReference>? references) => _$this._references = references;
+  set references(covariant MapBuilder<String, CoreReference>? references) => _$this._references = references;
 
   CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -19143,7 +20365,7 @@ class CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_Data;
   }
@@ -19175,6 +20397,16 @@ class CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiResolveOneResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreReferenceApiResolveOneResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreReferenceApiResolveOneResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs
@@ -19231,17 +20463,18 @@ class _$CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs
 class CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs,
-            CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder> {
+            CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder>,
+        CoreReferenceApiResolveOneResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder();
 
@@ -19256,7 +20489,7 @@ class CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiResolveOneResponse200ApplicationJson_Ocs;
   }
@@ -19290,6 +20523,13 @@ class CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiResolveOneResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreReferenceApiResolveOneResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreReferenceApiResolveOneResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreReferenceApiResolveOneResponse200ApplicationJson
@@ -19338,13 +20578,14 @@ class _$CoreReferenceApiResolveOneResponse200ApplicationJson
 class CoreReferenceApiResolveOneResponse200ApplicationJsonBuilder
     implements
         Builder<CoreReferenceApiResolveOneResponse200ApplicationJson,
-            CoreReferenceApiResolveOneResponse200ApplicationJsonBuilder> {
+            CoreReferenceApiResolveOneResponse200ApplicationJsonBuilder>,
+        CoreReferenceApiResolveOneResponse200ApplicationJsonInterfaceBuilder {
   _$CoreReferenceApiResolveOneResponse200ApplicationJson? _$v;
 
   CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreReferenceApiResolveOneResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreReferenceApiResolveOneResponse200ApplicationJsonBuilder();
 
@@ -19358,7 +20599,7 @@ class CoreReferenceApiResolveOneResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreReferenceApiResolveOneResponse200ApplicationJson other) {
+  void replace(covariant CoreReferenceApiResolveOneResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiResolveOneResponse200ApplicationJson;
   }
@@ -19519,6 +20760,13 @@ class CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data_ReferencesBuild
   }
 }
 
+abstract mixin class CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  MapBuilder<String, CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data_References> get references;
+  set references(MapBuilder<String, CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data_References>? references);
+}
+
 class _$CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data
     extends CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data {
   @override
@@ -19567,7 +20815,8 @@ class _$CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data
 class CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data,
-            CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data? _$v;
 
   MapBuilder<String, CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data_References>? _references;
@@ -19575,7 +20824,8 @@ class CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder
       _$this._references ??=
           MapBuilder<String, CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data_References>();
   set references(
-          MapBuilder<String, CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data_References>? references) =>
+          covariant MapBuilder<String, CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data_References>?
+              references) =>
       _$this._references = references;
 
   CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder();
@@ -19590,7 +20840,7 @@ class CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiResolveResponse200ApplicationJson_Ocs_Data;
   }
@@ -19621,6 +20871,16 @@ class CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiResolveResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreReferenceApiResolveResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreReferenceApiResolveResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreReferenceApiResolveResponse200ApplicationJson_Ocs
@@ -19675,17 +20935,18 @@ class _$CoreReferenceApiResolveResponse200ApplicationJson_Ocs
 class CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreReferenceApiResolveResponse200ApplicationJson_Ocs,
-            CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder> {
+            CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder>,
+        CoreReferenceApiResolveResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreReferenceApiResolveResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreReferenceApiResolveResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder();
 
@@ -19700,7 +20961,7 @@ class CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreReferenceApiResolveResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreReferenceApiResolveResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiResolveResponse200ApplicationJson_Ocs;
   }
@@ -19734,6 +20995,13 @@ class CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiResolveResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreReferenceApiResolveResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreReferenceApiResolveResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreReferenceApiResolveResponse200ApplicationJson extends CoreReferenceApiResolveResponse200ApplicationJson {
@@ -19781,13 +21049,14 @@ class _$CoreReferenceApiResolveResponse200ApplicationJson extends CoreReferenceA
 class CoreReferenceApiResolveResponse200ApplicationJsonBuilder
     implements
         Builder<CoreReferenceApiResolveResponse200ApplicationJson,
-            CoreReferenceApiResolveResponse200ApplicationJsonBuilder> {
+            CoreReferenceApiResolveResponse200ApplicationJsonBuilder>,
+        CoreReferenceApiResolveResponse200ApplicationJsonInterfaceBuilder {
   _$CoreReferenceApiResolveResponse200ApplicationJson? _$v;
 
   CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreReferenceApiResolveResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreReferenceApiResolveResponse200ApplicationJsonBuilder();
 
@@ -19801,7 +21070,7 @@ class CoreReferenceApiResolveResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreReferenceApiResolveResponse200ApplicationJson other) {
+  void replace(covariant CoreReferenceApiResolveResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiResolveResponse200ApplicationJson;
   }
@@ -19962,6 +21231,13 @@ class CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data_ReferencesBuild
   }
 }
 
+abstract mixin class CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  MapBuilder<String, CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data_References> get references;
+  set references(MapBuilder<String, CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data_References>? references);
+}
+
 class _$CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data
     extends CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data {
   @override
@@ -20010,7 +21286,8 @@ class _$CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data
 class CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data,
-            CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data? _$v;
 
   MapBuilder<String, CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data_References>? _references;
@@ -20018,7 +21295,8 @@ class CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder
       _$this._references ??=
           MapBuilder<String, CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data_References>();
   set references(
-          MapBuilder<String, CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data_References>? references) =>
+          covariant MapBuilder<String, CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data_References>?
+              references) =>
       _$this._references = references;
 
   CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder();
@@ -20033,7 +21311,7 @@ class CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiExtractResponse200ApplicationJson_Ocs_Data;
   }
@@ -20064,6 +21342,16 @@ class CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiExtractResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreReferenceApiExtractResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreReferenceApiExtractResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreReferenceApiExtractResponse200ApplicationJson_Ocs
@@ -20118,17 +21406,18 @@ class _$CoreReferenceApiExtractResponse200ApplicationJson_Ocs
 class CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreReferenceApiExtractResponse200ApplicationJson_Ocs,
-            CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder> {
+            CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder>,
+        CoreReferenceApiExtractResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreReferenceApiExtractResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreReferenceApiExtractResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder();
 
@@ -20143,7 +21432,7 @@ class CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreReferenceApiExtractResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreReferenceApiExtractResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiExtractResponse200ApplicationJson_Ocs;
   }
@@ -20177,6 +21466,13 @@ class CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiExtractResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreReferenceApiExtractResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreReferenceApiExtractResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreReferenceApiExtractResponse200ApplicationJson extends CoreReferenceApiExtractResponse200ApplicationJson {
@@ -20224,13 +21520,14 @@ class _$CoreReferenceApiExtractResponse200ApplicationJson extends CoreReferenceA
 class CoreReferenceApiExtractResponse200ApplicationJsonBuilder
     implements
         Builder<CoreReferenceApiExtractResponse200ApplicationJson,
-            CoreReferenceApiExtractResponse200ApplicationJsonBuilder> {
+            CoreReferenceApiExtractResponse200ApplicationJsonBuilder>,
+        CoreReferenceApiExtractResponse200ApplicationJsonInterfaceBuilder {
   _$CoreReferenceApiExtractResponse200ApplicationJson? _$v;
 
   CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreReferenceApiExtractResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreReferenceApiExtractResponse200ApplicationJsonBuilder();
 
@@ -20244,7 +21541,7 @@ class CoreReferenceApiExtractResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreReferenceApiExtractResponse200ApplicationJson other) {
+  void replace(covariant CoreReferenceApiExtractResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiExtractResponse200ApplicationJson;
   }
@@ -20275,6 +21572,25 @@ class CoreReferenceApiExtractResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceProviderInterfaceBuilder {
+  void replace(CoreReferenceProviderInterface other);
+  void update(void Function(CoreReferenceProviderInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get title;
+  set title(String? title);
+
+  String? get iconUrl;
+  set iconUrl(String? iconUrl);
+
+  int? get order;
+  set order(int? order);
+
+  ListBuilder<String> get searchProvidersIds;
+  set searchProvidersIds(ListBuilder<String>? searchProvidersIds);
 }
 
 class _$CoreReferenceProvider extends CoreReferenceProvider {
@@ -20343,28 +21659,30 @@ class _$CoreReferenceProvider extends CoreReferenceProvider {
   }
 }
 
-class CoreReferenceProviderBuilder implements Builder<CoreReferenceProvider, CoreReferenceProviderBuilder> {
+class CoreReferenceProviderBuilder
+    implements Builder<CoreReferenceProvider, CoreReferenceProviderBuilder>, CoreReferenceProviderInterfaceBuilder {
   _$CoreReferenceProvider? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _title;
   String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
+  set title(covariant String? title) => _$this._title = title;
 
   String? _iconUrl;
   String? get iconUrl => _$this._iconUrl;
-  set iconUrl(String? iconUrl) => _$this._iconUrl = iconUrl;
+  set iconUrl(covariant String? iconUrl) => _$this._iconUrl = iconUrl;
 
   int? _order;
   int? get order => _$this._order;
-  set order(int? order) => _$this._order = order;
+  set order(covariant int? order) => _$this._order = order;
 
   ListBuilder<String>? _searchProvidersIds;
   ListBuilder<String> get searchProvidersIds => _$this._searchProvidersIds ??= ListBuilder<String>();
-  set searchProvidersIds(ListBuilder<String>? searchProvidersIds) => _$this._searchProvidersIds = searchProvidersIds;
+  set searchProvidersIds(covariant ListBuilder<String>? searchProvidersIds) =>
+      _$this._searchProvidersIds = searchProvidersIds;
 
   CoreReferenceProviderBuilder();
 
@@ -20382,7 +21700,7 @@ class CoreReferenceProviderBuilder implements Builder<CoreReferenceProvider, Cor
   }
 
   @override
-  void replace(CoreReferenceProvider other) {
+  void replace(covariant CoreReferenceProvider other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceProvider;
   }
@@ -20418,6 +21736,16 @@ class CoreReferenceProviderBuilder implements Builder<CoreReferenceProvider, Cor
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  ListBuilder<CoreReferenceProvider> get data;
+  set data(ListBuilder<CoreReferenceProvider>? data);
 }
 
 class _$CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs
@@ -20477,16 +21805,17 @@ class _$CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs
 class CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs,
-            CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder> {
+            CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder>,
+        CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<CoreReferenceProvider>? _data;
   ListBuilder<CoreReferenceProvider> get data => _$this._data ??= ListBuilder<CoreReferenceProvider>();
-  set data(ListBuilder<CoreReferenceProvider>? data) => _$this._data = data;
+  set data(covariant ListBuilder<CoreReferenceProvider>? data) => _$this._data = data;
 
   CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder();
 
@@ -20501,7 +21830,7 @@ class CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_Ocs;
   }
@@ -20535,6 +21864,13 @@ class CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreReferenceApiGetProvidersInfoResponse200ApplicationJson
@@ -20583,13 +21919,14 @@ class _$CoreReferenceApiGetProvidersInfoResponse200ApplicationJson
 class CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonBuilder
     implements
         Builder<CoreReferenceApiGetProvidersInfoResponse200ApplicationJson,
-            CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonBuilder> {
+            CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonBuilder>,
+        CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonInterfaceBuilder {
   _$CoreReferenceApiGetProvidersInfoResponse200ApplicationJson? _$v;
 
   CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreReferenceApiGetProvidersInfoResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonBuilder();
 
@@ -20603,7 +21940,7 @@ class CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreReferenceApiGetProvidersInfoResponse200ApplicationJson other) {
+  void replace(covariant CoreReferenceApiGetProvidersInfoResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiGetProvidersInfoResponse200ApplicationJson;
   }
@@ -20634,6 +21971,13 @@ class CoreReferenceApiGetProvidersInfoResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
 }
 
 class _$CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data
@@ -20684,12 +22028,13 @@ class _$CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data
 class CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data,
-            CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -20703,7 +22048,7 @@ class CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_Data;
   }
@@ -20724,6 +22069,16 @@ class CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs
@@ -20781,17 +22136,19 @@ class _$CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs
 class CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs,
-            CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder> {
+            CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder>,
+        CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder();
 
@@ -20806,7 +22163,7 @@ class CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiTouchProviderResponse200ApplicationJson_Ocs;
   }
@@ -20840,6 +22197,13 @@ class CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreReferenceApiTouchProviderResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreReferenceApiTouchProviderResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreReferenceApiTouchProviderResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreReferenceApiTouchProviderResponse200ApplicationJson
@@ -20888,13 +22252,14 @@ class _$CoreReferenceApiTouchProviderResponse200ApplicationJson
 class CoreReferenceApiTouchProviderResponse200ApplicationJsonBuilder
     implements
         Builder<CoreReferenceApiTouchProviderResponse200ApplicationJson,
-            CoreReferenceApiTouchProviderResponse200ApplicationJsonBuilder> {
+            CoreReferenceApiTouchProviderResponse200ApplicationJsonBuilder>,
+        CoreReferenceApiTouchProviderResponse200ApplicationJsonInterfaceBuilder {
   _$CoreReferenceApiTouchProviderResponse200ApplicationJson? _$v;
 
   CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreReferenceApiTouchProviderResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreReferenceApiTouchProviderResponse200ApplicationJsonBuilder();
 
@@ -20908,7 +22273,7 @@ class CoreReferenceApiTouchProviderResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreReferenceApiTouchProviderResponse200ApplicationJson other) {
+  void replace(covariant CoreReferenceApiTouchProviderResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreReferenceApiTouchProviderResponse200ApplicationJson;
   }
@@ -20939,6 +22304,20 @@ class CoreReferenceApiTouchProviderResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesInterfaceBuilder {
+  void replace(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesInterface other);
+  void update(
+      void Function(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get name;
+  set name(String? name);
+
+  String? get description;
+  set description(String? description);
 }
 
 class _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types
@@ -21006,20 +22385,21 @@ class _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types
 class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesBuilder
     implements
         Builder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types,
-            CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesBuilder> {
+            CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesBuilder>,
+        CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesInterfaceBuilder {
   _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   String? _description;
   String? get description => _$this._description;
-  set description(String? description) => _$this._description = description;
+  set description(covariant String? description) => _$this._description = description;
 
   CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesBuilder();
 
@@ -21035,7 +22415,7 @@ class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesBui
   }
 
   @override
-  void replace(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types other) {
+  void replace(covariant CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types;
   }
@@ -21060,6 +22440,13 @@ class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_TypesBui
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types> get types;
+  set types(ListBuilder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types>? types);
 }
 
 class _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data
@@ -21110,13 +22497,14 @@ class _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data
 class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data,
-            CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types>? _types;
   ListBuilder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types> get types =>
       _$this._types ??= ListBuilder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types>();
-  set types(ListBuilder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types>? types) =>
+  set types(covariant ListBuilder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data_Types>? types) =>
       _$this._types = types;
 
   CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder();
@@ -21131,7 +22519,7 @@ class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_Data;
   }
@@ -21162,6 +22550,16 @@ class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs
@@ -21221,17 +22619,19 @@ class _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs
 class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs,
-            CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder> {
+            CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder>,
+        CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder();
 
@@ -21246,7 +22646,7 @@ class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson_Ocs;
   }
@@ -21280,6 +22680,13 @@ class CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiTaskTypesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreTextProcessingApiTaskTypesResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreTextProcessingApiTaskTypesResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson
@@ -21328,13 +22735,14 @@ class _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson
 class CoreTextProcessingApiTaskTypesResponse200ApplicationJsonBuilder
     implements
         Builder<CoreTextProcessingApiTaskTypesResponse200ApplicationJson,
-            CoreTextProcessingApiTaskTypesResponse200ApplicationJsonBuilder> {
+            CoreTextProcessingApiTaskTypesResponse200ApplicationJsonBuilder>,
+        CoreTextProcessingApiTaskTypesResponse200ApplicationJsonInterfaceBuilder {
   _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson? _$v;
 
   CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreTextProcessingApiTaskTypesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreTextProcessingApiTaskTypesResponse200ApplicationJsonBuilder();
 
@@ -21348,7 +22756,7 @@ class CoreTextProcessingApiTaskTypesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiTaskTypesResponse200ApplicationJson other) {
+  void replace(covariant CoreTextProcessingApiTaskTypesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiTaskTypesResponse200ApplicationJson;
   }
@@ -21379,6 +22787,34 @@ class CoreTextProcessingApiTaskTypesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingTaskInterfaceBuilder {
+  void replace(CoreTextProcessingTaskInterface other);
+  void update(void Function(CoreTextProcessingTaskInterfaceBuilder) updates);
+  int? get id;
+  set id(int? id);
+
+  String? get type;
+  set type(String? type);
+
+  int? get status;
+  set status(int? status);
+
+  String? get userId;
+  set userId(String? userId);
+
+  String? get appId;
+  set appId(String? appId);
+
+  String? get input;
+  set input(String? input);
+
+  String? get output;
+  set output(String? output);
+
+  String? get identifier;
+  set identifier(String? identifier);
 }
 
 class _$CoreTextProcessingTask extends CoreTextProcessingTask {
@@ -21470,40 +22906,41 @@ class _$CoreTextProcessingTask extends CoreTextProcessingTask {
   }
 }
 
-class CoreTextProcessingTaskBuilder implements Builder<CoreTextProcessingTask, CoreTextProcessingTaskBuilder> {
+class CoreTextProcessingTaskBuilder
+    implements Builder<CoreTextProcessingTask, CoreTextProcessingTaskBuilder>, CoreTextProcessingTaskInterfaceBuilder {
   _$CoreTextProcessingTask? _$v;
 
   int? _id;
   int? get id => _$this._id;
-  set id(int? id) => _$this._id = id;
+  set id(covariant int? id) => _$this._id = id;
 
   String? _type;
   String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
+  set type(covariant String? type) => _$this._type = type;
 
   int? _status;
   int? get status => _$this._status;
-  set status(int? status) => _$this._status = status;
+  set status(covariant int? status) => _$this._status = status;
 
   String? _userId;
   String? get userId => _$this._userId;
-  set userId(String? userId) => _$this._userId = userId;
+  set userId(covariant String? userId) => _$this._userId = userId;
 
   String? _appId;
   String? get appId => _$this._appId;
-  set appId(String? appId) => _$this._appId = appId;
+  set appId(covariant String? appId) => _$this._appId = appId;
 
   String? _input;
   String? get input => _$this._input;
-  set input(String? input) => _$this._input = input;
+  set input(covariant String? input) => _$this._input = input;
 
   String? _output;
   String? get output => _$this._output;
-  set output(String? output) => _$this._output = output;
+  set output(covariant String? output) => _$this._output = output;
 
   String? _identifier;
   String? get identifier => _$this._identifier;
-  set identifier(String? identifier) => _$this._identifier = identifier;
+  set identifier(covariant String? identifier) => _$this._identifier = identifier;
 
   CoreTextProcessingTaskBuilder();
 
@@ -21524,7 +22961,7 @@ class CoreTextProcessingTaskBuilder implements Builder<CoreTextProcessingTask, C
   }
 
   @override
-  void replace(CoreTextProcessingTask other) {
+  void replace(covariant CoreTextProcessingTask other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingTask;
   }
@@ -21551,6 +22988,13 @@ class CoreTextProcessingTaskBuilder implements Builder<CoreTextProcessingTask, C
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  CoreTextProcessingTaskBuilder get task;
+  set task(CoreTextProcessingTaskBuilder? task);
 }
 
 class _$CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data
@@ -21601,12 +23045,13 @@ class _$CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data
 class CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data,
-            CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data? _$v;
 
   CoreTextProcessingTaskBuilder? _task;
   CoreTextProcessingTaskBuilder get task => _$this._task ??= CoreTextProcessingTaskBuilder();
-  set task(CoreTextProcessingTaskBuilder? task) => _$this._task = task;
+  set task(covariant CoreTextProcessingTaskBuilder? task) => _$this._task = task;
 
   CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -21620,7 +23065,7 @@ class CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_Data;
   }
@@ -21651,6 +23096,16 @@ class CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs
@@ -21708,17 +23163,19 @@ class _$CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs
 class CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs,
-            CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder> {
+            CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder>,
+        CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder();
 
@@ -21733,7 +23190,7 @@ class CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiScheduleResponse200ApplicationJson_Ocs;
   }
@@ -21767,6 +23224,13 @@ class CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiScheduleResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreTextProcessingApiScheduleResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreTextProcessingApiScheduleResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreTextProcessingApiScheduleResponse200ApplicationJson
@@ -21815,13 +23279,14 @@ class _$CoreTextProcessingApiScheduleResponse200ApplicationJson
 class CoreTextProcessingApiScheduleResponse200ApplicationJsonBuilder
     implements
         Builder<CoreTextProcessingApiScheduleResponse200ApplicationJson,
-            CoreTextProcessingApiScheduleResponse200ApplicationJsonBuilder> {
+            CoreTextProcessingApiScheduleResponse200ApplicationJsonBuilder>,
+        CoreTextProcessingApiScheduleResponse200ApplicationJsonInterfaceBuilder {
   _$CoreTextProcessingApiScheduleResponse200ApplicationJson? _$v;
 
   CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreTextProcessingApiScheduleResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreTextProcessingApiScheduleResponse200ApplicationJsonBuilder();
 
@@ -21835,7 +23300,7 @@ class CoreTextProcessingApiScheduleResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiScheduleResponse200ApplicationJson other) {
+  void replace(covariant CoreTextProcessingApiScheduleResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiScheduleResponse200ApplicationJson;
   }
@@ -21866,6 +23331,13 @@ class CoreTextProcessingApiScheduleResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  CoreTextProcessingTaskBuilder get task;
+  set task(CoreTextProcessingTaskBuilder? task);
 }
 
 class _$CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data
@@ -21916,12 +23388,13 @@ class _$CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data
 class CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data,
-            CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data? _$v;
 
   CoreTextProcessingTaskBuilder? _task;
   CoreTextProcessingTaskBuilder get task => _$this._task ??= CoreTextProcessingTaskBuilder();
-  set task(CoreTextProcessingTaskBuilder? task) => _$this._task = task;
+  set task(covariant CoreTextProcessingTaskBuilder? task) => _$this._task = task;
 
   CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -21935,7 +23408,7 @@ class CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_Data;
   }
@@ -21966,6 +23439,16 @@ class CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs
@@ -22022,17 +23505,19 @@ class _$CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs
 class CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs,
-            CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder> {
+            CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder>,
+        CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder();
 
@@ -22047,7 +23532,7 @@ class CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiGetTaskResponse200ApplicationJson_Ocs;
   }
@@ -22081,6 +23566,13 @@ class CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiGetTaskResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreTextProcessingApiGetTaskResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreTextProcessingApiGetTaskResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreTextProcessingApiGetTaskResponse200ApplicationJson
@@ -22129,13 +23621,14 @@ class _$CoreTextProcessingApiGetTaskResponse200ApplicationJson
 class CoreTextProcessingApiGetTaskResponse200ApplicationJsonBuilder
     implements
         Builder<CoreTextProcessingApiGetTaskResponse200ApplicationJson,
-            CoreTextProcessingApiGetTaskResponse200ApplicationJsonBuilder> {
+            CoreTextProcessingApiGetTaskResponse200ApplicationJsonBuilder>,
+        CoreTextProcessingApiGetTaskResponse200ApplicationJsonInterfaceBuilder {
   _$CoreTextProcessingApiGetTaskResponse200ApplicationJson? _$v;
 
   CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreTextProcessingApiGetTaskResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreTextProcessingApiGetTaskResponse200ApplicationJsonBuilder();
 
@@ -22149,7 +23642,7 @@ class CoreTextProcessingApiGetTaskResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiGetTaskResponse200ApplicationJson other) {
+  void replace(covariant CoreTextProcessingApiGetTaskResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiGetTaskResponse200ApplicationJson;
   }
@@ -22180,6 +23673,14 @@ class CoreTextProcessingApiGetTaskResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  CoreTextProcessingTaskBuilder get task;
+  set task(CoreTextProcessingTaskBuilder? task);
 }
 
 class _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data
@@ -22230,12 +23731,13 @@ class _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data
 class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data,
-            CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data? _$v;
 
   CoreTextProcessingTaskBuilder? _task;
   CoreTextProcessingTaskBuilder get task => _$this._task ??= CoreTextProcessingTaskBuilder();
-  set task(CoreTextProcessingTaskBuilder? task) => _$this._task = task;
+  set task(covariant CoreTextProcessingTaskBuilder? task) => _$this._task = task;
 
   CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -22249,7 +23751,7 @@ class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_Data;
   }
@@ -22280,6 +23782,16 @@ class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs
@@ -22339,17 +23851,19 @@ class _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs
 class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs,
-            CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder> {
+            CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder>,
+        CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder();
 
@@ -22364,7 +23878,7 @@ class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_Ocs;
   }
@@ -22398,6 +23912,13 @@ class CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson
@@ -22446,13 +23967,14 @@ class _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson
 class CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonBuilder
     implements
         Builder<CoreTextProcessingApiDeleteTaskResponse200ApplicationJson,
-            CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonBuilder> {
+            CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonBuilder>,
+        CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonInterfaceBuilder {
   _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson? _$v;
 
   CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreTextProcessingApiDeleteTaskResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonBuilder();
 
@@ -22466,7 +23988,7 @@ class CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiDeleteTaskResponse200ApplicationJson other) {
+  void replace(covariant CoreTextProcessingApiDeleteTaskResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiDeleteTaskResponse200ApplicationJson;
   }
@@ -22497,6 +24019,14 @@ class CoreTextProcessingApiDeleteTaskResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<CoreTextProcessingTask> get tasks;
+  set tasks(ListBuilder<CoreTextProcessingTask>? tasks);
 }
 
 class _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data
@@ -22547,12 +24077,13 @@ class _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data
 class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data,
-            CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<CoreTextProcessingTask>? _tasks;
   ListBuilder<CoreTextProcessingTask> get tasks => _$this._tasks ??= ListBuilder<CoreTextProcessingTask>();
-  set tasks(ListBuilder<CoreTextProcessingTask>? tasks) => _$this._tasks = tasks;
+  set tasks(covariant ListBuilder<CoreTextProcessingTask>? tasks) => _$this._tasks = tasks;
 
   CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -22566,7 +24097,7 @@ class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuil
   }
 
   @override
-  void replace(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_Data;
   }
@@ -22598,6 +24129,16 @@ class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs
@@ -22657,17 +24198,19 @@ class _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs
 class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs,
-            CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder> {
+            CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder>,
+        CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder();
 
@@ -22682,7 +24225,7 @@ class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_Ocs;
   }
@@ -22716,6 +24259,13 @@ class CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson
@@ -22765,13 +24315,14 @@ class _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson
 class CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonBuilder
     implements
         Builder<CoreTextProcessingApiListTasksByAppResponse200ApplicationJson,
-            CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonBuilder> {
+            CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonBuilder>,
+        CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonInterfaceBuilder {
   _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson? _$v;
 
   CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreTextProcessingApiListTasksByAppResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonBuilder();
 
@@ -22785,7 +24336,7 @@ class CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreTextProcessingApiListTasksByAppResponse200ApplicationJson other) {
+  void replace(covariant CoreTextProcessingApiListTasksByAppResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTextProcessingApiListTasksByAppResponse200ApplicationJson;
   }
@@ -22816,6 +24367,23 @@ class CoreTextProcessingApiListTasksByAppResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesInterfaceBuilder {
+  void replace(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesInterface other);
+  void update(
+      void Function(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesInterfaceBuilder) updates);
+  String? get from;
+  set from(String? from);
+
+  String? get fromLabel;
+  set fromLabel(String? fromLabel);
+
+  String? get to;
+  set to(String? to);
+
+  String? get toLabel;
+  set toLabel(String? toLabel);
 }
 
 class _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages
@@ -22890,24 +24458,25 @@ class _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages
 class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesBuilder
     implements
         Builder<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages,
-            CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesBuilder> {
+            CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesBuilder>,
+        CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesInterfaceBuilder {
   _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages? _$v;
 
   String? _from;
   String? get from => _$this._from;
-  set from(String? from) => _$this._from = from;
+  set from(covariant String? from) => _$this._from = from;
 
   String? _fromLabel;
   String? get fromLabel => _$this._fromLabel;
-  set fromLabel(String? fromLabel) => _$this._fromLabel = fromLabel;
+  set fromLabel(covariant String? fromLabel) => _$this._fromLabel = fromLabel;
 
   String? _to;
   String? get to => _$this._to;
-  set to(String? to) => _$this._to = to;
+  set to(covariant String? to) => _$this._to = to;
 
   String? _toLabel;
   String? get toLabel => _$this._toLabel;
-  set toLabel(String? toLabel) => _$this._toLabel = toLabel;
+  set toLabel(covariant String? toLabel) => _$this._toLabel = toLabel;
 
   CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesBuilder();
 
@@ -22924,7 +24493,7 @@ class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesBu
   }
 
   @override
-  void replace(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages other) {
+  void replace(covariant CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages;
   }
@@ -22951,6 +24520,16 @@ class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_LanguagesBu
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages> get languages;
+  set languages(ListBuilder<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages>? languages);
+
+  bool? get languageDetection;
+  set languageDetection(bool? languageDetection);
 }
 
 class _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data
@@ -23011,18 +24590,20 @@ class _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data
 class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data,
-            CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages>? _languages;
   ListBuilder<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages> get languages =>
       _$this._languages ??= ListBuilder<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages>();
-  set languages(ListBuilder<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages>? languages) =>
+  set languages(
+          covariant ListBuilder<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data_Languages>? languages) =>
       _$this._languages = languages;
 
   bool? _languageDetection;
   bool? get languageDetection => _$this._languageDetection;
-  set languageDetection(bool? languageDetection) => _$this._languageDetection = languageDetection;
+  set languageDetection(covariant bool? languageDetection) => _$this._languageDetection = languageDetection;
 
   CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -23037,7 +24618,7 @@ class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_Data;
   }
@@ -23072,6 +24653,16 @@ class CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTranslationApiLanguagesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreTranslationApiLanguagesResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreTranslationApiLanguagesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs
@@ -23128,17 +24719,19 @@ class _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs
 class CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs,
-            CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder> {
+            CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder>,
+        CoreTranslationApiLanguagesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder();
 
@@ -23153,7 +24746,7 @@ class CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTranslationApiLanguagesResponse200ApplicationJson_Ocs;
   }
@@ -23187,6 +24780,13 @@ class CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTranslationApiLanguagesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreTranslationApiLanguagesResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreTranslationApiLanguagesResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreTranslationApiLanguagesResponse200ApplicationJson
@@ -23235,13 +24835,14 @@ class _$CoreTranslationApiLanguagesResponse200ApplicationJson
 class CoreTranslationApiLanguagesResponse200ApplicationJsonBuilder
     implements
         Builder<CoreTranslationApiLanguagesResponse200ApplicationJson,
-            CoreTranslationApiLanguagesResponse200ApplicationJsonBuilder> {
+            CoreTranslationApiLanguagesResponse200ApplicationJsonBuilder>,
+        CoreTranslationApiLanguagesResponse200ApplicationJsonInterfaceBuilder {
   _$CoreTranslationApiLanguagesResponse200ApplicationJson? _$v;
 
   CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreTranslationApiLanguagesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreTranslationApiLanguagesResponse200ApplicationJsonBuilder();
 
@@ -23255,7 +24856,7 @@ class CoreTranslationApiLanguagesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreTranslationApiLanguagesResponse200ApplicationJson other) {
+  void replace(covariant CoreTranslationApiLanguagesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTranslationApiLanguagesResponse200ApplicationJson;
   }
@@ -23286,6 +24887,16 @@ class CoreTranslationApiLanguagesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get text;
+  set text(String? text);
+
+  String? get from;
+  set from(String? from);
 }
 
 class _$CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data
@@ -23342,16 +24953,17 @@ class _$CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data
 class CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data,
-            CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _text;
   String? get text => _$this._text;
-  set text(String? text) => _$this._text = text;
+  set text(covariant String? text) => _$this._text = text;
 
   String? _from;
   String? get from => _$this._from;
-  set from(String? from) => _$this._from = from;
+  set from(covariant String? from) => _$this._from = from;
 
   CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -23366,7 +24978,7 @@ class CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_Data;
   }
@@ -23388,6 +25000,16 @@ class CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTranslationApiTranslateResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreTranslationApiTranslateResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreTranslationApiTranslateResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreTranslationApiTranslateResponse200ApplicationJson_Ocs
@@ -23444,17 +25066,19 @@ class _$CoreTranslationApiTranslateResponse200ApplicationJson_Ocs
 class CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreTranslationApiTranslateResponse200ApplicationJson_Ocs,
-            CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder> {
+            CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder>,
+        CoreTranslationApiTranslateResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreTranslationApiTranslateResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreTranslationApiTranslateResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder();
 
@@ -23469,7 +25093,7 @@ class CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreTranslationApiTranslateResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreTranslationApiTranslateResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTranslationApiTranslateResponse200ApplicationJson_Ocs;
   }
@@ -23503,6 +25127,13 @@ class CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreTranslationApiTranslateResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreTranslationApiTranslateResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreTranslationApiTranslateResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreTranslationApiTranslateResponse200ApplicationJson
@@ -23551,13 +25182,14 @@ class _$CoreTranslationApiTranslateResponse200ApplicationJson
 class CoreTranslationApiTranslateResponse200ApplicationJsonBuilder
     implements
         Builder<CoreTranslationApiTranslateResponse200ApplicationJson,
-            CoreTranslationApiTranslateResponse200ApplicationJsonBuilder> {
+            CoreTranslationApiTranslateResponse200ApplicationJsonBuilder>,
+        CoreTranslationApiTranslateResponse200ApplicationJsonInterfaceBuilder {
   _$CoreTranslationApiTranslateResponse200ApplicationJson? _$v;
 
   CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreTranslationApiTranslateResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreTranslationApiTranslateResponse200ApplicationJsonBuilder();
 
@@ -23571,7 +25203,7 @@ class CoreTranslationApiTranslateResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreTranslationApiTranslateResponse200ApplicationJson other) {
+  void replace(covariant CoreTranslationApiTranslateResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreTranslationApiTranslateResponse200ApplicationJson;
   }
@@ -23602,6 +25234,19 @@ class CoreTranslationApiTranslateResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreUnifiedSearchProviderInterfaceBuilder {
+  void replace(CoreUnifiedSearchProviderInterface other);
+  void update(void Function(CoreUnifiedSearchProviderInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get name;
+  set name(String? name);
+
+  int? get order;
+  set order(int? order);
 }
 
 class _$CoreUnifiedSearchProvider extends CoreUnifiedSearchProvider {
@@ -23654,20 +25299,23 @@ class _$CoreUnifiedSearchProvider extends CoreUnifiedSearchProvider {
   }
 }
 
-class CoreUnifiedSearchProviderBuilder implements Builder<CoreUnifiedSearchProvider, CoreUnifiedSearchProviderBuilder> {
+class CoreUnifiedSearchProviderBuilder
+    implements
+        Builder<CoreUnifiedSearchProvider, CoreUnifiedSearchProviderBuilder>,
+        CoreUnifiedSearchProviderInterfaceBuilder {
   _$CoreUnifiedSearchProvider? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   int? _order;
   int? get order => _$this._order;
-  set order(int? order) => _$this._order = order;
+  set order(covariant int? order) => _$this._order = order;
 
   CoreUnifiedSearchProviderBuilder();
 
@@ -23683,7 +25331,7 @@ class CoreUnifiedSearchProviderBuilder implements Builder<CoreUnifiedSearchProvi
   }
 
   @override
-  void replace(CoreUnifiedSearchProvider other) {
+  void replace(covariant CoreUnifiedSearchProvider other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreUnifiedSearchProvider;
   }
@@ -23705,6 +25353,16 @@ class CoreUnifiedSearchProviderBuilder implements Builder<CoreUnifiedSearchProvi
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  ListBuilder<CoreUnifiedSearchProvider> get data;
+  set data(ListBuilder<CoreUnifiedSearchProvider>? data);
 }
 
 class _$CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs
@@ -23762,16 +25420,17 @@ class _$CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs
 class CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs,
-            CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder> {
+            CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder>,
+        CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<CoreUnifiedSearchProvider>? _data;
   ListBuilder<CoreUnifiedSearchProvider> get data => _$this._data ??= ListBuilder<CoreUnifiedSearchProvider>();
-  set data(ListBuilder<CoreUnifiedSearchProvider>? data) => _$this._data = data;
+  set data(covariant ListBuilder<CoreUnifiedSearchProvider>? data) => _$this._data = data;
 
   CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder();
 
@@ -23786,7 +25445,7 @@ class CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreUnifiedSearchGetProvidersResponse200ApplicationJson_Ocs;
   }
@@ -23820,6 +25479,13 @@ class CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreUnifiedSearchGetProvidersResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreUnifiedSearchGetProvidersResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreUnifiedSearchGetProvidersResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreUnifiedSearchGetProvidersResponse200ApplicationJson
@@ -23868,13 +25534,14 @@ class _$CoreUnifiedSearchGetProvidersResponse200ApplicationJson
 class CoreUnifiedSearchGetProvidersResponse200ApplicationJsonBuilder
     implements
         Builder<CoreUnifiedSearchGetProvidersResponse200ApplicationJson,
-            CoreUnifiedSearchGetProvidersResponse200ApplicationJsonBuilder> {
+            CoreUnifiedSearchGetProvidersResponse200ApplicationJsonBuilder>,
+        CoreUnifiedSearchGetProvidersResponse200ApplicationJsonInterfaceBuilder {
   _$CoreUnifiedSearchGetProvidersResponse200ApplicationJson? _$v;
 
   CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreUnifiedSearchGetProvidersResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreUnifiedSearchGetProvidersResponse200ApplicationJsonBuilder();
 
@@ -23888,7 +25555,7 @@ class CoreUnifiedSearchGetProvidersResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreUnifiedSearchGetProvidersResponse200ApplicationJson other) {
+  void replace(covariant CoreUnifiedSearchGetProvidersResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreUnifiedSearchGetProvidersResponse200ApplicationJson;
   }
@@ -24023,6 +25690,31 @@ class CoreUnifiedSearchSearchCursorBuilder
   }
 }
 
+abstract mixin class CoreUnifiedSearchResultEntryInterfaceBuilder {
+  void replace(CoreUnifiedSearchResultEntryInterface other);
+  void update(void Function(CoreUnifiedSearchResultEntryInterfaceBuilder) updates);
+  String? get thumbnailUrl;
+  set thumbnailUrl(String? thumbnailUrl);
+
+  String? get title;
+  set title(String? title);
+
+  String? get subline;
+  set subline(String? subline);
+
+  String? get resourceUrl;
+  set resourceUrl(String? resourceUrl);
+
+  String? get icon;
+  set icon(String? icon);
+
+  bool? get rounded;
+  set rounded(bool? rounded);
+
+  ListBuilder<String> get attributes;
+  set attributes(ListBuilder<String>? attributes);
+}
+
 class _$CoreUnifiedSearchResultEntry extends CoreUnifiedSearchResultEntry {
   @override
   final String thumbnailUrl;
@@ -24109,36 +25801,38 @@ class _$CoreUnifiedSearchResultEntry extends CoreUnifiedSearchResultEntry {
 }
 
 class CoreUnifiedSearchResultEntryBuilder
-    implements Builder<CoreUnifiedSearchResultEntry, CoreUnifiedSearchResultEntryBuilder> {
+    implements
+        Builder<CoreUnifiedSearchResultEntry, CoreUnifiedSearchResultEntryBuilder>,
+        CoreUnifiedSearchResultEntryInterfaceBuilder {
   _$CoreUnifiedSearchResultEntry? _$v;
 
   String? _thumbnailUrl;
   String? get thumbnailUrl => _$this._thumbnailUrl;
-  set thumbnailUrl(String? thumbnailUrl) => _$this._thumbnailUrl = thumbnailUrl;
+  set thumbnailUrl(covariant String? thumbnailUrl) => _$this._thumbnailUrl = thumbnailUrl;
 
   String? _title;
   String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
+  set title(covariant String? title) => _$this._title = title;
 
   String? _subline;
   String? get subline => _$this._subline;
-  set subline(String? subline) => _$this._subline = subline;
+  set subline(covariant String? subline) => _$this._subline = subline;
 
   String? _resourceUrl;
   String? get resourceUrl => _$this._resourceUrl;
-  set resourceUrl(String? resourceUrl) => _$this._resourceUrl = resourceUrl;
+  set resourceUrl(covariant String? resourceUrl) => _$this._resourceUrl = resourceUrl;
 
   String? _icon;
   String? get icon => _$this._icon;
-  set icon(String? icon) => _$this._icon = icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
 
   bool? _rounded;
   bool? get rounded => _$this._rounded;
-  set rounded(bool? rounded) => _$this._rounded = rounded;
+  set rounded(covariant bool? rounded) => _$this._rounded = rounded;
 
   ListBuilder<String>? _attributes;
   ListBuilder<String> get attributes => _$this._attributes ??= ListBuilder<String>();
-  set attributes(ListBuilder<String>? attributes) => _$this._attributes = attributes;
+  set attributes(covariant ListBuilder<String>? attributes) => _$this._attributes = attributes;
 
   CoreUnifiedSearchResultEntryBuilder();
 
@@ -24158,7 +25852,7 @@ class CoreUnifiedSearchResultEntryBuilder
   }
 
   @override
-  void replace(CoreUnifiedSearchResultEntry other) {
+  void replace(covariant CoreUnifiedSearchResultEntry other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreUnifiedSearchResultEntry;
   }
@@ -24305,6 +25999,22 @@ class CoreUnifiedSearchResult_CursorBuilder
   }
 }
 
+abstract mixin class CoreUnifiedSearchResultInterfaceBuilder {
+  void replace(CoreUnifiedSearchResultInterface other);
+  void update(void Function(CoreUnifiedSearchResultInterfaceBuilder) updates);
+  String? get name;
+  set name(String? name);
+
+  bool? get isPaginated;
+  set isPaginated(bool? isPaginated);
+
+  ListBuilder<CoreUnifiedSearchResultEntry> get entries;
+  set entries(ListBuilder<CoreUnifiedSearchResultEntry>? entries);
+
+  CoreUnifiedSearchResult_CursorBuilder get cursor;
+  set cursor(CoreUnifiedSearchResult_CursorBuilder? cursor);
+}
+
 class _$CoreUnifiedSearchResult extends CoreUnifiedSearchResult {
   @override
   final String name;
@@ -24364,25 +26074,28 @@ class _$CoreUnifiedSearchResult extends CoreUnifiedSearchResult {
   }
 }
 
-class CoreUnifiedSearchResultBuilder implements Builder<CoreUnifiedSearchResult, CoreUnifiedSearchResultBuilder> {
+class CoreUnifiedSearchResultBuilder
+    implements
+        Builder<CoreUnifiedSearchResult, CoreUnifiedSearchResultBuilder>,
+        CoreUnifiedSearchResultInterfaceBuilder {
   _$CoreUnifiedSearchResult? _$v;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   bool? _isPaginated;
   bool? get isPaginated => _$this._isPaginated;
-  set isPaginated(bool? isPaginated) => _$this._isPaginated = isPaginated;
+  set isPaginated(covariant bool? isPaginated) => _$this._isPaginated = isPaginated;
 
   ListBuilder<CoreUnifiedSearchResultEntry>? _entries;
   ListBuilder<CoreUnifiedSearchResultEntry> get entries =>
       _$this._entries ??= ListBuilder<CoreUnifiedSearchResultEntry>();
-  set entries(ListBuilder<CoreUnifiedSearchResultEntry>? entries) => _$this._entries = entries;
+  set entries(covariant ListBuilder<CoreUnifiedSearchResultEntry>? entries) => _$this._entries = entries;
 
   CoreUnifiedSearchResult_CursorBuilder? _cursor;
   CoreUnifiedSearchResult_CursorBuilder get cursor => _$this._cursor ??= CoreUnifiedSearchResult_CursorBuilder();
-  set cursor(CoreUnifiedSearchResult_CursorBuilder? cursor) => _$this._cursor = cursor;
+  set cursor(covariant CoreUnifiedSearchResult_CursorBuilder? cursor) => _$this._cursor = cursor;
 
   CoreUnifiedSearchResultBuilder();
 
@@ -24399,7 +26112,7 @@ class CoreUnifiedSearchResultBuilder implements Builder<CoreUnifiedSearchResult,
   }
 
   @override
-  void replace(CoreUnifiedSearchResult other) {
+  void replace(covariant CoreUnifiedSearchResult other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreUnifiedSearchResult;
   }
@@ -24437,6 +26150,16 @@ class CoreUnifiedSearchResultBuilder implements Builder<CoreUnifiedSearchResult,
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreUnifiedSearchSearchResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreUnifiedSearchSearchResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreUnifiedSearchSearchResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreUnifiedSearchResultBuilder get data;
+  set data(CoreUnifiedSearchResultBuilder? data);
 }
 
 class _$CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs
@@ -24491,16 +26214,17 @@ class _$CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs
 class CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs,
-            CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder> {
+            CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder>,
+        CoreUnifiedSearchSearchResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreUnifiedSearchResultBuilder? _data;
   CoreUnifiedSearchResultBuilder get data => _$this._data ??= CoreUnifiedSearchResultBuilder();
-  set data(CoreUnifiedSearchResultBuilder? data) => _$this._data = data;
+  set data(covariant CoreUnifiedSearchResultBuilder? data) => _$this._data = data;
 
   CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder();
 
@@ -24515,7 +26239,7 @@ class CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreUnifiedSearchSearchResponse200ApplicationJson_Ocs;
   }
@@ -24549,6 +26273,13 @@ class CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreUnifiedSearchSearchResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreUnifiedSearchSearchResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreUnifiedSearchSearchResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreUnifiedSearchSearchResponse200ApplicationJson extends CoreUnifiedSearchSearchResponse200ApplicationJson {
@@ -24596,13 +26327,14 @@ class _$CoreUnifiedSearchSearchResponse200ApplicationJson extends CoreUnifiedSea
 class CoreUnifiedSearchSearchResponse200ApplicationJsonBuilder
     implements
         Builder<CoreUnifiedSearchSearchResponse200ApplicationJson,
-            CoreUnifiedSearchSearchResponse200ApplicationJsonBuilder> {
+            CoreUnifiedSearchSearchResponse200ApplicationJsonBuilder>,
+        CoreUnifiedSearchSearchResponse200ApplicationJsonInterfaceBuilder {
   _$CoreUnifiedSearchSearchResponse200ApplicationJson? _$v;
 
   CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreUnifiedSearchSearchResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreUnifiedSearchSearchResponse200ApplicationJsonBuilder();
 
@@ -24616,7 +26348,7 @@ class CoreUnifiedSearchSearchResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreUnifiedSearchSearchResponse200ApplicationJson other) {
+  void replace(covariant CoreUnifiedSearchSearchResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreUnifiedSearchSearchResponse200ApplicationJson;
   }
@@ -24647,6 +26379,16 @@ class CoreUnifiedSearchSearchResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder {
+  void replace(CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewInterface other);
+  void update(void Function(CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder) updates);
+  ListBuilder<String> get regular;
+  set regular(ListBuilder<String>? regular);
+
+  ListBuilder<String> get admin;
+  set admin(ListBuilder<String>? admin);
 }
 
 class _$CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew
@@ -24706,16 +26448,17 @@ class _$CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew
 class CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder
     implements
         Builder<CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew,
-            CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder> {
+            CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder>,
+        CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder {
   _$CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew? _$v;
 
   ListBuilder<String>? _regular;
   ListBuilder<String> get regular => _$this._regular ??= ListBuilder<String>();
-  set regular(ListBuilder<String>? regular) => _$this._regular = regular;
+  set regular(covariant ListBuilder<String>? regular) => _$this._regular = regular;
 
   ListBuilder<String>? _admin;
   ListBuilder<String> get admin => _$this._admin ??= ListBuilder<String>();
-  set admin(ListBuilder<String>? admin) => _$this._admin = admin;
+  set admin(covariant ListBuilder<String>? admin) => _$this._admin = admin;
 
   CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder();
 
@@ -24730,7 +26473,7 @@ class CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder
   }
 
   @override
-  void replace(CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew other) {
+  void replace(covariant CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNew;
   }
@@ -24765,6 +26508,22 @@ class CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get changelogURL;
+  set changelogURL(String? changelogURL);
+
+  String? get product;
+  set product(String? product);
+
+  String? get version;
+  set version(String? version);
+
+  CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder get whatsNew;
+  set whatsNew(CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder? whatsNew);
 }
 
 class _$CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data extends CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data {
@@ -24834,25 +26593,26 @@ class _$CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data extends CoreWhatsNewG
 class CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data,
-            CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder> {
+            CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder>,
+        CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _changelogURL;
   String? get changelogURL => _$this._changelogURL;
-  set changelogURL(String? changelogURL) => _$this._changelogURL = changelogURL;
+  set changelogURL(covariant String? changelogURL) => _$this._changelogURL = changelogURL;
 
   String? _product;
   String? get product => _$this._product;
-  set product(String? product) => _$this._product = product;
+  set product(covariant String? product) => _$this._product = product;
 
   String? _version;
   String? get version => _$this._version;
-  set version(String? version) => _$this._version = version;
+  set version(covariant String? version) => _$this._version = version;
 
   CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder? _whatsNew;
   CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder get whatsNew =>
       _$this._whatsNew ??= CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder();
-  set whatsNew(CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder? whatsNew) =>
+  set whatsNew(covariant CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data_WhatsNewBuilder? whatsNew) =>
       _$this._whatsNew = whatsNew;
 
   CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder();
@@ -24870,7 +26630,7 @@ class CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreWhatsNewGetResponse200ApplicationJson_Ocs_Data;
   }
@@ -24909,6 +26669,16 @@ class CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreWhatsNewGetResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreWhatsNewGetResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreWhatsNewGetResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$CoreWhatsNewGetResponse200ApplicationJson_Ocs extends CoreWhatsNewGetResponse200ApplicationJson_Ocs {
@@ -24961,17 +26731,18 @@ class _$CoreWhatsNewGetResponse200ApplicationJson_Ocs extends CoreWhatsNewGetRes
 
 class CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder
     implements
-        Builder<CoreWhatsNewGetResponse200ApplicationJson_Ocs, CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder> {
+        Builder<CoreWhatsNewGetResponse200ApplicationJson_Ocs, CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder>,
+        CoreWhatsNewGetResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreWhatsNewGetResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder? _data;
   CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant CoreWhatsNewGetResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder();
 
@@ -24986,7 +26757,7 @@ class CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreWhatsNewGetResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreWhatsNewGetResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreWhatsNewGetResponse200ApplicationJson_Ocs;
   }
@@ -25018,6 +26789,13 @@ class CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreWhatsNewGetResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreWhatsNewGetResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreWhatsNewGetResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreWhatsNewGetResponse200ApplicationJson extends CoreWhatsNewGetResponse200ApplicationJson {
@@ -25062,13 +26840,15 @@ class _$CoreWhatsNewGetResponse200ApplicationJson extends CoreWhatsNewGetRespons
 }
 
 class CoreWhatsNewGetResponse200ApplicationJsonBuilder
-    implements Builder<CoreWhatsNewGetResponse200ApplicationJson, CoreWhatsNewGetResponse200ApplicationJsonBuilder> {
+    implements
+        Builder<CoreWhatsNewGetResponse200ApplicationJson, CoreWhatsNewGetResponse200ApplicationJsonBuilder>,
+        CoreWhatsNewGetResponse200ApplicationJsonInterfaceBuilder {
   _$CoreWhatsNewGetResponse200ApplicationJson? _$v;
 
   CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreWhatsNewGetResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreWhatsNewGetResponse200ApplicationJsonBuilder();
 
@@ -25082,7 +26862,7 @@ class CoreWhatsNewGetResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreWhatsNewGetResponse200ApplicationJson other) {
+  void replace(covariant CoreWhatsNewGetResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreWhatsNewGetResponse200ApplicationJson;
   }
@@ -25112,6 +26892,16 @@ class CoreWhatsNewGetResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreWhatsNewDismissResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(CoreWhatsNewDismissResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(CoreWhatsNewDismissResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  CoreOCSMetaBuilder get meta;
+  set meta(CoreOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$CoreWhatsNewDismissResponse200ApplicationJson_Ocs extends CoreWhatsNewDismissResponse200ApplicationJson_Ocs {
@@ -25165,16 +26955,17 @@ class _$CoreWhatsNewDismissResponse200ApplicationJson_Ocs extends CoreWhatsNewDi
 class CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder
     implements
         Builder<CoreWhatsNewDismissResponse200ApplicationJson_Ocs,
-            CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder> {
+            CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder>,
+        CoreWhatsNewDismissResponse200ApplicationJson_OcsInterfaceBuilder {
   _$CoreWhatsNewDismissResponse200ApplicationJson_Ocs? _$v;
 
   CoreOCSMetaBuilder? _meta;
   CoreOCSMetaBuilder get meta => _$this._meta ??= CoreOCSMetaBuilder();
-  set meta(CoreOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant CoreOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder();
 
@@ -25189,7 +26980,7 @@ class CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(CoreWhatsNewDismissResponse200ApplicationJson_Ocs other) {
+  void replace(covariant CoreWhatsNewDismissResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreWhatsNewDismissResponse200ApplicationJson_Ocs;
   }
@@ -25224,6 +27015,13 @@ class CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreWhatsNewDismissResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreWhatsNewDismissResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreWhatsNewDismissResponse200ApplicationJsonInterfaceBuilder) updates);
+  CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$CoreWhatsNewDismissResponse200ApplicationJson extends CoreWhatsNewDismissResponse200ApplicationJson {
@@ -25269,13 +27067,14 @@ class _$CoreWhatsNewDismissResponse200ApplicationJson extends CoreWhatsNewDismis
 
 class CoreWhatsNewDismissResponse200ApplicationJsonBuilder
     implements
-        Builder<CoreWhatsNewDismissResponse200ApplicationJson, CoreWhatsNewDismissResponse200ApplicationJsonBuilder> {
+        Builder<CoreWhatsNewDismissResponse200ApplicationJson, CoreWhatsNewDismissResponse200ApplicationJsonBuilder>,
+        CoreWhatsNewDismissResponse200ApplicationJsonInterfaceBuilder {
   _$CoreWhatsNewDismissResponse200ApplicationJson? _$v;
 
   CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder? _ocs;
   CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder();
-  set ocs(CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant CoreWhatsNewDismissResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   CoreWhatsNewDismissResponse200ApplicationJsonBuilder();
 
@@ -25289,7 +27088,7 @@ class CoreWhatsNewDismissResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreWhatsNewDismissResponse200ApplicationJson other) {
+  void replace(covariant CoreWhatsNewDismissResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreWhatsNewDismissResponse200ApplicationJson;
   }
@@ -25319,6 +27118,13 @@ class CoreWhatsNewDismissResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class CoreWipeCheckWipeResponse200ApplicationJsonInterfaceBuilder {
+  void replace(CoreWipeCheckWipeResponse200ApplicationJsonInterface other);
+  void update(void Function(CoreWipeCheckWipeResponse200ApplicationJsonInterfaceBuilder) updates);
+  bool? get wipe;
+  set wipe(bool? wipe);
 }
 
 class _$CoreWipeCheckWipeResponse200ApplicationJson extends CoreWipeCheckWipeResponse200ApplicationJson {
@@ -25364,12 +27170,13 @@ class _$CoreWipeCheckWipeResponse200ApplicationJson extends CoreWipeCheckWipeRes
 
 class CoreWipeCheckWipeResponse200ApplicationJsonBuilder
     implements
-        Builder<CoreWipeCheckWipeResponse200ApplicationJson, CoreWipeCheckWipeResponse200ApplicationJsonBuilder> {
+        Builder<CoreWipeCheckWipeResponse200ApplicationJson, CoreWipeCheckWipeResponse200ApplicationJsonBuilder>,
+        CoreWipeCheckWipeResponse200ApplicationJsonInterfaceBuilder {
   _$CoreWipeCheckWipeResponse200ApplicationJson? _$v;
 
   bool? _wipe;
   bool? get wipe => _$this._wipe;
-  set wipe(bool? wipe) => _$this._wipe = wipe;
+  set wipe(covariant bool? wipe) => _$this._wipe = wipe;
 
   CoreWipeCheckWipeResponse200ApplicationJsonBuilder();
 
@@ -25383,7 +27190,7 @@ class CoreWipeCheckWipeResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(CoreWipeCheckWipeResponse200ApplicationJson other) {
+  void replace(covariant CoreWipeCheckWipeResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$CoreWipeCheckWipeResponse200ApplicationJson;
   }

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.dart
@@ -229,7 +229,18 @@ class DashboardDashboardApiClient {
   }
 }
 
-abstract class DashboardOCSMeta implements Built<DashboardOCSMeta, DashboardOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class DashboardOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  DashboardOCSMetaInterface rebuild(final void Function(DashboardOCSMetaInterfaceBuilder) updates);
+  DashboardOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class DashboardOCSMeta implements DashboardOCSMetaInterface, Built<DashboardOCSMeta, DashboardOCSMetaBuilder> {
   factory DashboardOCSMeta([final void Function(DashboardOCSMetaBuilder)? b]) = _$DashboardOCSMeta;
 
   // coverage:ignore-start
@@ -244,15 +255,20 @@ abstract class DashboardOCSMeta implements Built<DashboardOCSMeta, DashboardOCSM
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<DashboardOCSMeta> get serializer => _$dashboardOCSMetaSerializer;
 }
 
-abstract class DashboardWidget_Buttons implements Built<DashboardWidget_Buttons, DashboardWidget_ButtonsBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class DashboardWidget_ButtonsInterface {
+  String get type;
+  String get text;
+  String get link;
+  DashboardWidget_ButtonsInterface rebuild(final void Function(DashboardWidget_ButtonsInterfaceBuilder) updates);
+  DashboardWidget_ButtonsInterfaceBuilder toBuilder();
+}
+
+abstract class DashboardWidget_Buttons
+    implements DashboardWidget_ButtonsInterface, Built<DashboardWidget_Buttons, DashboardWidget_ButtonsBuilder> {
   factory DashboardWidget_Buttons([final void Function(DashboardWidget_ButtonsBuilder)? b]) = _$DashboardWidget_Buttons;
 
   // coverage:ignore-start
@@ -267,27 +283,11 @@ abstract class DashboardWidget_Buttons implements Built<DashboardWidget_Buttons,
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get type;
-  String get text;
-  String get link;
   static Serializer<DashboardWidget_Buttons> get serializer => _$dashboardWidgetButtonsSerializer;
 }
 
-abstract class DashboardWidget implements Built<DashboardWidget, DashboardWidgetBuilder> {
-  factory DashboardWidget([final void Function(DashboardWidgetBuilder)? b]) = _$DashboardWidget;
-
-  // coverage:ignore-start
-  const DashboardWidget._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory DashboardWidget.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class DashboardWidgetInterface {
   String get id;
   String get title;
   int get order;
@@ -304,11 +304,41 @@ abstract class DashboardWidget implements Built<DashboardWidget, DashboardWidget
   @BuiltValueField(wireName: 'reload_interval')
   int get reloadInterval;
   BuiltList<DashboardWidget_Buttons>? get buttons;
+  DashboardWidgetInterface rebuild(final void Function(DashboardWidgetInterfaceBuilder) updates);
+  DashboardWidgetInterfaceBuilder toBuilder();
+}
+
+abstract class DashboardWidget implements DashboardWidgetInterface, Built<DashboardWidget, DashboardWidgetBuilder> {
+  factory DashboardWidget([final void Function(DashboardWidgetBuilder)? b]) = _$DashboardWidget;
+
+  // coverage:ignore-start
+  const DashboardWidget._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory DashboardWidget.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<DashboardWidget> get serializer => _$dashboardWidgetSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsInterface {
+  DashboardOCSMeta get meta;
+  BuiltList<DashboardWidget> get data;
+  DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs
     implements
+        DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsInterface,
         Built<DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs,
             DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder> {
   factory DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs([
@@ -327,14 +357,22 @@ abstract class DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  DashboardOCSMeta get meta;
-  BuiltList<DashboardWidget> get data;
   static Serializer<DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs> get serializer =>
       _$dashboardDashboardApiGetWidgetsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class DashboardDashboardApiGetWidgetsResponse200ApplicationJsonInterface {
+  DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs get ocs;
+  DashboardDashboardApiGetWidgetsResponse200ApplicationJsonInterface rebuild(
+    final void Function(DashboardDashboardApiGetWidgetsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  DashboardDashboardApiGetWidgetsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class DashboardDashboardApiGetWidgetsResponse200ApplicationJson
     implements
+        DashboardDashboardApiGetWidgetsResponse200ApplicationJsonInterface,
         Built<DashboardDashboardApiGetWidgetsResponse200ApplicationJson,
             DashboardDashboardApiGetWidgetsResponse200ApplicationJsonBuilder> {
   factory DashboardDashboardApiGetWidgetsResponse200ApplicationJson([
@@ -353,12 +391,24 @@ abstract class DashboardDashboardApiGetWidgetsResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<DashboardDashboardApiGetWidgetsResponse200ApplicationJson> get serializer =>
       _$dashboardDashboardApiGetWidgetsResponse200ApplicationJsonSerializer;
 }
 
-abstract class DashboardWidgetItem implements Built<DashboardWidgetItem, DashboardWidgetItemBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class DashboardWidgetItemInterface {
+  String get subtitle;
+  String get title;
+  String get link;
+  String get iconUrl;
+  String get overlayIconUrl;
+  String get sinceId;
+  DashboardWidgetItemInterface rebuild(final void Function(DashboardWidgetItemInterfaceBuilder) updates);
+  DashboardWidgetItemInterfaceBuilder toBuilder();
+}
+
+abstract class DashboardWidgetItem
+    implements DashboardWidgetItemInterface, Built<DashboardWidgetItem, DashboardWidgetItemBuilder> {
   factory DashboardWidgetItem([final void Function(DashboardWidgetItemBuilder)? b]) = _$DashboardWidgetItem;
 
   // coverage:ignore-start
@@ -373,17 +423,22 @@ abstract class DashboardWidgetItem implements Built<DashboardWidgetItem, Dashboa
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get subtitle;
-  String get title;
-  String get link;
-  String get iconUrl;
-  String get overlayIconUrl;
-  String get sinceId;
   static Serializer<DashboardWidgetItem> get serializer => _$dashboardWidgetItemSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsInterface {
+  DashboardOCSMeta get meta;
+  BuiltMap<String, BuiltList<DashboardWidgetItem>> get data;
+  DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs
     implements
+        DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsInterface,
         Built<DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs,
             DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder> {
   factory DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs([
@@ -402,14 +457,22 @@ abstract class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  DashboardOCSMeta get meta;
-  BuiltMap<String, BuiltList<DashboardWidgetItem>> get data;
   static Serializer<DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs> get serializer =>
       _$dashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonInterface {
+  DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs get ocs;
+  DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonInterface rebuild(
+    final void Function(DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson
     implements
+        DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonInterface,
         Built<DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson,
             DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonBuilder> {
   factory DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson([
@@ -428,12 +491,21 @@ abstract class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson> get serializer =>
       _$dashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonSerializer;
 }
 
-abstract class DashboardWidgetItems implements Built<DashboardWidgetItems, DashboardWidgetItemsBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class DashboardWidgetItemsInterface {
+  BuiltList<DashboardWidgetItem> get items;
+  String get emptyContentMessage;
+  String get halfEmptyContentMessage;
+  DashboardWidgetItemsInterface rebuild(final void Function(DashboardWidgetItemsInterfaceBuilder) updates);
+  DashboardWidgetItemsInterfaceBuilder toBuilder();
+}
+
+abstract class DashboardWidgetItems
+    implements DashboardWidgetItemsInterface, Built<DashboardWidgetItems, DashboardWidgetItemsBuilder> {
   factory DashboardWidgetItems([final void Function(DashboardWidgetItemsBuilder)? b]) = _$DashboardWidgetItems;
 
   // coverage:ignore-start
@@ -448,14 +520,22 @@ abstract class DashboardWidgetItems implements Built<DashboardWidgetItems, Dashb
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<DashboardWidgetItem> get items;
-  String get emptyContentMessage;
-  String get halfEmptyContentMessage;
   static Serializer<DashboardWidgetItems> get serializer => _$dashboardWidgetItemsSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsInterface {
+  DashboardOCSMeta get meta;
+  BuiltMap<String, DashboardWidgetItems> get data;
+  DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsInterface rebuild(
+    final void Function(DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs
     implements
+        DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsInterface,
         Built<DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs,
             DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder> {
   factory DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs([
@@ -476,14 +556,22 @@ abstract class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  DashboardOCSMeta get meta;
-  BuiltMap<String, DashboardWidgetItems> get data;
   static Serializer<DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs> get serializer =>
       _$dashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonInterface {
+  DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs get ocs;
+  DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonInterface rebuild(
+    final void Function(DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonInterfaceBuilder) updates,
+  );
+  DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson
     implements
+        DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonInterface,
         Built<DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson,
             DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonBuilder> {
   factory DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson([
@@ -502,7 +590,6 @@ abstract class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs get ocs;
   static Serializer<DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson> get serializer =>
       _$dashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonSerializer;
 }

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.g.dart
@@ -656,6 +656,25 @@ class _$DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonSerialize
   }
 }
 
+abstract mixin class DashboardOCSMetaInterfaceBuilder {
+  void replace(DashboardOCSMetaInterface other);
+  void update(void Function(DashboardOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
+}
+
 class _$DashboardOCSMeta extends DashboardOCSMeta {
   @override
   final String status;
@@ -719,28 +738,29 @@ class _$DashboardOCSMeta extends DashboardOCSMeta {
   }
 }
 
-class DashboardOCSMetaBuilder implements Builder<DashboardOCSMeta, DashboardOCSMetaBuilder> {
+class DashboardOCSMetaBuilder
+    implements Builder<DashboardOCSMeta, DashboardOCSMetaBuilder>, DashboardOCSMetaInterfaceBuilder {
   _$DashboardOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   DashboardOCSMetaBuilder();
 
@@ -758,7 +778,7 @@ class DashboardOCSMetaBuilder implements Builder<DashboardOCSMeta, DashboardOCSM
   }
 
   @override
-  void replace(DashboardOCSMeta other) {
+  void replace(covariant DashboardOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardOCSMeta;
   }
@@ -782,6 +802,19 @@ class DashboardOCSMetaBuilder implements Builder<DashboardOCSMeta, DashboardOCSM
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DashboardWidget_ButtonsInterfaceBuilder {
+  void replace(DashboardWidget_ButtonsInterface other);
+  void update(void Function(DashboardWidget_ButtonsInterfaceBuilder) updates);
+  String? get type;
+  set type(String? type);
+
+  String? get text;
+  set text(String? text);
+
+  String? get link;
+  set link(String? link);
 }
 
 class _$DashboardWidget_Buttons extends DashboardWidget_Buttons {
@@ -834,20 +867,23 @@ class _$DashboardWidget_Buttons extends DashboardWidget_Buttons {
   }
 }
 
-class DashboardWidget_ButtonsBuilder implements Builder<DashboardWidget_Buttons, DashboardWidget_ButtonsBuilder> {
+class DashboardWidget_ButtonsBuilder
+    implements
+        Builder<DashboardWidget_Buttons, DashboardWidget_ButtonsBuilder>,
+        DashboardWidget_ButtonsInterfaceBuilder {
   _$DashboardWidget_Buttons? _$v;
 
   String? _type;
   String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
+  set type(covariant String? type) => _$this._type = type;
 
   String? _text;
   String? get text => _$this._text;
-  set text(String? text) => _$this._text = text;
+  set text(covariant String? text) => _$this._text = text;
 
   String? _link;
   String? get link => _$this._link;
-  set link(String? link) => _$this._link = link;
+  set link(covariant String? link) => _$this._link = link;
 
   DashboardWidget_ButtonsBuilder();
 
@@ -863,7 +899,7 @@ class DashboardWidget_ButtonsBuilder implements Builder<DashboardWidget_Buttons,
   }
 
   @override
-  void replace(DashboardWidget_Buttons other) {
+  void replace(covariant DashboardWidget_Buttons other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardWidget_Buttons;
   }
@@ -885,6 +921,40 @@ class DashboardWidget_ButtonsBuilder implements Builder<DashboardWidget_Buttons,
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DashboardWidgetInterfaceBuilder {
+  void replace(DashboardWidgetInterface other);
+  void update(void Function(DashboardWidgetInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get title;
+  set title(String? title);
+
+  int? get order;
+  set order(int? order);
+
+  String? get iconClass;
+  set iconClass(String? iconClass);
+
+  String? get iconUrl;
+  set iconUrl(String? iconUrl);
+
+  String? get widgetUrl;
+  set widgetUrl(String? widgetUrl);
+
+  bool? get itemIconsRound;
+  set itemIconsRound(bool? itemIconsRound);
+
+  ListBuilder<int> get itemApiVersions;
+  set itemApiVersions(ListBuilder<int>? itemApiVersions);
+
+  int? get reloadInterval;
+  set reloadInterval(int? reloadInterval);
+
+  ListBuilder<DashboardWidget_Buttons> get buttons;
+  set buttons(ListBuilder<DashboardWidget_Buttons>? buttons);
 }
 
 class _$DashboardWidget extends DashboardWidget {
@@ -990,48 +1060,49 @@ class _$DashboardWidget extends DashboardWidget {
   }
 }
 
-class DashboardWidgetBuilder implements Builder<DashboardWidget, DashboardWidgetBuilder> {
+class DashboardWidgetBuilder
+    implements Builder<DashboardWidget, DashboardWidgetBuilder>, DashboardWidgetInterfaceBuilder {
   _$DashboardWidget? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _title;
   String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
+  set title(covariant String? title) => _$this._title = title;
 
   int? _order;
   int? get order => _$this._order;
-  set order(int? order) => _$this._order = order;
+  set order(covariant int? order) => _$this._order = order;
 
   String? _iconClass;
   String? get iconClass => _$this._iconClass;
-  set iconClass(String? iconClass) => _$this._iconClass = iconClass;
+  set iconClass(covariant String? iconClass) => _$this._iconClass = iconClass;
 
   String? _iconUrl;
   String? get iconUrl => _$this._iconUrl;
-  set iconUrl(String? iconUrl) => _$this._iconUrl = iconUrl;
+  set iconUrl(covariant String? iconUrl) => _$this._iconUrl = iconUrl;
 
   String? _widgetUrl;
   String? get widgetUrl => _$this._widgetUrl;
-  set widgetUrl(String? widgetUrl) => _$this._widgetUrl = widgetUrl;
+  set widgetUrl(covariant String? widgetUrl) => _$this._widgetUrl = widgetUrl;
 
   bool? _itemIconsRound;
   bool? get itemIconsRound => _$this._itemIconsRound;
-  set itemIconsRound(bool? itemIconsRound) => _$this._itemIconsRound = itemIconsRound;
+  set itemIconsRound(covariant bool? itemIconsRound) => _$this._itemIconsRound = itemIconsRound;
 
   ListBuilder<int>? _itemApiVersions;
   ListBuilder<int> get itemApiVersions => _$this._itemApiVersions ??= ListBuilder<int>();
-  set itemApiVersions(ListBuilder<int>? itemApiVersions) => _$this._itemApiVersions = itemApiVersions;
+  set itemApiVersions(covariant ListBuilder<int>? itemApiVersions) => _$this._itemApiVersions = itemApiVersions;
 
   int? _reloadInterval;
   int? get reloadInterval => _$this._reloadInterval;
-  set reloadInterval(int? reloadInterval) => _$this._reloadInterval = reloadInterval;
+  set reloadInterval(covariant int? reloadInterval) => _$this._reloadInterval = reloadInterval;
 
   ListBuilder<DashboardWidget_Buttons>? _buttons;
   ListBuilder<DashboardWidget_Buttons> get buttons => _$this._buttons ??= ListBuilder<DashboardWidget_Buttons>();
-  set buttons(ListBuilder<DashboardWidget_Buttons>? buttons) => _$this._buttons = buttons;
+  set buttons(covariant ListBuilder<DashboardWidget_Buttons>? buttons) => _$this._buttons = buttons;
 
   DashboardWidgetBuilder();
 
@@ -1054,7 +1125,7 @@ class DashboardWidgetBuilder implements Builder<DashboardWidget, DashboardWidget
   }
 
   @override
-  void replace(DashboardWidget other) {
+  void replace(covariant DashboardWidget other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardWidget;
   }
@@ -1100,6 +1171,16 @@ class DashboardWidgetBuilder implements Builder<DashboardWidget, DashboardWidget
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  DashboardOCSMetaBuilder get meta;
+  set meta(DashboardOCSMetaBuilder? meta);
+
+  ListBuilder<DashboardWidget> get data;
+  set data(ListBuilder<DashboardWidget>? data);
 }
 
 class _$DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs
@@ -1159,16 +1240,17 @@ class _$DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs
 class DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs,
-            DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder> {
+            DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder>,
+        DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs? _$v;
 
   DashboardOCSMetaBuilder? _meta;
   DashboardOCSMetaBuilder get meta => _$this._meta ??= DashboardOCSMetaBuilder();
-  set meta(DashboardOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant DashboardOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<DashboardWidget>? _data;
   ListBuilder<DashboardWidget> get data => _$this._data ??= ListBuilder<DashboardWidget>();
-  set data(ListBuilder<DashboardWidget>? data) => _$this._data = data;
+  set data(covariant ListBuilder<DashboardWidget>? data) => _$this._data = data;
 
   DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder();
 
@@ -1183,7 +1265,7 @@ class DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardDashboardApiGetWidgetsResponse200ApplicationJson_Ocs;
   }
@@ -1217,6 +1299,13 @@ class DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DashboardDashboardApiGetWidgetsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(DashboardDashboardApiGetWidgetsResponse200ApplicationJsonInterface other);
+  void update(void Function(DashboardDashboardApiGetWidgetsResponse200ApplicationJsonInterfaceBuilder) updates);
+  DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$DashboardDashboardApiGetWidgetsResponse200ApplicationJson
@@ -1265,13 +1354,14 @@ class _$DashboardDashboardApiGetWidgetsResponse200ApplicationJson
 class DashboardDashboardApiGetWidgetsResponse200ApplicationJsonBuilder
     implements
         Builder<DashboardDashboardApiGetWidgetsResponse200ApplicationJson,
-            DashboardDashboardApiGetWidgetsResponse200ApplicationJsonBuilder> {
+            DashboardDashboardApiGetWidgetsResponse200ApplicationJsonBuilder>,
+        DashboardDashboardApiGetWidgetsResponse200ApplicationJsonInterfaceBuilder {
   _$DashboardDashboardApiGetWidgetsResponse200ApplicationJson? _$v;
 
   DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder? _ocs;
   DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder();
-  set ocs(DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant DashboardDashboardApiGetWidgetsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   DashboardDashboardApiGetWidgetsResponse200ApplicationJsonBuilder();
 
@@ -1285,7 +1375,7 @@ class DashboardDashboardApiGetWidgetsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(DashboardDashboardApiGetWidgetsResponse200ApplicationJson other) {
+  void replace(covariant DashboardDashboardApiGetWidgetsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardDashboardApiGetWidgetsResponse200ApplicationJson;
   }
@@ -1316,6 +1406,28 @@ class DashboardDashboardApiGetWidgetsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DashboardWidgetItemInterfaceBuilder {
+  void replace(DashboardWidgetItemInterface other);
+  void update(void Function(DashboardWidgetItemInterfaceBuilder) updates);
+  String? get subtitle;
+  set subtitle(String? subtitle);
+
+  String? get title;
+  set title(String? title);
+
+  String? get link;
+  set link(String? link);
+
+  String? get iconUrl;
+  set iconUrl(String? iconUrl);
+
+  String? get overlayIconUrl;
+  set overlayIconUrl(String? overlayIconUrl);
+
+  String? get sinceId;
+  set sinceId(String? sinceId);
 }
 
 class _$DashboardWidgetItem extends DashboardWidgetItem {
@@ -1396,32 +1508,33 @@ class _$DashboardWidgetItem extends DashboardWidgetItem {
   }
 }
 
-class DashboardWidgetItemBuilder implements Builder<DashboardWidgetItem, DashboardWidgetItemBuilder> {
+class DashboardWidgetItemBuilder
+    implements Builder<DashboardWidgetItem, DashboardWidgetItemBuilder>, DashboardWidgetItemInterfaceBuilder {
   _$DashboardWidgetItem? _$v;
 
   String? _subtitle;
   String? get subtitle => _$this._subtitle;
-  set subtitle(String? subtitle) => _$this._subtitle = subtitle;
+  set subtitle(covariant String? subtitle) => _$this._subtitle = subtitle;
 
   String? _title;
   String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
+  set title(covariant String? title) => _$this._title = title;
 
   String? _link;
   String? get link => _$this._link;
-  set link(String? link) => _$this._link = link;
+  set link(covariant String? link) => _$this._link = link;
 
   String? _iconUrl;
   String? get iconUrl => _$this._iconUrl;
-  set iconUrl(String? iconUrl) => _$this._iconUrl = iconUrl;
+  set iconUrl(covariant String? iconUrl) => _$this._iconUrl = iconUrl;
 
   String? _overlayIconUrl;
   String? get overlayIconUrl => _$this._overlayIconUrl;
-  set overlayIconUrl(String? overlayIconUrl) => _$this._overlayIconUrl = overlayIconUrl;
+  set overlayIconUrl(covariant String? overlayIconUrl) => _$this._overlayIconUrl = overlayIconUrl;
 
   String? _sinceId;
   String? get sinceId => _$this._sinceId;
-  set sinceId(String? sinceId) => _$this._sinceId = sinceId;
+  set sinceId(covariant String? sinceId) => _$this._sinceId = sinceId;
 
   DashboardWidgetItemBuilder();
 
@@ -1440,7 +1553,7 @@ class DashboardWidgetItemBuilder implements Builder<DashboardWidgetItem, Dashboa
   }
 
   @override
-  void replace(DashboardWidgetItem other) {
+  void replace(covariant DashboardWidgetItem other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardWidgetItem;
   }
@@ -1466,6 +1579,16 @@ class DashboardWidgetItemBuilder implements Builder<DashboardWidgetItem, Dashboa
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  DashboardOCSMetaBuilder get meta;
+  set meta(DashboardOCSMetaBuilder? meta);
+
+  MapBuilder<String, BuiltList<DashboardWidgetItem>> get data;
+  set data(MapBuilder<String, BuiltList<DashboardWidgetItem>>? data);
 }
 
 class _$DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs
@@ -1525,17 +1648,18 @@ class _$DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs
 class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs,
-            DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder> {
+            DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder>,
+        DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs? _$v;
 
   DashboardOCSMetaBuilder? _meta;
   DashboardOCSMetaBuilder get meta => _$this._meta ??= DashboardOCSMetaBuilder();
-  set meta(DashboardOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant DashboardOCSMetaBuilder? meta) => _$this._meta = meta;
 
   MapBuilder<String, BuiltList<DashboardWidgetItem>>? _data;
   MapBuilder<String, BuiltList<DashboardWidgetItem>> get data =>
       _$this._data ??= MapBuilder<String, BuiltList<DashboardWidgetItem>>();
-  set data(MapBuilder<String, BuiltList<DashboardWidgetItem>>? data) => _$this._data = data;
+  set data(covariant MapBuilder<String, BuiltList<DashboardWidgetItem>>? data) => _$this._data = data;
 
   DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder();
 
@@ -1550,7 +1674,7 @@ class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_Ocs;
   }
@@ -1584,6 +1708,13 @@ class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonInterface other);
+  void update(void Function(DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonInterfaceBuilder) updates);
+  DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson
@@ -1633,13 +1764,14 @@ class _$DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson
 class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonBuilder
     implements
         Builder<DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson,
-            DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonBuilder> {
+            DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonBuilder>,
+        DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonInterfaceBuilder {
   _$DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson? _$v;
 
   DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder? _ocs;
   DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder();
-  set ocs(DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonBuilder();
 
@@ -1653,7 +1785,7 @@ class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson other) {
+  void replace(covariant DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardDashboardApiGetWidgetItemsResponse200ApplicationJson;
   }
@@ -1684,6 +1816,19 @@ class DashboardDashboardApiGetWidgetItemsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DashboardWidgetItemsInterfaceBuilder {
+  void replace(DashboardWidgetItemsInterface other);
+  void update(void Function(DashboardWidgetItemsInterfaceBuilder) updates);
+  ListBuilder<DashboardWidgetItem> get items;
+  set items(ListBuilder<DashboardWidgetItem>? items);
+
+  String? get emptyContentMessage;
+  set emptyContentMessage(String? emptyContentMessage);
+
+  String? get halfEmptyContentMessage;
+  set halfEmptyContentMessage(String? halfEmptyContentMessage);
 }
 
 class _$DashboardWidgetItems extends DashboardWidgetItems {
@@ -1741,20 +1886,21 @@ class _$DashboardWidgetItems extends DashboardWidgetItems {
   }
 }
 
-class DashboardWidgetItemsBuilder implements Builder<DashboardWidgetItems, DashboardWidgetItemsBuilder> {
+class DashboardWidgetItemsBuilder
+    implements Builder<DashboardWidgetItems, DashboardWidgetItemsBuilder>, DashboardWidgetItemsInterfaceBuilder {
   _$DashboardWidgetItems? _$v;
 
   ListBuilder<DashboardWidgetItem>? _items;
   ListBuilder<DashboardWidgetItem> get items => _$this._items ??= ListBuilder<DashboardWidgetItem>();
-  set items(ListBuilder<DashboardWidgetItem>? items) => _$this._items = items;
+  set items(covariant ListBuilder<DashboardWidgetItem>? items) => _$this._items = items;
 
   String? _emptyContentMessage;
   String? get emptyContentMessage => _$this._emptyContentMessage;
-  set emptyContentMessage(String? emptyContentMessage) => _$this._emptyContentMessage = emptyContentMessage;
+  set emptyContentMessage(covariant String? emptyContentMessage) => _$this._emptyContentMessage = emptyContentMessage;
 
   String? _halfEmptyContentMessage;
   String? get halfEmptyContentMessage => _$this._halfEmptyContentMessage;
-  set halfEmptyContentMessage(String? halfEmptyContentMessage) =>
+  set halfEmptyContentMessage(covariant String? halfEmptyContentMessage) =>
       _$this._halfEmptyContentMessage = halfEmptyContentMessage;
 
   DashboardWidgetItemsBuilder();
@@ -1771,7 +1917,7 @@ class DashboardWidgetItemsBuilder implements Builder<DashboardWidgetItems, Dashb
   }
 
   @override
-  void replace(DashboardWidgetItems other) {
+  void replace(covariant DashboardWidgetItems other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardWidgetItems;
   }
@@ -1807,6 +1953,17 @@ class DashboardWidgetItemsBuilder implements Builder<DashboardWidgetItems, Dashb
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsInterfaceBuilder {
+  void replace(DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsInterfaceBuilder) updates);
+  DashboardOCSMetaBuilder get meta;
+  set meta(DashboardOCSMetaBuilder? meta);
+
+  MapBuilder<String, DashboardWidgetItems> get data;
+  set data(MapBuilder<String, DashboardWidgetItems>? data);
 }
 
 class _$DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs
@@ -1866,16 +2023,17 @@ class _$DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs
 class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder
     implements
         Builder<DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs,
-            DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder> {
+            DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder>,
+        DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsInterfaceBuilder {
   _$DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs? _$v;
 
   DashboardOCSMetaBuilder? _meta;
   DashboardOCSMetaBuilder get meta => _$this._meta ??= DashboardOCSMetaBuilder();
-  set meta(DashboardOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant DashboardOCSMetaBuilder? meta) => _$this._meta = meta;
 
   MapBuilder<String, DashboardWidgetItems>? _data;
   MapBuilder<String, DashboardWidgetItems> get data => _$this._data ??= MapBuilder<String, DashboardWidgetItems>();
-  set data(MapBuilder<String, DashboardWidgetItems>? data) => _$this._data = data;
+  set data(covariant MapBuilder<String, DashboardWidgetItems>? data) => _$this._data = data;
 
   DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder();
 
@@ -1890,7 +2048,7 @@ class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs other) {
+  void replace(covariant DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_Ocs;
   }
@@ -1925,6 +2083,13 @@ class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonInterfaceBuilder {
+  void replace(DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonInterface other);
+  void update(void Function(DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonInterfaceBuilder) updates);
+  DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder get ocs;
+  set ocs(DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson
@@ -1975,13 +2140,15 @@ class _$DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson
 class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonBuilder
     implements
         Builder<DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson,
-            DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonBuilder> {
+            DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonBuilder>,
+        DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonInterfaceBuilder {
   _$DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson? _$v;
 
   DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder? _ocs;
   DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder();
-  set ocs(DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonBuilder();
 
@@ -1995,7 +2162,7 @@ class DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJsonBuilder
   }
 
   @override
-  void replace(DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson other) {
+  void replace(covariant DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DashboardDashboardApiGetWidgetItemsV2Response200ApplicationJson;
   }

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -122,7 +122,18 @@ class DavDirectClient {
   }
 }
 
-abstract class DavOCSMeta implements Built<DavOCSMeta, DavOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class DavOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  DavOCSMetaInterface rebuild(final void Function(DavOCSMetaInterfaceBuilder) updates);
+  DavOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class DavOCSMeta implements DavOCSMetaInterface, Built<DavOCSMeta, DavOCSMetaBuilder> {
   factory DavOCSMeta([final void Function(DavOCSMetaBuilder)? b]) = _$DavOCSMeta;
 
   // coverage:ignore-start
@@ -136,16 +147,21 @@ abstract class DavOCSMeta implements Built<DavOCSMeta, DavOCSMetaBuilder> {
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<DavOCSMeta> get serializer => _$davOCSMetaSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class DavDirectGetUrlResponse200ApplicationJson_Ocs_DataInterface {
+  String get url;
+  DavDirectGetUrlResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(DavDirectGetUrlResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  DavDirectGetUrlResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
 }
 
 abstract class DavDirectGetUrlResponse200ApplicationJson_Ocs_Data
     implements
+        DavDirectGetUrlResponse200ApplicationJson_Ocs_DataInterface,
         Built<DavDirectGetUrlResponse200ApplicationJson_Ocs_Data,
             DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder> {
   factory DavDirectGetUrlResponse200ApplicationJson_Ocs_Data([
@@ -164,13 +180,23 @@ abstract class DavDirectGetUrlResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get url;
   static Serializer<DavDirectGetUrlResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$davDirectGetUrlResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class DavDirectGetUrlResponse200ApplicationJson_OcsInterface {
+  DavOCSMeta get meta;
+  DavDirectGetUrlResponse200ApplicationJson_Ocs_Data get data;
+  DavDirectGetUrlResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(DavDirectGetUrlResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  DavDirectGetUrlResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class DavDirectGetUrlResponse200ApplicationJson_Ocs
     implements
+        DavDirectGetUrlResponse200ApplicationJson_OcsInterface,
         Built<DavDirectGetUrlResponse200ApplicationJson_Ocs, DavDirectGetUrlResponse200ApplicationJson_OcsBuilder> {
   factory DavDirectGetUrlResponse200ApplicationJson_Ocs([
     final void Function(DavDirectGetUrlResponse200ApplicationJson_OcsBuilder)? b,
@@ -188,14 +214,23 @@ abstract class DavDirectGetUrlResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  DavOCSMeta get meta;
-  DavDirectGetUrlResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<DavDirectGetUrlResponse200ApplicationJson_Ocs> get serializer =>
       _$davDirectGetUrlResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class DavDirectGetUrlResponse200ApplicationJsonInterface {
+  DavDirectGetUrlResponse200ApplicationJson_Ocs get ocs;
+  DavDirectGetUrlResponse200ApplicationJsonInterface rebuild(
+    final void Function(DavDirectGetUrlResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  DavDirectGetUrlResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class DavDirectGetUrlResponse200ApplicationJson
-    implements Built<DavDirectGetUrlResponse200ApplicationJson, DavDirectGetUrlResponse200ApplicationJsonBuilder> {
+    implements
+        DavDirectGetUrlResponse200ApplicationJsonInterface,
+        Built<DavDirectGetUrlResponse200ApplicationJson, DavDirectGetUrlResponse200ApplicationJsonBuilder> {
   factory DavDirectGetUrlResponse200ApplicationJson([
     final void Function(DavDirectGetUrlResponse200ApplicationJsonBuilder)? b,
   ]) = _$DavDirectGetUrlResponse200ApplicationJson;
@@ -212,12 +247,20 @@ abstract class DavDirectGetUrlResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  DavDirectGetUrlResponse200ApplicationJson_Ocs get ocs;
   static Serializer<DavDirectGetUrlResponse200ApplicationJson> get serializer =>
       _$davDirectGetUrlResponse200ApplicationJsonSerializer;
 }
 
-abstract class DavCapabilities_Dav implements Built<DavCapabilities_Dav, DavCapabilities_DavBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class DavCapabilities_DavInterface {
+  String get chunking;
+  String? get bulkupload;
+  DavCapabilities_DavInterface rebuild(final void Function(DavCapabilities_DavInterfaceBuilder) updates);
+  DavCapabilities_DavInterfaceBuilder toBuilder();
+}
+
+abstract class DavCapabilities_Dav
+    implements DavCapabilities_DavInterface, Built<DavCapabilities_Dav, DavCapabilities_DavBuilder> {
   factory DavCapabilities_Dav([final void Function(DavCapabilities_DavBuilder)? b]) = _$DavCapabilities_Dav;
 
   // coverage:ignore-start
@@ -232,12 +275,17 @@ abstract class DavCapabilities_Dav implements Built<DavCapabilities_Dav, DavCapa
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get chunking;
-  String? get bulkupload;
   static Serializer<DavCapabilities_Dav> get serializer => _$davCapabilitiesDavSerializer;
 }
 
-abstract class DavCapabilities implements Built<DavCapabilities, DavCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class DavCapabilitiesInterface {
+  DavCapabilities_Dav get dav;
+  DavCapabilitiesInterface rebuild(final void Function(DavCapabilitiesInterfaceBuilder) updates);
+  DavCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class DavCapabilities implements DavCapabilitiesInterface, Built<DavCapabilities, DavCapabilitiesBuilder> {
   factory DavCapabilities([final void Function(DavCapabilitiesBuilder)? b]) = _$DavCapabilities;
 
   // coverage:ignore-start
@@ -252,7 +300,6 @@ abstract class DavCapabilities implements Built<DavCapabilities, DavCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  DavCapabilities_Dav get dav;
   static Serializer<DavCapabilities> get serializer => _$davCapabilitiesSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/dav.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.g.dart
@@ -309,6 +309,25 @@ class _$DavCapabilitiesSerializer implements StructuredSerializer<DavCapabilitie
   }
 }
 
+abstract mixin class DavOCSMetaInterfaceBuilder {
+  void replace(DavOCSMetaInterface other);
+  void update(void Function(DavOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
+}
+
 class _$DavOCSMeta extends DavOCSMeta {
   @override
   final String status;
@@ -370,28 +389,28 @@ class _$DavOCSMeta extends DavOCSMeta {
   }
 }
 
-class DavOCSMetaBuilder implements Builder<DavOCSMeta, DavOCSMetaBuilder> {
+class DavOCSMetaBuilder implements Builder<DavOCSMeta, DavOCSMetaBuilder>, DavOCSMetaInterfaceBuilder {
   _$DavOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   DavOCSMetaBuilder();
 
@@ -409,7 +428,7 @@ class DavOCSMetaBuilder implements Builder<DavOCSMeta, DavOCSMetaBuilder> {
   }
 
   @override
-  void replace(DavOCSMeta other) {
+  void replace(covariant DavOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DavOCSMeta;
   }
@@ -433,6 +452,13 @@ class DavOCSMetaBuilder implements Builder<DavOCSMeta, DavOCSMetaBuilder> {
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DavDirectGetUrlResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(DavDirectGetUrlResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(DavDirectGetUrlResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get url;
+  set url(String? url);
 }
 
 class _$DavDirectGetUrlResponse200ApplicationJson_Ocs_Data extends DavDirectGetUrlResponse200ApplicationJson_Ocs_Data {
@@ -480,12 +506,13 @@ class _$DavDirectGetUrlResponse200ApplicationJson_Ocs_Data extends DavDirectGetU
 class DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<DavDirectGetUrlResponse200ApplicationJson_Ocs_Data,
-            DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder> {
+            DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder>,
+        DavDirectGetUrlResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$DavDirectGetUrlResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _url;
   String? get url => _$this._url;
-  set url(String? url) => _$this._url = url;
+  set url(covariant String? url) => _$this._url = url;
 
   DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -499,7 +526,7 @@ class DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(DavDirectGetUrlResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant DavDirectGetUrlResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DavDirectGetUrlResponse200ApplicationJson_Ocs_Data;
   }
@@ -520,6 +547,16 @@ class DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DavDirectGetUrlResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(DavDirectGetUrlResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(DavDirectGetUrlResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  DavOCSMetaBuilder get meta;
+  set meta(DavOCSMetaBuilder? meta);
+
+  DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$DavDirectGetUrlResponse200ApplicationJson_Ocs extends DavDirectGetUrlResponse200ApplicationJson_Ocs {
@@ -572,17 +609,18 @@ class _$DavDirectGetUrlResponse200ApplicationJson_Ocs extends DavDirectGetUrlRes
 
 class DavDirectGetUrlResponse200ApplicationJson_OcsBuilder
     implements
-        Builder<DavDirectGetUrlResponse200ApplicationJson_Ocs, DavDirectGetUrlResponse200ApplicationJson_OcsBuilder> {
+        Builder<DavDirectGetUrlResponse200ApplicationJson_Ocs, DavDirectGetUrlResponse200ApplicationJson_OcsBuilder>,
+        DavDirectGetUrlResponse200ApplicationJson_OcsInterfaceBuilder {
   _$DavDirectGetUrlResponse200ApplicationJson_Ocs? _$v;
 
   DavOCSMetaBuilder? _meta;
   DavOCSMetaBuilder get meta => _$this._meta ??= DavOCSMetaBuilder();
-  set meta(DavOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant DavOCSMetaBuilder? meta) => _$this._meta = meta;
 
   DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder? _data;
   DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant DavDirectGetUrlResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   DavDirectGetUrlResponse200ApplicationJson_OcsBuilder();
 
@@ -597,7 +635,7 @@ class DavDirectGetUrlResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(DavDirectGetUrlResponse200ApplicationJson_Ocs other) {
+  void replace(covariant DavDirectGetUrlResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DavDirectGetUrlResponse200ApplicationJson_Ocs;
   }
@@ -629,6 +667,13 @@ class DavDirectGetUrlResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DavDirectGetUrlResponse200ApplicationJsonInterfaceBuilder {
+  void replace(DavDirectGetUrlResponse200ApplicationJsonInterface other);
+  void update(void Function(DavDirectGetUrlResponse200ApplicationJsonInterfaceBuilder) updates);
+  DavDirectGetUrlResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(DavDirectGetUrlResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$DavDirectGetUrlResponse200ApplicationJson extends DavDirectGetUrlResponse200ApplicationJson {
@@ -673,13 +718,15 @@ class _$DavDirectGetUrlResponse200ApplicationJson extends DavDirectGetUrlRespons
 }
 
 class DavDirectGetUrlResponse200ApplicationJsonBuilder
-    implements Builder<DavDirectGetUrlResponse200ApplicationJson, DavDirectGetUrlResponse200ApplicationJsonBuilder> {
+    implements
+        Builder<DavDirectGetUrlResponse200ApplicationJson, DavDirectGetUrlResponse200ApplicationJsonBuilder>,
+        DavDirectGetUrlResponse200ApplicationJsonInterfaceBuilder {
   _$DavDirectGetUrlResponse200ApplicationJson? _$v;
 
   DavDirectGetUrlResponse200ApplicationJson_OcsBuilder? _ocs;
   DavDirectGetUrlResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= DavDirectGetUrlResponse200ApplicationJson_OcsBuilder();
-  set ocs(DavDirectGetUrlResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant DavDirectGetUrlResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   DavDirectGetUrlResponse200ApplicationJsonBuilder();
 
@@ -693,7 +740,7 @@ class DavDirectGetUrlResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(DavDirectGetUrlResponse200ApplicationJson other) {
+  void replace(covariant DavDirectGetUrlResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DavDirectGetUrlResponse200ApplicationJson;
   }
@@ -723,6 +770,16 @@ class DavDirectGetUrlResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DavCapabilities_DavInterfaceBuilder {
+  void replace(DavCapabilities_DavInterface other);
+  void update(void Function(DavCapabilities_DavInterfaceBuilder) updates);
+  String? get chunking;
+  set chunking(String? chunking);
+
+  String? get bulkupload;
+  set bulkupload(String? bulkupload);
 }
 
 class _$DavCapabilities_Dav extends DavCapabilities_Dav {
@@ -769,16 +826,17 @@ class _$DavCapabilities_Dav extends DavCapabilities_Dav {
   }
 }
 
-class DavCapabilities_DavBuilder implements Builder<DavCapabilities_Dav, DavCapabilities_DavBuilder> {
+class DavCapabilities_DavBuilder
+    implements Builder<DavCapabilities_Dav, DavCapabilities_DavBuilder>, DavCapabilities_DavInterfaceBuilder {
   _$DavCapabilities_Dav? _$v;
 
   String? _chunking;
   String? get chunking => _$this._chunking;
-  set chunking(String? chunking) => _$this._chunking = chunking;
+  set chunking(covariant String? chunking) => _$this._chunking = chunking;
 
   String? _bulkupload;
   String? get bulkupload => _$this._bulkupload;
-  set bulkupload(String? bulkupload) => _$this._bulkupload = bulkupload;
+  set bulkupload(covariant String? bulkupload) => _$this._bulkupload = bulkupload;
 
   DavCapabilities_DavBuilder();
 
@@ -793,7 +851,7 @@ class DavCapabilities_DavBuilder implements Builder<DavCapabilities_Dav, DavCapa
   }
 
   @override
-  void replace(DavCapabilities_Dav other) {
+  void replace(covariant DavCapabilities_Dav other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DavCapabilities_Dav;
   }
@@ -814,6 +872,13 @@ class DavCapabilities_DavBuilder implements Builder<DavCapabilities_Dav, DavCapa
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class DavCapabilitiesInterfaceBuilder {
+  void replace(DavCapabilitiesInterface other);
+  void update(void Function(DavCapabilitiesInterfaceBuilder) updates);
+  DavCapabilities_DavBuilder get dav;
+  set dav(DavCapabilities_DavBuilder? dav);
 }
 
 class _$DavCapabilities extends DavCapabilities {
@@ -853,12 +918,13 @@ class _$DavCapabilities extends DavCapabilities {
   }
 }
 
-class DavCapabilitiesBuilder implements Builder<DavCapabilities, DavCapabilitiesBuilder> {
+class DavCapabilitiesBuilder
+    implements Builder<DavCapabilities, DavCapabilitiesBuilder>, DavCapabilitiesInterfaceBuilder {
   _$DavCapabilities? _$v;
 
   DavCapabilities_DavBuilder? _dav;
   DavCapabilities_DavBuilder get dav => _$this._dav ??= DavCapabilities_DavBuilder();
-  set dav(DavCapabilities_DavBuilder? dav) => _$this._dav = dav;
+  set dav(covariant DavCapabilities_DavBuilder? dav) => _$this._dav = dav;
 
   DavCapabilitiesBuilder();
 
@@ -872,7 +938,7 @@ class DavCapabilitiesBuilder implements Builder<DavCapabilities, DavCapabilities
   }
 
   @override
-  void replace(DavCapabilities other) {
+  void replace(covariant DavCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DavCapabilities;
   }

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -707,8 +707,20 @@ class FilesTransferOwnershipClient {
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesApiApiServiceWorkerHeadersInterface {
+  @BuiltValueField(wireName: 'service-worker-allowed')
+  String? get serviceWorkerAllowed;
+  FilesApiApiServiceWorkerHeadersInterface rebuild(
+    final void Function(FilesApiApiServiceWorkerHeadersInterfaceBuilder) updates,
+  );
+  FilesApiApiServiceWorkerHeadersInterfaceBuilder toBuilder();
+}
+
 abstract class FilesApiApiServiceWorkerHeaders
-    implements Built<FilesApiApiServiceWorkerHeaders, FilesApiApiServiceWorkerHeadersBuilder> {
+    implements
+        FilesApiApiServiceWorkerHeadersInterface,
+        Built<FilesApiApiServiceWorkerHeaders, FilesApiApiServiceWorkerHeadersBuilder> {
   factory FilesApiApiServiceWorkerHeaders([final void Function(FilesApiApiServiceWorkerHeadersBuilder)? b]) =
       _$FilesApiApiServiceWorkerHeaders;
 
@@ -724,8 +736,6 @@ abstract class FilesApiApiServiceWorkerHeaders
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'service-worker-allowed')
-  String? get serviceWorkerAllowed;
   @BuiltValueSerializer(custom: true)
   static Serializer<FilesApiApiServiceWorkerHeaders> get serializer => _$FilesApiApiServiceWorkerHeadersSerializer();
 }
@@ -769,7 +779,18 @@ class _$FilesApiApiServiceWorkerHeadersSerializer implements StructuredSerialize
   }
 }
 
-abstract class FilesOCSMeta implements Built<FilesOCSMeta, FilesOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  FilesOCSMetaInterface rebuild(final void Function(FilesOCSMetaInterfaceBuilder) updates);
+  FilesOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class FilesOCSMeta implements FilesOCSMetaInterface, Built<FilesOCSMeta, FilesOCSMetaBuilder> {
   factory FilesOCSMeta([final void Function(FilesOCSMetaBuilder)? b]) = _$FilesOCSMeta;
 
   // coverage:ignore-start
@@ -783,16 +804,25 @@ abstract class FilesOCSMeta implements Built<FilesOCSMeta, FilesOCSMetaBuilder> 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<FilesOCSMeta> get serializer => _$filesOCSMetaSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsInterface {
+  String get id;
+  String get name;
+  BuiltList<String> get mimetypes;
+  BuiltList<String> get optionalMimetypes;
+  bool get secure;
+  FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsInterface rebuild(
+    final void Function(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsInterfaceBuilder) updates,
+  );
+  FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsInterfaceBuilder toBuilder();
 }
 
 abstract class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors
     implements
+        FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsInterface,
         Built<FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors,
             FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsBuilder> {
   factory FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors([
@@ -811,17 +841,28 @@ abstract class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  String get name;
-  BuiltList<String> get mimetypes;
-  BuiltList<String> get optionalMimetypes;
-  bool get secure;
   static Serializer<FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors> get serializer =>
       _$filesDirectEditingInfoResponse200ApplicationJsonOcsDataEditorsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsInterface {
+  String get id;
+  String get editor;
+  String get name;
+  @BuiltValueField(wireName: 'extension')
+  String get $extension;
+  bool get templates;
+  BuiltList<String> get mimetypes;
+  FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsInterface rebuild(
+    final void Function(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsInterfaceBuilder) updates,
+  );
+  FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators
     implements
+        FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsInterface,
         Built<FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators,
             FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsBuilder> {
   factory FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators([
@@ -842,19 +883,23 @@ abstract class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creator
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  String get editor;
-  String get name;
-  @BuiltValueField(wireName: 'extension')
-  String get $extension;
-  bool get templates;
-  BuiltList<String> get mimetypes;
   static Serializer<FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators> get serializer =>
       _$filesDirectEditingInfoResponse200ApplicationJsonOcsDataCreatorsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltMap<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors> get editors;
+  BuiltMap<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators> get creators;
+  FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data
     implements
+        FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataInterface,
         Built<FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data,
             FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder> {
   factory FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data([
@@ -873,14 +918,23 @@ abstract class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltMap<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors> get editors;
-  BuiltMap<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators> get creators;
   static Serializer<FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$filesDirectEditingInfoResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingInfoResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data get data;
+  FilesDirectEditingInfoResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesDirectEditingInfoResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesDirectEditingInfoResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingInfoResponse200ApplicationJson_Ocs
     implements
+        FilesDirectEditingInfoResponse200ApplicationJson_OcsInterface,
         Built<FilesDirectEditingInfoResponse200ApplicationJson_Ocs,
             FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder> {
   factory FilesDirectEditingInfoResponse200ApplicationJson_Ocs([
@@ -899,14 +953,22 @@ abstract class FilesDirectEditingInfoResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<FilesDirectEditingInfoResponse200ApplicationJson_Ocs> get serializer =>
       _$filesDirectEditingInfoResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingInfoResponse200ApplicationJsonInterface {
+  FilesDirectEditingInfoResponse200ApplicationJson_Ocs get ocs;
+  FilesDirectEditingInfoResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesDirectEditingInfoResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesDirectEditingInfoResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingInfoResponse200ApplicationJson
     implements
+        FilesDirectEditingInfoResponse200ApplicationJsonInterface,
         Built<FilesDirectEditingInfoResponse200ApplicationJson,
             FilesDirectEditingInfoResponse200ApplicationJsonBuilder> {
   factory FilesDirectEditingInfoResponse200ApplicationJson([
@@ -925,13 +987,28 @@ abstract class FilesDirectEditingInfoResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesDirectEditingInfoResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesDirectEditingInfoResponse200ApplicationJson> get serializer =>
       _$filesDirectEditingInfoResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesInterface {
+  String get id;
+  String get title;
+  String? get preview;
+  @BuiltValueField(wireName: 'extension')
+  String get $extension;
+  String get mimetype;
+  FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesInterface rebuild(
+    final void Function(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesInterfaceBuilder)
+        updates,
+  );
+  FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates
     implements
+        FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesInterface,
         Built<FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates,
             FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesBuilder> {
   factory FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates([
@@ -952,18 +1029,22 @@ abstract class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Te
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  String get title;
-  String? get preview;
-  @BuiltValueField(wireName: 'extension')
-  String get $extension;
-  String get mimetype;
   static Serializer<FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates> get serializer =>
       _$filesDirectEditingTemplatesResponse200ApplicationJsonOcsDataTemplatesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltMap<String, FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates> get templates;
+  FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data
     implements
+        FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataInterface,
         Built<FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data,
             FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder> {
   factory FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data([
@@ -982,13 +1063,23 @@ abstract class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltMap<String, FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates> get templates;
   static Serializer<FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$filesDirectEditingTemplatesResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingTemplatesResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data get data;
+  FilesDirectEditingTemplatesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesDirectEditingTemplatesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesDirectEditingTemplatesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs
     implements
+        FilesDirectEditingTemplatesResponse200ApplicationJson_OcsInterface,
         Built<FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs,
             FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder> {
   factory FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs([
@@ -1007,14 +1098,22 @@ abstract class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs> get serializer =>
       _$filesDirectEditingTemplatesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingTemplatesResponse200ApplicationJsonInterface {
+  FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs get ocs;
+  FilesDirectEditingTemplatesResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesDirectEditingTemplatesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesDirectEditingTemplatesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingTemplatesResponse200ApplicationJson
     implements
+        FilesDirectEditingTemplatesResponse200ApplicationJsonInterface,
         Built<FilesDirectEditingTemplatesResponse200ApplicationJson,
             FilesDirectEditingTemplatesResponse200ApplicationJsonBuilder> {
   factory FilesDirectEditingTemplatesResponse200ApplicationJson([
@@ -1033,13 +1132,22 @@ abstract class FilesDirectEditingTemplatesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesDirectEditingTemplatesResponse200ApplicationJson> get serializer =>
       _$filesDirectEditingTemplatesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataInterface {
+  String get url;
+  FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data
     implements
+        FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataInterface,
         Built<FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data,
             FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder> {
   factory FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data([
@@ -1058,13 +1166,23 @@ abstract class FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get url;
   static Serializer<FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$filesDirectEditingOpenResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingOpenResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data get data;
+  FilesDirectEditingOpenResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesDirectEditingOpenResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesDirectEditingOpenResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingOpenResponse200ApplicationJson_Ocs
     implements
+        FilesDirectEditingOpenResponse200ApplicationJson_OcsInterface,
         Built<FilesDirectEditingOpenResponse200ApplicationJson_Ocs,
             FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder> {
   factory FilesDirectEditingOpenResponse200ApplicationJson_Ocs([
@@ -1083,14 +1201,22 @@ abstract class FilesDirectEditingOpenResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<FilesDirectEditingOpenResponse200ApplicationJson_Ocs> get serializer =>
       _$filesDirectEditingOpenResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingOpenResponse200ApplicationJsonInterface {
+  FilesDirectEditingOpenResponse200ApplicationJson_Ocs get ocs;
+  FilesDirectEditingOpenResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesDirectEditingOpenResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesDirectEditingOpenResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingOpenResponse200ApplicationJson
     implements
+        FilesDirectEditingOpenResponse200ApplicationJsonInterface,
         Built<FilesDirectEditingOpenResponse200ApplicationJson,
             FilesDirectEditingOpenResponse200ApplicationJsonBuilder> {
   factory FilesDirectEditingOpenResponse200ApplicationJson([
@@ -1109,13 +1235,22 @@ abstract class FilesDirectEditingOpenResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesDirectEditingOpenResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesDirectEditingOpenResponse200ApplicationJson> get serializer =>
       _$filesDirectEditingOpenResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataInterface {
+  String get url;
+  FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data
     implements
+        FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataInterface,
         Built<FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data,
             FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder> {
   factory FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data([
@@ -1134,13 +1269,23 @@ abstract class FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get url;
   static Serializer<FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$filesDirectEditingCreateResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingCreateResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data get data;
+  FilesDirectEditingCreateResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesDirectEditingCreateResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesDirectEditingCreateResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingCreateResponse200ApplicationJson_Ocs
     implements
+        FilesDirectEditingCreateResponse200ApplicationJson_OcsInterface,
         Built<FilesDirectEditingCreateResponse200ApplicationJson_Ocs,
             FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder> {
   factory FilesDirectEditingCreateResponse200ApplicationJson_Ocs([
@@ -1159,14 +1304,22 @@ abstract class FilesDirectEditingCreateResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<FilesDirectEditingCreateResponse200ApplicationJson_Ocs> get serializer =>
       _$filesDirectEditingCreateResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesDirectEditingCreateResponse200ApplicationJsonInterface {
+  FilesDirectEditingCreateResponse200ApplicationJson_Ocs get ocs;
+  FilesDirectEditingCreateResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesDirectEditingCreateResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesDirectEditingCreateResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesDirectEditingCreateResponse200ApplicationJson
     implements
+        FilesDirectEditingCreateResponse200ApplicationJsonInterface,
         Built<FilesDirectEditingCreateResponse200ApplicationJson,
             FilesDirectEditingCreateResponse200ApplicationJsonBuilder> {
   factory FilesDirectEditingCreateResponse200ApplicationJson([
@@ -1185,13 +1338,25 @@ abstract class FilesDirectEditingCreateResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesDirectEditingCreateResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesDirectEditingCreateResponse200ApplicationJson> get serializer =>
       _$filesDirectEditingCreateResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataInterface {
+  String? get userId;
+  String get pathHash;
+  int get expirationTime;
+  String get token;
+  FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data
     implements
+        FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataInterface,
         Built<FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data,
             FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder> {
   factory FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data([
@@ -1210,16 +1375,23 @@ abstract class FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String? get userId;
-  String get pathHash;
-  int get expirationTime;
-  String get token;
   static Serializer<FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$filesOpenLocalEditorCreateResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data get data;
+  FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs
     implements
+        FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsInterface,
         Built<FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs,
             FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder> {
   factory FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs([
@@ -1238,14 +1410,22 @@ abstract class FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs> get serializer =>
       _$filesOpenLocalEditorCreateResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesOpenLocalEditorCreateResponse200ApplicationJsonInterface {
+  FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs get ocs;
+  FilesOpenLocalEditorCreateResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesOpenLocalEditorCreateResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesOpenLocalEditorCreateResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesOpenLocalEditorCreateResponse200ApplicationJson
     implements
+        FilesOpenLocalEditorCreateResponse200ApplicationJsonInterface,
         Built<FilesOpenLocalEditorCreateResponse200ApplicationJson,
             FilesOpenLocalEditorCreateResponse200ApplicationJsonBuilder> {
   factory FilesOpenLocalEditorCreateResponse200ApplicationJson([
@@ -1264,13 +1444,25 @@ abstract class FilesOpenLocalEditorCreateResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesOpenLocalEditorCreateResponse200ApplicationJson> get serializer =>
       _$filesOpenLocalEditorCreateResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataInterface {
+  String get userId;
+  String get pathHash;
+  int get expirationTime;
+  String get token;
+  FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data
     implements
+        FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataInterface,
         Built<FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data,
             FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder> {
   factory FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data([
@@ -1289,16 +1481,23 @@ abstract class FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get userId;
-  String get pathHash;
-  int get expirationTime;
-  String get token;
   static Serializer<FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$filesOpenLocalEditorValidateResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data get data;
+  FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs
     implements
+        FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsInterface,
         Built<FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs,
             FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder> {
   factory FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs([
@@ -1317,14 +1516,22 @@ abstract class FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs> get serializer =>
       _$filesOpenLocalEditorValidateResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesOpenLocalEditorValidateResponse200ApplicationJsonInterface {
+  FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs get ocs;
+  FilesOpenLocalEditorValidateResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesOpenLocalEditorValidateResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesOpenLocalEditorValidateResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesOpenLocalEditorValidateResponse200ApplicationJson
     implements
+        FilesOpenLocalEditorValidateResponse200ApplicationJsonInterface,
         Built<FilesOpenLocalEditorValidateResponse200ApplicationJson,
             FilesOpenLocalEditorValidateResponse200ApplicationJsonBuilder> {
   factory FilesOpenLocalEditorValidateResponse200ApplicationJson([
@@ -1343,12 +1550,26 @@ abstract class FilesOpenLocalEditorValidateResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesOpenLocalEditorValidateResponse200ApplicationJson> get serializer =>
       _$filesOpenLocalEditorValidateResponse200ApplicationJsonSerializer;
 }
 
-abstract class FilesTemplateFileCreator implements Built<FilesTemplateFileCreator, FilesTemplateFileCreatorBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesTemplateFileCreatorInterface {
+  String get app;
+  String get label;
+  @BuiltValueField(wireName: 'extension')
+  String get $extension;
+  String? get iconClass;
+  BuiltList<String> get mimetypes;
+  num? get ratio;
+  String get actionLabel;
+  FilesTemplateFileCreatorInterface rebuild(final void Function(FilesTemplateFileCreatorInterfaceBuilder) updates);
+  FilesTemplateFileCreatorInterfaceBuilder toBuilder();
+}
+
+abstract class FilesTemplateFileCreator
+    implements FilesTemplateFileCreatorInterface, Built<FilesTemplateFileCreator, FilesTemplateFileCreatorBuilder> {
   factory FilesTemplateFileCreator([final void Function(FilesTemplateFileCreatorBuilder)? b]) =
       _$FilesTemplateFileCreator;
 
@@ -1364,19 +1585,22 @@ abstract class FilesTemplateFileCreator implements Built<FilesTemplateFileCreato
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get app;
-  String get label;
-  @BuiltValueField(wireName: 'extension')
-  String get $extension;
-  String? get iconClass;
-  BuiltList<String> get mimetypes;
-  num? get ratio;
-  String get actionLabel;
   static Serializer<FilesTemplateFileCreator> get serializer => _$filesTemplateFileCreatorSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesTemplateListResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  BuiltList<FilesTemplateFileCreator> get data;
+  FilesTemplateListResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesTemplateListResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesTemplateListResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class FilesTemplateListResponse200ApplicationJson_Ocs
     implements
+        FilesTemplateListResponse200ApplicationJson_OcsInterface,
         Built<FilesTemplateListResponse200ApplicationJson_Ocs, FilesTemplateListResponse200ApplicationJson_OcsBuilder> {
   factory FilesTemplateListResponse200ApplicationJson_Ocs([
     final void Function(FilesTemplateListResponse200ApplicationJson_OcsBuilder)? b,
@@ -1394,14 +1618,23 @@ abstract class FilesTemplateListResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  BuiltList<FilesTemplateFileCreator> get data;
   static Serializer<FilesTemplateListResponse200ApplicationJson_Ocs> get serializer =>
       _$filesTemplateListResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTemplateListResponse200ApplicationJsonInterface {
+  FilesTemplateListResponse200ApplicationJson_Ocs get ocs;
+  FilesTemplateListResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesTemplateListResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesTemplateListResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTemplateListResponse200ApplicationJson
-    implements Built<FilesTemplateListResponse200ApplicationJson, FilesTemplateListResponse200ApplicationJsonBuilder> {
+    implements
+        FilesTemplateListResponse200ApplicationJsonInterface,
+        Built<FilesTemplateListResponse200ApplicationJson, FilesTemplateListResponse200ApplicationJsonBuilder> {
   factory FilesTemplateListResponse200ApplicationJson([
     final void Function(FilesTemplateListResponse200ApplicationJsonBuilder)? b,
   ]) = _$FilesTemplateListResponse200ApplicationJson;
@@ -1418,12 +1651,27 @@ abstract class FilesTemplateListResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesTemplateListResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesTemplateListResponse200ApplicationJson> get serializer =>
       _$filesTemplateListResponse200ApplicationJsonSerializer;
 }
 
-abstract class FilesTemplateFile implements Built<FilesTemplateFile, FilesTemplateFileBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesTemplateFileInterface {
+  String get basename;
+  String get etag;
+  int get fileid;
+  String? get filename;
+  int get lastmod;
+  String get mime;
+  int get size;
+  String get type;
+  bool get hasPreview;
+  FilesTemplateFileInterface rebuild(final void Function(FilesTemplateFileInterfaceBuilder) updates);
+  FilesTemplateFileInterfaceBuilder toBuilder();
+}
+
+abstract class FilesTemplateFile
+    implements FilesTemplateFileInterface, Built<FilesTemplateFile, FilesTemplateFileBuilder> {
   factory FilesTemplateFile([final void Function(FilesTemplateFileBuilder)? b]) = _$FilesTemplateFile;
 
   // coverage:ignore-start
@@ -1438,20 +1686,22 @@ abstract class FilesTemplateFile implements Built<FilesTemplateFile, FilesTempla
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get basename;
-  String get etag;
-  int get fileid;
-  String? get filename;
-  int get lastmod;
-  String get mime;
-  int get size;
-  String get type;
-  bool get hasPreview;
   static Serializer<FilesTemplateFile> get serializer => _$filesTemplateFileSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesTemplateCreateResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  FilesTemplateFile get data;
+  FilesTemplateCreateResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesTemplateCreateResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesTemplateCreateResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class FilesTemplateCreateResponse200ApplicationJson_Ocs
     implements
+        FilesTemplateCreateResponse200ApplicationJson_OcsInterface,
         Built<FilesTemplateCreateResponse200ApplicationJson_Ocs,
             FilesTemplateCreateResponse200ApplicationJson_OcsBuilder> {
   factory FilesTemplateCreateResponse200ApplicationJson_Ocs([
@@ -1470,14 +1720,22 @@ abstract class FilesTemplateCreateResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  FilesTemplateFile get data;
   static Serializer<FilesTemplateCreateResponse200ApplicationJson_Ocs> get serializer =>
       _$filesTemplateCreateResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTemplateCreateResponse200ApplicationJsonInterface {
+  FilesTemplateCreateResponse200ApplicationJson_Ocs get ocs;
+  FilesTemplateCreateResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesTemplateCreateResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesTemplateCreateResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTemplateCreateResponse200ApplicationJson
     implements
+        FilesTemplateCreateResponse200ApplicationJsonInterface,
         Built<FilesTemplateCreateResponse200ApplicationJson, FilesTemplateCreateResponse200ApplicationJsonBuilder> {
   factory FilesTemplateCreateResponse200ApplicationJson([
     final void Function(FilesTemplateCreateResponse200ApplicationJsonBuilder)? b,
@@ -1495,13 +1753,24 @@ abstract class FilesTemplateCreateResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesTemplateCreateResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesTemplateCreateResponse200ApplicationJson> get serializer =>
       _$filesTemplateCreateResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTemplatePathResponse200ApplicationJson_Ocs_DataInterface {
+  @BuiltValueField(wireName: 'template_path')
+  String get templatePath;
+  BuiltList<FilesTemplateFileCreator> get templates;
+  FilesTemplatePathResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(FilesTemplatePathResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  FilesTemplatePathResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTemplatePathResponse200ApplicationJson_Ocs_Data
     implements
+        FilesTemplatePathResponse200ApplicationJson_Ocs_DataInterface,
         Built<FilesTemplatePathResponse200ApplicationJson_Ocs_Data,
             FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder> {
   factory FilesTemplatePathResponse200ApplicationJson_Ocs_Data([
@@ -1520,15 +1789,23 @@ abstract class FilesTemplatePathResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'template_path')
-  String get templatePath;
-  BuiltList<FilesTemplateFileCreator> get templates;
   static Serializer<FilesTemplatePathResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$filesTemplatePathResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTemplatePathResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  FilesTemplatePathResponse200ApplicationJson_Ocs_Data get data;
+  FilesTemplatePathResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesTemplatePathResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesTemplatePathResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTemplatePathResponse200ApplicationJson_Ocs
     implements
+        FilesTemplatePathResponse200ApplicationJson_OcsInterface,
         Built<FilesTemplatePathResponse200ApplicationJson_Ocs, FilesTemplatePathResponse200ApplicationJson_OcsBuilder> {
   factory FilesTemplatePathResponse200ApplicationJson_Ocs([
     final void Function(FilesTemplatePathResponse200ApplicationJson_OcsBuilder)? b,
@@ -1546,14 +1823,23 @@ abstract class FilesTemplatePathResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  FilesTemplatePathResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<FilesTemplatePathResponse200ApplicationJson_Ocs> get serializer =>
       _$filesTemplatePathResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTemplatePathResponse200ApplicationJsonInterface {
+  FilesTemplatePathResponse200ApplicationJson_Ocs get ocs;
+  FilesTemplatePathResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesTemplatePathResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesTemplatePathResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTemplatePathResponse200ApplicationJson
-    implements Built<FilesTemplatePathResponse200ApplicationJson, FilesTemplatePathResponse200ApplicationJsonBuilder> {
+    implements
+        FilesTemplatePathResponse200ApplicationJsonInterface,
+        Built<FilesTemplatePathResponse200ApplicationJson, FilesTemplatePathResponse200ApplicationJsonBuilder> {
   factory FilesTemplatePathResponse200ApplicationJson([
     final void Function(FilesTemplatePathResponse200ApplicationJsonBuilder)? b,
   ]) = _$FilesTemplatePathResponse200ApplicationJson;
@@ -1570,13 +1856,23 @@ abstract class FilesTemplatePathResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesTemplatePathResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesTemplatePathResponse200ApplicationJson> get serializer =>
       _$filesTemplatePathResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTransferOwnershipTransferResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  JsonObject get data;
+  FilesTransferOwnershipTransferResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesTransferOwnershipTransferResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesTransferOwnershipTransferResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs
     implements
+        FilesTransferOwnershipTransferResponse200ApplicationJson_OcsInterface,
         Built<FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs,
             FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder> {
   factory FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs([
@@ -1595,14 +1891,22 @@ abstract class FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs> get serializer =>
       _$filesTransferOwnershipTransferResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTransferOwnershipTransferResponse200ApplicationJsonInterface {
+  FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs get ocs;
+  FilesTransferOwnershipTransferResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesTransferOwnershipTransferResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesTransferOwnershipTransferResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTransferOwnershipTransferResponse200ApplicationJson
     implements
+        FilesTransferOwnershipTransferResponse200ApplicationJsonInterface,
         Built<FilesTransferOwnershipTransferResponse200ApplicationJson,
             FilesTransferOwnershipTransferResponse200ApplicationJsonBuilder> {
   factory FilesTransferOwnershipTransferResponse200ApplicationJson([
@@ -1621,13 +1925,23 @@ abstract class FilesTransferOwnershipTransferResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesTransferOwnershipTransferResponse200ApplicationJson> get serializer =>
       _$filesTransferOwnershipTransferResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  JsonObject get data;
+  FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs
     implements
+        FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsInterface,
         Built<FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs,
             FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder> {
   factory FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs([
@@ -1646,14 +1960,22 @@ abstract class FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs> get serializer =>
       _$filesTransferOwnershipAcceptResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTransferOwnershipAcceptResponse200ApplicationJsonInterface {
+  FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs get ocs;
+  FilesTransferOwnershipAcceptResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesTransferOwnershipAcceptResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesTransferOwnershipAcceptResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTransferOwnershipAcceptResponse200ApplicationJson
     implements
+        FilesTransferOwnershipAcceptResponse200ApplicationJsonInterface,
         Built<FilesTransferOwnershipAcceptResponse200ApplicationJson,
             FilesTransferOwnershipAcceptResponse200ApplicationJsonBuilder> {
   factory FilesTransferOwnershipAcceptResponse200ApplicationJson([
@@ -1672,13 +1994,23 @@ abstract class FilesTransferOwnershipAcceptResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesTransferOwnershipAcceptResponse200ApplicationJson> get serializer =>
       _$filesTransferOwnershipAcceptResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTransferOwnershipRejectResponse200ApplicationJson_OcsInterface {
+  FilesOCSMeta get meta;
+  JsonObject get data;
+  FilesTransferOwnershipRejectResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesTransferOwnershipRejectResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesTransferOwnershipRejectResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs
     implements
+        FilesTransferOwnershipRejectResponse200ApplicationJson_OcsInterface,
         Built<FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs,
             FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder> {
   factory FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs([
@@ -1697,14 +2029,22 @@ abstract class FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs> get serializer =>
       _$filesTransferOwnershipRejectResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTransferOwnershipRejectResponse200ApplicationJsonInterface {
+  FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs get ocs;
+  FilesTransferOwnershipRejectResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesTransferOwnershipRejectResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesTransferOwnershipRejectResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTransferOwnershipRejectResponse200ApplicationJson
     implements
+        FilesTransferOwnershipRejectResponse200ApplicationJsonInterface,
         Built<FilesTransferOwnershipRejectResponse200ApplicationJson,
             FilesTransferOwnershipRejectResponse200ApplicationJsonBuilder> {
   factory FilesTransferOwnershipRejectResponse200ApplicationJson([
@@ -1723,13 +2063,25 @@ abstract class FilesTransferOwnershipRejectResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesTransferOwnershipRejectResponse200ApplicationJson> get serializer =>
       _$filesTransferOwnershipRejectResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesCapabilities_Files_DirectEditingInterface {
+  String get url;
+  String get etag;
+  bool get supportsFileId;
+  FilesCapabilities_Files_DirectEditingInterface rebuild(
+    final void Function(FilesCapabilities_Files_DirectEditingInterfaceBuilder) updates,
+  );
+  FilesCapabilities_Files_DirectEditingInterfaceBuilder toBuilder();
+}
+
 abstract class FilesCapabilities_Files_DirectEditing
-    implements Built<FilesCapabilities_Files_DirectEditing, FilesCapabilities_Files_DirectEditingBuilder> {
+    implements
+        FilesCapabilities_Files_DirectEditingInterface,
+        Built<FilesCapabilities_Files_DirectEditing, FilesCapabilities_Files_DirectEditingBuilder> {
   factory FilesCapabilities_Files_DirectEditing([
     final void Function(FilesCapabilities_Files_DirectEditingBuilder)? b,
   ]) = _$FilesCapabilities_Files_DirectEditing;
@@ -1746,14 +2098,22 @@ abstract class FilesCapabilities_Files_DirectEditing
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get url;
-  String get etag;
-  bool get supportsFileId;
   static Serializer<FilesCapabilities_Files_DirectEditing> get serializer =>
       _$filesCapabilitiesFilesDirectEditingSerializer;
 }
 
-abstract class FilesCapabilities_Files implements Built<FilesCapabilities_Files, FilesCapabilities_FilesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesCapabilities_FilesInterface {
+  bool get bigfilechunking;
+  @BuiltValueField(wireName: 'blacklisted_files')
+  BuiltList<JsonObject> get blacklistedFiles;
+  FilesCapabilities_Files_DirectEditing get directEditing;
+  FilesCapabilities_FilesInterface rebuild(final void Function(FilesCapabilities_FilesInterfaceBuilder) updates);
+  FilesCapabilities_FilesInterfaceBuilder toBuilder();
+}
+
+abstract class FilesCapabilities_Files
+    implements FilesCapabilities_FilesInterface, Built<FilesCapabilities_Files, FilesCapabilities_FilesBuilder> {
   factory FilesCapabilities_Files([final void Function(FilesCapabilities_FilesBuilder)? b]) = _$FilesCapabilities_Files;
 
   // coverage:ignore-start
@@ -1768,14 +2128,18 @@ abstract class FilesCapabilities_Files implements Built<FilesCapabilities_Files,
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get bigfilechunking;
-  @BuiltValueField(wireName: 'blacklisted_files')
-  BuiltList<JsonObject> get blacklistedFiles;
-  FilesCapabilities_Files_DirectEditing get directEditing;
   static Serializer<FilesCapabilities_Files> get serializer => _$filesCapabilitiesFilesSerializer;
 }
 
-abstract class FilesCapabilities implements Built<FilesCapabilities, FilesCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesCapabilitiesInterface {
+  FilesCapabilities_Files get files;
+  FilesCapabilitiesInterface rebuild(final void Function(FilesCapabilitiesInterfaceBuilder) updates);
+  FilesCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class FilesCapabilities
+    implements FilesCapabilitiesInterface, Built<FilesCapabilities, FilesCapabilitiesBuilder> {
   factory FilesCapabilities([final void Function(FilesCapabilitiesBuilder)? b]) = _$FilesCapabilities;
 
   // coverage:ignore-start
@@ -1790,11 +2154,28 @@ abstract class FilesCapabilities implements Built<FilesCapabilities, FilesCapabi
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesCapabilities_Files get files;
   static Serializer<FilesCapabilities> get serializer => _$filesCapabilitiesSerializer;
 }
 
-abstract class FilesTemplate implements Built<FilesTemplate, FilesTemplateBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesTemplateInterface {
+  String get templateType;
+  String get templateId;
+  String get basename;
+  String get etag;
+  int get fileid;
+  String get filename;
+  int get lastmod;
+  String get mime;
+  int get size;
+  String get type;
+  bool get hasPreview;
+  String? get previewUrl;
+  FilesTemplateInterface rebuild(final void Function(FilesTemplateInterfaceBuilder) updates);
+  FilesTemplateInterfaceBuilder toBuilder();
+}
+
+abstract class FilesTemplate implements FilesTemplateInterface, Built<FilesTemplate, FilesTemplateBuilder> {
   factory FilesTemplate([final void Function(FilesTemplateBuilder)? b]) = _$FilesTemplate;
 
   // coverage:ignore-start
@@ -1809,18 +2190,6 @@ abstract class FilesTemplate implements Built<FilesTemplate, FilesTemplateBuilde
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get templateType;
-  String get templateId;
-  String get basename;
-  String get etag;
-  int get fileid;
-  String get filename;
-  int get lastmod;
-  String get mime;
-  int get size;
-  String get type;
-  bool get hasPreview;
-  String? get previewUrl;
   static Serializer<FilesTemplate> get serializer => _$filesTemplateSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/files.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.g.dart
@@ -2303,6 +2303,13 @@ class _$FilesTemplateSerializer implements StructuredSerializer<FilesTemplate> {
   }
 }
 
+abstract mixin class FilesApiApiServiceWorkerHeadersInterfaceBuilder {
+  void replace(FilesApiApiServiceWorkerHeadersInterface other);
+  void update(void Function(FilesApiApiServiceWorkerHeadersInterfaceBuilder) updates);
+  String? get serviceWorkerAllowed;
+  set serviceWorkerAllowed(String? serviceWorkerAllowed);
+}
+
 class _$FilesApiApiServiceWorkerHeaders extends FilesApiApiServiceWorkerHeaders {
   @override
   final String? serviceWorkerAllowed;
@@ -2342,12 +2349,15 @@ class _$FilesApiApiServiceWorkerHeaders extends FilesApiApiServiceWorkerHeaders 
 }
 
 class FilesApiApiServiceWorkerHeadersBuilder
-    implements Builder<FilesApiApiServiceWorkerHeaders, FilesApiApiServiceWorkerHeadersBuilder> {
+    implements
+        Builder<FilesApiApiServiceWorkerHeaders, FilesApiApiServiceWorkerHeadersBuilder>,
+        FilesApiApiServiceWorkerHeadersInterfaceBuilder {
   _$FilesApiApiServiceWorkerHeaders? _$v;
 
   String? _serviceWorkerAllowed;
   String? get serviceWorkerAllowed => _$this._serviceWorkerAllowed;
-  set serviceWorkerAllowed(String? serviceWorkerAllowed) => _$this._serviceWorkerAllowed = serviceWorkerAllowed;
+  set serviceWorkerAllowed(covariant String? serviceWorkerAllowed) =>
+      _$this._serviceWorkerAllowed = serviceWorkerAllowed;
 
   FilesApiApiServiceWorkerHeadersBuilder();
 
@@ -2361,7 +2371,7 @@ class FilesApiApiServiceWorkerHeadersBuilder
   }
 
   @override
-  void replace(FilesApiApiServiceWorkerHeaders other) {
+  void replace(covariant FilesApiApiServiceWorkerHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesApiApiServiceWorkerHeaders;
   }
@@ -2379,6 +2389,25 @@ class FilesApiApiServiceWorkerHeadersBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesOCSMetaInterfaceBuilder {
+  void replace(FilesOCSMetaInterface other);
+  void update(void Function(FilesOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
 }
 
 class _$FilesOCSMeta extends FilesOCSMeta {
@@ -2443,28 +2472,28 @@ class _$FilesOCSMeta extends FilesOCSMeta {
   }
 }
 
-class FilesOCSMetaBuilder implements Builder<FilesOCSMeta, FilesOCSMetaBuilder> {
+class FilesOCSMetaBuilder implements Builder<FilesOCSMeta, FilesOCSMetaBuilder>, FilesOCSMetaInterfaceBuilder {
   _$FilesOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   FilesOCSMetaBuilder();
 
@@ -2482,7 +2511,7 @@ class FilesOCSMetaBuilder implements Builder<FilesOCSMeta, FilesOCSMetaBuilder> 
   }
 
   @override
-  void replace(FilesOCSMeta other) {
+  void replace(covariant FilesOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesOCSMeta;
   }
@@ -2506,6 +2535,25 @@ class FilesOCSMetaBuilder implements Builder<FilesOCSMeta, FilesOCSMetaBuilder> 
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsInterfaceBuilder {
+  void replace(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsInterface other);
+  void update(void Function(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get name;
+  set name(String? name);
+
+  ListBuilder<String> get mimetypes;
+  set mimetypes(ListBuilder<String>? mimetypes);
+
+  ListBuilder<String> get optionalMimetypes;
+  set optionalMimetypes(ListBuilder<String>? optionalMimetypes);
+
+  bool? get secure;
+  set secure(bool? secure);
 }
 
 class _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors
@@ -2591,28 +2639,30 @@ class _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors
 class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsBuilder
     implements
         Builder<FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors,
-            FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsBuilder> {
+            FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsBuilder>,
+        FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsInterfaceBuilder {
   _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   ListBuilder<String>? _mimetypes;
   ListBuilder<String> get mimetypes => _$this._mimetypes ??= ListBuilder<String>();
-  set mimetypes(ListBuilder<String>? mimetypes) => _$this._mimetypes = mimetypes;
+  set mimetypes(covariant ListBuilder<String>? mimetypes) => _$this._mimetypes = mimetypes;
 
   ListBuilder<String>? _optionalMimetypes;
   ListBuilder<String> get optionalMimetypes => _$this._optionalMimetypes ??= ListBuilder<String>();
-  set optionalMimetypes(ListBuilder<String>? optionalMimetypes) => _$this._optionalMimetypes = optionalMimetypes;
+  set optionalMimetypes(covariant ListBuilder<String>? optionalMimetypes) =>
+      _$this._optionalMimetypes = optionalMimetypes;
 
   bool? _secure;
   bool? get secure => _$this._secure;
-  set secure(bool? secure) => _$this._secure = secure;
+  set secure(covariant bool? secure) => _$this._secure = secure;
 
   FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsBuilder();
 
@@ -2630,7 +2680,7 @@ class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsBuilder
   }
 
   @override
-  void replace(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors other) {
+  void replace(covariant FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors;
   }
@@ -2672,6 +2722,29 @@ class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_EditorsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsInterfaceBuilder {
+  void replace(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsInterface other);
+  void update(
+      void Function(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get editor;
+  set editor(String? editor);
+
+  String? get name;
+  set name(String? name);
+
+  String? get $extension;
+  set $extension(String? $extension);
+
+  bool? get templates;
+  set templates(bool? templates);
+
+  ListBuilder<String> get mimetypes;
+  set mimetypes(ListBuilder<String>? mimetypes);
 }
 
 class _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators
@@ -2765,32 +2838,33 @@ class _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators
 class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsBuilder
     implements
         Builder<FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators,
-            FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsBuilder> {
+            FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsBuilder>,
+        FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsInterfaceBuilder {
   _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _editor;
   String? get editor => _$this._editor;
-  set editor(String? editor) => _$this._editor = editor;
+  set editor(covariant String? editor) => _$this._editor = editor;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   String? _$extension;
   String? get $extension => _$this._$extension;
-  set $extension(String? $extension) => _$this._$extension = $extension;
+  set $extension(covariant String? $extension) => _$this._$extension = $extension;
 
   bool? _templates;
   bool? get templates => _$this._templates;
-  set templates(bool? templates) => _$this._templates = templates;
+  set templates(covariant bool? templates) => _$this._templates = templates;
 
   ListBuilder<String>? _mimetypes;
   ListBuilder<String> get mimetypes => _$this._mimetypes ??= ListBuilder<String>();
-  set mimetypes(ListBuilder<String>? mimetypes) => _$this._mimetypes = mimetypes;
+  set mimetypes(covariant ListBuilder<String>? mimetypes) => _$this._mimetypes = mimetypes;
 
   FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsBuilder();
 
@@ -2809,7 +2883,7 @@ class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsBuilder
   }
 
   @override
-  void replace(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators other) {
+  void replace(covariant FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators;
   }
@@ -2852,6 +2926,16 @@ class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_CreatorsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors> get editors;
+  set editors(MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors>? editors);
+
+  MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators> get creators;
+  set creators(MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators>? creators);
 }
 
 class _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data
@@ -2911,19 +2995,22 @@ class _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data
 class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data,
-            FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder> {
+            FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder>,
+        FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data? _$v;
 
   MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors>? _editors;
   MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors> get editors =>
       _$this._editors ??= MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors>();
-  set editors(MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors>? editors) =>
+  set editors(
+          covariant MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Editors>? editors) =>
       _$this._editors = editors;
 
   MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators>? _creators;
   MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators> get creators =>
       _$this._creators ??= MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators>();
-  set creators(MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators>? creators) =>
+  set creators(
+          covariant MapBuilder<String, FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data_Creators>? creators) =>
       _$this._creators = creators;
 
   FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder();
@@ -2939,7 +3026,7 @@ class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs_Data;
   }
@@ -2974,6 +3061,16 @@ class FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingInfoResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesDirectEditingInfoResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesDirectEditingInfoResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs
@@ -3028,17 +3125,18 @@ class _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs
 class FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesDirectEditingInfoResponse200ApplicationJson_Ocs,
-            FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder> {
+            FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder>,
+        FilesDirectEditingInfoResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder? _data;
   FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant FilesDirectEditingInfoResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder();
 
@@ -3053,7 +3151,7 @@ class FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesDirectEditingInfoResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesDirectEditingInfoResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingInfoResponse200ApplicationJson_Ocs;
   }
@@ -3087,6 +3185,13 @@ class FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingInfoResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesDirectEditingInfoResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesDirectEditingInfoResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesDirectEditingInfoResponse200ApplicationJson extends FilesDirectEditingInfoResponse200ApplicationJson {
@@ -3134,13 +3239,14 @@ class _$FilesDirectEditingInfoResponse200ApplicationJson extends FilesDirectEdit
 class FilesDirectEditingInfoResponse200ApplicationJsonBuilder
     implements
         Builder<FilesDirectEditingInfoResponse200ApplicationJson,
-            FilesDirectEditingInfoResponse200ApplicationJsonBuilder> {
+            FilesDirectEditingInfoResponse200ApplicationJsonBuilder>,
+        FilesDirectEditingInfoResponse200ApplicationJsonInterfaceBuilder {
   _$FilesDirectEditingInfoResponse200ApplicationJson? _$v;
 
   FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesDirectEditingInfoResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesDirectEditingInfoResponse200ApplicationJsonBuilder();
 
@@ -3154,7 +3260,7 @@ class FilesDirectEditingInfoResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesDirectEditingInfoResponse200ApplicationJson other) {
+  void replace(covariant FilesDirectEditingInfoResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingInfoResponse200ApplicationJson;
   }
@@ -3185,6 +3291,26 @@ class FilesDirectEditingInfoResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesInterfaceBuilder {
+  void replace(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesInterface other);
+  void update(
+      void Function(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get title;
+  set title(String? title);
+
+  String? get preview;
+  set preview(String? preview);
+
+  String? get $extension;
+  set $extension(String? $extension);
+
+  String? get mimetype;
+  set mimetype(String? mimetype);
 }
 
 class _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates
@@ -3264,28 +3390,29 @@ class _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates
 class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesBuilder
     implements
         Builder<FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates,
-            FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesBuilder> {
+            FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesBuilder>,
+        FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesInterfaceBuilder {
   _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _title;
   String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
+  set title(covariant String? title) => _$this._title = title;
 
   String? _preview;
   String? get preview => _$this._preview;
-  set preview(String? preview) => _$this._preview = preview;
+  set preview(covariant String? preview) => _$this._preview = preview;
 
   String? _$extension;
   String? get $extension => _$this._$extension;
-  set $extension(String? $extension) => _$this._$extension = $extension;
+  set $extension(covariant String? $extension) => _$this._$extension = $extension;
 
   String? _mimetype;
   String? get mimetype => _$this._mimetype;
-  set mimetype(String? mimetype) => _$this._mimetype = mimetype;
+  set mimetype(covariant String? mimetype) => _$this._mimetype = mimetype;
 
   FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesBuilder();
 
@@ -3303,7 +3430,7 @@ class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesBu
   }
 
   @override
-  void replace(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates other) {
+  void replace(covariant FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates;
   }
@@ -3331,6 +3458,14 @@ class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_TemplatesBu
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  MapBuilder<String, FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates> get templates;
+  set templates(
+      MapBuilder<String, FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates>? templates);
 }
 
 class _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data
@@ -3381,7 +3516,8 @@ class _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data
 class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data,
-            FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder> {
+            FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder>,
+        FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data? _$v;
 
   MapBuilder<String, FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates>? _templates;
@@ -3389,7 +3525,8 @@ class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder
       _$this._templates ??=
           MapBuilder<String, FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates>();
   set templates(
-          MapBuilder<String, FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates>? templates) =>
+          covariant MapBuilder<String, FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data_Templates>?
+              templates) =>
       _$this._templates = templates;
 
   FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder();
@@ -3404,7 +3541,7 @@ class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_Data;
   }
@@ -3436,6 +3573,16 @@ class FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingTemplatesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesDirectEditingTemplatesResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesDirectEditingTemplatesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs
@@ -3492,17 +3639,19 @@ class _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs
 class FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs,
-            FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder> {
+            FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder>,
+        FilesDirectEditingTemplatesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder? _data;
   FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder();
 
@@ -3517,7 +3666,7 @@ class FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingTemplatesResponse200ApplicationJson_Ocs;
   }
@@ -3551,6 +3700,13 @@ class FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingTemplatesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesDirectEditingTemplatesResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesDirectEditingTemplatesResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesDirectEditingTemplatesResponse200ApplicationJson
@@ -3599,13 +3755,14 @@ class _$FilesDirectEditingTemplatesResponse200ApplicationJson
 class FilesDirectEditingTemplatesResponse200ApplicationJsonBuilder
     implements
         Builder<FilesDirectEditingTemplatesResponse200ApplicationJson,
-            FilesDirectEditingTemplatesResponse200ApplicationJsonBuilder> {
+            FilesDirectEditingTemplatesResponse200ApplicationJsonBuilder>,
+        FilesDirectEditingTemplatesResponse200ApplicationJsonInterfaceBuilder {
   _$FilesDirectEditingTemplatesResponse200ApplicationJson? _$v;
 
   FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesDirectEditingTemplatesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesDirectEditingTemplatesResponse200ApplicationJsonBuilder();
 
@@ -3619,7 +3776,7 @@ class FilesDirectEditingTemplatesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesDirectEditingTemplatesResponse200ApplicationJson other) {
+  void replace(covariant FilesDirectEditingTemplatesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingTemplatesResponse200ApplicationJson;
   }
@@ -3650,6 +3807,13 @@ class FilesDirectEditingTemplatesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get url;
+  set url(String? url);
 }
 
 class _$FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data
@@ -3698,12 +3862,13 @@ class _$FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data
 class FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data,
-            FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder> {
+            FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder>,
+        FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _url;
   String? get url => _$this._url;
-  set url(String? url) => _$this._url = url;
+  set url(covariant String? url) => _$this._url = url;
 
   FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -3717,7 +3882,7 @@ class FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingOpenResponse200ApplicationJson_Ocs_Data;
   }
@@ -3738,6 +3903,16 @@ class FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingOpenResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesDirectEditingOpenResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesDirectEditingOpenResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$FilesDirectEditingOpenResponse200ApplicationJson_Ocs
@@ -3792,17 +3967,18 @@ class _$FilesDirectEditingOpenResponse200ApplicationJson_Ocs
 class FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesDirectEditingOpenResponse200ApplicationJson_Ocs,
-            FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder> {
+            FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder>,
+        FilesDirectEditingOpenResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesDirectEditingOpenResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder? _data;
   FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant FilesDirectEditingOpenResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder();
 
@@ -3817,7 +3993,7 @@ class FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesDirectEditingOpenResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesDirectEditingOpenResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingOpenResponse200ApplicationJson_Ocs;
   }
@@ -3851,6 +4027,13 @@ class FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingOpenResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesDirectEditingOpenResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesDirectEditingOpenResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesDirectEditingOpenResponse200ApplicationJson extends FilesDirectEditingOpenResponse200ApplicationJson {
@@ -3898,13 +4081,14 @@ class _$FilesDirectEditingOpenResponse200ApplicationJson extends FilesDirectEdit
 class FilesDirectEditingOpenResponse200ApplicationJsonBuilder
     implements
         Builder<FilesDirectEditingOpenResponse200ApplicationJson,
-            FilesDirectEditingOpenResponse200ApplicationJsonBuilder> {
+            FilesDirectEditingOpenResponse200ApplicationJsonBuilder>,
+        FilesDirectEditingOpenResponse200ApplicationJsonInterfaceBuilder {
   _$FilesDirectEditingOpenResponse200ApplicationJson? _$v;
 
   FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesDirectEditingOpenResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesDirectEditingOpenResponse200ApplicationJsonBuilder();
 
@@ -3918,7 +4102,7 @@ class FilesDirectEditingOpenResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesDirectEditingOpenResponse200ApplicationJson other) {
+  void replace(covariant FilesDirectEditingOpenResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingOpenResponse200ApplicationJson;
   }
@@ -3949,6 +4133,13 @@ class FilesDirectEditingOpenResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get url;
+  set url(String? url);
 }
 
 class _$FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data
@@ -3998,12 +4189,13 @@ class _$FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data
 class FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data,
-            FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder> {
+            FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder>,
+        FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _url;
   String? get url => _$this._url;
-  set url(String? url) => _$this._url = url;
+  set url(covariant String? url) => _$this._url = url;
 
   FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -4017,7 +4209,7 @@ class FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingCreateResponse200ApplicationJson_Ocs_Data;
   }
@@ -4038,6 +4230,16 @@ class FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingCreateResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesDirectEditingCreateResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesDirectEditingCreateResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$FilesDirectEditingCreateResponse200ApplicationJson_Ocs
@@ -4092,17 +4294,18 @@ class _$FilesDirectEditingCreateResponse200ApplicationJson_Ocs
 class FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesDirectEditingCreateResponse200ApplicationJson_Ocs,
-            FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder> {
+            FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder>,
+        FilesDirectEditingCreateResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesDirectEditingCreateResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder? _data;
   FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant FilesDirectEditingCreateResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder();
 
@@ -4117,7 +4320,7 @@ class FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesDirectEditingCreateResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesDirectEditingCreateResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingCreateResponse200ApplicationJson_Ocs;
   }
@@ -4151,6 +4354,13 @@ class FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesDirectEditingCreateResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesDirectEditingCreateResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesDirectEditingCreateResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesDirectEditingCreateResponse200ApplicationJson extends FilesDirectEditingCreateResponse200ApplicationJson {
@@ -4198,13 +4408,14 @@ class _$FilesDirectEditingCreateResponse200ApplicationJson extends FilesDirectEd
 class FilesDirectEditingCreateResponse200ApplicationJsonBuilder
     implements
         Builder<FilesDirectEditingCreateResponse200ApplicationJson,
-            FilesDirectEditingCreateResponse200ApplicationJsonBuilder> {
+            FilesDirectEditingCreateResponse200ApplicationJsonBuilder>,
+        FilesDirectEditingCreateResponse200ApplicationJsonInterfaceBuilder {
   _$FilesDirectEditingCreateResponse200ApplicationJson? _$v;
 
   FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesDirectEditingCreateResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesDirectEditingCreateResponse200ApplicationJsonBuilder();
 
@@ -4218,7 +4429,7 @@ class FilesDirectEditingCreateResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesDirectEditingCreateResponse200ApplicationJson other) {
+  void replace(covariant FilesDirectEditingCreateResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesDirectEditingCreateResponse200ApplicationJson;
   }
@@ -4249,6 +4460,22 @@ class FilesDirectEditingCreateResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get userId;
+  set userId(String? userId);
+
+  String? get pathHash;
+  set pathHash(String? pathHash);
+
+  int? get expirationTime;
+  set expirationTime(int? expirationTime);
+
+  String? get token;
+  set token(String? token);
 }
 
 class _$FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data
@@ -4321,24 +4548,25 @@ class _$FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data
 class FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data,
-            FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder> {
+            FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder>,
+        FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _userId;
   String? get userId => _$this._userId;
-  set userId(String? userId) => _$this._userId = userId;
+  set userId(covariant String? userId) => _$this._userId = userId;
 
   String? _pathHash;
   String? get pathHash => _$this._pathHash;
-  set pathHash(String? pathHash) => _$this._pathHash = pathHash;
+  set pathHash(covariant String? pathHash) => _$this._pathHash = pathHash;
 
   int? _expirationTime;
   int? get expirationTime => _$this._expirationTime;
-  set expirationTime(int? expirationTime) => _$this._expirationTime = expirationTime;
+  set expirationTime(covariant int? expirationTime) => _$this._expirationTime = expirationTime;
 
   String? _token;
   String? get token => _$this._token;
-  set token(String? token) => _$this._token = token;
+  set token(covariant String? token) => _$this._token = token;
 
   FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -4355,7 +4583,7 @@ class FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_Data;
   }
@@ -4381,6 +4609,16 @@ class FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs
@@ -4437,17 +4675,18 @@ class _$FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs
 class FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs,
-            FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder> {
+            FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder>,
+        FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder? _data;
   FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder();
 
@@ -4462,7 +4701,7 @@ class FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesOpenLocalEditorCreateResponse200ApplicationJson_Ocs;
   }
@@ -4496,6 +4735,13 @@ class FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesOpenLocalEditorCreateResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesOpenLocalEditorCreateResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesOpenLocalEditorCreateResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesOpenLocalEditorCreateResponse200ApplicationJson
@@ -4544,13 +4790,14 @@ class _$FilesOpenLocalEditorCreateResponse200ApplicationJson
 class FilesOpenLocalEditorCreateResponse200ApplicationJsonBuilder
     implements
         Builder<FilesOpenLocalEditorCreateResponse200ApplicationJson,
-            FilesOpenLocalEditorCreateResponse200ApplicationJsonBuilder> {
+            FilesOpenLocalEditorCreateResponse200ApplicationJsonBuilder>,
+        FilesOpenLocalEditorCreateResponse200ApplicationJsonInterfaceBuilder {
   _$FilesOpenLocalEditorCreateResponse200ApplicationJson? _$v;
 
   FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesOpenLocalEditorCreateResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesOpenLocalEditorCreateResponse200ApplicationJsonBuilder();
 
@@ -4564,7 +4811,7 @@ class FilesOpenLocalEditorCreateResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesOpenLocalEditorCreateResponse200ApplicationJson other) {
+  void replace(covariant FilesOpenLocalEditorCreateResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesOpenLocalEditorCreateResponse200ApplicationJson;
   }
@@ -4595,6 +4842,22 @@ class FilesOpenLocalEditorCreateResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get userId;
+  set userId(String? userId);
+
+  String? get pathHash;
+  set pathHash(String? pathHash);
+
+  int? get expirationTime;
+  set expirationTime(int? expirationTime);
+
+  String? get token;
+  set token(String? token);
 }
 
 class _$FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data
@@ -4669,24 +4932,25 @@ class _$FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data
 class FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data,
-            FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder> {
+            FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder>,
+        FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _userId;
   String? get userId => _$this._userId;
-  set userId(String? userId) => _$this._userId = userId;
+  set userId(covariant String? userId) => _$this._userId = userId;
 
   String? _pathHash;
   String? get pathHash => _$this._pathHash;
-  set pathHash(String? pathHash) => _$this._pathHash = pathHash;
+  set pathHash(covariant String? pathHash) => _$this._pathHash = pathHash;
 
   int? _expirationTime;
   int? get expirationTime => _$this._expirationTime;
-  set expirationTime(int? expirationTime) => _$this._expirationTime = expirationTime;
+  set expirationTime(covariant int? expirationTime) => _$this._expirationTime = expirationTime;
 
   String? _token;
   String? get token => _$this._token;
-  set token(String? token) => _$this._token = token;
+  set token(covariant String? token) => _$this._token = token;
 
   FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -4703,7 +4967,7 @@ class FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_Data;
   }
@@ -4730,6 +4994,16 @@ class FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs
@@ -4786,17 +5060,19 @@ class _$FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs
 class FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs,
-            FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder> {
+            FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder>,
+        FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder? _data;
   FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder();
 
@@ -4811,7 +5087,7 @@ class FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesOpenLocalEditorValidateResponse200ApplicationJson_Ocs;
   }
@@ -4845,6 +5121,13 @@ class FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesOpenLocalEditorValidateResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesOpenLocalEditorValidateResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesOpenLocalEditorValidateResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesOpenLocalEditorValidateResponse200ApplicationJson
@@ -4893,13 +5176,14 @@ class _$FilesOpenLocalEditorValidateResponse200ApplicationJson
 class FilesOpenLocalEditorValidateResponse200ApplicationJsonBuilder
     implements
         Builder<FilesOpenLocalEditorValidateResponse200ApplicationJson,
-            FilesOpenLocalEditorValidateResponse200ApplicationJsonBuilder> {
+            FilesOpenLocalEditorValidateResponse200ApplicationJsonBuilder>,
+        FilesOpenLocalEditorValidateResponse200ApplicationJsonInterfaceBuilder {
   _$FilesOpenLocalEditorValidateResponse200ApplicationJson? _$v;
 
   FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesOpenLocalEditorValidateResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesOpenLocalEditorValidateResponse200ApplicationJsonBuilder();
 
@@ -4913,7 +5197,7 @@ class FilesOpenLocalEditorValidateResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesOpenLocalEditorValidateResponse200ApplicationJson other) {
+  void replace(covariant FilesOpenLocalEditorValidateResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesOpenLocalEditorValidateResponse200ApplicationJson;
   }
@@ -4944,6 +5228,31 @@ class FilesOpenLocalEditorValidateResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTemplateFileCreatorInterfaceBuilder {
+  void replace(FilesTemplateFileCreatorInterface other);
+  void update(void Function(FilesTemplateFileCreatorInterfaceBuilder) updates);
+  String? get app;
+  set app(String? app);
+
+  String? get label;
+  set label(String? label);
+
+  String? get $extension;
+  set $extension(String? $extension);
+
+  String? get iconClass;
+  set iconClass(String? iconClass);
+
+  ListBuilder<String> get mimetypes;
+  set mimetypes(ListBuilder<String>? mimetypes);
+
+  num? get ratio;
+  set ratio(num? ratio);
+
+  String? get actionLabel;
+  set actionLabel(String? actionLabel);
 }
 
 class _$FilesTemplateFileCreator extends FilesTemplateFileCreator {
@@ -5029,36 +5338,39 @@ class _$FilesTemplateFileCreator extends FilesTemplateFileCreator {
   }
 }
 
-class FilesTemplateFileCreatorBuilder implements Builder<FilesTemplateFileCreator, FilesTemplateFileCreatorBuilder> {
+class FilesTemplateFileCreatorBuilder
+    implements
+        Builder<FilesTemplateFileCreator, FilesTemplateFileCreatorBuilder>,
+        FilesTemplateFileCreatorInterfaceBuilder {
   _$FilesTemplateFileCreator? _$v;
 
   String? _app;
   String? get app => _$this._app;
-  set app(String? app) => _$this._app = app;
+  set app(covariant String? app) => _$this._app = app;
 
   String? _label;
   String? get label => _$this._label;
-  set label(String? label) => _$this._label = label;
+  set label(covariant String? label) => _$this._label = label;
 
   String? _$extension;
   String? get $extension => _$this._$extension;
-  set $extension(String? $extension) => _$this._$extension = $extension;
+  set $extension(covariant String? $extension) => _$this._$extension = $extension;
 
   String? _iconClass;
   String? get iconClass => _$this._iconClass;
-  set iconClass(String? iconClass) => _$this._iconClass = iconClass;
+  set iconClass(covariant String? iconClass) => _$this._iconClass = iconClass;
 
   ListBuilder<String>? _mimetypes;
   ListBuilder<String> get mimetypes => _$this._mimetypes ??= ListBuilder<String>();
-  set mimetypes(ListBuilder<String>? mimetypes) => _$this._mimetypes = mimetypes;
+  set mimetypes(covariant ListBuilder<String>? mimetypes) => _$this._mimetypes = mimetypes;
 
   num? _ratio;
   num? get ratio => _$this._ratio;
-  set ratio(num? ratio) => _$this._ratio = ratio;
+  set ratio(covariant num? ratio) => _$this._ratio = ratio;
 
   String? _actionLabel;
   String? get actionLabel => _$this._actionLabel;
-  set actionLabel(String? actionLabel) => _$this._actionLabel = actionLabel;
+  set actionLabel(covariant String? actionLabel) => _$this._actionLabel = actionLabel;
 
   FilesTemplateFileCreatorBuilder();
 
@@ -5078,7 +5390,7 @@ class FilesTemplateFileCreatorBuilder implements Builder<FilesTemplateFileCreato
   }
 
   @override
-  void replace(FilesTemplateFileCreator other) {
+  void replace(covariant FilesTemplateFileCreator other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTemplateFileCreator;
   }
@@ -5117,6 +5429,16 @@ class FilesTemplateFileCreatorBuilder implements Builder<FilesTemplateFileCreato
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTemplateListResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesTemplateListResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesTemplateListResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  ListBuilder<FilesTemplateFileCreator> get data;
+  set data(ListBuilder<FilesTemplateFileCreator>? data);
 }
 
 class _$FilesTemplateListResponse200ApplicationJson_Ocs extends FilesTemplateListResponse200ApplicationJson_Ocs {
@@ -5170,16 +5492,17 @@ class _$FilesTemplateListResponse200ApplicationJson_Ocs extends FilesTemplateLis
 class FilesTemplateListResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesTemplateListResponse200ApplicationJson_Ocs,
-            FilesTemplateListResponse200ApplicationJson_OcsBuilder> {
+            FilesTemplateListResponse200ApplicationJson_OcsBuilder>,
+        FilesTemplateListResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesTemplateListResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<FilesTemplateFileCreator>? _data;
   ListBuilder<FilesTemplateFileCreator> get data => _$this._data ??= ListBuilder<FilesTemplateFileCreator>();
-  set data(ListBuilder<FilesTemplateFileCreator>? data) => _$this._data = data;
+  set data(covariant ListBuilder<FilesTemplateFileCreator>? data) => _$this._data = data;
 
   FilesTemplateListResponse200ApplicationJson_OcsBuilder();
 
@@ -5194,7 +5517,7 @@ class FilesTemplateListResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesTemplateListResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesTemplateListResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTemplateListResponse200ApplicationJson_Ocs;
   }
@@ -5227,6 +5550,13 @@ class FilesTemplateListResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTemplateListResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesTemplateListResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesTemplateListResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesTemplateListResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesTemplateListResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesTemplateListResponse200ApplicationJson extends FilesTemplateListResponse200ApplicationJson {
@@ -5272,13 +5602,14 @@ class _$FilesTemplateListResponse200ApplicationJson extends FilesTemplateListRes
 
 class FilesTemplateListResponse200ApplicationJsonBuilder
     implements
-        Builder<FilesTemplateListResponse200ApplicationJson, FilesTemplateListResponse200ApplicationJsonBuilder> {
+        Builder<FilesTemplateListResponse200ApplicationJson, FilesTemplateListResponse200ApplicationJsonBuilder>,
+        FilesTemplateListResponse200ApplicationJsonInterfaceBuilder {
   _$FilesTemplateListResponse200ApplicationJson? _$v;
 
   FilesTemplateListResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesTemplateListResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesTemplateListResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesTemplateListResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesTemplateListResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesTemplateListResponse200ApplicationJsonBuilder();
 
@@ -5292,7 +5623,7 @@ class FilesTemplateListResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesTemplateListResponse200ApplicationJson other) {
+  void replace(covariant FilesTemplateListResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTemplateListResponse200ApplicationJson;
   }
@@ -5322,6 +5653,37 @@ class FilesTemplateListResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTemplateFileInterfaceBuilder {
+  void replace(FilesTemplateFileInterface other);
+  void update(void Function(FilesTemplateFileInterfaceBuilder) updates);
+  String? get basename;
+  set basename(String? basename);
+
+  String? get etag;
+  set etag(String? etag);
+
+  int? get fileid;
+  set fileid(int? fileid);
+
+  String? get filename;
+  set filename(String? filename);
+
+  int? get lastmod;
+  set lastmod(int? lastmod);
+
+  String? get mime;
+  set mime(String? mime);
+
+  int? get size;
+  set size(int? size);
+
+  String? get type;
+  set type(String? type);
+
+  bool? get hasPreview;
+  set hasPreview(bool? hasPreview);
 }
 
 class _$FilesTemplateFile extends FilesTemplateFile {
@@ -5421,44 +5783,45 @@ class _$FilesTemplateFile extends FilesTemplateFile {
   }
 }
 
-class FilesTemplateFileBuilder implements Builder<FilesTemplateFile, FilesTemplateFileBuilder> {
+class FilesTemplateFileBuilder
+    implements Builder<FilesTemplateFile, FilesTemplateFileBuilder>, FilesTemplateFileInterfaceBuilder {
   _$FilesTemplateFile? _$v;
 
   String? _basename;
   String? get basename => _$this._basename;
-  set basename(String? basename) => _$this._basename = basename;
+  set basename(covariant String? basename) => _$this._basename = basename;
 
   String? _etag;
   String? get etag => _$this._etag;
-  set etag(String? etag) => _$this._etag = etag;
+  set etag(covariant String? etag) => _$this._etag = etag;
 
   int? _fileid;
   int? get fileid => _$this._fileid;
-  set fileid(int? fileid) => _$this._fileid = fileid;
+  set fileid(covariant int? fileid) => _$this._fileid = fileid;
 
   String? _filename;
   String? get filename => _$this._filename;
-  set filename(String? filename) => _$this._filename = filename;
+  set filename(covariant String? filename) => _$this._filename = filename;
 
   int? _lastmod;
   int? get lastmod => _$this._lastmod;
-  set lastmod(int? lastmod) => _$this._lastmod = lastmod;
+  set lastmod(covariant int? lastmod) => _$this._lastmod = lastmod;
 
   String? _mime;
   String? get mime => _$this._mime;
-  set mime(String? mime) => _$this._mime = mime;
+  set mime(covariant String? mime) => _$this._mime = mime;
 
   int? _size;
   int? get size => _$this._size;
-  set size(int? size) => _$this._size = size;
+  set size(covariant int? size) => _$this._size = size;
 
   String? _type;
   String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
+  set type(covariant String? type) => _$this._type = type;
 
   bool? _hasPreview;
   bool? get hasPreview => _$this._hasPreview;
-  set hasPreview(bool? hasPreview) => _$this._hasPreview = hasPreview;
+  set hasPreview(covariant bool? hasPreview) => _$this._hasPreview = hasPreview;
 
   FilesTemplateFileBuilder();
 
@@ -5480,7 +5843,7 @@ class FilesTemplateFileBuilder implements Builder<FilesTemplateFile, FilesTempla
   }
 
   @override
-  void replace(FilesTemplateFile other) {
+  void replace(covariant FilesTemplateFile other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTemplateFile;
   }
@@ -5508,6 +5871,16 @@ class FilesTemplateFileBuilder implements Builder<FilesTemplateFile, FilesTempla
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTemplateCreateResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesTemplateCreateResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesTemplateCreateResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  FilesTemplateFileBuilder get data;
+  set data(FilesTemplateFileBuilder? data);
 }
 
 class _$FilesTemplateCreateResponse200ApplicationJson_Ocs extends FilesTemplateCreateResponse200ApplicationJson_Ocs {
@@ -5561,16 +5934,17 @@ class _$FilesTemplateCreateResponse200ApplicationJson_Ocs extends FilesTemplateC
 class FilesTemplateCreateResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesTemplateCreateResponse200ApplicationJson_Ocs,
-            FilesTemplateCreateResponse200ApplicationJson_OcsBuilder> {
+            FilesTemplateCreateResponse200ApplicationJson_OcsBuilder>,
+        FilesTemplateCreateResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesTemplateCreateResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesTemplateFileBuilder? _data;
   FilesTemplateFileBuilder get data => _$this._data ??= FilesTemplateFileBuilder();
-  set data(FilesTemplateFileBuilder? data) => _$this._data = data;
+  set data(covariant FilesTemplateFileBuilder? data) => _$this._data = data;
 
   FilesTemplateCreateResponse200ApplicationJson_OcsBuilder();
 
@@ -5585,7 +5959,7 @@ class FilesTemplateCreateResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesTemplateCreateResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesTemplateCreateResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTemplateCreateResponse200ApplicationJson_Ocs;
   }
@@ -5618,6 +5992,13 @@ class FilesTemplateCreateResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTemplateCreateResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesTemplateCreateResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesTemplateCreateResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesTemplateCreateResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesTemplateCreateResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesTemplateCreateResponse200ApplicationJson extends FilesTemplateCreateResponse200ApplicationJson {
@@ -5663,13 +6044,14 @@ class _$FilesTemplateCreateResponse200ApplicationJson extends FilesTemplateCreat
 
 class FilesTemplateCreateResponse200ApplicationJsonBuilder
     implements
-        Builder<FilesTemplateCreateResponse200ApplicationJson, FilesTemplateCreateResponse200ApplicationJsonBuilder> {
+        Builder<FilesTemplateCreateResponse200ApplicationJson, FilesTemplateCreateResponse200ApplicationJsonBuilder>,
+        FilesTemplateCreateResponse200ApplicationJsonInterfaceBuilder {
   _$FilesTemplateCreateResponse200ApplicationJson? _$v;
 
   FilesTemplateCreateResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesTemplateCreateResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesTemplateCreateResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesTemplateCreateResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesTemplateCreateResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesTemplateCreateResponse200ApplicationJsonBuilder();
 
@@ -5683,7 +6065,7 @@ class FilesTemplateCreateResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesTemplateCreateResponse200ApplicationJson other) {
+  void replace(covariant FilesTemplateCreateResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTemplateCreateResponse200ApplicationJson;
   }
@@ -5713,6 +6095,16 @@ class FilesTemplateCreateResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTemplatePathResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(FilesTemplatePathResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(FilesTemplatePathResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get templatePath;
+  set templatePath(String? templatePath);
+
+  ListBuilder<FilesTemplateFileCreator> get templates;
+  set templates(ListBuilder<FilesTemplateFileCreator>? templates);
 }
 
 class _$FilesTemplatePathResponse200ApplicationJson_Ocs_Data
@@ -5772,16 +6164,17 @@ class _$FilesTemplatePathResponse200ApplicationJson_Ocs_Data
 class FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<FilesTemplatePathResponse200ApplicationJson_Ocs_Data,
-            FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder> {
+            FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder>,
+        FilesTemplatePathResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$FilesTemplatePathResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _templatePath;
   String? get templatePath => _$this._templatePath;
-  set templatePath(String? templatePath) => _$this._templatePath = templatePath;
+  set templatePath(covariant String? templatePath) => _$this._templatePath = templatePath;
 
   ListBuilder<FilesTemplateFileCreator>? _templates;
   ListBuilder<FilesTemplateFileCreator> get templates => _$this._templates ??= ListBuilder<FilesTemplateFileCreator>();
-  set templates(ListBuilder<FilesTemplateFileCreator>? templates) => _$this._templates = templates;
+  set templates(covariant ListBuilder<FilesTemplateFileCreator>? templates) => _$this._templates = templates;
 
   FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -5796,7 +6189,7 @@ class FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(FilesTemplatePathResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant FilesTemplatePathResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTemplatePathResponse200ApplicationJson_Ocs_Data;
   }
@@ -5831,6 +6224,16 @@ class FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTemplatePathResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesTemplatePathResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesTemplatePathResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$FilesTemplatePathResponse200ApplicationJson_Ocs extends FilesTemplatePathResponse200ApplicationJson_Ocs {
@@ -5884,17 +6287,18 @@ class _$FilesTemplatePathResponse200ApplicationJson_Ocs extends FilesTemplatePat
 class FilesTemplatePathResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesTemplatePathResponse200ApplicationJson_Ocs,
-            FilesTemplatePathResponse200ApplicationJson_OcsBuilder> {
+            FilesTemplatePathResponse200ApplicationJson_OcsBuilder>,
+        FilesTemplatePathResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesTemplatePathResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder? _data;
   FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant FilesTemplatePathResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   FilesTemplatePathResponse200ApplicationJson_OcsBuilder();
 
@@ -5909,7 +6313,7 @@ class FilesTemplatePathResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesTemplatePathResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesTemplatePathResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTemplatePathResponse200ApplicationJson_Ocs;
   }
@@ -5942,6 +6346,13 @@ class FilesTemplatePathResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTemplatePathResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesTemplatePathResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesTemplatePathResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesTemplatePathResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesTemplatePathResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesTemplatePathResponse200ApplicationJson extends FilesTemplatePathResponse200ApplicationJson {
@@ -5987,13 +6398,14 @@ class _$FilesTemplatePathResponse200ApplicationJson extends FilesTemplatePathRes
 
 class FilesTemplatePathResponse200ApplicationJsonBuilder
     implements
-        Builder<FilesTemplatePathResponse200ApplicationJson, FilesTemplatePathResponse200ApplicationJsonBuilder> {
+        Builder<FilesTemplatePathResponse200ApplicationJson, FilesTemplatePathResponse200ApplicationJsonBuilder>,
+        FilesTemplatePathResponse200ApplicationJsonInterfaceBuilder {
   _$FilesTemplatePathResponse200ApplicationJson? _$v;
 
   FilesTemplatePathResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesTemplatePathResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesTemplatePathResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesTemplatePathResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesTemplatePathResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesTemplatePathResponse200ApplicationJsonBuilder();
 
@@ -6007,7 +6419,7 @@ class FilesTemplatePathResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesTemplatePathResponse200ApplicationJson other) {
+  void replace(covariant FilesTemplatePathResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTemplatePathResponse200ApplicationJson;
   }
@@ -6037,6 +6449,16 @@ class FilesTemplatePathResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTransferOwnershipTransferResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesTransferOwnershipTransferResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesTransferOwnershipTransferResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs
@@ -6096,16 +6518,17 @@ class _$FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs
 class FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs,
-            FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder> {
+            FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder>,
+        FilesTransferOwnershipTransferResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder();
 
@@ -6120,7 +6543,7 @@ class FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTransferOwnershipTransferResponse200ApplicationJson_Ocs;
   }
@@ -6155,6 +6578,13 @@ class FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTransferOwnershipTransferResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesTransferOwnershipTransferResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesTransferOwnershipTransferResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesTransferOwnershipTransferResponse200ApplicationJson
@@ -6203,13 +6633,14 @@ class _$FilesTransferOwnershipTransferResponse200ApplicationJson
 class FilesTransferOwnershipTransferResponse200ApplicationJsonBuilder
     implements
         Builder<FilesTransferOwnershipTransferResponse200ApplicationJson,
-            FilesTransferOwnershipTransferResponse200ApplicationJsonBuilder> {
+            FilesTransferOwnershipTransferResponse200ApplicationJsonBuilder>,
+        FilesTransferOwnershipTransferResponse200ApplicationJsonInterfaceBuilder {
   _$FilesTransferOwnershipTransferResponse200ApplicationJson? _$v;
 
   FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesTransferOwnershipTransferResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesTransferOwnershipTransferResponse200ApplicationJsonBuilder();
 
@@ -6223,7 +6654,7 @@ class FilesTransferOwnershipTransferResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesTransferOwnershipTransferResponse200ApplicationJson other) {
+  void replace(covariant FilesTransferOwnershipTransferResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTransferOwnershipTransferResponse200ApplicationJson;
   }
@@ -6254,6 +6685,16 @@ class FilesTransferOwnershipTransferResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs
@@ -6310,16 +6751,17 @@ class _$FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs
 class FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs,
-            FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder> {
+            FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder>,
+        FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder();
 
@@ -6334,7 +6776,7 @@ class FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTransferOwnershipAcceptResponse200ApplicationJson_Ocs;
   }
@@ -6369,6 +6811,13 @@ class FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTransferOwnershipAcceptResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesTransferOwnershipAcceptResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesTransferOwnershipAcceptResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesTransferOwnershipAcceptResponse200ApplicationJson
@@ -6417,13 +6866,14 @@ class _$FilesTransferOwnershipAcceptResponse200ApplicationJson
 class FilesTransferOwnershipAcceptResponse200ApplicationJsonBuilder
     implements
         Builder<FilesTransferOwnershipAcceptResponse200ApplicationJson,
-            FilesTransferOwnershipAcceptResponse200ApplicationJsonBuilder> {
+            FilesTransferOwnershipAcceptResponse200ApplicationJsonBuilder>,
+        FilesTransferOwnershipAcceptResponse200ApplicationJsonInterfaceBuilder {
   _$FilesTransferOwnershipAcceptResponse200ApplicationJson? _$v;
 
   FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesTransferOwnershipAcceptResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesTransferOwnershipAcceptResponse200ApplicationJsonBuilder();
 
@@ -6437,7 +6887,7 @@ class FilesTransferOwnershipAcceptResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesTransferOwnershipAcceptResponse200ApplicationJson other) {
+  void replace(covariant FilesTransferOwnershipAcceptResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTransferOwnershipAcceptResponse200ApplicationJson;
   }
@@ -6468,6 +6918,16 @@ class FilesTransferOwnershipAcceptResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTransferOwnershipRejectResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesTransferOwnershipRejectResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesTransferOwnershipRejectResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesOCSMetaBuilder get meta;
+  set meta(FilesOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs
@@ -6524,16 +6984,17 @@ class _$FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs
 class FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs,
-            FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder> {
+            FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder>,
+        FilesTransferOwnershipRejectResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs? _$v;
 
   FilesOCSMetaBuilder? _meta;
   FilesOCSMetaBuilder get meta => _$this._meta ??= FilesOCSMetaBuilder();
-  set meta(FilesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder();
 
@@ -6548,7 +7009,7 @@ class FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTransferOwnershipRejectResponse200ApplicationJson_Ocs;
   }
@@ -6583,6 +7044,13 @@ class FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTransferOwnershipRejectResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesTransferOwnershipRejectResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesTransferOwnershipRejectResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesTransferOwnershipRejectResponse200ApplicationJson
@@ -6631,13 +7099,14 @@ class _$FilesTransferOwnershipRejectResponse200ApplicationJson
 class FilesTransferOwnershipRejectResponse200ApplicationJsonBuilder
     implements
         Builder<FilesTransferOwnershipRejectResponse200ApplicationJson,
-            FilesTransferOwnershipRejectResponse200ApplicationJsonBuilder> {
+            FilesTransferOwnershipRejectResponse200ApplicationJsonBuilder>,
+        FilesTransferOwnershipRejectResponse200ApplicationJsonInterfaceBuilder {
   _$FilesTransferOwnershipRejectResponse200ApplicationJson? _$v;
 
   FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesTransferOwnershipRejectResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesTransferOwnershipRejectResponse200ApplicationJsonBuilder();
 
@@ -6651,7 +7120,7 @@ class FilesTransferOwnershipRejectResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesTransferOwnershipRejectResponse200ApplicationJson other) {
+  void replace(covariant FilesTransferOwnershipRejectResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTransferOwnershipRejectResponse200ApplicationJson;
   }
@@ -6682,6 +7151,19 @@ class FilesTransferOwnershipRejectResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesCapabilities_Files_DirectEditingInterfaceBuilder {
+  void replace(FilesCapabilities_Files_DirectEditingInterface other);
+  void update(void Function(FilesCapabilities_Files_DirectEditingInterfaceBuilder) updates);
+  String? get url;
+  set url(String? url);
+
+  String? get etag;
+  set etag(String? etag);
+
+  bool? get supportsFileId;
+  set supportsFileId(bool? supportsFileId);
 }
 
 class _$FilesCapabilities_Files_DirectEditing extends FilesCapabilities_Files_DirectEditing {
@@ -6741,20 +7223,22 @@ class _$FilesCapabilities_Files_DirectEditing extends FilesCapabilities_Files_Di
 }
 
 class FilesCapabilities_Files_DirectEditingBuilder
-    implements Builder<FilesCapabilities_Files_DirectEditing, FilesCapabilities_Files_DirectEditingBuilder> {
+    implements
+        Builder<FilesCapabilities_Files_DirectEditing, FilesCapabilities_Files_DirectEditingBuilder>,
+        FilesCapabilities_Files_DirectEditingInterfaceBuilder {
   _$FilesCapabilities_Files_DirectEditing? _$v;
 
   String? _url;
   String? get url => _$this._url;
-  set url(String? url) => _$this._url = url;
+  set url(covariant String? url) => _$this._url = url;
 
   String? _etag;
   String? get etag => _$this._etag;
-  set etag(String? etag) => _$this._etag = etag;
+  set etag(covariant String? etag) => _$this._etag = etag;
 
   bool? _supportsFileId;
   bool? get supportsFileId => _$this._supportsFileId;
-  set supportsFileId(bool? supportsFileId) => _$this._supportsFileId = supportsFileId;
+  set supportsFileId(covariant bool? supportsFileId) => _$this._supportsFileId = supportsFileId;
 
   FilesCapabilities_Files_DirectEditingBuilder();
 
@@ -6770,7 +7254,7 @@ class FilesCapabilities_Files_DirectEditingBuilder
   }
 
   @override
-  void replace(FilesCapabilities_Files_DirectEditing other) {
+  void replace(covariant FilesCapabilities_Files_DirectEditing other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesCapabilities_Files_DirectEditing;
   }
@@ -6793,6 +7277,19 @@ class FilesCapabilities_Files_DirectEditingBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesCapabilities_FilesInterfaceBuilder {
+  void replace(FilesCapabilities_FilesInterface other);
+  void update(void Function(FilesCapabilities_FilesInterfaceBuilder) updates);
+  bool? get bigfilechunking;
+  set bigfilechunking(bool? bigfilechunking);
+
+  ListBuilder<JsonObject> get blacklistedFiles;
+  set blacklistedFiles(ListBuilder<JsonObject>? blacklistedFiles);
+
+  FilesCapabilities_Files_DirectEditingBuilder get directEditing;
+  set directEditing(FilesCapabilities_Files_DirectEditingBuilder? directEditing);
 }
 
 class _$FilesCapabilities_Files extends FilesCapabilities_Files {
@@ -6850,21 +7347,25 @@ class _$FilesCapabilities_Files extends FilesCapabilities_Files {
   }
 }
 
-class FilesCapabilities_FilesBuilder implements Builder<FilesCapabilities_Files, FilesCapabilities_FilesBuilder> {
+class FilesCapabilities_FilesBuilder
+    implements
+        Builder<FilesCapabilities_Files, FilesCapabilities_FilesBuilder>,
+        FilesCapabilities_FilesInterfaceBuilder {
   _$FilesCapabilities_Files? _$v;
 
   bool? _bigfilechunking;
   bool? get bigfilechunking => _$this._bigfilechunking;
-  set bigfilechunking(bool? bigfilechunking) => _$this._bigfilechunking = bigfilechunking;
+  set bigfilechunking(covariant bool? bigfilechunking) => _$this._bigfilechunking = bigfilechunking;
 
   ListBuilder<JsonObject>? _blacklistedFiles;
   ListBuilder<JsonObject> get blacklistedFiles => _$this._blacklistedFiles ??= ListBuilder<JsonObject>();
-  set blacklistedFiles(ListBuilder<JsonObject>? blacklistedFiles) => _$this._blacklistedFiles = blacklistedFiles;
+  set blacklistedFiles(covariant ListBuilder<JsonObject>? blacklistedFiles) =>
+      _$this._blacklistedFiles = blacklistedFiles;
 
   FilesCapabilities_Files_DirectEditingBuilder? _directEditing;
   FilesCapabilities_Files_DirectEditingBuilder get directEditing =>
       _$this._directEditing ??= FilesCapabilities_Files_DirectEditingBuilder();
-  set directEditing(FilesCapabilities_Files_DirectEditingBuilder? directEditing) =>
+  set directEditing(covariant FilesCapabilities_Files_DirectEditingBuilder? directEditing) =>
       _$this._directEditing = directEditing;
 
   FilesCapabilities_FilesBuilder();
@@ -6881,7 +7382,7 @@ class FilesCapabilities_FilesBuilder implements Builder<FilesCapabilities_Files,
   }
 
   @override
-  void replace(FilesCapabilities_Files other) {
+  void replace(covariant FilesCapabilities_Files other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesCapabilities_Files;
   }
@@ -6918,6 +7419,13 @@ class FilesCapabilities_FilesBuilder implements Builder<FilesCapabilities_Files,
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesCapabilitiesInterfaceBuilder {
+  void replace(FilesCapabilitiesInterface other);
+  void update(void Function(FilesCapabilitiesInterfaceBuilder) updates);
+  FilesCapabilities_FilesBuilder get files;
+  set files(FilesCapabilities_FilesBuilder? files);
 }
 
 class _$FilesCapabilities extends FilesCapabilities {
@@ -6957,12 +7465,13 @@ class _$FilesCapabilities extends FilesCapabilities {
   }
 }
 
-class FilesCapabilitiesBuilder implements Builder<FilesCapabilities, FilesCapabilitiesBuilder> {
+class FilesCapabilitiesBuilder
+    implements Builder<FilesCapabilities, FilesCapabilitiesBuilder>, FilesCapabilitiesInterfaceBuilder {
   _$FilesCapabilities? _$v;
 
   FilesCapabilities_FilesBuilder? _files;
   FilesCapabilities_FilesBuilder get files => _$this._files ??= FilesCapabilities_FilesBuilder();
-  set files(FilesCapabilities_FilesBuilder? files) => _$this._files = files;
+  set files(covariant FilesCapabilities_FilesBuilder? files) => _$this._files = files;
 
   FilesCapabilitiesBuilder();
 
@@ -6976,7 +7485,7 @@ class FilesCapabilitiesBuilder implements Builder<FilesCapabilities, FilesCapabi
   }
 
   @override
-  void replace(FilesCapabilities other) {
+  void replace(covariant FilesCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesCapabilities;
   }
@@ -7006,6 +7515,46 @@ class FilesCapabilitiesBuilder implements Builder<FilesCapabilities, FilesCapabi
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTemplateInterfaceBuilder {
+  void replace(FilesTemplateInterface other);
+  void update(void Function(FilesTemplateInterfaceBuilder) updates);
+  String? get templateType;
+  set templateType(String? templateType);
+
+  String? get templateId;
+  set templateId(String? templateId);
+
+  String? get basename;
+  set basename(String? basename);
+
+  String? get etag;
+  set etag(String? etag);
+
+  int? get fileid;
+  set fileid(int? fileid);
+
+  String? get filename;
+  set filename(String? filename);
+
+  int? get lastmod;
+  set lastmod(int? lastmod);
+
+  String? get mime;
+  set mime(String? mime);
+
+  int? get size;
+  set size(int? size);
+
+  String? get type;
+  set type(String? type);
+
+  bool? get hasPreview;
+  set hasPreview(bool? hasPreview);
+
+  String? get previewUrl;
+  set previewUrl(String? previewUrl);
 }
 
 class _$FilesTemplate extends FilesTemplate {
@@ -7126,56 +7675,56 @@ class _$FilesTemplate extends FilesTemplate {
   }
 }
 
-class FilesTemplateBuilder implements Builder<FilesTemplate, FilesTemplateBuilder> {
+class FilesTemplateBuilder implements Builder<FilesTemplate, FilesTemplateBuilder>, FilesTemplateInterfaceBuilder {
   _$FilesTemplate? _$v;
 
   String? _templateType;
   String? get templateType => _$this._templateType;
-  set templateType(String? templateType) => _$this._templateType = templateType;
+  set templateType(covariant String? templateType) => _$this._templateType = templateType;
 
   String? _templateId;
   String? get templateId => _$this._templateId;
-  set templateId(String? templateId) => _$this._templateId = templateId;
+  set templateId(covariant String? templateId) => _$this._templateId = templateId;
 
   String? _basename;
   String? get basename => _$this._basename;
-  set basename(String? basename) => _$this._basename = basename;
+  set basename(covariant String? basename) => _$this._basename = basename;
 
   String? _etag;
   String? get etag => _$this._etag;
-  set etag(String? etag) => _$this._etag = etag;
+  set etag(covariant String? etag) => _$this._etag = etag;
 
   int? _fileid;
   int? get fileid => _$this._fileid;
-  set fileid(int? fileid) => _$this._fileid = fileid;
+  set fileid(covariant int? fileid) => _$this._fileid = fileid;
 
   String? _filename;
   String? get filename => _$this._filename;
-  set filename(String? filename) => _$this._filename = filename;
+  set filename(covariant String? filename) => _$this._filename = filename;
 
   int? _lastmod;
   int? get lastmod => _$this._lastmod;
-  set lastmod(int? lastmod) => _$this._lastmod = lastmod;
+  set lastmod(covariant int? lastmod) => _$this._lastmod = lastmod;
 
   String? _mime;
   String? get mime => _$this._mime;
-  set mime(String? mime) => _$this._mime = mime;
+  set mime(covariant String? mime) => _$this._mime = mime;
 
   int? _size;
   int? get size => _$this._size;
-  set size(int? size) => _$this._size = size;
+  set size(covariant int? size) => _$this._size = size;
 
   String? _type;
   String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
+  set type(covariant String? type) => _$this._type = type;
 
   bool? _hasPreview;
   bool? get hasPreview => _$this._hasPreview;
-  set hasPreview(bool? hasPreview) => _$this._hasPreview = hasPreview;
+  set hasPreview(covariant bool? hasPreview) => _$this._hasPreview = hasPreview;
 
   String? _previewUrl;
   String? get previewUrl => _$this._previewUrl;
-  set previewUrl(String? previewUrl) => _$this._previewUrl = previewUrl;
+  set previewUrl(covariant String? previewUrl) => _$this._previewUrl = previewUrl;
 
   FilesTemplateBuilder();
 
@@ -7200,7 +7749,7 @@ class FilesTemplateBuilder implements Builder<FilesTemplate, FilesTemplateBuilde
   }
 
   @override
-  void replace(FilesTemplate other) {
+  void replace(covariant FilesTemplate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTemplate;
   }

--- a/packages/nextcloud/lib/src/api/files_external.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.dart
@@ -118,7 +118,19 @@ class FilesExternalApiClient {
   }
 }
 
-abstract class FilesExternalOCSMeta implements Built<FilesExternalOCSMeta, FilesExternalOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesExternalOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  FilesExternalOCSMetaInterface rebuild(final void Function(FilesExternalOCSMetaInterfaceBuilder) updates);
+  FilesExternalOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class FilesExternalOCSMeta
+    implements FilesExternalOCSMetaInterface, Built<FilesExternalOCSMeta, FilesExternalOCSMetaBuilder> {
   factory FilesExternalOCSMeta([final void Function(FilesExternalOCSMetaBuilder)? b]) = _$FilesExternalOCSMeta;
 
   // coverage:ignore-start
@@ -133,11 +145,6 @@ abstract class FilesExternalOCSMeta implements Built<FilesExternalOCSMeta, Files
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<FilesExternalOCSMeta> get serializer => _$filesExternalOCSMetaSerializer;
 }
 
@@ -181,8 +188,29 @@ class FilesExternalStorageConfig_Type extends EnumClass {
   static Serializer<FilesExternalStorageConfig_Type> get serializer => _$filesExternalStorageConfigTypeSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesExternalStorageConfigInterface {
+  BuiltList<String>? get applicableGroups;
+  BuiltList<String>? get applicableUsers;
+  String get authMechanism;
+  String get backend;
+  BuiltMap<String, JsonObject> get backendOptions;
+  int? get id;
+  BuiltMap<String, JsonObject>? get mountOptions;
+  String get mountPoint;
+  int? get priority;
+  int? get status;
+  String? get statusMessage;
+  FilesExternalStorageConfig_Type get type;
+  bool get userProvided;
+  FilesExternalStorageConfigInterface rebuild(final void Function(FilesExternalStorageConfigInterfaceBuilder) updates);
+  FilesExternalStorageConfigInterfaceBuilder toBuilder();
+}
+
 abstract class FilesExternalStorageConfig
-    implements Built<FilesExternalStorageConfig, FilesExternalStorageConfigBuilder> {
+    implements
+        FilesExternalStorageConfigInterface,
+        Built<FilesExternalStorageConfig, FilesExternalStorageConfigBuilder> {
   factory FilesExternalStorageConfig([final void Function(FilesExternalStorageConfigBuilder)? b]) =
       _$FilesExternalStorageConfig;
 
@@ -198,23 +226,27 @@ abstract class FilesExternalStorageConfig
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String>? get applicableGroups;
-  BuiltList<String>? get applicableUsers;
-  String get authMechanism;
-  String get backend;
-  BuiltMap<String, JsonObject> get backendOptions;
-  int? get id;
-  BuiltMap<String, JsonObject>? get mountOptions;
-  String get mountPoint;
-  int? get priority;
-  int? get status;
-  String? get statusMessage;
-  FilesExternalStorageConfig_Type get type;
-  bool get userProvided;
   static Serializer<FilesExternalStorageConfig> get serializer => _$filesExternalStorageConfigSerializer;
 }
 
-abstract class FilesExternalMount implements Built<FilesExternalMount, FilesExternalMountBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesExternalMountInterface {
+  String get name;
+  String get path;
+  FilesExternalMount_Type get type;
+  String get backend;
+  FilesExternalMount_Scope get scope;
+  int get permissions;
+  int get id;
+  @BuiltValueField(wireName: 'class')
+  String get $class;
+  FilesExternalStorageConfig get config;
+  FilesExternalMountInterface rebuild(final void Function(FilesExternalMountInterfaceBuilder) updates);
+  FilesExternalMountInterfaceBuilder toBuilder();
+}
+
+abstract class FilesExternalMount
+    implements FilesExternalMountInterface, Built<FilesExternalMount, FilesExternalMountBuilder> {
   factory FilesExternalMount([final void Function(FilesExternalMountBuilder)? b]) = _$FilesExternalMount;
 
   // coverage:ignore-start
@@ -229,21 +261,22 @@ abstract class FilesExternalMount implements Built<FilesExternalMount, FilesExte
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get name;
-  String get path;
-  FilesExternalMount_Type get type;
-  String get backend;
-  FilesExternalMount_Scope get scope;
-  int get permissions;
-  int get id;
-  @BuiltValueField(wireName: 'class')
-  String get $class;
-  FilesExternalStorageConfig get config;
   static Serializer<FilesExternalMount> get serializer => _$filesExternalMountSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsInterface {
+  FilesExternalOCSMeta get meta;
+  BuiltList<FilesExternalMount> get data;
+  FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs
     implements
+        FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsInterface,
         Built<FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs,
             FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder> {
   factory FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs([
@@ -262,14 +295,22 @@ abstract class FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesExternalOCSMeta get meta;
-  BuiltList<FilesExternalMount> get data;
   static Serializer<FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs> get serializer =>
       _$filesExternalApiGetUserMountsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesExternalApiGetUserMountsResponse200ApplicationJsonInterface {
+  FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs get ocs;
+  FilesExternalApiGetUserMountsResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesExternalApiGetUserMountsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesExternalApiGetUserMountsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesExternalApiGetUserMountsResponse200ApplicationJson
     implements
+        FilesExternalApiGetUserMountsResponse200ApplicationJsonInterface,
         Built<FilesExternalApiGetUserMountsResponse200ApplicationJson,
             FilesExternalApiGetUserMountsResponse200ApplicationJsonBuilder> {
   factory FilesExternalApiGetUserMountsResponse200ApplicationJson([
@@ -288,7 +329,6 @@ abstract class FilesExternalApiGetUserMountsResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesExternalApiGetUserMountsResponse200ApplicationJson> get serializer =>
       _$filesExternalApiGetUserMountsResponse200ApplicationJsonSerializer;
 }

--- a/packages/nextcloud/lib/src/api/files_external.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.g.dart
@@ -511,6 +511,25 @@ class _$FilesExternalApiGetUserMountsResponse200ApplicationJsonSerializer
   }
 }
 
+abstract mixin class FilesExternalOCSMetaInterfaceBuilder {
+  void replace(FilesExternalOCSMetaInterface other);
+  void update(void Function(FilesExternalOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
+}
+
 class _$FilesExternalOCSMeta extends FilesExternalOCSMeta {
   @override
   final String status;
@@ -575,28 +594,29 @@ class _$FilesExternalOCSMeta extends FilesExternalOCSMeta {
   }
 }
 
-class FilesExternalOCSMetaBuilder implements Builder<FilesExternalOCSMeta, FilesExternalOCSMetaBuilder> {
+class FilesExternalOCSMetaBuilder
+    implements Builder<FilesExternalOCSMeta, FilesExternalOCSMetaBuilder>, FilesExternalOCSMetaInterfaceBuilder {
   _$FilesExternalOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   FilesExternalOCSMetaBuilder();
 
@@ -614,7 +634,7 @@ class FilesExternalOCSMetaBuilder implements Builder<FilesExternalOCSMeta, Files
   }
 
   @override
-  void replace(FilesExternalOCSMeta other) {
+  void replace(covariant FilesExternalOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesExternalOCSMeta;
   }
@@ -638,6 +658,49 @@ class FilesExternalOCSMetaBuilder implements Builder<FilesExternalOCSMeta, Files
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesExternalStorageConfigInterfaceBuilder {
+  void replace(FilesExternalStorageConfigInterface other);
+  void update(void Function(FilesExternalStorageConfigInterfaceBuilder) updates);
+  ListBuilder<String> get applicableGroups;
+  set applicableGroups(ListBuilder<String>? applicableGroups);
+
+  ListBuilder<String> get applicableUsers;
+  set applicableUsers(ListBuilder<String>? applicableUsers);
+
+  String? get authMechanism;
+  set authMechanism(String? authMechanism);
+
+  String? get backend;
+  set backend(String? backend);
+
+  MapBuilder<String, JsonObject> get backendOptions;
+  set backendOptions(MapBuilder<String, JsonObject>? backendOptions);
+
+  int? get id;
+  set id(int? id);
+
+  MapBuilder<String, JsonObject> get mountOptions;
+  set mountOptions(MapBuilder<String, JsonObject>? mountOptions);
+
+  String? get mountPoint;
+  set mountPoint(String? mountPoint);
+
+  int? get priority;
+  set priority(int? priority);
+
+  int? get status;
+  set status(int? status);
+
+  String? get statusMessage;
+  set statusMessage(String? statusMessage);
+
+  FilesExternalStorageConfig_Type? get type;
+  set type(FilesExternalStorageConfig_Type? type);
+
+  bool? get userProvided;
+  set userProvided(bool? userProvided);
 }
 
 class _$FilesExternalStorageConfig extends FilesExternalStorageConfig {
@@ -761,60 +824,63 @@ class _$FilesExternalStorageConfig extends FilesExternalStorageConfig {
 }
 
 class FilesExternalStorageConfigBuilder
-    implements Builder<FilesExternalStorageConfig, FilesExternalStorageConfigBuilder> {
+    implements
+        Builder<FilesExternalStorageConfig, FilesExternalStorageConfigBuilder>,
+        FilesExternalStorageConfigInterfaceBuilder {
   _$FilesExternalStorageConfig? _$v;
 
   ListBuilder<String>? _applicableGroups;
   ListBuilder<String> get applicableGroups => _$this._applicableGroups ??= ListBuilder<String>();
-  set applicableGroups(ListBuilder<String>? applicableGroups) => _$this._applicableGroups = applicableGroups;
+  set applicableGroups(covariant ListBuilder<String>? applicableGroups) => _$this._applicableGroups = applicableGroups;
 
   ListBuilder<String>? _applicableUsers;
   ListBuilder<String> get applicableUsers => _$this._applicableUsers ??= ListBuilder<String>();
-  set applicableUsers(ListBuilder<String>? applicableUsers) => _$this._applicableUsers = applicableUsers;
+  set applicableUsers(covariant ListBuilder<String>? applicableUsers) => _$this._applicableUsers = applicableUsers;
 
   String? _authMechanism;
   String? get authMechanism => _$this._authMechanism;
-  set authMechanism(String? authMechanism) => _$this._authMechanism = authMechanism;
+  set authMechanism(covariant String? authMechanism) => _$this._authMechanism = authMechanism;
 
   String? _backend;
   String? get backend => _$this._backend;
-  set backend(String? backend) => _$this._backend = backend;
+  set backend(covariant String? backend) => _$this._backend = backend;
 
   MapBuilder<String, JsonObject>? _backendOptions;
   MapBuilder<String, JsonObject> get backendOptions => _$this._backendOptions ??= MapBuilder<String, JsonObject>();
-  set backendOptions(MapBuilder<String, JsonObject>? backendOptions) => _$this._backendOptions = backendOptions;
+  set backendOptions(covariant MapBuilder<String, JsonObject>? backendOptions) =>
+      _$this._backendOptions = backendOptions;
 
   int? _id;
   int? get id => _$this._id;
-  set id(int? id) => _$this._id = id;
+  set id(covariant int? id) => _$this._id = id;
 
   MapBuilder<String, JsonObject>? _mountOptions;
   MapBuilder<String, JsonObject> get mountOptions => _$this._mountOptions ??= MapBuilder<String, JsonObject>();
-  set mountOptions(MapBuilder<String, JsonObject>? mountOptions) => _$this._mountOptions = mountOptions;
+  set mountOptions(covariant MapBuilder<String, JsonObject>? mountOptions) => _$this._mountOptions = mountOptions;
 
   String? _mountPoint;
   String? get mountPoint => _$this._mountPoint;
-  set mountPoint(String? mountPoint) => _$this._mountPoint = mountPoint;
+  set mountPoint(covariant String? mountPoint) => _$this._mountPoint = mountPoint;
 
   int? _priority;
   int? get priority => _$this._priority;
-  set priority(int? priority) => _$this._priority = priority;
+  set priority(covariant int? priority) => _$this._priority = priority;
 
   int? _status;
   int? get status => _$this._status;
-  set status(int? status) => _$this._status = status;
+  set status(covariant int? status) => _$this._status = status;
 
   String? _statusMessage;
   String? get statusMessage => _$this._statusMessage;
-  set statusMessage(String? statusMessage) => _$this._statusMessage = statusMessage;
+  set statusMessage(covariant String? statusMessage) => _$this._statusMessage = statusMessage;
 
   FilesExternalStorageConfig_Type? _type;
   FilesExternalStorageConfig_Type? get type => _$this._type;
-  set type(FilesExternalStorageConfig_Type? type) => _$this._type = type;
+  set type(covariant FilesExternalStorageConfig_Type? type) => _$this._type = type;
 
   bool? _userProvided;
   bool? get userProvided => _$this._userProvided;
-  set userProvided(bool? userProvided) => _$this._userProvided = userProvided;
+  set userProvided(covariant bool? userProvided) => _$this._userProvided = userProvided;
 
   FilesExternalStorageConfigBuilder();
 
@@ -840,7 +906,7 @@ class FilesExternalStorageConfigBuilder
   }
 
   @override
-  void replace(FilesExternalStorageConfig other) {
+  void replace(covariant FilesExternalStorageConfig other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesExternalStorageConfig;
   }
@@ -895,6 +961,37 @@ class FilesExternalStorageConfigBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesExternalMountInterfaceBuilder {
+  void replace(FilesExternalMountInterface other);
+  void update(void Function(FilesExternalMountInterfaceBuilder) updates);
+  String? get name;
+  set name(String? name);
+
+  String? get path;
+  set path(String? path);
+
+  FilesExternalMount_Type? get type;
+  set type(FilesExternalMount_Type? type);
+
+  String? get backend;
+  set backend(String? backend);
+
+  FilesExternalMount_Scope? get scope;
+  set scope(FilesExternalMount_Scope? scope);
+
+  int? get permissions;
+  set permissions(int? permissions);
+
+  int? get id;
+  set id(int? id);
+
+  String? get $class;
+  set $class(String? $class);
+
+  FilesExternalStorageConfigBuilder get config;
+  set config(FilesExternalStorageConfigBuilder? config);
 }
 
 class _$FilesExternalMount extends FilesExternalMount {
@@ -996,44 +1093,45 @@ class _$FilesExternalMount extends FilesExternalMount {
   }
 }
 
-class FilesExternalMountBuilder implements Builder<FilesExternalMount, FilesExternalMountBuilder> {
+class FilesExternalMountBuilder
+    implements Builder<FilesExternalMount, FilesExternalMountBuilder>, FilesExternalMountInterfaceBuilder {
   _$FilesExternalMount? _$v;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   String? _path;
   String? get path => _$this._path;
-  set path(String? path) => _$this._path = path;
+  set path(covariant String? path) => _$this._path = path;
 
   FilesExternalMount_Type? _type;
   FilesExternalMount_Type? get type => _$this._type;
-  set type(FilesExternalMount_Type? type) => _$this._type = type;
+  set type(covariant FilesExternalMount_Type? type) => _$this._type = type;
 
   String? _backend;
   String? get backend => _$this._backend;
-  set backend(String? backend) => _$this._backend = backend;
+  set backend(covariant String? backend) => _$this._backend = backend;
 
   FilesExternalMount_Scope? _scope;
   FilesExternalMount_Scope? get scope => _$this._scope;
-  set scope(FilesExternalMount_Scope? scope) => _$this._scope = scope;
+  set scope(covariant FilesExternalMount_Scope? scope) => _$this._scope = scope;
 
   int? _permissions;
   int? get permissions => _$this._permissions;
-  set permissions(int? permissions) => _$this._permissions = permissions;
+  set permissions(covariant int? permissions) => _$this._permissions = permissions;
 
   int? _id;
   int? get id => _$this._id;
-  set id(int? id) => _$this._id = id;
+  set id(covariant int? id) => _$this._id = id;
 
   String? _$class;
   String? get $class => _$this._$class;
-  set $class(String? $class) => _$this._$class = $class;
+  set $class(covariant String? $class) => _$this._$class = $class;
 
   FilesExternalStorageConfigBuilder? _config;
   FilesExternalStorageConfigBuilder get config => _$this._config ??= FilesExternalStorageConfigBuilder();
-  set config(FilesExternalStorageConfigBuilder? config) => _$this._config = config;
+  set config(covariant FilesExternalStorageConfigBuilder? config) => _$this._config = config;
 
   FilesExternalMountBuilder();
 
@@ -1055,7 +1153,7 @@ class FilesExternalMountBuilder implements Builder<FilesExternalMount, FilesExte
   }
 
   @override
-  void replace(FilesExternalMount other) {
+  void replace(covariant FilesExternalMount other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesExternalMount;
   }
@@ -1095,6 +1193,16 @@ class FilesExternalMountBuilder implements Builder<FilesExternalMount, FilesExte
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesExternalOCSMetaBuilder get meta;
+  set meta(FilesExternalOCSMetaBuilder? meta);
+
+  ListBuilder<FilesExternalMount> get data;
+  set data(ListBuilder<FilesExternalMount>? data);
 }
 
 class _$FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs
@@ -1152,16 +1260,17 @@ class _$FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs
 class FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs,
-            FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder> {
+            FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder>,
+        FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs? _$v;
 
   FilesExternalOCSMetaBuilder? _meta;
   FilesExternalOCSMetaBuilder get meta => _$this._meta ??= FilesExternalOCSMetaBuilder();
-  set meta(FilesExternalOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesExternalOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<FilesExternalMount>? _data;
   ListBuilder<FilesExternalMount> get data => _$this._data ??= ListBuilder<FilesExternalMount>();
-  set data(ListBuilder<FilesExternalMount>? data) => _$this._data = data;
+  set data(covariant ListBuilder<FilesExternalMount>? data) => _$this._data = data;
 
   FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder();
 
@@ -1176,7 +1285,7 @@ class FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesExternalApiGetUserMountsResponse200ApplicationJson_Ocs;
   }
@@ -1210,6 +1319,13 @@ class FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesExternalApiGetUserMountsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesExternalApiGetUserMountsResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesExternalApiGetUserMountsResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesExternalApiGetUserMountsResponse200ApplicationJson
@@ -1258,13 +1374,14 @@ class _$FilesExternalApiGetUserMountsResponse200ApplicationJson
 class FilesExternalApiGetUserMountsResponse200ApplicationJsonBuilder
     implements
         Builder<FilesExternalApiGetUserMountsResponse200ApplicationJson,
-            FilesExternalApiGetUserMountsResponse200ApplicationJsonBuilder> {
+            FilesExternalApiGetUserMountsResponse200ApplicationJsonBuilder>,
+        FilesExternalApiGetUserMountsResponse200ApplicationJsonInterfaceBuilder {
   _$FilesExternalApiGetUserMountsResponse200ApplicationJson? _$v;
 
   FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesExternalApiGetUserMountsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesExternalApiGetUserMountsResponse200ApplicationJsonBuilder();
 
@@ -1278,7 +1395,7 @@ class FilesExternalApiGetUserMountsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesExternalApiGetUserMountsResponse200ApplicationJson other) {
+  void replace(covariant FilesExternalApiGetUserMountsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesExternalApiGetUserMountsResponse200ApplicationJson;
   }

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
@@ -224,7 +224,19 @@ class FilesRemindersApiClient {
   }
 }
 
-abstract class FilesRemindersOCSMeta implements Built<FilesRemindersOCSMeta, FilesRemindersOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesRemindersOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  FilesRemindersOCSMetaInterface rebuild(final void Function(FilesRemindersOCSMetaInterfaceBuilder) updates);
+  FilesRemindersOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class FilesRemindersOCSMeta
+    implements FilesRemindersOCSMetaInterface, Built<FilesRemindersOCSMeta, FilesRemindersOCSMetaBuilder> {
   factory FilesRemindersOCSMeta([final void Function(FilesRemindersOCSMetaBuilder)? b]) = _$FilesRemindersOCSMeta;
 
   // coverage:ignore-start
@@ -239,16 +251,21 @@ abstract class FilesRemindersOCSMeta implements Built<FilesRemindersOCSMeta, Fil
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<FilesRemindersOCSMeta> get serializer => _$filesRemindersOCSMetaSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataInterface {
+  String? get dueDate;
+  FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
 }
 
 abstract class FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data
     implements
+        FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataInterface,
         Built<FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data,
             FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder> {
   factory FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data([
@@ -267,13 +284,23 @@ abstract class FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String? get dueDate;
   static Serializer<FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$filesRemindersApiGetResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesRemindersApiGetResponse200ApplicationJson_OcsInterface {
+  FilesRemindersOCSMeta get meta;
+  FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data get data;
+  FilesRemindersApiGetResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesRemindersApiGetResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesRemindersApiGetResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesRemindersApiGetResponse200ApplicationJson_Ocs
     implements
+        FilesRemindersApiGetResponse200ApplicationJson_OcsInterface,
         Built<FilesRemindersApiGetResponse200ApplicationJson_Ocs,
             FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder> {
   factory FilesRemindersApiGetResponse200ApplicationJson_Ocs([
@@ -292,14 +319,22 @@ abstract class FilesRemindersApiGetResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesRemindersOCSMeta get meta;
-  FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<FilesRemindersApiGetResponse200ApplicationJson_Ocs> get serializer =>
       _$filesRemindersApiGetResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesRemindersApiGetResponse200ApplicationJsonInterface {
+  FilesRemindersApiGetResponse200ApplicationJson_Ocs get ocs;
+  FilesRemindersApiGetResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesRemindersApiGetResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesRemindersApiGetResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesRemindersApiGetResponse200ApplicationJson
     implements
+        FilesRemindersApiGetResponse200ApplicationJsonInterface,
         Built<FilesRemindersApiGetResponse200ApplicationJson, FilesRemindersApiGetResponse200ApplicationJsonBuilder> {
   factory FilesRemindersApiGetResponse200ApplicationJson([
     final void Function(FilesRemindersApiGetResponse200ApplicationJsonBuilder)? b,
@@ -317,13 +352,23 @@ abstract class FilesRemindersApiGetResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesRemindersApiGetResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesRemindersApiGetResponse200ApplicationJson> get serializer =>
       _$filesRemindersApiGetResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesRemindersApiSetResponse200ApplicationJson_OcsInterface {
+  FilesRemindersOCSMeta get meta;
+  JsonObject get data;
+  FilesRemindersApiSetResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesRemindersApiSetResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesRemindersApiSetResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesRemindersApiSetResponse200ApplicationJson_Ocs
     implements
+        FilesRemindersApiSetResponse200ApplicationJson_OcsInterface,
         Built<FilesRemindersApiSetResponse200ApplicationJson_Ocs,
             FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder> {
   factory FilesRemindersApiSetResponse200ApplicationJson_Ocs([
@@ -342,14 +387,22 @@ abstract class FilesRemindersApiSetResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesRemindersOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesRemindersApiSetResponse200ApplicationJson_Ocs> get serializer =>
       _$filesRemindersApiSetResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesRemindersApiSetResponse200ApplicationJsonInterface {
+  FilesRemindersApiSetResponse200ApplicationJson_Ocs get ocs;
+  FilesRemindersApiSetResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesRemindersApiSetResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesRemindersApiSetResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesRemindersApiSetResponse200ApplicationJson
     implements
+        FilesRemindersApiSetResponse200ApplicationJsonInterface,
         Built<FilesRemindersApiSetResponse200ApplicationJson, FilesRemindersApiSetResponse200ApplicationJsonBuilder> {
   factory FilesRemindersApiSetResponse200ApplicationJson([
     final void Function(FilesRemindersApiSetResponse200ApplicationJsonBuilder)? b,
@@ -367,13 +420,23 @@ abstract class FilesRemindersApiSetResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesRemindersApiSetResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesRemindersApiSetResponse200ApplicationJson> get serializer =>
       _$filesRemindersApiSetResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesRemindersApiRemoveResponse200ApplicationJson_OcsInterface {
+  FilesRemindersOCSMeta get meta;
+  JsonObject get data;
+  FilesRemindersApiRemoveResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesRemindersApiRemoveResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesRemindersApiRemoveResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesRemindersApiRemoveResponse200ApplicationJson_Ocs
     implements
+        FilesRemindersApiRemoveResponse200ApplicationJson_OcsInterface,
         Built<FilesRemindersApiRemoveResponse200ApplicationJson_Ocs,
             FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder> {
   factory FilesRemindersApiRemoveResponse200ApplicationJson_Ocs([
@@ -392,14 +455,22 @@ abstract class FilesRemindersApiRemoveResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesRemindersOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesRemindersApiRemoveResponse200ApplicationJson_Ocs> get serializer =>
       _$filesRemindersApiRemoveResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesRemindersApiRemoveResponse200ApplicationJsonInterface {
+  FilesRemindersApiRemoveResponse200ApplicationJson_Ocs get ocs;
+  FilesRemindersApiRemoveResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesRemindersApiRemoveResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesRemindersApiRemoveResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesRemindersApiRemoveResponse200ApplicationJson
     implements
+        FilesRemindersApiRemoveResponse200ApplicationJsonInterface,
         Built<FilesRemindersApiRemoveResponse200ApplicationJson,
             FilesRemindersApiRemoveResponse200ApplicationJsonBuilder> {
   factory FilesRemindersApiRemoveResponse200ApplicationJson([
@@ -418,7 +489,6 @@ abstract class FilesRemindersApiRemoveResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesRemindersApiRemoveResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesRemindersApiRemoveResponse200ApplicationJson> get serializer =>
       _$filesRemindersApiRemoveResponse200ApplicationJsonSerializer;
 }

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.g.dart
@@ -426,6 +426,25 @@ class _$FilesRemindersApiRemoveResponse200ApplicationJsonSerializer
   }
 }
 
+abstract mixin class FilesRemindersOCSMetaInterfaceBuilder {
+  void replace(FilesRemindersOCSMetaInterface other);
+  void update(void Function(FilesRemindersOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
+}
+
 class _$FilesRemindersOCSMeta extends FilesRemindersOCSMeta {
   @override
   final String status;
@@ -490,28 +509,29 @@ class _$FilesRemindersOCSMeta extends FilesRemindersOCSMeta {
   }
 }
 
-class FilesRemindersOCSMetaBuilder implements Builder<FilesRemindersOCSMeta, FilesRemindersOCSMetaBuilder> {
+class FilesRemindersOCSMetaBuilder
+    implements Builder<FilesRemindersOCSMeta, FilesRemindersOCSMetaBuilder>, FilesRemindersOCSMetaInterfaceBuilder {
   _$FilesRemindersOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   FilesRemindersOCSMetaBuilder();
 
@@ -529,7 +549,7 @@ class FilesRemindersOCSMetaBuilder implements Builder<FilesRemindersOCSMeta, Fil
   }
 
   @override
-  void replace(FilesRemindersOCSMeta other) {
+  void replace(covariant FilesRemindersOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesRemindersOCSMeta;
   }
@@ -553,6 +573,13 @@ class FilesRemindersOCSMetaBuilder implements Builder<FilesRemindersOCSMeta, Fil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get dueDate;
+  set dueDate(String? dueDate);
 }
 
 class _$FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data
@@ -600,12 +627,13 @@ class _$FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data
 class FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data,
-            FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder> {
+            FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder>,
+        FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _dueDate;
   String? get dueDate => _$this._dueDate;
-  set dueDate(String? dueDate) => _$this._dueDate = dueDate;
+  set dueDate(covariant String? dueDate) => _$this._dueDate = dueDate;
 
   FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -619,7 +647,7 @@ class FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesRemindersApiGetResponse200ApplicationJson_Ocs_Data;
   }
@@ -637,6 +665,16 @@ class FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesRemindersApiGetResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesRemindersApiGetResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesRemindersApiGetResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesRemindersOCSMetaBuilder get meta;
+  set meta(FilesRemindersOCSMetaBuilder? meta);
+
+  FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$FilesRemindersApiGetResponse200ApplicationJson_Ocs extends FilesRemindersApiGetResponse200ApplicationJson_Ocs {
@@ -690,17 +728,18 @@ class _$FilesRemindersApiGetResponse200ApplicationJson_Ocs extends FilesReminder
 class FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesRemindersApiGetResponse200ApplicationJson_Ocs,
-            FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder> {
+            FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder>,
+        FilesRemindersApiGetResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesRemindersApiGetResponse200ApplicationJson_Ocs? _$v;
 
   FilesRemindersOCSMetaBuilder? _meta;
   FilesRemindersOCSMetaBuilder get meta => _$this._meta ??= FilesRemindersOCSMetaBuilder();
-  set meta(FilesRemindersOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesRemindersOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder? _data;
   FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant FilesRemindersApiGetResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder();
 
@@ -715,7 +754,7 @@ class FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesRemindersApiGetResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesRemindersApiGetResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesRemindersApiGetResponse200ApplicationJson_Ocs;
   }
@@ -748,6 +787,13 @@ class FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesRemindersApiGetResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesRemindersApiGetResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesRemindersApiGetResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesRemindersApiGetResponse200ApplicationJson extends FilesRemindersApiGetResponse200ApplicationJson {
@@ -793,13 +839,14 @@ class _$FilesRemindersApiGetResponse200ApplicationJson extends FilesRemindersApi
 
 class FilesRemindersApiGetResponse200ApplicationJsonBuilder
     implements
-        Builder<FilesRemindersApiGetResponse200ApplicationJson, FilesRemindersApiGetResponse200ApplicationJsonBuilder> {
+        Builder<FilesRemindersApiGetResponse200ApplicationJson, FilesRemindersApiGetResponse200ApplicationJsonBuilder>,
+        FilesRemindersApiGetResponse200ApplicationJsonInterfaceBuilder {
   _$FilesRemindersApiGetResponse200ApplicationJson? _$v;
 
   FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesRemindersApiGetResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesRemindersApiGetResponse200ApplicationJsonBuilder();
 
@@ -813,7 +860,7 @@ class FilesRemindersApiGetResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesRemindersApiGetResponse200ApplicationJson other) {
+  void replace(covariant FilesRemindersApiGetResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesRemindersApiGetResponse200ApplicationJson;
   }
@@ -844,6 +891,16 @@ class FilesRemindersApiGetResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesRemindersApiSetResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesRemindersApiSetResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesRemindersApiSetResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesRemindersOCSMetaBuilder get meta;
+  set meta(FilesRemindersOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesRemindersApiSetResponse200ApplicationJson_Ocs extends FilesRemindersApiSetResponse200ApplicationJson_Ocs {
@@ -897,16 +954,17 @@ class _$FilesRemindersApiSetResponse200ApplicationJson_Ocs extends FilesReminder
 class FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesRemindersApiSetResponse200ApplicationJson_Ocs,
-            FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder> {
+            FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder>,
+        FilesRemindersApiSetResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesRemindersApiSetResponse200ApplicationJson_Ocs? _$v;
 
   FilesRemindersOCSMetaBuilder? _meta;
   FilesRemindersOCSMetaBuilder get meta => _$this._meta ??= FilesRemindersOCSMetaBuilder();
-  set meta(FilesRemindersOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesRemindersOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder();
 
@@ -921,7 +979,7 @@ class FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesRemindersApiSetResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesRemindersApiSetResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesRemindersApiSetResponse200ApplicationJson_Ocs;
   }
@@ -956,6 +1014,13 @@ class FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesRemindersApiSetResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesRemindersApiSetResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesRemindersApiSetResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesRemindersApiSetResponse200ApplicationJson extends FilesRemindersApiSetResponse200ApplicationJson {
@@ -1001,13 +1066,14 @@ class _$FilesRemindersApiSetResponse200ApplicationJson extends FilesRemindersApi
 
 class FilesRemindersApiSetResponse200ApplicationJsonBuilder
     implements
-        Builder<FilesRemindersApiSetResponse200ApplicationJson, FilesRemindersApiSetResponse200ApplicationJsonBuilder> {
+        Builder<FilesRemindersApiSetResponse200ApplicationJson, FilesRemindersApiSetResponse200ApplicationJsonBuilder>,
+        FilesRemindersApiSetResponse200ApplicationJsonInterfaceBuilder {
   _$FilesRemindersApiSetResponse200ApplicationJson? _$v;
 
   FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesRemindersApiSetResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesRemindersApiSetResponse200ApplicationJsonBuilder();
 
@@ -1021,7 +1087,7 @@ class FilesRemindersApiSetResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesRemindersApiSetResponse200ApplicationJson other) {
+  void replace(covariant FilesRemindersApiSetResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesRemindersApiSetResponse200ApplicationJson;
   }
@@ -1052,6 +1118,16 @@ class FilesRemindersApiSetResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesRemindersApiRemoveResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesRemindersApiRemoveResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesRemindersApiRemoveResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesRemindersOCSMetaBuilder get meta;
+  set meta(FilesRemindersOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesRemindersApiRemoveResponse200ApplicationJson_Ocs
@@ -1106,16 +1182,17 @@ class _$FilesRemindersApiRemoveResponse200ApplicationJson_Ocs
 class FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesRemindersApiRemoveResponse200ApplicationJson_Ocs,
-            FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder> {
+            FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder>,
+        FilesRemindersApiRemoveResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesRemindersApiRemoveResponse200ApplicationJson_Ocs? _$v;
 
   FilesRemindersOCSMetaBuilder? _meta;
   FilesRemindersOCSMetaBuilder get meta => _$this._meta ??= FilesRemindersOCSMetaBuilder();
-  set meta(FilesRemindersOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesRemindersOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder();
 
@@ -1130,7 +1207,7 @@ class FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesRemindersApiRemoveResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesRemindersApiRemoveResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesRemindersApiRemoveResponse200ApplicationJson_Ocs;
   }
@@ -1165,6 +1242,13 @@ class FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesRemindersApiRemoveResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesRemindersApiRemoveResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesRemindersApiRemoveResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesRemindersApiRemoveResponse200ApplicationJson extends FilesRemindersApiRemoveResponse200ApplicationJson {
@@ -1212,13 +1296,14 @@ class _$FilesRemindersApiRemoveResponse200ApplicationJson extends FilesReminders
 class FilesRemindersApiRemoveResponse200ApplicationJsonBuilder
     implements
         Builder<FilesRemindersApiRemoveResponse200ApplicationJson,
-            FilesRemindersApiRemoveResponse200ApplicationJsonBuilder> {
+            FilesRemindersApiRemoveResponse200ApplicationJsonBuilder>,
+        FilesRemindersApiRemoveResponse200ApplicationJsonInterfaceBuilder {
   _$FilesRemindersApiRemoveResponse200ApplicationJson? _$v;
 
   FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesRemindersApiRemoveResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesRemindersApiRemoveResponse200ApplicationJsonBuilder();
 
@@ -1232,7 +1317,7 @@ class FilesRemindersApiRemoveResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesRemindersApiRemoveResponse200ApplicationJson other) {
+  void replace(covariant FilesRemindersApiRemoveResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesRemindersApiRemoveResponse200ApplicationJson;
   }

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -1118,7 +1118,19 @@ class FilesSharingShareesapiClient {
   }
 }
 
-abstract class FilesSharingOCSMeta implements Built<FilesSharingOCSMeta, FilesSharingOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  FilesSharingOCSMetaInterface rebuild(final void Function(FilesSharingOCSMetaInterfaceBuilder) updates);
+  FilesSharingOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class FilesSharingOCSMeta
+    implements FilesSharingOCSMetaInterface, Built<FilesSharingOCSMeta, FilesSharingOCSMetaBuilder> {
   factory FilesSharingOCSMeta([final void Function(FilesSharingOCSMetaBuilder)? b]) = _$FilesSharingOCSMeta;
 
   // coverage:ignore-start
@@ -1133,30 +1145,11 @@ abstract class FilesSharingOCSMeta implements Built<FilesSharingOCSMeta, FilesSh
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<FilesSharingOCSMeta> get serializer => _$filesSharingOCSMetaSerializer;
 }
 
-abstract class FilesSharingDeletedShare implements Built<FilesSharingDeletedShare, FilesSharingDeletedShareBuilder> {
-  factory FilesSharingDeletedShare([final void Function(FilesSharingDeletedShareBuilder)? b]) =
-      _$FilesSharingDeletedShare;
-
-  // coverage:ignore-start
-  const FilesSharingDeletedShare._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingDeletedShare.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingDeletedShareInterface {
   String get id;
   @BuiltValueField(wireName: 'share_type')
   int get shareType;
@@ -1190,11 +1183,43 @@ abstract class FilesSharingDeletedShare implements Built<FilesSharingDeletedShar
   String? get shareWithDisplayname;
   @BuiltValueField(wireName: 'share_with_link')
   String? get shareWithLink;
+  FilesSharingDeletedShareInterface rebuild(final void Function(FilesSharingDeletedShareInterfaceBuilder) updates);
+  FilesSharingDeletedShareInterfaceBuilder toBuilder();
+}
+
+abstract class FilesSharingDeletedShare
+    implements FilesSharingDeletedShareInterface, Built<FilesSharingDeletedShare, FilesSharingDeletedShareBuilder> {
+  factory FilesSharingDeletedShare([final void Function(FilesSharingDeletedShareBuilder)? b]) =
+      _$FilesSharingDeletedShare;
+
+  // coverage:ignore-start
+  const FilesSharingDeletedShare._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory FilesSharingDeletedShare.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<FilesSharingDeletedShare> get serializer => _$filesSharingDeletedShareSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  BuiltList<FilesSharingDeletedShare> get data;
+  FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs
     implements
+        FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs,
             FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs([
@@ -1213,14 +1238,22 @@ abstract class FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  BuiltList<FilesSharingDeletedShare> get data;
   static Serializer<FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingDeletedShareapiListResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingDeletedShareapiListResponse200ApplicationJsonInterface {
+  FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingDeletedShareapiListResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingDeletedShareapiListResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingDeletedShareapiListResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingDeletedShareapiListResponse200ApplicationJson
     implements
+        FilesSharingDeletedShareapiListResponse200ApplicationJsonInterface,
         Built<FilesSharingDeletedShareapiListResponse200ApplicationJson,
             FilesSharingDeletedShareapiListResponse200ApplicationJsonBuilder> {
   factory FilesSharingDeletedShareapiListResponse200ApplicationJson([
@@ -1239,13 +1272,23 @@ abstract class FilesSharingDeletedShareapiListResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingDeletedShareapiListResponse200ApplicationJson> get serializer =>
       _$filesSharingDeletedShareapiListResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  JsonObject get data;
+  FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs
     implements
+        FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs,
             FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs([
@@ -1264,14 +1307,22 @@ abstract class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingDeletedShareapiUndeleteResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonInterface {
+  FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson
     implements
+        FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonInterface,
         Built<FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson,
             FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonBuilder> {
   factory FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson([
@@ -1290,26 +1341,12 @@ abstract class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson> get serializer =>
       _$filesSharingDeletedShareapiUndeleteResponse200ApplicationJsonSerializer;
 }
 
-abstract class FilesSharingRemoteShare implements Built<FilesSharingRemoteShare, FilesSharingRemoteShareBuilder> {
-  factory FilesSharingRemoteShare([final void Function(FilesSharingRemoteShareBuilder)? b]) = _$FilesSharingRemoteShare;
-
-  // coverage:ignore-start
-  const FilesSharingRemoteShare._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingRemoteShare.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteShareInterface {
   bool get accepted;
   @BuiltValueField(wireName: 'file_id')
   int? get fileId;
@@ -1330,11 +1367,42 @@ abstract class FilesSharingRemoteShare implements Built<FilesSharingRemoteShare,
   int get shareType;
   String? get type;
   String get user;
+  FilesSharingRemoteShareInterface rebuild(final void Function(FilesSharingRemoteShareInterfaceBuilder) updates);
+  FilesSharingRemoteShareInterfaceBuilder toBuilder();
+}
+
+abstract class FilesSharingRemoteShare
+    implements FilesSharingRemoteShareInterface, Built<FilesSharingRemoteShare, FilesSharingRemoteShareBuilder> {
+  factory FilesSharingRemoteShare([final void Function(FilesSharingRemoteShareBuilder)? b]) = _$FilesSharingRemoteShare;
+
+  // coverage:ignore-start
+  const FilesSharingRemoteShare._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory FilesSharingRemoteShare.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<FilesSharingRemoteShare> get serializer => _$filesSharingRemoteShareSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  BuiltList<FilesSharingRemoteShare> get data;
+  FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs
     implements
+        FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs,
             FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs([
@@ -1353,14 +1421,22 @@ abstract class FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  BuiltList<FilesSharingRemoteShare> get data;
   static Serializer<FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingRemoteGetSharesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteGetSharesResponse200ApplicationJsonInterface {
+  FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingRemoteGetSharesResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingRemoteGetSharesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteGetSharesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteGetSharesResponse200ApplicationJson
     implements
+        FilesSharingRemoteGetSharesResponse200ApplicationJsonInterface,
         Built<FilesSharingRemoteGetSharesResponse200ApplicationJson,
             FilesSharingRemoteGetSharesResponse200ApplicationJsonBuilder> {
   factory FilesSharingRemoteGetSharesResponse200ApplicationJson([
@@ -1379,13 +1455,23 @@ abstract class FilesSharingRemoteGetSharesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingRemoteGetSharesResponse200ApplicationJson> get serializer =>
       _$filesSharingRemoteGetSharesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  BuiltList<FilesSharingRemoteShare> get data;
+  FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs
     implements
+        FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs,
             FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs([
@@ -1404,14 +1490,22 @@ abstract class FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  BuiltList<FilesSharingRemoteShare> get data;
   static Serializer<FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingRemoteGetOpenSharesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonInterface {
+  FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteGetOpenSharesResponse200ApplicationJson
     implements
+        FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonInterface,
         Built<FilesSharingRemoteGetOpenSharesResponse200ApplicationJson,
             FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonBuilder> {
   factory FilesSharingRemoteGetOpenSharesResponse200ApplicationJson([
@@ -1430,13 +1524,23 @@ abstract class FilesSharingRemoteGetOpenSharesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingRemoteGetOpenSharesResponse200ApplicationJson> get serializer =>
       _$filesSharingRemoteGetOpenSharesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  JsonObject get data;
+  FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs
     implements
+        FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs,
             FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs([
@@ -1455,14 +1559,22 @@ abstract class FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingRemoteAcceptShareResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteAcceptShareResponse200ApplicationJsonInterface {
+  FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingRemoteAcceptShareResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingRemoteAcceptShareResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteAcceptShareResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteAcceptShareResponse200ApplicationJson
     implements
+        FilesSharingRemoteAcceptShareResponse200ApplicationJsonInterface,
         Built<FilesSharingRemoteAcceptShareResponse200ApplicationJson,
             FilesSharingRemoteAcceptShareResponse200ApplicationJsonBuilder> {
   factory FilesSharingRemoteAcceptShareResponse200ApplicationJson([
@@ -1481,13 +1593,23 @@ abstract class FilesSharingRemoteAcceptShareResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingRemoteAcceptShareResponse200ApplicationJson> get serializer =>
       _$filesSharingRemoteAcceptShareResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  JsonObject get data;
+  FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs
     implements
+        FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs,
             FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs([
@@ -1506,14 +1628,22 @@ abstract class FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingRemoteDeclineShareResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteDeclineShareResponse200ApplicationJsonInterface {
+  FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingRemoteDeclineShareResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingRemoteDeclineShareResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteDeclineShareResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteDeclineShareResponse200ApplicationJson
     implements
+        FilesSharingRemoteDeclineShareResponse200ApplicationJsonInterface,
         Built<FilesSharingRemoteDeclineShareResponse200ApplicationJson,
             FilesSharingRemoteDeclineShareResponse200ApplicationJsonBuilder> {
   factory FilesSharingRemoteDeclineShareResponse200ApplicationJson([
@@ -1532,13 +1662,23 @@ abstract class FilesSharingRemoteDeclineShareResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingRemoteDeclineShareResponse200ApplicationJson> get serializer =>
       _$filesSharingRemoteDeclineShareResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteGetShareResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  FilesSharingRemoteShare get data;
+  FilesSharingRemoteGetShareResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingRemoteGetShareResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteGetShareResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs
     implements
+        FilesSharingRemoteGetShareResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs,
             FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs([
@@ -1557,14 +1697,22 @@ abstract class FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  FilesSharingRemoteShare get data;
   static Serializer<FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingRemoteGetShareResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteGetShareResponse200ApplicationJsonInterface {
+  FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingRemoteGetShareResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingRemoteGetShareResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteGetShareResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteGetShareResponse200ApplicationJson
     implements
+        FilesSharingRemoteGetShareResponse200ApplicationJsonInterface,
         Built<FilesSharingRemoteGetShareResponse200ApplicationJson,
             FilesSharingRemoteGetShareResponse200ApplicationJsonBuilder> {
   factory FilesSharingRemoteGetShareResponse200ApplicationJson([
@@ -1583,13 +1731,23 @@ abstract class FilesSharingRemoteGetShareResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingRemoteGetShareResponse200ApplicationJson> get serializer =>
       _$filesSharingRemoteGetShareResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteUnshareResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  JsonObject get data;
+  FilesSharingRemoteUnshareResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingRemoteUnshareResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteUnshareResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs
     implements
+        FilesSharingRemoteUnshareResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs,
             FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs([
@@ -1608,14 +1766,22 @@ abstract class FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingRemoteUnshareResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingRemoteUnshareResponse200ApplicationJsonInterface {
+  FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingRemoteUnshareResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingRemoteUnshareResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingRemoteUnshareResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingRemoteUnshareResponse200ApplicationJson
     implements
+        FilesSharingRemoteUnshareResponse200ApplicationJsonInterface,
         Built<FilesSharingRemoteUnshareResponse200ApplicationJson,
             FilesSharingRemoteUnshareResponse200ApplicationJsonBuilder> {
   factory FilesSharingRemoteUnshareResponse200ApplicationJson([
@@ -1634,7 +1800,6 @@ abstract class FilesSharingRemoteUnshareResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingRemoteUnshareResponse200ApplicationJson> get serializer =>
       _$filesSharingRemoteUnshareResponse200ApplicationJsonSerializer;
 }
@@ -1696,7 +1861,24 @@ class _$FilesSharingShareInfo_SizeSerializer implements PrimitiveSerializer<File
   }
 }
 
-abstract class FilesSharingShareInfo implements Built<FilesSharingShareInfo, FilesSharingShareInfoBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareInfoInterface {
+  int get id;
+  int get parentId;
+  int get mtime;
+  String get name;
+  int get permissions;
+  String get mimetype;
+  FilesSharingShareInfo_Size get size;
+  String get type;
+  String get etag;
+  BuiltList<BuiltMap<String, JsonObject>>? get children;
+  FilesSharingShareInfoInterface rebuild(final void Function(FilesSharingShareInfoInterfaceBuilder) updates);
+  FilesSharingShareInfoInterfaceBuilder toBuilder();
+}
+
+abstract class FilesSharingShareInfo
+    implements FilesSharingShareInfoInterface, Built<FilesSharingShareInfo, FilesSharingShareInfoBuilder> {
   factory FilesSharingShareInfo([final void Function(FilesSharingShareInfoBuilder)? b]) = _$FilesSharingShareInfo;
 
   // coverage:ignore-start
@@ -1711,16 +1893,6 @@ abstract class FilesSharingShareInfo implements Built<FilesSharingShareInfo, Fil
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int get id;
-  int get parentId;
-  int get mtime;
-  String get name;
-  int get permissions;
-  String get mimetype;
-  FilesSharingShareInfo_Size get size;
-  String get type;
-  String get etag;
-  BuiltList<BuiltMap<String, JsonObject>>? get children;
   static Serializer<FilesSharingShareInfo> get serializer => _$filesSharingShareInfoSerializer;
 }
 
@@ -1795,7 +1967,18 @@ class FilesSharingShare_ItemType extends EnumClass {
   static Serializer<FilesSharingShare_ItemType> get serializer => _$filesSharingShareItemTypeSerializer;
 }
 
-abstract class FilesSharingShare_Status implements Built<FilesSharingShare_Status, FilesSharingShare_StatusBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShare_StatusInterface {
+  int? get clearAt;
+  String? get icon;
+  String? get message;
+  String? get status;
+  FilesSharingShare_StatusInterface rebuild(final void Function(FilesSharingShare_StatusInterfaceBuilder) updates);
+  FilesSharingShare_StatusInterfaceBuilder toBuilder();
+}
+
+abstract class FilesSharingShare_Status
+    implements FilesSharingShare_StatusInterface, Built<FilesSharingShare_Status, FilesSharingShare_StatusBuilder> {
   factory FilesSharingShare_Status([final void Function(FilesSharingShare_StatusBuilder)? b]) =
       _$FilesSharingShare_Status;
 
@@ -1811,28 +1994,11 @@ abstract class FilesSharingShare_Status implements Built<FilesSharingShare_Statu
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int? get clearAt;
-  String? get icon;
-  String? get message;
-  String? get status;
   static Serializer<FilesSharingShare_Status> get serializer => _$filesSharingShareStatusSerializer;
 }
 
-abstract class FilesSharingShare implements Built<FilesSharingShare, FilesSharingShareBuilder> {
-  factory FilesSharingShare([final void Function(FilesSharingShareBuilder)? b]) = _$FilesSharingShare;
-
-  // coverage:ignore-start
-  const FilesSharingShare._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShare.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareInterface {
   String? get attributes;
   @BuiltValueField(wireName: 'can_delete')
   bool get canDelete;
@@ -1900,11 +2066,42 @@ abstract class FilesSharingShare implements Built<FilesSharingShare, FilesSharin
   @BuiltValueField(wireName: 'uid_owner')
   String get uidOwner;
   String? get url;
+  FilesSharingShareInterface rebuild(final void Function(FilesSharingShareInterfaceBuilder) updates);
+  FilesSharingShareInterfaceBuilder toBuilder();
+}
+
+abstract class FilesSharingShare
+    implements FilesSharingShareInterface, Built<FilesSharingShare, FilesSharingShareBuilder> {
+  factory FilesSharingShare([final void Function(FilesSharingShareBuilder)? b]) = _$FilesSharingShare;
+
+  // coverage:ignore-start
+  const FilesSharingShare._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory FilesSharingShare.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<FilesSharingShare> get serializer => _$filesSharingShareSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  BuiltList<FilesSharingShare> get data;
+  FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs
     implements
+        FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs,
             FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs([
@@ -1923,14 +2120,22 @@ abstract class FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  BuiltList<FilesSharingShare> get data;
   static Serializer<FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingShareapiGetSharesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiGetSharesResponse200ApplicationJsonInterface {
+  FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingShareapiGetSharesResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingShareapiGetSharesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiGetSharesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiGetSharesResponse200ApplicationJson
     implements
+        FilesSharingShareapiGetSharesResponse200ApplicationJsonInterface,
         Built<FilesSharingShareapiGetSharesResponse200ApplicationJson,
             FilesSharingShareapiGetSharesResponse200ApplicationJsonBuilder> {
   factory FilesSharingShareapiGetSharesResponse200ApplicationJson([
@@ -1949,13 +2154,23 @@ abstract class FilesSharingShareapiGetSharesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingShareapiGetSharesResponse200ApplicationJson> get serializer =>
       _$filesSharingShareapiGetSharesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  FilesSharingShare get data;
+  FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs
     implements
+        FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs,
             FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs([
@@ -1974,14 +2189,22 @@ abstract class FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  FilesSharingShare get data;
   static Serializer<FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingShareapiCreateShareResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiCreateShareResponse200ApplicationJsonInterface {
+  FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingShareapiCreateShareResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingShareapiCreateShareResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiCreateShareResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiCreateShareResponse200ApplicationJson
     implements
+        FilesSharingShareapiCreateShareResponse200ApplicationJsonInterface,
         Built<FilesSharingShareapiCreateShareResponse200ApplicationJson,
             FilesSharingShareapiCreateShareResponse200ApplicationJsonBuilder> {
   factory FilesSharingShareapiCreateShareResponse200ApplicationJson([
@@ -2000,13 +2223,23 @@ abstract class FilesSharingShareapiCreateShareResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingShareapiCreateShareResponse200ApplicationJson> get serializer =>
       _$filesSharingShareapiCreateShareResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  BuiltList<FilesSharingShare> get data;
+  FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs
     implements
+        FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs,
             FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs([
@@ -2027,14 +2260,22 @@ abstract class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  BuiltList<FilesSharingShare> get data;
   static Serializer<FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingShareapiGetInheritedSharesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonInterface {
+  FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson
     implements
+        FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonInterface,
         Built<FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson,
             FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonBuilder> {
   factory FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson([
@@ -2053,13 +2294,23 @@ abstract class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson> get serializer =>
       _$filesSharingShareapiGetInheritedSharesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  BuiltList<FilesSharingShare> get data;
+  FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs
     implements
+        FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs,
             FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs([
@@ -2078,14 +2329,22 @@ abstract class FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  BuiltList<FilesSharingShare> get data;
   static Serializer<FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingShareapiPendingSharesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiPendingSharesResponse200ApplicationJsonInterface {
+  FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingShareapiPendingSharesResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingShareapiPendingSharesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiPendingSharesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiPendingSharesResponse200ApplicationJson
     implements
+        FilesSharingShareapiPendingSharesResponse200ApplicationJsonInterface,
         Built<FilesSharingShareapiPendingSharesResponse200ApplicationJson,
             FilesSharingShareapiPendingSharesResponse200ApplicationJsonBuilder> {
   factory FilesSharingShareapiPendingSharesResponse200ApplicationJson([
@@ -2104,13 +2363,23 @@ abstract class FilesSharingShareapiPendingSharesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingShareapiPendingSharesResponse200ApplicationJson> get serializer =>
       _$filesSharingShareapiPendingSharesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiGetShareResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  FilesSharingShare get data;
+  FilesSharingShareapiGetShareResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingShareapiGetShareResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiGetShareResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs
     implements
+        FilesSharingShareapiGetShareResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs,
             FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs([
@@ -2129,14 +2398,22 @@ abstract class FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  FilesSharingShare get data;
   static Serializer<FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingShareapiGetShareResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiGetShareResponse200ApplicationJsonInterface {
+  FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingShareapiGetShareResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingShareapiGetShareResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiGetShareResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiGetShareResponse200ApplicationJson
     implements
+        FilesSharingShareapiGetShareResponse200ApplicationJsonInterface,
         Built<FilesSharingShareapiGetShareResponse200ApplicationJson,
             FilesSharingShareapiGetShareResponse200ApplicationJsonBuilder> {
   factory FilesSharingShareapiGetShareResponse200ApplicationJson([
@@ -2155,13 +2432,23 @@ abstract class FilesSharingShareapiGetShareResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingShareapiGetShareResponse200ApplicationJson> get serializer =>
       _$filesSharingShareapiGetShareResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  FilesSharingShare get data;
+  FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs
     implements
+        FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs,
             FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs([
@@ -2180,14 +2467,22 @@ abstract class FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  FilesSharingShare get data;
   static Serializer<FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingShareapiUpdateShareResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiUpdateShareResponse200ApplicationJsonInterface {
+  FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingShareapiUpdateShareResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingShareapiUpdateShareResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiUpdateShareResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiUpdateShareResponse200ApplicationJson
     implements
+        FilesSharingShareapiUpdateShareResponse200ApplicationJsonInterface,
         Built<FilesSharingShareapiUpdateShareResponse200ApplicationJson,
             FilesSharingShareapiUpdateShareResponse200ApplicationJsonBuilder> {
   factory FilesSharingShareapiUpdateShareResponse200ApplicationJson([
@@ -2206,13 +2501,23 @@ abstract class FilesSharingShareapiUpdateShareResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingShareapiUpdateShareResponse200ApplicationJson> get serializer =>
       _$filesSharingShareapiUpdateShareResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  JsonObject get data;
+  FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs
     implements
+        FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs,
             FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs([
@@ -2231,14 +2536,22 @@ abstract class FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingShareapiDeleteShareResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiDeleteShareResponse200ApplicationJsonInterface {
+  FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingShareapiDeleteShareResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingShareapiDeleteShareResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiDeleteShareResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiDeleteShareResponse200ApplicationJson
     implements
+        FilesSharingShareapiDeleteShareResponse200ApplicationJsonInterface,
         Built<FilesSharingShareapiDeleteShareResponse200ApplicationJson,
             FilesSharingShareapiDeleteShareResponse200ApplicationJsonBuilder> {
   factory FilesSharingShareapiDeleteShareResponse200ApplicationJson([
@@ -2257,13 +2570,23 @@ abstract class FilesSharingShareapiDeleteShareResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingShareapiDeleteShareResponse200ApplicationJson> get serializer =>
       _$filesSharingShareapiDeleteShareResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  JsonObject get data;
+  FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs
     implements
+        FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs,
             FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs([
@@ -2282,14 +2605,22 @@ abstract class FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  JsonObject get data;
   static Serializer<FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingShareapiAcceptShareResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareapiAcceptShareResponse200ApplicationJsonInterface {
+  FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingShareapiAcceptShareResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingShareapiAcceptShareResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingShareapiAcceptShareResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareapiAcceptShareResponse200ApplicationJson
     implements
+        FilesSharingShareapiAcceptShareResponse200ApplicationJsonInterface,
         Built<FilesSharingShareapiAcceptShareResponse200ApplicationJson,
             FilesSharingShareapiAcceptShareResponse200ApplicationJsonBuilder> {
   factory FilesSharingShareapiAcceptShareResponse200ApplicationJson([
@@ -2308,7 +2639,6 @@ abstract class FilesSharingShareapiAcceptShareResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingShareapiAcceptShareResponse200ApplicationJson> get serializer =>
       _$filesSharingShareapiAcceptShareResponse200ApplicationJsonSerializer;
 }
@@ -2380,8 +2710,18 @@ class _$FilesSharingShareesapiSearchShareTypeSerializer
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareesapiShareesapiSearchHeadersInterface {
+  String? get link;
+  FilesSharingShareesapiShareesapiSearchHeadersInterface rebuild(
+    final void Function(FilesSharingShareesapiShareesapiSearchHeadersInterfaceBuilder) updates,
+  );
+  FilesSharingShareesapiShareesapiSearchHeadersInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareesapiShareesapiSearchHeaders
     implements
+        FilesSharingShareesapiShareesapiSearchHeadersInterface,
         Built<FilesSharingShareesapiShareesapiSearchHeaders, FilesSharingShareesapiShareesapiSearchHeadersBuilder> {
   factory FilesSharingShareesapiShareesapiSearchHeaders([
     final void Function(FilesSharingShareesapiShareesapiSearchHeadersBuilder)? b,
@@ -2399,7 +2739,6 @@ abstract class FilesSharingShareesapiShareesapiSearchHeaders
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String? get link;
   @BuiltValueSerializer(custom: true)
   static Serializer<FilesSharingShareesapiShareesapiSearchHeaders> get serializer =>
       _$FilesSharingShareesapiShareesapiSearchHeadersSerializer();
@@ -2448,7 +2787,16 @@ class _$FilesSharingShareesapiShareesapiSearchHeadersSerializer
   }
 }
 
-abstract class FilesSharingSharee implements Built<FilesSharingSharee, FilesSharingShareeBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeInterface {
+  int? get count;
+  String get label;
+  FilesSharingShareeInterface rebuild(final void Function(FilesSharingShareeInterfaceBuilder) updates);
+  FilesSharingShareeInterfaceBuilder toBuilder();
+}
+
+abstract class FilesSharingSharee
+    implements FilesSharingShareeInterface, Built<FilesSharingSharee, FilesSharingShareeBuilder> {
   factory FilesSharingSharee([final void Function(FilesSharingShareeBuilder)? b]) = _$FilesSharingSharee;
 
   // coverage:ignore-start
@@ -2463,12 +2811,19 @@ abstract class FilesSharingSharee implements Built<FilesSharingSharee, FilesShar
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int? get count;
-  String get label;
   static Serializer<FilesSharingSharee> get serializer => _$filesSharingShareeSerializer;
 }
 
-abstract class FilesSharingShareeValue implements Built<FilesSharingShareeValue, FilesSharingShareeValueBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeValueInterface {
+  int get shareType;
+  String get shareWith;
+  FilesSharingShareeValueInterface rebuild(final void Function(FilesSharingShareeValueInterfaceBuilder) updates);
+  FilesSharingShareeValueInterfaceBuilder toBuilder();
+}
+
+abstract class FilesSharingShareeValue
+    implements FilesSharingShareeValueInterface, Built<FilesSharingShareeValue, FilesSharingShareeValueBuilder> {
   factory FilesSharingShareeValue([final void Function(FilesSharingShareeValueBuilder)? b]) = _$FilesSharingShareeValue;
 
   // coverage:ignore-start
@@ -2483,116 +2838,54 @@ abstract class FilesSharingShareeValue implements Built<FilesSharingShareeValue,
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int get shareType;
-  String get shareWith;
   static Serializer<FilesSharingShareeValue> get serializer => _$filesSharingShareeValueSerializer;
 }
 
-abstract class FilesSharingShareeCircle1_Value1
-    implements Built<FilesSharingShareeCircle1_Value1, FilesSharingShareeCircle1_Value1Builder> {
-  factory FilesSharingShareeCircle1_Value1([final void Function(FilesSharingShareeCircle1_Value1Builder)? b]) =
-      _$FilesSharingShareeCircle1_Value1;
-
-  // coverage:ignore-start
-  const FilesSharingShareeCircle1_Value1._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShareeCircle1_Value1.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeCircle_1_Value_1Interface {
   String get circle;
-  static Serializer<FilesSharingShareeCircle1_Value1> get serializer => _$filesSharingShareeCircle1Value1Serializer;
+  FilesSharingShareeCircle_1_Value_1Interface rebuild(
+    final void Function(FilesSharingShareeCircle_1_Value_1InterfaceBuilder) updates,
+  );
+  FilesSharingShareeCircle_1_Value_1InterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeCircle1_Value
-    implements Built<FilesSharingShareeCircle1_Value, FilesSharingShareeCircle1_ValueBuilder> {
-  factory FilesSharingShareeCircle1_Value([final void Function(FilesSharingShareeCircle1_ValueBuilder)? b]) =
-      _$FilesSharingShareeCircle1_Value;
+abstract class FilesSharingShareeCircle_1_Value
+    implements
+        FilesSharingShareeValueInterface,
+        FilesSharingShareeCircle_1_Value_1Interface,
+        Built<FilesSharingShareeCircle_1_Value, FilesSharingShareeCircle_1_ValueBuilder> {
+  factory FilesSharingShareeCircle_1_Value([final void Function(FilesSharingShareeCircle_1_ValueBuilder)? b]) =
+      _$FilesSharingShareeCircle_1_Value;
 
   // coverage:ignore-start
-  const FilesSharingShareeCircle1_Value._();
+  const FilesSharingShareeCircle_1_Value._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingShareeCircle1_Value.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingShareeCircle_1_Value.fromJson(final Map<String, dynamic> json) =>
       _jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  FilesSharingShareeValue get shareeValue;
-  FilesSharingShareeCircle1_Value1 get shareeCircle1Value1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<FilesSharingShareeCircle1_Value> get serializer => _$FilesSharingShareeCircle1_ValueSerializer();
+  static Serializer<FilesSharingShareeCircle_1_Value> get serializer => _$filesSharingShareeCircle1ValueSerializer;
 }
 
-class _$FilesSharingShareeCircle1_ValueSerializer implements PrimitiveSerializer<FilesSharingShareeCircle1_Value> {
-  @override
-  final Iterable<Type> types = const [FilesSharingShareeCircle1_Value, _$FilesSharingShareeCircle1_Value];
-
-  @override
-  final String wireName = 'FilesSharingShareeCircle1_Value';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final FilesSharingShareeCircle1_Value object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  FilesSharingShareeCircle1_Value deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = FilesSharingShareeCircle1_ValueBuilder()..data = JsonObject(data);
-    result.shareeValue.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeValue),
-      )! as FilesSharingShareeValue,
-    );
-    result.shareeCircle1Value1.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeCircle1_Value1),
-      )! as FilesSharingShareeCircle1_Value1,
-    );
-    return result.build();
-  }
-}
-
-abstract class FilesSharingShareeCircle1 implements Built<FilesSharingShareeCircle1, FilesSharingShareeCircle1Builder> {
-  factory FilesSharingShareeCircle1([final void Function(FilesSharingShareeCircle1Builder)? b]) =
-      _$FilesSharingShareeCircle1;
-
-  // coverage:ignore-start
-  const FilesSharingShareeCircle1._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShareeCircle1.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeCircle_1Interface {
   String get shareWithDescription;
-  FilesSharingShareeCircle1_Value get value;
-  static Serializer<FilesSharingShareeCircle1> get serializer => _$filesSharingShareeCircle1Serializer;
+  FilesSharingShareeCircle_1_Value get value;
+  FilesSharingShareeCircle_1Interface rebuild(final void Function(FilesSharingShareeCircle_1InterfaceBuilder) updates);
+  FilesSharingShareeCircle_1InterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeCircle implements Built<FilesSharingShareeCircle, FilesSharingShareeCircleBuilder> {
+abstract class FilesSharingShareeCircle
+    implements
+        FilesSharingShareeInterface,
+        FilesSharingShareeCircle_1Interface,
+        Built<FilesSharingShareeCircle, FilesSharingShareeCircleBuilder> {
   factory FilesSharingShareeCircle([final void Function(FilesSharingShareeCircleBuilder)? b]) =
       _$FilesSharingShareeCircle;
 
@@ -2608,73 +2901,25 @@ abstract class FilesSharingShareeCircle implements Built<FilesSharingShareeCircl
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  FilesSharingSharee get sharee;
-  FilesSharingShareeCircle1 get shareeCircle1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<FilesSharingShareeCircle> get serializer => _$FilesSharingShareeCircleSerializer();
+  static Serializer<FilesSharingShareeCircle> get serializer => _$filesSharingShareeCircleSerializer;
 }
 
-class _$FilesSharingShareeCircleSerializer implements PrimitiveSerializer<FilesSharingShareeCircle> {
-  @override
-  final Iterable<Type> types = const [FilesSharingShareeCircle, _$FilesSharingShareeCircle];
-
-  @override
-  final String wireName = 'FilesSharingShareeCircle';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final FilesSharingShareeCircle object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  FilesSharingShareeCircle deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = FilesSharingShareeCircleBuilder()..data = JsonObject(data);
-    result.sharee.replace(
-      _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesSharingSharee))! as FilesSharingSharee,
-    );
-    result.shareeCircle1.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeCircle1),
-      )! as FilesSharingShareeCircle1,
-    );
-    return result.build();
-  }
-}
-
-abstract class FilesSharingShareeEmail1 implements Built<FilesSharingShareeEmail1, FilesSharingShareeEmail1Builder> {
-  factory FilesSharingShareeEmail1([final void Function(FilesSharingShareeEmail1Builder)? b]) =
-      _$FilesSharingShareeEmail1;
-
-  // coverage:ignore-start
-  const FilesSharingShareeEmail1._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShareeEmail1.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeEmail_1Interface {
   String get uuid;
   String get name;
   String get type;
   String get shareWithDisplayNameUnique;
   FilesSharingShareeValue get value;
-  static Serializer<FilesSharingShareeEmail1> get serializer => _$filesSharingShareeEmail1Serializer;
+  FilesSharingShareeEmail_1Interface rebuild(final void Function(FilesSharingShareeEmail_1InterfaceBuilder) updates);
+  FilesSharingShareeEmail_1InterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeEmail implements Built<FilesSharingShareeEmail, FilesSharingShareeEmailBuilder> {
+abstract class FilesSharingShareeEmail
+    implements
+        FilesSharingShareeInterface,
+        FilesSharingShareeEmail_1Interface,
+        Built<FilesSharingShareeEmail, FilesSharingShareeEmailBuilder> {
   factory FilesSharingShareeEmail([final void Function(FilesSharingShareeEmailBuilder)? b]) = _$FilesSharingShareeEmail;
 
   // coverage:ignore-start
@@ -2689,158 +2934,59 @@ abstract class FilesSharingShareeEmail implements Built<FilesSharingShareeEmail,
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  FilesSharingSharee get sharee;
-  FilesSharingShareeEmail1 get shareeEmail1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<FilesSharingShareeEmail> get serializer => _$FilesSharingShareeEmailSerializer();
+  static Serializer<FilesSharingShareeEmail> get serializer => _$filesSharingShareeEmailSerializer;
 }
 
-class _$FilesSharingShareeEmailSerializer implements PrimitiveSerializer<FilesSharingShareeEmail> {
-  @override
-  final Iterable<Type> types = const [FilesSharingShareeEmail, _$FilesSharingShareeEmail];
-
-  @override
-  final String wireName = 'FilesSharingShareeEmail';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final FilesSharingShareeEmail object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  FilesSharingShareeEmail deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = FilesSharingShareeEmailBuilder()..data = JsonObject(data);
-    result.sharee.replace(
-      _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesSharingSharee))! as FilesSharingSharee,
-    );
-    result.shareeEmail1.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeEmail1),
-      )! as FilesSharingShareeEmail1,
-    );
-    return result.build();
-  }
-}
-
-abstract class FilesSharingShareeRemoteGroup1_Value1
-    implements Built<FilesSharingShareeRemoteGroup1_Value1, FilesSharingShareeRemoteGroup1_Value1Builder> {
-  factory FilesSharingShareeRemoteGroup1_Value1([
-    final void Function(FilesSharingShareeRemoteGroup1_Value1Builder)? b,
-  ]) = _$FilesSharingShareeRemoteGroup1_Value1;
-
-  // coverage:ignore-start
-  const FilesSharingShareeRemoteGroup1_Value1._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShareeRemoteGroup1_Value1.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeRemoteGroup_1_Value_1Interface {
   String get server;
-  static Serializer<FilesSharingShareeRemoteGroup1_Value1> get serializer =>
-      _$filesSharingShareeRemoteGroup1Value1Serializer;
+  FilesSharingShareeRemoteGroup_1_Value_1Interface rebuild(
+    final void Function(FilesSharingShareeRemoteGroup_1_Value_1InterfaceBuilder) updates,
+  );
+  FilesSharingShareeRemoteGroup_1_Value_1InterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeRemoteGroup1_Value
-    implements Built<FilesSharingShareeRemoteGroup1_Value, FilesSharingShareeRemoteGroup1_ValueBuilder> {
-  factory FilesSharingShareeRemoteGroup1_Value([final void Function(FilesSharingShareeRemoteGroup1_ValueBuilder)? b]) =
-      _$FilesSharingShareeRemoteGroup1_Value;
+abstract class FilesSharingShareeRemoteGroup_1_Value
+    implements
+        FilesSharingShareeValueInterface,
+        FilesSharingShareeRemoteGroup_1_Value_1Interface,
+        Built<FilesSharingShareeRemoteGroup_1_Value, FilesSharingShareeRemoteGroup_1_ValueBuilder> {
+  factory FilesSharingShareeRemoteGroup_1_Value([
+    final void Function(FilesSharingShareeRemoteGroup_1_ValueBuilder)? b,
+  ]) = _$FilesSharingShareeRemoteGroup_1_Value;
 
   // coverage:ignore-start
-  const FilesSharingShareeRemoteGroup1_Value._();
+  const FilesSharingShareeRemoteGroup_1_Value._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingShareeRemoteGroup1_Value.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingShareeRemoteGroup_1_Value.fromJson(final Map<String, dynamic> json) =>
       _jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  FilesSharingShareeValue get shareeValue;
-  FilesSharingShareeRemoteGroup1_Value1 get shareeRemoteGroup1Value1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<FilesSharingShareeRemoteGroup1_Value> get serializer =>
-      _$FilesSharingShareeRemoteGroup1_ValueSerializer();
+  static Serializer<FilesSharingShareeRemoteGroup_1_Value> get serializer =>
+      _$filesSharingShareeRemoteGroup1ValueSerializer;
 }
 
-class _$FilesSharingShareeRemoteGroup1_ValueSerializer
-    implements PrimitiveSerializer<FilesSharingShareeRemoteGroup1_Value> {
-  @override
-  final Iterable<Type> types = const [FilesSharingShareeRemoteGroup1_Value, _$FilesSharingShareeRemoteGroup1_Value];
-
-  @override
-  final String wireName = 'FilesSharingShareeRemoteGroup1_Value';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final FilesSharingShareeRemoteGroup1_Value object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  FilesSharingShareeRemoteGroup1_Value deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = FilesSharingShareeRemoteGroup1_ValueBuilder()..data = JsonObject(data);
-    result.shareeValue.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeValue),
-      )! as FilesSharingShareeValue,
-    );
-    result.shareeRemoteGroup1Value1.replace(
-      _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesSharingShareeRemoteGroup1_Value1))!
-          as FilesSharingShareeRemoteGroup1_Value1,
-    );
-    return result.build();
-  }
-}
-
-abstract class FilesSharingShareeRemoteGroup1
-    implements Built<FilesSharingShareeRemoteGroup1, FilesSharingShareeRemoteGroup1Builder> {
-  factory FilesSharingShareeRemoteGroup1([final void Function(FilesSharingShareeRemoteGroup1Builder)? b]) =
-      _$FilesSharingShareeRemoteGroup1;
-
-  // coverage:ignore-start
-  const FilesSharingShareeRemoteGroup1._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShareeRemoteGroup1.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeRemoteGroup_1Interface {
   String get guid;
   String get name;
-  FilesSharingShareeRemoteGroup1_Value get value;
-  static Serializer<FilesSharingShareeRemoteGroup1> get serializer => _$filesSharingShareeRemoteGroup1Serializer;
+  FilesSharingShareeRemoteGroup_1_Value get value;
+  FilesSharingShareeRemoteGroup_1Interface rebuild(
+    final void Function(FilesSharingShareeRemoteGroup_1InterfaceBuilder) updates,
+  );
+  FilesSharingShareeRemoteGroup_1InterfaceBuilder toBuilder();
 }
 
 abstract class FilesSharingShareeRemoteGroup
-    implements Built<FilesSharingShareeRemoteGroup, FilesSharingShareeRemoteGroupBuilder> {
+    implements
+        FilesSharingShareeInterface,
+        FilesSharingShareeRemoteGroup_1Interface,
+        Built<FilesSharingShareeRemoteGroup, FilesSharingShareeRemoteGroupBuilder> {
   factory FilesSharingShareeRemoteGroup([final void Function(FilesSharingShareeRemoteGroupBuilder)? b]) =
       _$FilesSharingShareeRemoteGroup;
 
@@ -2856,155 +3002,56 @@ abstract class FilesSharingShareeRemoteGroup
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  FilesSharingSharee get sharee;
-  FilesSharingShareeRemoteGroup1 get shareeRemoteGroup1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<FilesSharingShareeRemoteGroup> get serializer => _$FilesSharingShareeRemoteGroupSerializer();
+  static Serializer<FilesSharingShareeRemoteGroup> get serializer => _$filesSharingShareeRemoteGroupSerializer;
 }
 
-class _$FilesSharingShareeRemoteGroupSerializer implements PrimitiveSerializer<FilesSharingShareeRemoteGroup> {
-  @override
-  final Iterable<Type> types = const [FilesSharingShareeRemoteGroup, _$FilesSharingShareeRemoteGroup];
-
-  @override
-  final String wireName = 'FilesSharingShareeRemoteGroup';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final FilesSharingShareeRemoteGroup object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  FilesSharingShareeRemoteGroup deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = FilesSharingShareeRemoteGroupBuilder()..data = JsonObject(data);
-    result.sharee.replace(
-      _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesSharingSharee))! as FilesSharingSharee,
-    );
-    result.shareeRemoteGroup1.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeRemoteGroup1),
-      )! as FilesSharingShareeRemoteGroup1,
-    );
-    return result.build();
-  }
-}
-
-abstract class FilesSharingShareeRemote1_Value1
-    implements Built<FilesSharingShareeRemote1_Value1, FilesSharingShareeRemote1_Value1Builder> {
-  factory FilesSharingShareeRemote1_Value1([final void Function(FilesSharingShareeRemote1_Value1Builder)? b]) =
-      _$FilesSharingShareeRemote1_Value1;
-
-  // coverage:ignore-start
-  const FilesSharingShareeRemote1_Value1._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShareeRemote1_Value1.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeRemote_1_Value_1Interface {
   String get server;
-  static Serializer<FilesSharingShareeRemote1_Value1> get serializer => _$filesSharingShareeRemote1Value1Serializer;
+  FilesSharingShareeRemote_1_Value_1Interface rebuild(
+    final void Function(FilesSharingShareeRemote_1_Value_1InterfaceBuilder) updates,
+  );
+  FilesSharingShareeRemote_1_Value_1InterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeRemote1_Value
-    implements Built<FilesSharingShareeRemote1_Value, FilesSharingShareeRemote1_ValueBuilder> {
-  factory FilesSharingShareeRemote1_Value([final void Function(FilesSharingShareeRemote1_ValueBuilder)? b]) =
-      _$FilesSharingShareeRemote1_Value;
+abstract class FilesSharingShareeRemote_1_Value
+    implements
+        FilesSharingShareeValueInterface,
+        FilesSharingShareeRemote_1_Value_1Interface,
+        Built<FilesSharingShareeRemote_1_Value, FilesSharingShareeRemote_1_ValueBuilder> {
+  factory FilesSharingShareeRemote_1_Value([final void Function(FilesSharingShareeRemote_1_ValueBuilder)? b]) =
+      _$FilesSharingShareeRemote_1_Value;
 
   // coverage:ignore-start
-  const FilesSharingShareeRemote1_Value._();
+  const FilesSharingShareeRemote_1_Value._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingShareeRemote1_Value.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingShareeRemote_1_Value.fromJson(final Map<String, dynamic> json) =>
       _jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  FilesSharingShareeValue get shareeValue;
-  FilesSharingShareeRemote1_Value1 get shareeRemote1Value1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<FilesSharingShareeRemote1_Value> get serializer => _$FilesSharingShareeRemote1_ValueSerializer();
+  static Serializer<FilesSharingShareeRemote_1_Value> get serializer => _$filesSharingShareeRemote1ValueSerializer;
 }
 
-class _$FilesSharingShareeRemote1_ValueSerializer implements PrimitiveSerializer<FilesSharingShareeRemote1_Value> {
-  @override
-  final Iterable<Type> types = const [FilesSharingShareeRemote1_Value, _$FilesSharingShareeRemote1_Value];
-
-  @override
-  final String wireName = 'FilesSharingShareeRemote1_Value';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final FilesSharingShareeRemote1_Value object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  FilesSharingShareeRemote1_Value deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = FilesSharingShareeRemote1_ValueBuilder()..data = JsonObject(data);
-    result.shareeValue.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeValue),
-      )! as FilesSharingShareeValue,
-    );
-    result.shareeRemote1Value1.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeRemote1_Value1),
-      )! as FilesSharingShareeRemote1_Value1,
-    );
-    return result.build();
-  }
-}
-
-abstract class FilesSharingShareeRemote1 implements Built<FilesSharingShareeRemote1, FilesSharingShareeRemote1Builder> {
-  factory FilesSharingShareeRemote1([final void Function(FilesSharingShareeRemote1Builder)? b]) =
-      _$FilesSharingShareeRemote1;
-
-  // coverage:ignore-start
-  const FilesSharingShareeRemote1._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShareeRemote1.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeRemote_1Interface {
   String get uuid;
   String get name;
   String get type;
-  FilesSharingShareeRemote1_Value get value;
-  static Serializer<FilesSharingShareeRemote1> get serializer => _$filesSharingShareeRemote1Serializer;
+  FilesSharingShareeRemote_1_Value get value;
+  FilesSharingShareeRemote_1Interface rebuild(final void Function(FilesSharingShareeRemote_1InterfaceBuilder) updates);
+  FilesSharingShareeRemote_1InterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeRemote implements Built<FilesSharingShareeRemote, FilesSharingShareeRemoteBuilder> {
+abstract class FilesSharingShareeRemote
+    implements
+        FilesSharingShareeInterface,
+        FilesSharingShareeRemote_1Interface,
+        Built<FilesSharingShareeRemote, FilesSharingShareeRemoteBuilder> {
   factory FilesSharingShareeRemote([final void Function(FilesSharingShareeRemoteBuilder)? b]) =
       _$FilesSharingShareeRemote;
 
@@ -3020,96 +3067,59 @@ abstract class FilesSharingShareeRemote implements Built<FilesSharingShareeRemot
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  FilesSharingSharee get sharee;
-  FilesSharingShareeRemote1 get shareeRemote1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<FilesSharingShareeRemote> get serializer => _$FilesSharingShareeRemoteSerializer();
+  static Serializer<FilesSharingShareeRemote> get serializer => _$filesSharingShareeRemoteSerializer;
 }
 
-class _$FilesSharingShareeRemoteSerializer implements PrimitiveSerializer<FilesSharingShareeRemote> {
-  @override
-  final Iterable<Type> types = const [FilesSharingShareeRemote, _$FilesSharingShareeRemote];
-
-  @override
-  final String wireName = 'FilesSharingShareeRemote';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final FilesSharingShareeRemote object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  FilesSharingShareeRemote deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = FilesSharingShareeRemoteBuilder()..data = JsonObject(data);
-    result.sharee.replace(
-      _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesSharingSharee))! as FilesSharingSharee,
-    );
-    result.shareeRemote1.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeRemote1),
-      )! as FilesSharingShareeRemote1,
-    );
-    return result.build();
-  }
-}
-
-abstract class FilesSharingShareeUser1_Status
-    implements Built<FilesSharingShareeUser1_Status, FilesSharingShareeUser1_StatusBuilder> {
-  factory FilesSharingShareeUser1_Status([final void Function(FilesSharingShareeUser1_StatusBuilder)? b]) =
-      _$FilesSharingShareeUser1_Status;
-
-  // coverage:ignore-start
-  const FilesSharingShareeUser1_Status._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShareeUser1_Status.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeUser_1_StatusInterface {
   String get status;
   String get message;
   String get icon;
   int? get clearAt;
-  static Serializer<FilesSharingShareeUser1_Status> get serializer => _$filesSharingShareeUser1StatusSerializer;
+  FilesSharingShareeUser_1_StatusInterface rebuild(
+    final void Function(FilesSharingShareeUser_1_StatusInterfaceBuilder) updates,
+  );
+  FilesSharingShareeUser_1_StatusInterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeUser1 implements Built<FilesSharingShareeUser1, FilesSharingShareeUser1Builder> {
-  factory FilesSharingShareeUser1([final void Function(FilesSharingShareeUser1Builder)? b]) = _$FilesSharingShareeUser1;
+abstract class FilesSharingShareeUser_1_Status
+    implements
+        FilesSharingShareeUser_1_StatusInterface,
+        Built<FilesSharingShareeUser_1_Status, FilesSharingShareeUser_1_StatusBuilder> {
+  factory FilesSharingShareeUser_1_Status([final void Function(FilesSharingShareeUser_1_StatusBuilder)? b]) =
+      _$FilesSharingShareeUser_1_Status;
 
   // coverage:ignore-start
-  const FilesSharingShareeUser1._();
+  const FilesSharingShareeUser_1_Status._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingShareeUser1.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingShareeUser_1_Status.fromJson(final Map<String, dynamic> json) =>
       _jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
+  static Serializer<FilesSharingShareeUser_1_Status> get serializer => _$filesSharingShareeUser1StatusSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeUser_1Interface {
   String get subline;
   String get icon;
   String get shareWithDisplayNameUnique;
-  FilesSharingShareeUser1_Status get status;
+  FilesSharingShareeUser_1_Status get status;
   FilesSharingShareeValue get value;
-  static Serializer<FilesSharingShareeUser1> get serializer => _$filesSharingShareeUser1Serializer;
+  FilesSharingShareeUser_1Interface rebuild(final void Function(FilesSharingShareeUser_1InterfaceBuilder) updates);
+  FilesSharingShareeUser_1InterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeUser implements Built<FilesSharingShareeUser, FilesSharingShareeUserBuilder> {
+abstract class FilesSharingShareeUser
+    implements
+        FilesSharingShareeInterface,
+        FilesSharingShareeUser_1Interface,
+        Built<FilesSharingShareeUser, FilesSharingShareeUserBuilder> {
   factory FilesSharingShareeUser([final void Function(FilesSharingShareeUserBuilder)? b]) = _$FilesSharingShareeUser;
 
   // coverage:ignore-start
@@ -3124,50 +3134,29 @@ abstract class FilesSharingShareeUser implements Built<FilesSharingShareeUser, F
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  FilesSharingSharee get sharee;
-  FilesSharingShareeUser1 get shareeUser1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<FilesSharingShareeUser> get serializer => _$FilesSharingShareeUserSerializer();
+  static Serializer<FilesSharingShareeUser> get serializer => _$filesSharingShareeUserSerializer;
 }
 
-class _$FilesSharingShareeUserSerializer implements PrimitiveSerializer<FilesSharingShareeUser> {
-  @override
-  final Iterable<Type> types = const [FilesSharingShareeUser, _$FilesSharingShareeUser];
-
-  @override
-  final String wireName = 'FilesSharingShareeUser';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final FilesSharingShareeUser object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  FilesSharingShareeUser deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = FilesSharingShareeUserBuilder()..data = JsonObject(data);
-    result.sharee.replace(
-      _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesSharingSharee))! as FilesSharingSharee,
-    );
-    result.shareeUser1.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeUser1),
-      )! as FilesSharingShareeUser1,
-    );
-    return result.build();
-  }
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareesSearchResult_ExactInterface {
+  BuiltList<FilesSharingShareeCircle> get circles;
+  BuiltList<FilesSharingShareeEmail> get emails;
+  BuiltList<FilesSharingSharee> get groups;
+  @BuiltValueField(wireName: 'remote_groups')
+  BuiltList<FilesSharingShareeRemoteGroup> get remoteGroups;
+  BuiltList<FilesSharingShareeRemote> get remotes;
+  BuiltList<FilesSharingSharee> get rooms;
+  BuiltList<FilesSharingShareeUser> get users;
+  FilesSharingShareesSearchResult_ExactInterface rebuild(
+    final void Function(FilesSharingShareesSearchResult_ExactInterfaceBuilder) updates,
+  );
+  FilesSharingShareesSearchResult_ExactInterfaceBuilder toBuilder();
 }
 
 abstract class FilesSharingShareesSearchResult_Exact
-    implements Built<FilesSharingShareesSearchResult_Exact, FilesSharingShareesSearchResult_ExactBuilder> {
+    implements
+        FilesSharingShareesSearchResult_ExactInterface,
+        Built<FilesSharingShareesSearchResult_Exact, FilesSharingShareesSearchResult_ExactBuilder> {
   factory FilesSharingShareesSearchResult_Exact([
     final void Function(FilesSharingShareesSearchResult_ExactBuilder)? b,
   ]) = _$FilesSharingShareesSearchResult_Exact;
@@ -3184,19 +3173,20 @@ abstract class FilesSharingShareesSearchResult_Exact
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<FilesSharingShareeCircle> get circles;
-  BuiltList<FilesSharingShareeEmail> get emails;
-  BuiltList<FilesSharingSharee> get groups;
-  @BuiltValueField(wireName: 'remote_groups')
-  BuiltList<FilesSharingShareeRemoteGroup> get remoteGroups;
-  BuiltList<FilesSharingShareeRemote> get remotes;
-  BuiltList<FilesSharingSharee> get rooms;
-  BuiltList<FilesSharingShareeUser> get users;
   static Serializer<FilesSharingShareesSearchResult_Exact> get serializer =>
       _$filesSharingShareesSearchResultExactSerializer;
 }
 
-abstract class FilesSharingLookup implements Built<FilesSharingLookup, FilesSharingLookupBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingLookupInterface {
+  String get value;
+  int get verified;
+  FilesSharingLookupInterface rebuild(final void Function(FilesSharingLookupInterfaceBuilder) updates);
+  FilesSharingLookupInterfaceBuilder toBuilder();
+}
+
+abstract class FilesSharingLookup
+    implements FilesSharingLookupInterface, Built<FilesSharingLookup, FilesSharingLookupBuilder> {
   factory FilesSharingLookup([final void Function(FilesSharingLookupBuilder)? b]) = _$FilesSharingLookup;
 
   // coverage:ignore-start
@@ -3211,28 +3201,11 @@ abstract class FilesSharingLookup implements Built<FilesSharingLookup, FilesShar
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get value;
-  int get verified;
   static Serializer<FilesSharingLookup> get serializer => _$filesSharingLookupSerializer;
 }
 
-abstract class FilesSharingShareeLookup1_Extra
-    implements Built<FilesSharingShareeLookup1_Extra, FilesSharingShareeLookup1_ExtraBuilder> {
-  factory FilesSharingShareeLookup1_Extra([final void Function(FilesSharingShareeLookup1_ExtraBuilder)? b]) =
-      _$FilesSharingShareeLookup1_Extra;
-
-  // coverage:ignore-start
-  const FilesSharingShareeLookup1_Extra._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShareeLookup1_Extra.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeLookup_1_ExtraInterface {
   String get federationId;
   FilesSharingLookup? get name;
   FilesSharingLookup? get email;
@@ -3245,114 +3218,79 @@ abstract class FilesSharingShareeLookup1_Extra
   @BuiltValueField(wireName: 'website_signature')
   FilesSharingLookup? get websiteSignature;
   FilesSharingLookup? get userid;
-  static Serializer<FilesSharingShareeLookup1_Extra> get serializer => _$filesSharingShareeLookup1ExtraSerializer;
+  FilesSharingShareeLookup_1_ExtraInterface rebuild(
+    final void Function(FilesSharingShareeLookup_1_ExtraInterfaceBuilder) updates,
+  );
+  FilesSharingShareeLookup_1_ExtraInterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeLookup1_Value1
-    implements Built<FilesSharingShareeLookup1_Value1, FilesSharingShareeLookup1_Value1Builder> {
-  factory FilesSharingShareeLookup1_Value1([final void Function(FilesSharingShareeLookup1_Value1Builder)? b]) =
-      _$FilesSharingShareeLookup1_Value1;
+abstract class FilesSharingShareeLookup_1_Extra
+    implements
+        FilesSharingShareeLookup_1_ExtraInterface,
+        Built<FilesSharingShareeLookup_1_Extra, FilesSharingShareeLookup_1_ExtraBuilder> {
+  factory FilesSharingShareeLookup_1_Extra([final void Function(FilesSharingShareeLookup_1_ExtraBuilder)? b]) =
+      _$FilesSharingShareeLookup_1_Extra;
 
   // coverage:ignore-start
-  const FilesSharingShareeLookup1_Value1._();
+  const FilesSharingShareeLookup_1_Extra._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingShareeLookup1_Value1.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingShareeLookup_1_Extra.fromJson(final Map<String, dynamic> json) =>
       _jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
+  static Serializer<FilesSharingShareeLookup_1_Extra> get serializer => _$filesSharingShareeLookup1ExtraSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeLookup_1_Value_1Interface {
   bool get globalScale;
-  static Serializer<FilesSharingShareeLookup1_Value1> get serializer => _$filesSharingShareeLookup1Value1Serializer;
+  FilesSharingShareeLookup_1_Value_1Interface rebuild(
+    final void Function(FilesSharingShareeLookup_1_Value_1InterfaceBuilder) updates,
+  );
+  FilesSharingShareeLookup_1_Value_1InterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeLookup1_Value
-    implements Built<FilesSharingShareeLookup1_Value, FilesSharingShareeLookup1_ValueBuilder> {
-  factory FilesSharingShareeLookup1_Value([final void Function(FilesSharingShareeLookup1_ValueBuilder)? b]) =
-      _$FilesSharingShareeLookup1_Value;
+abstract class FilesSharingShareeLookup_1_Value
+    implements
+        FilesSharingShareeValueInterface,
+        FilesSharingShareeLookup_1_Value_1Interface,
+        Built<FilesSharingShareeLookup_1_Value, FilesSharingShareeLookup_1_ValueBuilder> {
+  factory FilesSharingShareeLookup_1_Value([final void Function(FilesSharingShareeLookup_1_ValueBuilder)? b]) =
+      _$FilesSharingShareeLookup_1_Value;
 
   // coverage:ignore-start
-  const FilesSharingShareeLookup1_Value._();
+  const FilesSharingShareeLookup_1_Value._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingShareeLookup1_Value.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingShareeLookup_1_Value.fromJson(final Map<String, dynamic> json) =>
       _jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  FilesSharingShareeValue get shareeValue;
-  FilesSharingShareeLookup1_Value1 get shareeLookup1Value1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<FilesSharingShareeLookup1_Value> get serializer => _$FilesSharingShareeLookup1_ValueSerializer();
+  static Serializer<FilesSharingShareeLookup_1_Value> get serializer => _$filesSharingShareeLookup1ValueSerializer;
 }
 
-class _$FilesSharingShareeLookup1_ValueSerializer implements PrimitiveSerializer<FilesSharingShareeLookup1_Value> {
-  @override
-  final Iterable<Type> types = const [FilesSharingShareeLookup1_Value, _$FilesSharingShareeLookup1_Value];
-
-  @override
-  final String wireName = 'FilesSharingShareeLookup1_Value';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final FilesSharingShareeLookup1_Value object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  FilesSharingShareeLookup1_Value deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = FilesSharingShareeLookup1_ValueBuilder()..data = JsonObject(data);
-    result.shareeValue.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeValue),
-      )! as FilesSharingShareeValue,
-    );
-    result.shareeLookup1Value1.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeLookup1_Value1),
-      )! as FilesSharingShareeLookup1_Value1,
-    );
-    return result.build();
-  }
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareeLookup_1Interface {
+  FilesSharingShareeLookup_1_Extra get extra;
+  FilesSharingShareeLookup_1_Value get value;
+  FilesSharingShareeLookup_1Interface rebuild(final void Function(FilesSharingShareeLookup_1InterfaceBuilder) updates);
+  FilesSharingShareeLookup_1InterfaceBuilder toBuilder();
 }
 
-abstract class FilesSharingShareeLookup1 implements Built<FilesSharingShareeLookup1, FilesSharingShareeLookup1Builder> {
-  factory FilesSharingShareeLookup1([final void Function(FilesSharingShareeLookup1Builder)? b]) =
-      _$FilesSharingShareeLookup1;
-
-  // coverage:ignore-start
-  const FilesSharingShareeLookup1._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory FilesSharingShareeLookup1.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-  FilesSharingShareeLookup1_Extra get extra;
-  FilesSharingShareeLookup1_Value get value;
-  static Serializer<FilesSharingShareeLookup1> get serializer => _$filesSharingShareeLookup1Serializer;
-}
-
-abstract class FilesSharingShareeLookup implements Built<FilesSharingShareeLookup, FilesSharingShareeLookupBuilder> {
+abstract class FilesSharingShareeLookup
+    implements
+        FilesSharingShareeInterface,
+        FilesSharingShareeLookup_1Interface,
+        Built<FilesSharingShareeLookup, FilesSharingShareeLookupBuilder> {
   factory FilesSharingShareeLookup([final void Function(FilesSharingShareeLookupBuilder)? b]) =
       _$FilesSharingShareeLookup;
 
@@ -3368,50 +3306,32 @@ abstract class FilesSharingShareeLookup implements Built<FilesSharingShareeLooku
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  FilesSharingSharee get sharee;
-  FilesSharingShareeLookup1 get shareeLookup1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<FilesSharingShareeLookup> get serializer => _$FilesSharingShareeLookupSerializer();
+  static Serializer<FilesSharingShareeLookup> get serializer => _$filesSharingShareeLookupSerializer;
 }
 
-class _$FilesSharingShareeLookupSerializer implements PrimitiveSerializer<FilesSharingShareeLookup> {
-  @override
-  final Iterable<Type> types = const [FilesSharingShareeLookup, _$FilesSharingShareeLookup];
-
-  @override
-  final String wireName = 'FilesSharingShareeLookup';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final FilesSharingShareeLookup object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  FilesSharingShareeLookup deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = FilesSharingShareeLookupBuilder()..data = JsonObject(data);
-    result.sharee.replace(
-      _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesSharingSharee))! as FilesSharingSharee,
-    );
-    result.shareeLookup1.replace(
-      _jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingShareeLookup1),
-      )! as FilesSharingShareeLookup1,
-    );
-    return result.build();
-  }
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareesSearchResultInterface {
+  FilesSharingShareesSearchResult_Exact get exact;
+  BuiltList<FilesSharingShareeCircle> get circles;
+  BuiltList<FilesSharingShareeEmail> get emails;
+  BuiltList<FilesSharingSharee> get groups;
+  BuiltList<FilesSharingShareeLookup> get lookup;
+  @BuiltValueField(wireName: 'remote_groups')
+  BuiltList<FilesSharingShareeRemoteGroup> get remoteGroups;
+  BuiltList<FilesSharingShareeRemote> get remotes;
+  BuiltList<FilesSharingSharee> get rooms;
+  BuiltList<FilesSharingShareeUser> get users;
+  bool get lookupEnabled;
+  FilesSharingShareesSearchResultInterface rebuild(
+    final void Function(FilesSharingShareesSearchResultInterfaceBuilder) updates,
+  );
+  FilesSharingShareesSearchResultInterfaceBuilder toBuilder();
 }
 
 abstract class FilesSharingShareesSearchResult
-    implements Built<FilesSharingShareesSearchResult, FilesSharingShareesSearchResultBuilder> {
+    implements
+        FilesSharingShareesSearchResultInterface,
+        Built<FilesSharingShareesSearchResult, FilesSharingShareesSearchResultBuilder> {
   factory FilesSharingShareesSearchResult([final void Function(FilesSharingShareesSearchResultBuilder)? b]) =
       _$FilesSharingShareesSearchResult;
 
@@ -3427,22 +3347,22 @@ abstract class FilesSharingShareesSearchResult
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareesSearchResult_Exact get exact;
-  BuiltList<FilesSharingShareeCircle> get circles;
-  BuiltList<FilesSharingShareeEmail> get emails;
-  BuiltList<FilesSharingSharee> get groups;
-  BuiltList<FilesSharingShareeLookup> get lookup;
-  @BuiltValueField(wireName: 'remote_groups')
-  BuiltList<FilesSharingShareeRemoteGroup> get remoteGroups;
-  BuiltList<FilesSharingShareeRemote> get remotes;
-  BuiltList<FilesSharingSharee> get rooms;
-  BuiltList<FilesSharingShareeUser> get users;
-  bool get lookupEnabled;
   static Serializer<FilesSharingShareesSearchResult> get serializer => _$filesSharingShareesSearchResultSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareesapiSearchResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  FilesSharingShareesSearchResult get data;
+  FilesSharingShareesapiSearchResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingShareesapiSearchResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingShareesapiSearchResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs
     implements
+        FilesSharingShareesapiSearchResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs,
             FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs([
@@ -3461,14 +3381,22 @@ abstract class FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  FilesSharingShareesSearchResult get data;
   static Serializer<FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingShareesapiSearchResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareesapiSearchResponse200ApplicationJsonInterface {
+  FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingShareesapiSearchResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingShareesapiSearchResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingShareesapiSearchResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareesapiSearchResponse200ApplicationJson
     implements
+        FilesSharingShareesapiSearchResponse200ApplicationJsonInterface,
         Built<FilesSharingShareesapiSearchResponse200ApplicationJson,
             FilesSharingShareesapiSearchResponse200ApplicationJsonBuilder> {
   factory FilesSharingShareesapiSearchResponse200ApplicationJson([
@@ -3487,7 +3415,6 @@ abstract class FilesSharingShareesapiSearchResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingShareesapiSearchResponse200ApplicationJson> get serializer =>
       _$filesSharingShareesapiSearchResponse200ApplicationJsonSerializer;
 }
@@ -3563,8 +3490,24 @@ class _$FilesSharingShareesapiFindRecommendedShareTypeSerializer
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareesRecommendedResult_ExactInterface {
+  BuiltList<FilesSharingShareeEmail> get emails;
+  BuiltList<FilesSharingSharee> get groups;
+  @BuiltValueField(wireName: 'remote_groups')
+  BuiltList<FilesSharingShareeRemoteGroup> get remoteGroups;
+  BuiltList<FilesSharingShareeRemote> get remotes;
+  BuiltList<FilesSharingShareeUser> get users;
+  FilesSharingShareesRecommendedResult_ExactInterface rebuild(
+    final void Function(FilesSharingShareesRecommendedResult_ExactInterfaceBuilder) updates,
+  );
+  FilesSharingShareesRecommendedResult_ExactInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareesRecommendedResult_Exact
-    implements Built<FilesSharingShareesRecommendedResult_Exact, FilesSharingShareesRecommendedResult_ExactBuilder> {
+    implements
+        FilesSharingShareesRecommendedResult_ExactInterface,
+        Built<FilesSharingShareesRecommendedResult_Exact, FilesSharingShareesRecommendedResult_ExactBuilder> {
   factory FilesSharingShareesRecommendedResult_Exact([
     final void Function(FilesSharingShareesRecommendedResult_ExactBuilder)? b,
   ]) = _$FilesSharingShareesRecommendedResult_Exact;
@@ -3581,18 +3524,29 @@ abstract class FilesSharingShareesRecommendedResult_Exact
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
+  static Serializer<FilesSharingShareesRecommendedResult_Exact> get serializer =>
+      _$filesSharingShareesRecommendedResultExactSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareesRecommendedResultInterface {
+  FilesSharingShareesRecommendedResult_Exact get exact;
   BuiltList<FilesSharingShareeEmail> get emails;
   BuiltList<FilesSharingSharee> get groups;
   @BuiltValueField(wireName: 'remote_groups')
   BuiltList<FilesSharingShareeRemoteGroup> get remoteGroups;
   BuiltList<FilesSharingShareeRemote> get remotes;
   BuiltList<FilesSharingShareeUser> get users;
-  static Serializer<FilesSharingShareesRecommendedResult_Exact> get serializer =>
-      _$filesSharingShareesRecommendedResultExactSerializer;
+  FilesSharingShareesRecommendedResultInterface rebuild(
+    final void Function(FilesSharingShareesRecommendedResultInterfaceBuilder) updates,
+  );
+  FilesSharingShareesRecommendedResultInterfaceBuilder toBuilder();
 }
 
 abstract class FilesSharingShareesRecommendedResult
-    implements Built<FilesSharingShareesRecommendedResult, FilesSharingShareesRecommendedResultBuilder> {
+    implements
+        FilesSharingShareesRecommendedResultInterface,
+        Built<FilesSharingShareesRecommendedResult, FilesSharingShareesRecommendedResultBuilder> {
   factory FilesSharingShareesRecommendedResult([final void Function(FilesSharingShareesRecommendedResultBuilder)? b]) =
       _$FilesSharingShareesRecommendedResult;
 
@@ -3608,19 +3562,23 @@ abstract class FilesSharingShareesRecommendedResult
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareesRecommendedResult_Exact get exact;
-  BuiltList<FilesSharingShareeEmail> get emails;
-  BuiltList<FilesSharingSharee> get groups;
-  @BuiltValueField(wireName: 'remote_groups')
-  BuiltList<FilesSharingShareeRemoteGroup> get remoteGroups;
-  BuiltList<FilesSharingShareeRemote> get remotes;
-  BuiltList<FilesSharingShareeUser> get users;
   static Serializer<FilesSharingShareesRecommendedResult> get serializer =>
       _$filesSharingShareesRecommendedResultSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsInterface {
+  FilesSharingOCSMeta get meta;
+  FilesSharingShareesRecommendedResult get data;
+  FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs
     implements
+        FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsInterface,
         Built<FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs,
             FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder> {
   factory FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs([
@@ -3641,14 +3599,22 @@ abstract class FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingOCSMeta get meta;
-  FilesSharingShareesRecommendedResult get data;
   static Serializer<FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs> get serializer =>
       _$filesSharingShareesapiFindRecommendedResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonInterface {
+  FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs get ocs;
+  FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonInterface rebuild(
+    final void Function(FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingShareesapiFindRecommendedResponse200ApplicationJson
     implements
+        FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonInterface,
         Built<FilesSharingShareesapiFindRecommendedResponse200ApplicationJson,
             FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonBuilder> {
   factory FilesSharingShareesapiFindRecommendedResponse200ApplicationJson([
@@ -3667,13 +3633,23 @@ abstract class FilesSharingShareesapiFindRecommendedResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs get ocs;
   static Serializer<FilesSharingShareesapiFindRecommendedResponse200ApplicationJson> get serializer =>
       _$filesSharingShareesapiFindRecommendedResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_Public_PasswordInterface {
+  bool get enforced;
+  bool get askForOptionalPassword;
+  FilesSharingCapabilities_FilesSharing_Public_PasswordInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Public_Password
     implements
+        FilesSharingCapabilities_FilesSharing_Public_PasswordInterface,
         Built<FilesSharingCapabilities_FilesSharing_Public_Password,
             FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Public_Password([
@@ -3692,14 +3668,24 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_Password
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enforced;
-  bool get askForOptionalPassword;
   static Serializer<FilesSharingCapabilities_FilesSharing_Public_Password> get serializer =>
       _$filesSharingCapabilitiesFilesSharingPublicPasswordSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface {
+  bool get enabled;
+  int? get days;
+  bool? get enforced;
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDate
     implements
+        FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface,
         Built<FilesSharingCapabilities_FilesSharing_Public_ExpireDate,
             FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Public_ExpireDate([
@@ -3718,15 +3704,24 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDate
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  int? get days;
-  bool? get enforced;
   static Serializer<FilesSharingCapabilities_FilesSharing_Public_ExpireDate> get serializer =>
       _$filesSharingCapabilitiesFilesSharingPublicExpireDateSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface {
+  bool get enabled;
+  int? get days;
+  bool? get enforced;
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
     implements
+        FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface,
         Built<FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal,
             FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal([
@@ -3745,15 +3740,24 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  int? get days;
-  bool? get enforced;
   static Serializer<FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal> get serializer =>
       _$filesSharingCapabilitiesFilesSharingPublicExpireDateInternalSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface {
+  bool get enabled;
+  int? get days;
+  bool? get enforced;
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
     implements
+        FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface,
         Built<FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote,
             FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote([
@@ -3772,15 +3776,36 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  int? get days;
-  bool? get enforced;
   static Serializer<FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote> get serializer =>
       _$filesSharingCapabilitiesFilesSharingPublicExpireDateRemoteSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_PublicInterface {
+  bool get enabled;
+  FilesSharingCapabilities_FilesSharing_Public_Password? get password;
+  @BuiltValueField(wireName: 'multiple_links')
+  bool? get multipleLinks;
+  @BuiltValueField(wireName: 'expire_date')
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDate? get expireDate;
+  @BuiltValueField(wireName: 'expire_date_internal')
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal? get expireDateInternal;
+  @BuiltValueField(wireName: 'expire_date_remote')
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote? get expireDateRemote;
+  @BuiltValueField(wireName: 'send_mail')
+  bool? get sendMail;
+  bool? get upload;
+  @BuiltValueField(wireName: 'upload_files_drop')
+  bool? get uploadFilesDrop;
+  FilesSharingCapabilities_FilesSharing_PublicInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Public
     implements
+        FilesSharingCapabilities_FilesSharing_PublicInterface,
         Built<FilesSharingCapabilities_FilesSharing_Public, FilesSharingCapabilities_FilesSharing_PublicBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Public([
     final void Function(FilesSharingCapabilities_FilesSharing_PublicBuilder)? b,
@@ -3798,27 +3823,22 @@ abstract class FilesSharingCapabilities_FilesSharing_Public
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  FilesSharingCapabilities_FilesSharing_Public_Password? get password;
-  @BuiltValueField(wireName: 'multiple_links')
-  bool? get multipleLinks;
-  @BuiltValueField(wireName: 'expire_date')
-  FilesSharingCapabilities_FilesSharing_Public_ExpireDate? get expireDate;
-  @BuiltValueField(wireName: 'expire_date_internal')
-  FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal? get expireDateInternal;
-  @BuiltValueField(wireName: 'expire_date_remote')
-  FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote? get expireDateRemote;
-  @BuiltValueField(wireName: 'send_mail')
-  bool? get sendMail;
-  bool? get upload;
-  @BuiltValueField(wireName: 'upload_files_drop')
-  bool? get uploadFilesDrop;
   static Serializer<FilesSharingCapabilities_FilesSharing_Public> get serializer =>
       _$filesSharingCapabilitiesFilesSharingPublicSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_User_ExpireDateInterface {
+  bool get enabled;
+  FilesSharingCapabilities_FilesSharing_User_ExpireDateInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_User_ExpireDate
     implements
+        FilesSharingCapabilities_FilesSharing_User_ExpireDateInterface,
         Built<FilesSharingCapabilities_FilesSharing_User_ExpireDate,
             FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder> {
   factory FilesSharingCapabilities_FilesSharing_User_ExpireDate([
@@ -3837,13 +3857,26 @@ abstract class FilesSharingCapabilities_FilesSharing_User_ExpireDate
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<FilesSharingCapabilities_FilesSharing_User_ExpireDate> get serializer =>
       _$filesSharingCapabilitiesFilesSharingUserExpireDateSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_UserInterface {
+  @BuiltValueField(wireName: 'send_mail')
+  bool get sendMail;
+  @BuiltValueField(wireName: 'expire_date')
+  FilesSharingCapabilities_FilesSharing_User_ExpireDate? get expireDate;
+  FilesSharingCapabilities_FilesSharing_UserInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_User
-    implements Built<FilesSharingCapabilities_FilesSharing_User, FilesSharingCapabilities_FilesSharing_UserBuilder> {
+    implements
+        FilesSharingCapabilities_FilesSharing_UserInterface,
+        Built<FilesSharingCapabilities_FilesSharing_User, FilesSharingCapabilities_FilesSharing_UserBuilder> {
   factory FilesSharingCapabilities_FilesSharing_User([
     final void Function(FilesSharingCapabilities_FilesSharing_UserBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_User;
@@ -3860,16 +3893,22 @@ abstract class FilesSharingCapabilities_FilesSharing_User
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'send_mail')
-  bool get sendMail;
-  @BuiltValueField(wireName: 'expire_date')
-  FilesSharingCapabilities_FilesSharing_User_ExpireDate? get expireDate;
   static Serializer<FilesSharingCapabilities_FilesSharing_User> get serializer =>
       _$filesSharingCapabilitiesFilesSharingUserSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface {
+  bool get enabled;
+  FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Group_ExpireDate
     implements
+        FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface,
         Built<FilesSharingCapabilities_FilesSharing_Group_ExpireDate,
             FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Group_ExpireDate([
@@ -3888,13 +3927,25 @@ abstract class FilesSharingCapabilities_FilesSharing_Group_ExpireDate
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<FilesSharingCapabilities_FilesSharing_Group_ExpireDate> get serializer =>
       _$filesSharingCapabilitiesFilesSharingGroupExpireDateSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_GroupInterface {
+  bool get enabled;
+  @BuiltValueField(wireName: 'expire_date')
+  FilesSharingCapabilities_FilesSharing_Group_ExpireDate? get expireDate;
+  FilesSharingCapabilities_FilesSharing_GroupInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Group
-    implements Built<FilesSharingCapabilities_FilesSharing_Group, FilesSharingCapabilities_FilesSharing_GroupBuilder> {
+    implements
+        FilesSharingCapabilities_FilesSharing_GroupInterface,
+        Built<FilesSharingCapabilities_FilesSharing_Group, FilesSharingCapabilities_FilesSharing_GroupBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Group([
     final void Function(FilesSharingCapabilities_FilesSharing_GroupBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Group;
@@ -3911,15 +3962,22 @@ abstract class FilesSharingCapabilities_FilesSharing_Group
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  @BuiltValueField(wireName: 'expire_date')
-  FilesSharingCapabilities_FilesSharing_Group_ExpireDate? get expireDate;
   static Serializer<FilesSharingCapabilities_FilesSharing_Group> get serializer =>
       _$filesSharingCapabilitiesFilesSharingGroupSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface {
+  bool get enabled;
+  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDate
     implements
+        FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface,
         Built<FilesSharingCapabilities_FilesSharing_Federation_ExpireDate,
             FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Federation_ExpireDate([
@@ -3938,13 +3996,22 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDate
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<FilesSharingCapabilities_FilesSharing_Federation_ExpireDate> get serializer =>
       _$filesSharingCapabilitiesFilesSharingFederationExpireDateSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface {
+  bool get enabled;
+  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported
     implements
+        FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface,
         Built<FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported,
             FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported([
@@ -3965,13 +4032,27 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSuppor
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported> get serializer =>
       _$filesSharingCapabilitiesFilesSharingFederationExpireDateSupportedSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_FederationInterface {
+  bool get outgoing;
+  bool get incoming;
+  @BuiltValueField(wireName: 'expire_date')
+  FilesSharingCapabilities_FilesSharing_Federation_ExpireDate get expireDate;
+  @BuiltValueField(wireName: 'expire_date_supported')
+  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported get expireDateSupported;
+  FilesSharingCapabilities_FilesSharing_FederationInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Federation
     implements
+        FilesSharingCapabilities_FilesSharing_FederationInterface,
         Built<FilesSharingCapabilities_FilesSharing_Federation,
             FilesSharingCapabilities_FilesSharing_FederationBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Federation([
@@ -3990,18 +4071,25 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get outgoing;
-  bool get incoming;
-  @BuiltValueField(wireName: 'expire_date')
-  FilesSharingCapabilities_FilesSharing_Federation_ExpireDate get expireDate;
-  @BuiltValueField(wireName: 'expire_date_supported')
-  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported get expireDateSupported;
   static Serializer<FilesSharingCapabilities_FilesSharing_Federation> get serializer =>
       _$filesSharingCapabilitiesFilesSharingFederationSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharing_ShareeInterface {
+  @BuiltValueField(wireName: 'query_lookup_default')
+  bool get queryLookupDefault;
+  @BuiltValueField(wireName: 'always_show_unique')
+  bool get alwaysShowUnique;
+  FilesSharingCapabilities_FilesSharing_ShareeInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing_Sharee
     implements
+        FilesSharingCapabilities_FilesSharing_ShareeInterface,
         Built<FilesSharingCapabilities_FilesSharing_Sharee, FilesSharingCapabilities_FilesSharing_ShareeBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Sharee([
     final void Function(FilesSharingCapabilities_FilesSharing_ShareeBuilder)? b,
@@ -4019,16 +4107,34 @@ abstract class FilesSharingCapabilities_FilesSharing_Sharee
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'query_lookup_default')
-  bool get queryLookupDefault;
-  @BuiltValueField(wireName: 'always_show_unique')
-  bool get alwaysShowUnique;
   static Serializer<FilesSharingCapabilities_FilesSharing_Sharee> get serializer =>
       _$filesSharingCapabilitiesFilesSharingShareeSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilities_FilesSharingInterface {
+  @BuiltValueField(wireName: 'api_enabled')
+  bool get apiEnabled;
+  FilesSharingCapabilities_FilesSharing_Public get public;
+  FilesSharingCapabilities_FilesSharing_User get user;
+  bool get resharing;
+  @BuiltValueField(wireName: 'group_sharing')
+  bool? get groupSharing;
+  FilesSharingCapabilities_FilesSharing_Group? get group;
+  @BuiltValueField(wireName: 'default_permissions')
+  int? get defaultPermissions;
+  FilesSharingCapabilities_FilesSharing_Federation get federation;
+  FilesSharingCapabilities_FilesSharing_Sharee get sharee;
+  FilesSharingCapabilities_FilesSharingInterface rebuild(
+    final void Function(FilesSharingCapabilities_FilesSharingInterfaceBuilder) updates,
+  );
+  FilesSharingCapabilities_FilesSharingInterfaceBuilder toBuilder();
+}
+
 abstract class FilesSharingCapabilities_FilesSharing
-    implements Built<FilesSharingCapabilities_FilesSharing, FilesSharingCapabilities_FilesSharingBuilder> {
+    implements
+        FilesSharingCapabilities_FilesSharingInterface,
+        Built<FilesSharingCapabilities_FilesSharing, FilesSharingCapabilities_FilesSharingBuilder> {
   factory FilesSharingCapabilities_FilesSharing([
     final void Function(FilesSharingCapabilities_FilesSharingBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing;
@@ -4045,23 +4151,20 @@ abstract class FilesSharingCapabilities_FilesSharing
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'api_enabled')
-  bool get apiEnabled;
-  FilesSharingCapabilities_FilesSharing_Public get public;
-  FilesSharingCapabilities_FilesSharing_User get user;
-  bool get resharing;
-  @BuiltValueField(wireName: 'group_sharing')
-  bool? get groupSharing;
-  FilesSharingCapabilities_FilesSharing_Group? get group;
-  @BuiltValueField(wireName: 'default_permissions')
-  int? get defaultPermissions;
-  FilesSharingCapabilities_FilesSharing_Federation get federation;
-  FilesSharingCapabilities_FilesSharing_Sharee get sharee;
   static Serializer<FilesSharingCapabilities_FilesSharing> get serializer =>
       _$filesSharingCapabilitiesFilesSharingSerializer;
 }
 
-abstract class FilesSharingCapabilities implements Built<FilesSharingCapabilities, FilesSharingCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesSharingCapabilitiesInterface {
+  @BuiltValueField(wireName: 'files_sharing')
+  FilesSharingCapabilities_FilesSharing get filesSharing;
+  FilesSharingCapabilitiesInterface rebuild(final void Function(FilesSharingCapabilitiesInterfaceBuilder) updates);
+  FilesSharingCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class FilesSharingCapabilities
+    implements FilesSharingCapabilitiesInterface, Built<FilesSharingCapabilities, FilesSharingCapabilitiesBuilder> {
   factory FilesSharingCapabilities([final void Function(FilesSharingCapabilitiesBuilder)? b]) =
       _$FilesSharingCapabilities;
 
@@ -4077,8 +4180,6 @@ abstract class FilesSharingCapabilities implements Built<FilesSharingCapabilitie
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'files_sharing')
-  FilesSharingCapabilities_FilesSharing get filesSharing;
   static Serializer<FilesSharingCapabilities> get serializer => _$filesSharingCapabilitiesSerializer;
 }
 
@@ -4317,22 +4418,16 @@ final Serializers _serializers = (Serializers().toBuilder()
       ..add(FilesSharingShareeCircle.serializer)
       ..addBuilderFactory(const FullType(FilesSharingSharee), FilesSharingSharee.new)
       ..add(FilesSharingSharee.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeCircle1), FilesSharingShareeCircle1.new)
-      ..add(FilesSharingShareeCircle1.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeCircle1_Value), FilesSharingShareeCircle1_Value.new)
-      ..add(FilesSharingShareeCircle1_Value.serializer)
+      ..addBuilderFactory(const FullType(FilesSharingShareeCircle_1_Value), FilesSharingShareeCircle_1_Value.new)
+      ..add(FilesSharingShareeCircle_1_Value.serializer)
       ..addBuilderFactory(const FullType(FilesSharingShareeValue), FilesSharingShareeValue.new)
       ..add(FilesSharingShareeValue.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeCircle1_Value1), FilesSharingShareeCircle1_Value1.new)
-      ..add(FilesSharingShareeCircle1_Value1.serializer)
       ..addBuilderFactory(
         const FullType(BuiltList, [FullType(FilesSharingShareeCircle)]),
         ListBuilder<FilesSharingShareeCircle>.new,
       )
       ..addBuilderFactory(const FullType(FilesSharingShareeEmail), FilesSharingShareeEmail.new)
       ..add(FilesSharingShareeEmail.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeEmail1), FilesSharingShareeEmail1.new)
-      ..add(FilesSharingShareeEmail1.serializer)
       ..addBuilderFactory(
         const FullType(BuiltList, [FullType(FilesSharingShareeEmail)]),
         ListBuilder<FilesSharingShareeEmail>.new,
@@ -4343,56 +4438,39 @@ final Serializers _serializers = (Serializers().toBuilder()
       )
       ..addBuilderFactory(const FullType(FilesSharingShareeRemoteGroup), FilesSharingShareeRemoteGroup.new)
       ..add(FilesSharingShareeRemoteGroup.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeRemoteGroup1), FilesSharingShareeRemoteGroup1.new)
-      ..add(FilesSharingShareeRemoteGroup1.serializer)
       ..addBuilderFactory(
-        const FullType(FilesSharingShareeRemoteGroup1_Value),
-        FilesSharingShareeRemoteGroup1_Value.new,
+        const FullType(FilesSharingShareeRemoteGroup_1_Value),
+        FilesSharingShareeRemoteGroup_1_Value.new,
       )
-      ..add(FilesSharingShareeRemoteGroup1_Value.serializer)
-      ..addBuilderFactory(
-        const FullType(FilesSharingShareeRemoteGroup1_Value1),
-        FilesSharingShareeRemoteGroup1_Value1.new,
-      )
-      ..add(FilesSharingShareeRemoteGroup1_Value1.serializer)
+      ..add(FilesSharingShareeRemoteGroup_1_Value.serializer)
       ..addBuilderFactory(
         const FullType(BuiltList, [FullType(FilesSharingShareeRemoteGroup)]),
         ListBuilder<FilesSharingShareeRemoteGroup>.new,
       )
       ..addBuilderFactory(const FullType(FilesSharingShareeRemote), FilesSharingShareeRemote.new)
       ..add(FilesSharingShareeRemote.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeRemote1), FilesSharingShareeRemote1.new)
-      ..add(FilesSharingShareeRemote1.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeRemote1_Value), FilesSharingShareeRemote1_Value.new)
-      ..add(FilesSharingShareeRemote1_Value.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeRemote1_Value1), FilesSharingShareeRemote1_Value1.new)
-      ..add(FilesSharingShareeRemote1_Value1.serializer)
+      ..addBuilderFactory(const FullType(FilesSharingShareeRemote_1_Value), FilesSharingShareeRemote_1_Value.new)
+      ..add(FilesSharingShareeRemote_1_Value.serializer)
       ..addBuilderFactory(
         const FullType(BuiltList, [FullType(FilesSharingShareeRemote)]),
         ListBuilder<FilesSharingShareeRemote>.new,
       )
       ..addBuilderFactory(const FullType(FilesSharingShareeUser), FilesSharingShareeUser.new)
       ..add(FilesSharingShareeUser.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeUser1), FilesSharingShareeUser1.new)
-      ..add(FilesSharingShareeUser1.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeUser1_Status), FilesSharingShareeUser1_Status.new)
-      ..add(FilesSharingShareeUser1_Status.serializer)
+      ..addBuilderFactory(const FullType(FilesSharingShareeUser_1_Status), FilesSharingShareeUser_1_Status.new)
+      ..add(FilesSharingShareeUser_1_Status.serializer)
       ..addBuilderFactory(
         const FullType(BuiltList, [FullType(FilesSharingShareeUser)]),
         ListBuilder<FilesSharingShareeUser>.new,
       )
       ..addBuilderFactory(const FullType(FilesSharingShareeLookup), FilesSharingShareeLookup.new)
       ..add(FilesSharingShareeLookup.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeLookup1), FilesSharingShareeLookup1.new)
-      ..add(FilesSharingShareeLookup1.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeLookup1_Extra), FilesSharingShareeLookup1_Extra.new)
-      ..add(FilesSharingShareeLookup1_Extra.serializer)
+      ..addBuilderFactory(const FullType(FilesSharingShareeLookup_1_Extra), FilesSharingShareeLookup_1_Extra.new)
+      ..add(FilesSharingShareeLookup_1_Extra.serializer)
       ..addBuilderFactory(const FullType(FilesSharingLookup), FilesSharingLookup.new)
       ..add(FilesSharingLookup.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeLookup1_Value), FilesSharingShareeLookup1_Value.new)
-      ..add(FilesSharingShareeLookup1_Value.serializer)
-      ..addBuilderFactory(const FullType(FilesSharingShareeLookup1_Value1), FilesSharingShareeLookup1_Value1.new)
-      ..add(FilesSharingShareeLookup1_Value1.serializer)
+      ..addBuilderFactory(const FullType(FilesSharingShareeLookup_1_Value), FilesSharingShareeLookup_1_Value.new)
+      ..add(FilesSharingShareeLookup_1_Value.serializer)
       ..addBuilderFactory(
         const FullType(BuiltList, [FullType(FilesSharingShareeLookup)]),
         ListBuilder<FilesSharingShareeLookup>.new,

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
@@ -131,28 +131,28 @@ Serializer<FilesSharingShareapiAcceptShareResponse200ApplicationJson>
     _$FilesSharingShareapiAcceptShareResponse200ApplicationJsonSerializer();
 Serializer<FilesSharingSharee> _$filesSharingShareeSerializer = _$FilesSharingShareeSerializer();
 Serializer<FilesSharingShareeValue> _$filesSharingShareeValueSerializer = _$FilesSharingShareeValueSerializer();
-Serializer<FilesSharingShareeCircle1_Value1> _$filesSharingShareeCircle1Value1Serializer =
-    _$FilesSharingShareeCircle1_Value1Serializer();
-Serializer<FilesSharingShareeCircle1> _$filesSharingShareeCircle1Serializer = _$FilesSharingShareeCircle1Serializer();
-Serializer<FilesSharingShareeEmail1> _$filesSharingShareeEmail1Serializer = _$FilesSharingShareeEmail1Serializer();
-Serializer<FilesSharingShareeRemoteGroup1_Value1> _$filesSharingShareeRemoteGroup1Value1Serializer =
-    _$FilesSharingShareeRemoteGroup1_Value1Serializer();
-Serializer<FilesSharingShareeRemoteGroup1> _$filesSharingShareeRemoteGroup1Serializer =
-    _$FilesSharingShareeRemoteGroup1Serializer();
-Serializer<FilesSharingShareeRemote1_Value1> _$filesSharingShareeRemote1Value1Serializer =
-    _$FilesSharingShareeRemote1_Value1Serializer();
-Serializer<FilesSharingShareeRemote1> _$filesSharingShareeRemote1Serializer = _$FilesSharingShareeRemote1Serializer();
-Serializer<FilesSharingShareeUser1_Status> _$filesSharingShareeUser1StatusSerializer =
-    _$FilesSharingShareeUser1_StatusSerializer();
-Serializer<FilesSharingShareeUser1> _$filesSharingShareeUser1Serializer = _$FilesSharingShareeUser1Serializer();
+Serializer<FilesSharingShareeCircle_1_Value> _$filesSharingShareeCircle1ValueSerializer =
+    _$FilesSharingShareeCircle_1_ValueSerializer();
+Serializer<FilesSharingShareeCircle> _$filesSharingShareeCircleSerializer = _$FilesSharingShareeCircleSerializer();
+Serializer<FilesSharingShareeEmail> _$filesSharingShareeEmailSerializer = _$FilesSharingShareeEmailSerializer();
+Serializer<FilesSharingShareeRemoteGroup_1_Value> _$filesSharingShareeRemoteGroup1ValueSerializer =
+    _$FilesSharingShareeRemoteGroup_1_ValueSerializer();
+Serializer<FilesSharingShareeRemoteGroup> _$filesSharingShareeRemoteGroupSerializer =
+    _$FilesSharingShareeRemoteGroupSerializer();
+Serializer<FilesSharingShareeRemote_1_Value> _$filesSharingShareeRemote1ValueSerializer =
+    _$FilesSharingShareeRemote_1_ValueSerializer();
+Serializer<FilesSharingShareeRemote> _$filesSharingShareeRemoteSerializer = _$FilesSharingShareeRemoteSerializer();
+Serializer<FilesSharingShareeUser_1_Status> _$filesSharingShareeUser1StatusSerializer =
+    _$FilesSharingShareeUser_1_StatusSerializer();
+Serializer<FilesSharingShareeUser> _$filesSharingShareeUserSerializer = _$FilesSharingShareeUserSerializer();
 Serializer<FilesSharingShareesSearchResult_Exact> _$filesSharingShareesSearchResultExactSerializer =
     _$FilesSharingShareesSearchResult_ExactSerializer();
 Serializer<FilesSharingLookup> _$filesSharingLookupSerializer = _$FilesSharingLookupSerializer();
-Serializer<FilesSharingShareeLookup1_Extra> _$filesSharingShareeLookup1ExtraSerializer =
-    _$FilesSharingShareeLookup1_ExtraSerializer();
-Serializer<FilesSharingShareeLookup1_Value1> _$filesSharingShareeLookup1Value1Serializer =
-    _$FilesSharingShareeLookup1_Value1Serializer();
-Serializer<FilesSharingShareeLookup1> _$filesSharingShareeLookup1Serializer = _$FilesSharingShareeLookup1Serializer();
+Serializer<FilesSharingShareeLookup_1_Extra> _$filesSharingShareeLookup1ExtraSerializer =
+    _$FilesSharingShareeLookup_1_ExtraSerializer();
+Serializer<FilesSharingShareeLookup_1_Value> _$filesSharingShareeLookup1ValueSerializer =
+    _$FilesSharingShareeLookup_1_ValueSerializer();
+Serializer<FilesSharingShareeLookup> _$filesSharingShareeLookupSerializer = _$FilesSharingShareeLookupSerializer();
 Serializer<FilesSharingShareesSearchResult> _$filesSharingShareesSearchResultSerializer =
     _$FilesSharingShareesSearchResultSerializer();
 Serializer<FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs>
@@ -2692,16 +2692,20 @@ class _$FilesSharingShareeValueSerializer implements StructuredSerializer<FilesS
   }
 }
 
-class _$FilesSharingShareeCircle1_Value1Serializer implements StructuredSerializer<FilesSharingShareeCircle1_Value1> {
+class _$FilesSharingShareeCircle_1_ValueSerializer implements StructuredSerializer<FilesSharingShareeCircle_1_Value> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeCircle1_Value1, _$FilesSharingShareeCircle1_Value1];
+  final Iterable<Type> types = const [FilesSharingShareeCircle_1_Value, _$FilesSharingShareeCircle_1_Value];
   @override
-  final String wireName = 'FilesSharingShareeCircle1_Value1';
+  final String wireName = 'FilesSharingShareeCircle_1_Value';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeCircle1_Value1 object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeCircle_1_Value object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'shareType',
+      serializers.serialize(object.shareType, specifiedType: const FullType(int)),
+      'shareWith',
+      serializers.serialize(object.shareWith, specifiedType: const FullType(String)),
       'circle',
       serializers.serialize(object.circle, specifiedType: const FullType(String)),
     ];
@@ -2710,9 +2714,9 @@ class _$FilesSharingShareeCircle1_Value1Serializer implements StructuredSerializ
   }
 
   @override
-  FilesSharingShareeCircle1_Value1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeCircle_1_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeCircle1_Value1Builder();
+    final result = FilesSharingShareeCircle_1_ValueBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2720,6 +2724,12 @@ class _$FilesSharingShareeCircle1_Value1Serializer implements StructuredSerializ
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'shareType':
+          result.shareType = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'shareWith':
+          result.shareWith = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'circle':
           result.circle = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -2730,29 +2740,37 @@ class _$FilesSharingShareeCircle1_Value1Serializer implements StructuredSerializ
   }
 }
 
-class _$FilesSharingShareeCircle1Serializer implements StructuredSerializer<FilesSharingShareeCircle1> {
+class _$FilesSharingShareeCircleSerializer implements StructuredSerializer<FilesSharingShareeCircle> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeCircle1, _$FilesSharingShareeCircle1];
+  final Iterable<Type> types = const [FilesSharingShareeCircle, _$FilesSharingShareeCircle];
   @override
-  final String wireName = 'FilesSharingShareeCircle1';
+  final String wireName = 'FilesSharingShareeCircle';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeCircle1 object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeCircle object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'shareWithDescription',
       serializers.serialize(object.shareWithDescription, specifiedType: const FullType(String)),
       'value',
-      serializers.serialize(object.value, specifiedType: const FullType(FilesSharingShareeCircle1_Value)),
+      serializers.serialize(object.value, specifiedType: const FullType(FilesSharingShareeCircle_1_Value)),
     ];
-
+    Object? value;
+    value = object.count;
+    if (value != null) {
+      result
+        ..add('count')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
     return result;
   }
 
   @override
-  FilesSharingShareeCircle1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeCircle deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeCircle1Builder();
+    final result = FilesSharingShareeCircleBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2760,13 +2778,19 @@ class _$FilesSharingShareeCircle1Serializer implements StructuredSerializer<File
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'shareWithDescription':
           result.shareWithDescription =
               serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'value':
           result.value.replace(serializers.deserialize(value,
-              specifiedType: const FullType(FilesSharingShareeCircle1_Value))! as FilesSharingShareeCircle1_Value);
+              specifiedType: const FullType(FilesSharingShareeCircle_1_Value))! as FilesSharingShareeCircle_1_Value);
           break;
       }
     }
@@ -2775,16 +2799,18 @@ class _$FilesSharingShareeCircle1Serializer implements StructuredSerializer<File
   }
 }
 
-class _$FilesSharingShareeEmail1Serializer implements StructuredSerializer<FilesSharingShareeEmail1> {
+class _$FilesSharingShareeEmailSerializer implements StructuredSerializer<FilesSharingShareeEmail> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeEmail1, _$FilesSharingShareeEmail1];
+  final Iterable<Type> types = const [FilesSharingShareeEmail, _$FilesSharingShareeEmail];
   @override
-  final String wireName = 'FilesSharingShareeEmail1';
+  final String wireName = 'FilesSharingShareeEmail';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeEmail1 object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeEmail object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'uuid',
       serializers.serialize(object.uuid, specifiedType: const FullType(String)),
       'name',
@@ -2796,14 +2822,20 @@ class _$FilesSharingShareeEmail1Serializer implements StructuredSerializer<Files
       'value',
       serializers.serialize(object.value, specifiedType: const FullType(FilesSharingShareeValue)),
     ];
-
+    Object? value;
+    value = object.count;
+    if (value != null) {
+      result
+        ..add('count')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
     return result;
   }
 
   @override
-  FilesSharingShareeEmail1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeEmail deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeEmail1Builder();
+    final result = FilesSharingShareeEmailBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2811,6 +2843,12 @@ class _$FilesSharingShareeEmail1Serializer implements StructuredSerializer<Files
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'uuid':
           result.uuid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -2835,17 +2873,21 @@ class _$FilesSharingShareeEmail1Serializer implements StructuredSerializer<Files
   }
 }
 
-class _$FilesSharingShareeRemoteGroup1_Value1Serializer
-    implements StructuredSerializer<FilesSharingShareeRemoteGroup1_Value1> {
+class _$FilesSharingShareeRemoteGroup_1_ValueSerializer
+    implements StructuredSerializer<FilesSharingShareeRemoteGroup_1_Value> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeRemoteGroup1_Value1, _$FilesSharingShareeRemoteGroup1_Value1];
+  final Iterable<Type> types = const [FilesSharingShareeRemoteGroup_1_Value, _$FilesSharingShareeRemoteGroup_1_Value];
   @override
-  final String wireName = 'FilesSharingShareeRemoteGroup1_Value1';
+  final String wireName = 'FilesSharingShareeRemoteGroup_1_Value';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeRemoteGroup1_Value1 object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeRemoteGroup_1_Value object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'shareType',
+      serializers.serialize(object.shareType, specifiedType: const FullType(int)),
+      'shareWith',
+      serializers.serialize(object.shareWith, specifiedType: const FullType(String)),
       'server',
       serializers.serialize(object.server, specifiedType: const FullType(String)),
     ];
@@ -2854,9 +2896,9 @@ class _$FilesSharingShareeRemoteGroup1_Value1Serializer
   }
 
   @override
-  FilesSharingShareeRemoteGroup1_Value1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeRemoteGroup_1_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeRemoteGroup1_Value1Builder();
+    final result = FilesSharingShareeRemoteGroup_1_ValueBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2864,6 +2906,12 @@ class _$FilesSharingShareeRemoteGroup1_Value1Serializer
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'shareType':
+          result.shareType = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'shareWith':
+          result.shareWith = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'server':
           result.server = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -2874,31 +2922,39 @@ class _$FilesSharingShareeRemoteGroup1_Value1Serializer
   }
 }
 
-class _$FilesSharingShareeRemoteGroup1Serializer implements StructuredSerializer<FilesSharingShareeRemoteGroup1> {
+class _$FilesSharingShareeRemoteGroupSerializer implements StructuredSerializer<FilesSharingShareeRemoteGroup> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeRemoteGroup1, _$FilesSharingShareeRemoteGroup1];
+  final Iterable<Type> types = const [FilesSharingShareeRemoteGroup, _$FilesSharingShareeRemoteGroup];
   @override
-  final String wireName = 'FilesSharingShareeRemoteGroup1';
+  final String wireName = 'FilesSharingShareeRemoteGroup';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeRemoteGroup1 object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeRemoteGroup object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'guid',
       serializers.serialize(object.guid, specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
       'value',
-      serializers.serialize(object.value, specifiedType: const FullType(FilesSharingShareeRemoteGroup1_Value)),
+      serializers.serialize(object.value, specifiedType: const FullType(FilesSharingShareeRemoteGroup_1_Value)),
     ];
-
+    Object? value;
+    value = object.count;
+    if (value != null) {
+      result
+        ..add('count')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
     return result;
   }
 
   @override
-  FilesSharingShareeRemoteGroup1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeRemoteGroup deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeRemoteGroup1Builder();
+    final result = FilesSharingShareeRemoteGroupBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2906,6 +2962,12 @@ class _$FilesSharingShareeRemoteGroup1Serializer implements StructuredSerializer
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'guid':
           result.guid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -2914,8 +2976,8 @@ class _$FilesSharingShareeRemoteGroup1Serializer implements StructuredSerializer
           break;
         case 'value':
           result.value.replace(
-              serializers.deserialize(value, specifiedType: const FullType(FilesSharingShareeRemoteGroup1_Value))!
-                  as FilesSharingShareeRemoteGroup1_Value);
+              serializers.deserialize(value, specifiedType: const FullType(FilesSharingShareeRemoteGroup_1_Value))!
+                  as FilesSharingShareeRemoteGroup_1_Value);
           break;
       }
     }
@@ -2924,16 +2986,20 @@ class _$FilesSharingShareeRemoteGroup1Serializer implements StructuredSerializer
   }
 }
 
-class _$FilesSharingShareeRemote1_Value1Serializer implements StructuredSerializer<FilesSharingShareeRemote1_Value1> {
+class _$FilesSharingShareeRemote_1_ValueSerializer implements StructuredSerializer<FilesSharingShareeRemote_1_Value> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeRemote1_Value1, _$FilesSharingShareeRemote1_Value1];
+  final Iterable<Type> types = const [FilesSharingShareeRemote_1_Value, _$FilesSharingShareeRemote_1_Value];
   @override
-  final String wireName = 'FilesSharingShareeRemote1_Value1';
+  final String wireName = 'FilesSharingShareeRemote_1_Value';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeRemote1_Value1 object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeRemote_1_Value object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'shareType',
+      serializers.serialize(object.shareType, specifiedType: const FullType(int)),
+      'shareWith',
+      serializers.serialize(object.shareWith, specifiedType: const FullType(String)),
       'server',
       serializers.serialize(object.server, specifiedType: const FullType(String)),
     ];
@@ -2942,9 +3008,9 @@ class _$FilesSharingShareeRemote1_Value1Serializer implements StructuredSerializ
   }
 
   @override
-  FilesSharingShareeRemote1_Value1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeRemote_1_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeRemote1_Value1Builder();
+    final result = FilesSharingShareeRemote_1_ValueBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2952,6 +3018,12 @@ class _$FilesSharingShareeRemote1_Value1Serializer implements StructuredSerializ
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'shareType':
+          result.shareType = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'shareWith':
+          result.shareWith = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'server':
           result.server = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -2962,16 +3034,18 @@ class _$FilesSharingShareeRemote1_Value1Serializer implements StructuredSerializ
   }
 }
 
-class _$FilesSharingShareeRemote1Serializer implements StructuredSerializer<FilesSharingShareeRemote1> {
+class _$FilesSharingShareeRemoteSerializer implements StructuredSerializer<FilesSharingShareeRemote> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeRemote1, _$FilesSharingShareeRemote1];
+  final Iterable<Type> types = const [FilesSharingShareeRemote, _$FilesSharingShareeRemote];
   @override
-  final String wireName = 'FilesSharingShareeRemote1';
+  final String wireName = 'FilesSharingShareeRemote';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeRemote1 object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeRemote object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'uuid',
       serializers.serialize(object.uuid, specifiedType: const FullType(String)),
       'name',
@@ -2979,16 +3053,22 @@ class _$FilesSharingShareeRemote1Serializer implements StructuredSerializer<File
       'type',
       serializers.serialize(object.type, specifiedType: const FullType(String)),
       'value',
-      serializers.serialize(object.value, specifiedType: const FullType(FilesSharingShareeRemote1_Value)),
+      serializers.serialize(object.value, specifiedType: const FullType(FilesSharingShareeRemote_1_Value)),
     ];
-
+    Object? value;
+    value = object.count;
+    if (value != null) {
+      result
+        ..add('count')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
     return result;
   }
 
   @override
-  FilesSharingShareeRemote1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeRemote deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeRemote1Builder();
+    final result = FilesSharingShareeRemoteBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2996,6 +3076,12 @@ class _$FilesSharingShareeRemote1Serializer implements StructuredSerializer<File
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'uuid':
           result.uuid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -3007,7 +3093,7 @@ class _$FilesSharingShareeRemote1Serializer implements StructuredSerializer<File
           break;
         case 'value':
           result.value.replace(serializers.deserialize(value,
-              specifiedType: const FullType(FilesSharingShareeRemote1_Value))! as FilesSharingShareeRemote1_Value);
+              specifiedType: const FullType(FilesSharingShareeRemote_1_Value))! as FilesSharingShareeRemote_1_Value);
           break;
       }
     }
@@ -3016,14 +3102,14 @@ class _$FilesSharingShareeRemote1Serializer implements StructuredSerializer<File
   }
 }
 
-class _$FilesSharingShareeUser1_StatusSerializer implements StructuredSerializer<FilesSharingShareeUser1_Status> {
+class _$FilesSharingShareeUser_1_StatusSerializer implements StructuredSerializer<FilesSharingShareeUser_1_Status> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeUser1_Status, _$FilesSharingShareeUser1_Status];
+  final Iterable<Type> types = const [FilesSharingShareeUser_1_Status, _$FilesSharingShareeUser_1_Status];
   @override
-  final String wireName = 'FilesSharingShareeUser1_Status';
+  final String wireName = 'FilesSharingShareeUser_1_Status';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeUser1_Status object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeUser_1_Status object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'status',
@@ -3044,9 +3130,9 @@ class _$FilesSharingShareeUser1_StatusSerializer implements StructuredSerializer
   }
 
   @override
-  FilesSharingShareeUser1_Status deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeUser_1_Status deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeUser1_StatusBuilder();
+    final result = FilesSharingShareeUser_1_StatusBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -3073,16 +3159,18 @@ class _$FilesSharingShareeUser1_StatusSerializer implements StructuredSerializer
   }
 }
 
-class _$FilesSharingShareeUser1Serializer implements StructuredSerializer<FilesSharingShareeUser1> {
+class _$FilesSharingShareeUserSerializer implements StructuredSerializer<FilesSharingShareeUser> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeUser1, _$FilesSharingShareeUser1];
+  final Iterable<Type> types = const [FilesSharingShareeUser, _$FilesSharingShareeUser];
   @override
-  final String wireName = 'FilesSharingShareeUser1';
+  final String wireName = 'FilesSharingShareeUser';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeUser1 object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeUser object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'subline',
       serializers.serialize(object.subline, specifiedType: const FullType(String)),
       'icon',
@@ -3090,18 +3178,24 @@ class _$FilesSharingShareeUser1Serializer implements StructuredSerializer<FilesS
       'shareWithDisplayNameUnique',
       serializers.serialize(object.shareWithDisplayNameUnique, specifiedType: const FullType(String)),
       'status',
-      serializers.serialize(object.status, specifiedType: const FullType(FilesSharingShareeUser1_Status)),
+      serializers.serialize(object.status, specifiedType: const FullType(FilesSharingShareeUser_1_Status)),
       'value',
       serializers.serialize(object.value, specifiedType: const FullType(FilesSharingShareeValue)),
     ];
-
+    Object? value;
+    value = object.count;
+    if (value != null) {
+      result
+        ..add('count')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
     return result;
   }
 
   @override
-  FilesSharingShareeUser1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeUser deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeUser1Builder();
+    final result = FilesSharingShareeUserBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -3109,6 +3203,12 @@ class _$FilesSharingShareeUser1Serializer implements StructuredSerializer<FilesS
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'subline':
           result.subline = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -3121,7 +3221,7 @@ class _$FilesSharingShareeUser1Serializer implements StructuredSerializer<FilesS
           break;
         case 'status':
           result.status.replace(serializers.deserialize(value,
-              specifiedType: const FullType(FilesSharingShareeUser1_Status))! as FilesSharingShareeUser1_Status);
+              specifiedType: const FullType(FilesSharingShareeUser_1_Status))! as FilesSharingShareeUser_1_Status);
           break;
         case 'value':
           result.value.replace(serializers.deserialize(value, specifiedType: const FullType(FilesSharingShareeValue))!
@@ -3258,14 +3358,14 @@ class _$FilesSharingLookupSerializer implements StructuredSerializer<FilesSharin
   }
 }
 
-class _$FilesSharingShareeLookup1_ExtraSerializer implements StructuredSerializer<FilesSharingShareeLookup1_Extra> {
+class _$FilesSharingShareeLookup_1_ExtraSerializer implements StructuredSerializer<FilesSharingShareeLookup_1_Extra> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeLookup1_Extra, _$FilesSharingShareeLookup1_Extra];
+  final Iterable<Type> types = const [FilesSharingShareeLookup_1_Extra, _$FilesSharingShareeLookup_1_Extra];
   @override
-  final String wireName = 'FilesSharingShareeLookup1_Extra';
+  final String wireName = 'FilesSharingShareeLookup_1_Extra';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeLookup1_Extra object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeLookup_1_Extra object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'federationId',
@@ -3330,9 +3430,9 @@ class _$FilesSharingShareeLookup1_ExtraSerializer implements StructuredSerialize
   }
 
   @override
-  FilesSharingShareeLookup1_Extra deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeLookup_1_Extra deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeLookup1_ExtraBuilder();
+    final result = FilesSharingShareeLookup_1_ExtraBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -3386,16 +3486,20 @@ class _$FilesSharingShareeLookup1_ExtraSerializer implements StructuredSerialize
   }
 }
 
-class _$FilesSharingShareeLookup1_Value1Serializer implements StructuredSerializer<FilesSharingShareeLookup1_Value1> {
+class _$FilesSharingShareeLookup_1_ValueSerializer implements StructuredSerializer<FilesSharingShareeLookup_1_Value> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeLookup1_Value1, _$FilesSharingShareeLookup1_Value1];
+  final Iterable<Type> types = const [FilesSharingShareeLookup_1_Value, _$FilesSharingShareeLookup_1_Value];
   @override
-  final String wireName = 'FilesSharingShareeLookup1_Value1';
+  final String wireName = 'FilesSharingShareeLookup_1_Value';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeLookup1_Value1 object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeLookup_1_Value object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'shareType',
+      serializers.serialize(object.shareType, specifiedType: const FullType(int)),
+      'shareWith',
+      serializers.serialize(object.shareWith, specifiedType: const FullType(String)),
       'globalScale',
       serializers.serialize(object.globalScale, specifiedType: const FullType(bool)),
     ];
@@ -3404,9 +3508,9 @@ class _$FilesSharingShareeLookup1_Value1Serializer implements StructuredSerializ
   }
 
   @override
-  FilesSharingShareeLookup1_Value1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeLookup_1_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeLookup1_Value1Builder();
+    final result = FilesSharingShareeLookup_1_ValueBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -3414,6 +3518,12 @@ class _$FilesSharingShareeLookup1_Value1Serializer implements StructuredSerializ
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'shareType':
+          result.shareType = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'shareWith':
+          result.shareWith = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'globalScale':
           result.globalScale = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
@@ -3424,29 +3534,37 @@ class _$FilesSharingShareeLookup1_Value1Serializer implements StructuredSerializ
   }
 }
 
-class _$FilesSharingShareeLookup1Serializer implements StructuredSerializer<FilesSharingShareeLookup1> {
+class _$FilesSharingShareeLookupSerializer implements StructuredSerializer<FilesSharingShareeLookup> {
   @override
-  final Iterable<Type> types = const [FilesSharingShareeLookup1, _$FilesSharingShareeLookup1];
+  final Iterable<Type> types = const [FilesSharingShareeLookup, _$FilesSharingShareeLookup];
   @override
-  final String wireName = 'FilesSharingShareeLookup1';
+  final String wireName = 'FilesSharingShareeLookup';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeLookup1 object,
+  Iterable<Object?> serialize(Serializers serializers, FilesSharingShareeLookup object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'extra',
-      serializers.serialize(object.extra, specifiedType: const FullType(FilesSharingShareeLookup1_Extra)),
+      serializers.serialize(object.extra, specifiedType: const FullType(FilesSharingShareeLookup_1_Extra)),
       'value',
-      serializers.serialize(object.value, specifiedType: const FullType(FilesSharingShareeLookup1_Value)),
+      serializers.serialize(object.value, specifiedType: const FullType(FilesSharingShareeLookup_1_Value)),
     ];
-
+    Object? value;
+    value = object.count;
+    if (value != null) {
+      result
+        ..add('count')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
     return result;
   }
 
   @override
-  FilesSharingShareeLookup1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  FilesSharingShareeLookup deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = FilesSharingShareeLookup1Builder();
+    final result = FilesSharingShareeLookupBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -3454,13 +3572,19 @@ class _$FilesSharingShareeLookup1Serializer implements StructuredSerializer<File
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'extra':
           result.extra.replace(serializers.deserialize(value,
-              specifiedType: const FullType(FilesSharingShareeLookup1_Extra))! as FilesSharingShareeLookup1_Extra);
+              specifiedType: const FullType(FilesSharingShareeLookup_1_Extra))! as FilesSharingShareeLookup_1_Extra);
           break;
         case 'value':
           result.value.replace(serializers.deserialize(value,
-              specifiedType: const FullType(FilesSharingShareeLookup1_Value))! as FilesSharingShareeLookup1_Value);
+              specifiedType: const FullType(FilesSharingShareeLookup_1_Value))! as FilesSharingShareeLookup_1_Value);
           break;
       }
     }
@@ -4803,6 +4927,25 @@ class _$FilesSharingCapabilitiesSerializer implements StructuredSerializer<Files
   }
 }
 
+abstract mixin class FilesSharingOCSMetaInterfaceBuilder {
+  void replace(FilesSharingOCSMetaInterface other);
+  void update(void Function(FilesSharingOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
+}
+
 class _$FilesSharingOCSMeta extends FilesSharingOCSMeta {
   @override
   final String status;
@@ -4867,28 +5010,29 @@ class _$FilesSharingOCSMeta extends FilesSharingOCSMeta {
   }
 }
 
-class FilesSharingOCSMetaBuilder implements Builder<FilesSharingOCSMeta, FilesSharingOCSMetaBuilder> {
+class FilesSharingOCSMetaBuilder
+    implements Builder<FilesSharingOCSMeta, FilesSharingOCSMetaBuilder>, FilesSharingOCSMetaInterfaceBuilder {
   _$FilesSharingOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   FilesSharingOCSMetaBuilder();
 
@@ -4906,7 +5050,7 @@ class FilesSharingOCSMetaBuilder implements Builder<FilesSharingOCSMeta, FilesSh
   }
 
   @override
-  void replace(FilesSharingOCSMeta other) {
+  void replace(covariant FilesSharingOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingOCSMeta;
   }
@@ -4930,6 +5074,70 @@ class FilesSharingOCSMetaBuilder implements Builder<FilesSharingOCSMeta, FilesSh
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingDeletedShareInterfaceBuilder {
+  void replace(FilesSharingDeletedShareInterface other);
+  void update(void Function(FilesSharingDeletedShareInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  int? get shareType;
+  set shareType(int? shareType);
+
+  String? get uidOwner;
+  set uidOwner(String? uidOwner);
+
+  String? get displaynameOwner;
+  set displaynameOwner(String? displaynameOwner);
+
+  int? get permissions;
+  set permissions(int? permissions);
+
+  int? get stime;
+  set stime(int? stime);
+
+  String? get uidFileOwner;
+  set uidFileOwner(String? uidFileOwner);
+
+  String? get displaynameFileOwner;
+  set displaynameFileOwner(String? displaynameFileOwner);
+
+  String? get path;
+  set path(String? path);
+
+  String? get itemType;
+  set itemType(String? itemType);
+
+  String? get mimetype;
+  set mimetype(String? mimetype);
+
+  int? get storage;
+  set storage(int? storage);
+
+  int? get itemSource;
+  set itemSource(int? itemSource);
+
+  int? get fileSource;
+  set fileSource(int? fileSource);
+
+  int? get fileParent;
+  set fileParent(int? fileParent);
+
+  int? get fileTarget;
+  set fileTarget(int? fileTarget);
+
+  String? get expiration;
+  set expiration(String? expiration);
+
+  String? get shareWith;
+  set shareWith(String? shareWith);
+
+  String? get shareWithDisplayname;
+  set shareWithDisplayname(String? shareWithDisplayname);
+
+  String? get shareWithLink;
+  set shareWithLink(String? shareWithLink);
 }
 
 class _$FilesSharingDeletedShare extends FilesSharingDeletedShare {
@@ -5104,88 +5312,93 @@ class _$FilesSharingDeletedShare extends FilesSharingDeletedShare {
   }
 }
 
-class FilesSharingDeletedShareBuilder implements Builder<FilesSharingDeletedShare, FilesSharingDeletedShareBuilder> {
+class FilesSharingDeletedShareBuilder
+    implements
+        Builder<FilesSharingDeletedShare, FilesSharingDeletedShareBuilder>,
+        FilesSharingDeletedShareInterfaceBuilder {
   _$FilesSharingDeletedShare? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   int? _shareType;
   int? get shareType => _$this._shareType;
-  set shareType(int? shareType) => _$this._shareType = shareType;
+  set shareType(covariant int? shareType) => _$this._shareType = shareType;
 
   String? _uidOwner;
   String? get uidOwner => _$this._uidOwner;
-  set uidOwner(String? uidOwner) => _$this._uidOwner = uidOwner;
+  set uidOwner(covariant String? uidOwner) => _$this._uidOwner = uidOwner;
 
   String? _displaynameOwner;
   String? get displaynameOwner => _$this._displaynameOwner;
-  set displaynameOwner(String? displaynameOwner) => _$this._displaynameOwner = displaynameOwner;
+  set displaynameOwner(covariant String? displaynameOwner) => _$this._displaynameOwner = displaynameOwner;
 
   int? _permissions;
   int? get permissions => _$this._permissions;
-  set permissions(int? permissions) => _$this._permissions = permissions;
+  set permissions(covariant int? permissions) => _$this._permissions = permissions;
 
   int? _stime;
   int? get stime => _$this._stime;
-  set stime(int? stime) => _$this._stime = stime;
+  set stime(covariant int? stime) => _$this._stime = stime;
 
   String? _uidFileOwner;
   String? get uidFileOwner => _$this._uidFileOwner;
-  set uidFileOwner(String? uidFileOwner) => _$this._uidFileOwner = uidFileOwner;
+  set uidFileOwner(covariant String? uidFileOwner) => _$this._uidFileOwner = uidFileOwner;
 
   String? _displaynameFileOwner;
   String? get displaynameFileOwner => _$this._displaynameFileOwner;
-  set displaynameFileOwner(String? displaynameFileOwner) => _$this._displaynameFileOwner = displaynameFileOwner;
+  set displaynameFileOwner(covariant String? displaynameFileOwner) =>
+      _$this._displaynameFileOwner = displaynameFileOwner;
 
   String? _path;
   String? get path => _$this._path;
-  set path(String? path) => _$this._path = path;
+  set path(covariant String? path) => _$this._path = path;
 
   String? _itemType;
   String? get itemType => _$this._itemType;
-  set itemType(String? itemType) => _$this._itemType = itemType;
+  set itemType(covariant String? itemType) => _$this._itemType = itemType;
 
   String? _mimetype;
   String? get mimetype => _$this._mimetype;
-  set mimetype(String? mimetype) => _$this._mimetype = mimetype;
+  set mimetype(covariant String? mimetype) => _$this._mimetype = mimetype;
 
   int? _storage;
   int? get storage => _$this._storage;
-  set storage(int? storage) => _$this._storage = storage;
+  set storage(covariant int? storage) => _$this._storage = storage;
 
   int? _itemSource;
   int? get itemSource => _$this._itemSource;
-  set itemSource(int? itemSource) => _$this._itemSource = itemSource;
+  set itemSource(covariant int? itemSource) => _$this._itemSource = itemSource;
 
   int? _fileSource;
   int? get fileSource => _$this._fileSource;
-  set fileSource(int? fileSource) => _$this._fileSource = fileSource;
+  set fileSource(covariant int? fileSource) => _$this._fileSource = fileSource;
 
   int? _fileParent;
   int? get fileParent => _$this._fileParent;
-  set fileParent(int? fileParent) => _$this._fileParent = fileParent;
+  set fileParent(covariant int? fileParent) => _$this._fileParent = fileParent;
 
   int? _fileTarget;
   int? get fileTarget => _$this._fileTarget;
-  set fileTarget(int? fileTarget) => _$this._fileTarget = fileTarget;
+  set fileTarget(covariant int? fileTarget) => _$this._fileTarget = fileTarget;
 
   String? _expiration;
   String? get expiration => _$this._expiration;
-  set expiration(String? expiration) => _$this._expiration = expiration;
+  set expiration(covariant String? expiration) => _$this._expiration = expiration;
 
   String? _shareWith;
   String? get shareWith => _$this._shareWith;
-  set shareWith(String? shareWith) => _$this._shareWith = shareWith;
+  set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
   String? _shareWithDisplayname;
   String? get shareWithDisplayname => _$this._shareWithDisplayname;
-  set shareWithDisplayname(String? shareWithDisplayname) => _$this._shareWithDisplayname = shareWithDisplayname;
+  set shareWithDisplayname(covariant String? shareWithDisplayname) =>
+      _$this._shareWithDisplayname = shareWithDisplayname;
 
   String? _shareWithLink;
   String? get shareWithLink => _$this._shareWithLink;
-  set shareWithLink(String? shareWithLink) => _$this._shareWithLink = shareWithLink;
+  set shareWithLink(covariant String? shareWithLink) => _$this._shareWithLink = shareWithLink;
 
   FilesSharingDeletedShareBuilder();
 
@@ -5218,7 +5431,7 @@ class FilesSharingDeletedShareBuilder implements Builder<FilesSharingDeletedShar
   }
 
   @override
-  void replace(FilesSharingDeletedShare other) {
+  void replace(covariant FilesSharingDeletedShare other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingDeletedShare;
   }
@@ -5260,6 +5473,16 @@ class FilesSharingDeletedShareBuilder implements Builder<FilesSharingDeletedShar
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  ListBuilder<FilesSharingDeletedShare> get data;
+  set data(ListBuilder<FilesSharingDeletedShare>? data);
 }
 
 class _$FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs
@@ -5319,16 +5542,17 @@ class _$FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs
 class FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs,
-            FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<FilesSharingDeletedShare>? _data;
   ListBuilder<FilesSharingDeletedShare> get data => _$this._data ??= ListBuilder<FilesSharingDeletedShare>();
-  set data(ListBuilder<FilesSharingDeletedShare>? data) => _$this._data = data;
+  set data(covariant ListBuilder<FilesSharingDeletedShare>? data) => _$this._data = data;
 
   FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder();
 
@@ -5343,7 +5567,7 @@ class FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingDeletedShareapiListResponse200ApplicationJson_Ocs;
   }
@@ -5377,6 +5601,13 @@ class FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingDeletedShareapiListResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingDeletedShareapiListResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingDeletedShareapiListResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingDeletedShareapiListResponse200ApplicationJson
@@ -5425,13 +5656,14 @@ class _$FilesSharingDeletedShareapiListResponse200ApplicationJson
 class FilesSharingDeletedShareapiListResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingDeletedShareapiListResponse200ApplicationJson,
-            FilesSharingDeletedShareapiListResponse200ApplicationJsonBuilder> {
+            FilesSharingDeletedShareapiListResponse200ApplicationJsonBuilder>,
+        FilesSharingDeletedShareapiListResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingDeletedShareapiListResponse200ApplicationJson? _$v;
 
   FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingDeletedShareapiListResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingDeletedShareapiListResponse200ApplicationJsonBuilder();
 
@@ -5445,7 +5677,7 @@ class FilesSharingDeletedShareapiListResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingDeletedShareapiListResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingDeletedShareapiListResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingDeletedShareapiListResponse200ApplicationJson;
   }
@@ -5476,6 +5708,16 @@ class FilesSharingDeletedShareapiListResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs
@@ -5535,16 +5777,17 @@ class _$FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs
 class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs,
-            FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder();
 
@@ -5559,7 +5802,7 @@ class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_Ocs;
   }
@@ -5594,6 +5837,13 @@ class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson
@@ -5643,13 +5893,14 @@ class _$FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson
 class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson,
-            FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonBuilder> {
+            FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonBuilder>,
+        FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson? _$v;
 
   FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonBuilder();
 
@@ -5663,7 +5914,7 @@ class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingDeletedShareapiUndeleteResponse200ApplicationJson;
   }
@@ -5694,6 +5945,58 @@ class FilesSharingDeletedShareapiUndeleteResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteShareInterfaceBuilder {
+  void replace(FilesSharingRemoteShareInterface other);
+  void update(void Function(FilesSharingRemoteShareInterfaceBuilder) updates);
+  bool? get accepted;
+  set accepted(bool? accepted);
+
+  int? get fileId;
+  set fileId(int? fileId);
+
+  int? get id;
+  set id(int? id);
+
+  String? get mimetype;
+  set mimetype(String? mimetype);
+
+  String? get mountpoint;
+  set mountpoint(String? mountpoint);
+
+  int? get mtime;
+  set mtime(int? mtime);
+
+  String? get name;
+  set name(String? name);
+
+  String? get owner;
+  set owner(String? owner);
+
+  int? get parent;
+  set parent(int? parent);
+
+  int? get permissions;
+  set permissions(int? permissions);
+
+  String? get remote;
+  set remote(String? remote);
+
+  String? get remoteId;
+  set remoteId(String? remoteId);
+
+  String? get shareToken;
+  set shareToken(String? shareToken);
+
+  int? get shareType;
+  set shareType(int? shareType);
+
+  String? get type;
+  set type(String? type);
+
+  String? get user;
+  set user(String? user);
 }
 
 class _$FilesSharingRemoteShare extends FilesSharingRemoteShare {
@@ -5838,72 +6141,75 @@ class _$FilesSharingRemoteShare extends FilesSharingRemoteShare {
   }
 }
 
-class FilesSharingRemoteShareBuilder implements Builder<FilesSharingRemoteShare, FilesSharingRemoteShareBuilder> {
+class FilesSharingRemoteShareBuilder
+    implements
+        Builder<FilesSharingRemoteShare, FilesSharingRemoteShareBuilder>,
+        FilesSharingRemoteShareInterfaceBuilder {
   _$FilesSharingRemoteShare? _$v;
 
   bool? _accepted;
   bool? get accepted => _$this._accepted;
-  set accepted(bool? accepted) => _$this._accepted = accepted;
+  set accepted(covariant bool? accepted) => _$this._accepted = accepted;
 
   int? _fileId;
   int? get fileId => _$this._fileId;
-  set fileId(int? fileId) => _$this._fileId = fileId;
+  set fileId(covariant int? fileId) => _$this._fileId = fileId;
 
   int? _id;
   int? get id => _$this._id;
-  set id(int? id) => _$this._id = id;
+  set id(covariant int? id) => _$this._id = id;
 
   String? _mimetype;
   String? get mimetype => _$this._mimetype;
-  set mimetype(String? mimetype) => _$this._mimetype = mimetype;
+  set mimetype(covariant String? mimetype) => _$this._mimetype = mimetype;
 
   String? _mountpoint;
   String? get mountpoint => _$this._mountpoint;
-  set mountpoint(String? mountpoint) => _$this._mountpoint = mountpoint;
+  set mountpoint(covariant String? mountpoint) => _$this._mountpoint = mountpoint;
 
   int? _mtime;
   int? get mtime => _$this._mtime;
-  set mtime(int? mtime) => _$this._mtime = mtime;
+  set mtime(covariant int? mtime) => _$this._mtime = mtime;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   String? _owner;
   String? get owner => _$this._owner;
-  set owner(String? owner) => _$this._owner = owner;
+  set owner(covariant String? owner) => _$this._owner = owner;
 
   int? _parent;
   int? get parent => _$this._parent;
-  set parent(int? parent) => _$this._parent = parent;
+  set parent(covariant int? parent) => _$this._parent = parent;
 
   int? _permissions;
   int? get permissions => _$this._permissions;
-  set permissions(int? permissions) => _$this._permissions = permissions;
+  set permissions(covariant int? permissions) => _$this._permissions = permissions;
 
   String? _remote;
   String? get remote => _$this._remote;
-  set remote(String? remote) => _$this._remote = remote;
+  set remote(covariant String? remote) => _$this._remote = remote;
 
   String? _remoteId;
   String? get remoteId => _$this._remoteId;
-  set remoteId(String? remoteId) => _$this._remoteId = remoteId;
+  set remoteId(covariant String? remoteId) => _$this._remoteId = remoteId;
 
   String? _shareToken;
   String? get shareToken => _$this._shareToken;
-  set shareToken(String? shareToken) => _$this._shareToken = shareToken;
+  set shareToken(covariant String? shareToken) => _$this._shareToken = shareToken;
 
   int? _shareType;
   int? get shareType => _$this._shareType;
-  set shareType(int? shareType) => _$this._shareType = shareType;
+  set shareType(covariant int? shareType) => _$this._shareType = shareType;
 
   String? _type;
   String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
+  set type(covariant String? type) => _$this._type = type;
 
   String? _user;
   String? get user => _$this._user;
-  set user(String? user) => _$this._user = user;
+  set user(covariant String? user) => _$this._user = user;
 
   FilesSharingRemoteShareBuilder();
 
@@ -5932,7 +6238,7 @@ class FilesSharingRemoteShareBuilder implements Builder<FilesSharingRemoteShare,
   }
 
   @override
-  void replace(FilesSharingRemoteShare other) {
+  void replace(covariant FilesSharingRemoteShare other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteShare;
   }
@@ -5967,6 +6273,16 @@ class FilesSharingRemoteShareBuilder implements Builder<FilesSharingRemoteShare,
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  ListBuilder<FilesSharingRemoteShare> get data;
+  set data(ListBuilder<FilesSharingRemoteShare>? data);
 }
 
 class _$FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs
@@ -6023,16 +6339,17 @@ class _$FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs
 class FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs,
-            FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<FilesSharingRemoteShare>? _data;
   ListBuilder<FilesSharingRemoteShare> get data => _$this._data ??= ListBuilder<FilesSharingRemoteShare>();
-  set data(ListBuilder<FilesSharingRemoteShare>? data) => _$this._data = data;
+  set data(covariant ListBuilder<FilesSharingRemoteShare>? data) => _$this._data = data;
 
   FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder();
 
@@ -6047,7 +6364,7 @@ class FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteGetSharesResponse200ApplicationJson_Ocs;
   }
@@ -6081,6 +6398,13 @@ class FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteGetSharesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingRemoteGetSharesResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingRemoteGetSharesResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingRemoteGetSharesResponse200ApplicationJson
@@ -6129,13 +6453,14 @@ class _$FilesSharingRemoteGetSharesResponse200ApplicationJson
 class FilesSharingRemoteGetSharesResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingRemoteGetSharesResponse200ApplicationJson,
-            FilesSharingRemoteGetSharesResponse200ApplicationJsonBuilder> {
+            FilesSharingRemoteGetSharesResponse200ApplicationJsonBuilder>,
+        FilesSharingRemoteGetSharesResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingRemoteGetSharesResponse200ApplicationJson? _$v;
 
   FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingRemoteGetSharesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingRemoteGetSharesResponse200ApplicationJsonBuilder();
 
@@ -6149,7 +6474,7 @@ class FilesSharingRemoteGetSharesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteGetSharesResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingRemoteGetSharesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteGetSharesResponse200ApplicationJson;
   }
@@ -6180,6 +6505,16 @@ class FilesSharingRemoteGetSharesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  ListBuilder<FilesSharingRemoteShare> get data;
+  set data(ListBuilder<FilesSharingRemoteShare>? data);
 }
 
 class _$FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs
@@ -6239,16 +6574,17 @@ class _$FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs
 class FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs,
-            FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<FilesSharingRemoteShare>? _data;
   ListBuilder<FilesSharingRemoteShare> get data => _$this._data ??= ListBuilder<FilesSharingRemoteShare>();
-  set data(ListBuilder<FilesSharingRemoteShare>? data) => _$this._data = data;
+  set data(covariant ListBuilder<FilesSharingRemoteShare>? data) => _$this._data = data;
 
   FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder();
 
@@ -6263,7 +6599,7 @@ class FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_Ocs;
   }
@@ -6297,6 +6633,13 @@ class FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingRemoteGetOpenSharesResponse200ApplicationJson
@@ -6345,13 +6688,14 @@ class _$FilesSharingRemoteGetOpenSharesResponse200ApplicationJson
 class FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingRemoteGetOpenSharesResponse200ApplicationJson,
-            FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonBuilder> {
+            FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonBuilder>,
+        FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingRemoteGetOpenSharesResponse200ApplicationJson? _$v;
 
   FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingRemoteGetOpenSharesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonBuilder();
 
@@ -6365,7 +6709,7 @@ class FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteGetOpenSharesResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingRemoteGetOpenSharesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteGetOpenSharesResponse200ApplicationJson;
   }
@@ -6396,6 +6740,16 @@ class FilesSharingRemoteGetOpenSharesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs
@@ -6453,16 +6807,17 @@ class _$FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs
 class FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs,
-            FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder();
 
@@ -6477,7 +6832,7 @@ class FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteAcceptShareResponse200ApplicationJson_Ocs;
   }
@@ -6512,6 +6867,13 @@ class FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteAcceptShareResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingRemoteAcceptShareResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingRemoteAcceptShareResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingRemoteAcceptShareResponse200ApplicationJson
@@ -6560,13 +6922,14 @@ class _$FilesSharingRemoteAcceptShareResponse200ApplicationJson
 class FilesSharingRemoteAcceptShareResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingRemoteAcceptShareResponse200ApplicationJson,
-            FilesSharingRemoteAcceptShareResponse200ApplicationJsonBuilder> {
+            FilesSharingRemoteAcceptShareResponse200ApplicationJsonBuilder>,
+        FilesSharingRemoteAcceptShareResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingRemoteAcceptShareResponse200ApplicationJson? _$v;
 
   FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingRemoteAcceptShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingRemoteAcceptShareResponse200ApplicationJsonBuilder();
 
@@ -6580,7 +6943,7 @@ class FilesSharingRemoteAcceptShareResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteAcceptShareResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingRemoteAcceptShareResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteAcceptShareResponse200ApplicationJson;
   }
@@ -6611,6 +6974,16 @@ class FilesSharingRemoteAcceptShareResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs
@@ -6670,16 +7043,17 @@ class _$FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs
 class FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs,
-            FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder();
 
@@ -6694,7 +7068,7 @@ class FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteDeclineShareResponse200ApplicationJson_Ocs;
   }
@@ -6729,6 +7103,13 @@ class FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteDeclineShareResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingRemoteDeclineShareResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingRemoteDeclineShareResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingRemoteDeclineShareResponse200ApplicationJson
@@ -6777,13 +7158,14 @@ class _$FilesSharingRemoteDeclineShareResponse200ApplicationJson
 class FilesSharingRemoteDeclineShareResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingRemoteDeclineShareResponse200ApplicationJson,
-            FilesSharingRemoteDeclineShareResponse200ApplicationJsonBuilder> {
+            FilesSharingRemoteDeclineShareResponse200ApplicationJsonBuilder>,
+        FilesSharingRemoteDeclineShareResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingRemoteDeclineShareResponse200ApplicationJson? _$v;
 
   FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingRemoteDeclineShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingRemoteDeclineShareResponse200ApplicationJsonBuilder();
 
@@ -6797,7 +7179,7 @@ class FilesSharingRemoteDeclineShareResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteDeclineShareResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingRemoteDeclineShareResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteDeclineShareResponse200ApplicationJson;
   }
@@ -6828,6 +7210,16 @@ class FilesSharingRemoteDeclineShareResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteGetShareResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingRemoteGetShareResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingRemoteGetShareResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  FilesSharingRemoteShareBuilder get data;
+  set data(FilesSharingRemoteShareBuilder? data);
 }
 
 class _$FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs
@@ -6884,16 +7276,17 @@ class _$FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs
 class FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs,
-            FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingRemoteGetShareResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesSharingRemoteShareBuilder? _data;
   FilesSharingRemoteShareBuilder get data => _$this._data ??= FilesSharingRemoteShareBuilder();
-  set data(FilesSharingRemoteShareBuilder? data) => _$this._data = data;
+  set data(covariant FilesSharingRemoteShareBuilder? data) => _$this._data = data;
 
   FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder();
 
@@ -6908,7 +7301,7 @@ class FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteGetShareResponse200ApplicationJson_Ocs;
   }
@@ -6942,6 +7335,13 @@ class FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteGetShareResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingRemoteGetShareResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingRemoteGetShareResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingRemoteGetShareResponse200ApplicationJson
@@ -6990,13 +7390,14 @@ class _$FilesSharingRemoteGetShareResponse200ApplicationJson
 class FilesSharingRemoteGetShareResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingRemoteGetShareResponse200ApplicationJson,
-            FilesSharingRemoteGetShareResponse200ApplicationJsonBuilder> {
+            FilesSharingRemoteGetShareResponse200ApplicationJsonBuilder>,
+        FilesSharingRemoteGetShareResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingRemoteGetShareResponse200ApplicationJson? _$v;
 
   FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingRemoteGetShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingRemoteGetShareResponse200ApplicationJsonBuilder();
 
@@ -7010,7 +7411,7 @@ class FilesSharingRemoteGetShareResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteGetShareResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingRemoteGetShareResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteGetShareResponse200ApplicationJson;
   }
@@ -7041,6 +7442,16 @@ class FilesSharingRemoteGetShareResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteUnshareResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingRemoteUnshareResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingRemoteUnshareResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs
@@ -7095,16 +7506,17 @@ class _$FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs
 class FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs,
-            FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingRemoteUnshareResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder();
 
@@ -7119,7 +7531,7 @@ class FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteUnshareResponse200ApplicationJson_Ocs;
   }
@@ -7154,6 +7566,13 @@ class FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingRemoteUnshareResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingRemoteUnshareResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingRemoteUnshareResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingRemoteUnshareResponse200ApplicationJson
@@ -7202,13 +7621,14 @@ class _$FilesSharingRemoteUnshareResponse200ApplicationJson
 class FilesSharingRemoteUnshareResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingRemoteUnshareResponse200ApplicationJson,
-            FilesSharingRemoteUnshareResponse200ApplicationJsonBuilder> {
+            FilesSharingRemoteUnshareResponse200ApplicationJsonBuilder>,
+        FilesSharingRemoteUnshareResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingRemoteUnshareResponse200ApplicationJson? _$v;
 
   FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingRemoteUnshareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingRemoteUnshareResponse200ApplicationJsonBuilder();
 
@@ -7222,7 +7642,7 @@ class FilesSharingRemoteUnshareResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingRemoteUnshareResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingRemoteUnshareResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingRemoteUnshareResponse200ApplicationJson;
   }
@@ -7357,6 +7777,40 @@ class FilesSharingShareInfo_SizeBuilder
   }
 }
 
+abstract mixin class FilesSharingShareInfoInterfaceBuilder {
+  void replace(FilesSharingShareInfoInterface other);
+  void update(void Function(FilesSharingShareInfoInterfaceBuilder) updates);
+  int? get id;
+  set id(int? id);
+
+  int? get parentId;
+  set parentId(int? parentId);
+
+  int? get mtime;
+  set mtime(int? mtime);
+
+  String? get name;
+  set name(String? name);
+
+  int? get permissions;
+  set permissions(int? permissions);
+
+  String? get mimetype;
+  set mimetype(String? mimetype);
+
+  FilesSharingShareInfo_SizeBuilder get size;
+  set size(FilesSharingShareInfo_SizeBuilder? size);
+
+  String? get type;
+  set type(String? type);
+
+  String? get etag;
+  set etag(String? etag);
+
+  ListBuilder<BuiltMap<String, JsonObject>> get children;
+  set children(ListBuilder<BuiltMap<String, JsonObject>>? children);
+}
+
 class _$FilesSharingShareInfo extends FilesSharingShareInfo {
   @override
   final int id;
@@ -7462,49 +7916,50 @@ class _$FilesSharingShareInfo extends FilesSharingShareInfo {
   }
 }
 
-class FilesSharingShareInfoBuilder implements Builder<FilesSharingShareInfo, FilesSharingShareInfoBuilder> {
+class FilesSharingShareInfoBuilder
+    implements Builder<FilesSharingShareInfo, FilesSharingShareInfoBuilder>, FilesSharingShareInfoInterfaceBuilder {
   _$FilesSharingShareInfo? _$v;
 
   int? _id;
   int? get id => _$this._id;
-  set id(int? id) => _$this._id = id;
+  set id(covariant int? id) => _$this._id = id;
 
   int? _parentId;
   int? get parentId => _$this._parentId;
-  set parentId(int? parentId) => _$this._parentId = parentId;
+  set parentId(covariant int? parentId) => _$this._parentId = parentId;
 
   int? _mtime;
   int? get mtime => _$this._mtime;
-  set mtime(int? mtime) => _$this._mtime = mtime;
+  set mtime(covariant int? mtime) => _$this._mtime = mtime;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   int? _permissions;
   int? get permissions => _$this._permissions;
-  set permissions(int? permissions) => _$this._permissions = permissions;
+  set permissions(covariant int? permissions) => _$this._permissions = permissions;
 
   String? _mimetype;
   String? get mimetype => _$this._mimetype;
-  set mimetype(String? mimetype) => _$this._mimetype = mimetype;
+  set mimetype(covariant String? mimetype) => _$this._mimetype = mimetype;
 
   FilesSharingShareInfo_SizeBuilder? _size;
   FilesSharingShareInfo_SizeBuilder get size => _$this._size ??= FilesSharingShareInfo_SizeBuilder();
-  set size(FilesSharingShareInfo_SizeBuilder? size) => _$this._size = size;
+  set size(covariant FilesSharingShareInfo_SizeBuilder? size) => _$this._size = size;
 
   String? _type;
   String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
+  set type(covariant String? type) => _$this._type = type;
 
   String? _etag;
   String? get etag => _$this._etag;
-  set etag(String? etag) => _$this._etag = etag;
+  set etag(covariant String? etag) => _$this._etag = etag;
 
   ListBuilder<BuiltMap<String, JsonObject>>? _children;
   ListBuilder<BuiltMap<String, JsonObject>> get children =>
       _$this._children ??= ListBuilder<BuiltMap<String, JsonObject>>();
-  set children(ListBuilder<BuiltMap<String, JsonObject>>? children) => _$this._children = children;
+  set children(covariant ListBuilder<BuiltMap<String, JsonObject>>? children) => _$this._children = children;
 
   FilesSharingShareInfoBuilder();
 
@@ -7527,7 +7982,7 @@ class FilesSharingShareInfoBuilder implements Builder<FilesSharingShareInfo, Fil
   }
 
   @override
-  void replace(FilesSharingShareInfo other) {
+  void replace(covariant FilesSharingShareInfo other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareInfo;
   }
@@ -7675,6 +8130,22 @@ class FilesSharingShare_ItemSizeBuilder
   }
 }
 
+abstract mixin class FilesSharingShare_StatusInterfaceBuilder {
+  void replace(FilesSharingShare_StatusInterface other);
+  void update(void Function(FilesSharingShare_StatusInterfaceBuilder) updates);
+  int? get clearAt;
+  set clearAt(int? clearAt);
+
+  String? get icon;
+  set icon(String? icon);
+
+  String? get message;
+  set message(String? message);
+
+  String? get status;
+  set status(String? status);
+}
+
 class _$FilesSharingShare_Status extends FilesSharingShare_Status {
   @override
   final int? clearAt;
@@ -7729,24 +8200,27 @@ class _$FilesSharingShare_Status extends FilesSharingShare_Status {
   }
 }
 
-class FilesSharingShare_StatusBuilder implements Builder<FilesSharingShare_Status, FilesSharingShare_StatusBuilder> {
+class FilesSharingShare_StatusBuilder
+    implements
+        Builder<FilesSharingShare_Status, FilesSharingShare_StatusBuilder>,
+        FilesSharingShare_StatusInterfaceBuilder {
   _$FilesSharingShare_Status? _$v;
 
   int? _clearAt;
   int? get clearAt => _$this._clearAt;
-  set clearAt(int? clearAt) => _$this._clearAt = clearAt;
+  set clearAt(covariant int? clearAt) => _$this._clearAt = clearAt;
 
   String? _icon;
   String? get icon => _$this._icon;
-  set icon(String? icon) => _$this._icon = icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   FilesSharingShare_StatusBuilder();
 
@@ -7763,7 +8237,7 @@ class FilesSharingShare_StatusBuilder implements Builder<FilesSharingShare_Statu
   }
 
   @override
-  void replace(FilesSharingShare_Status other) {
+  void replace(covariant FilesSharingShare_Status other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShare_Status;
   }
@@ -7782,6 +8256,133 @@ class FilesSharingShare_StatusBuilder implements Builder<FilesSharingShare_Statu
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareInterfaceBuilder {
+  void replace(FilesSharingShareInterface other);
+  void update(void Function(FilesSharingShareInterfaceBuilder) updates);
+  String? get attributes;
+  set attributes(String? attributes);
+
+  bool? get canDelete;
+  set canDelete(bool? canDelete);
+
+  bool? get canEdit;
+  set canEdit(bool? canEdit);
+
+  String? get displaynameFileOwner;
+  set displaynameFileOwner(String? displaynameFileOwner);
+
+  String? get displaynameOwner;
+  set displaynameOwner(String? displaynameOwner);
+
+  String? get expiration;
+  set expiration(String? expiration);
+
+  int? get fileParent;
+  set fileParent(int? fileParent);
+
+  int? get fileSource;
+  set fileSource(int? fileSource);
+
+  String? get fileTarget;
+  set fileTarget(String? fileTarget);
+
+  bool? get hasPreview;
+  set hasPreview(bool? hasPreview);
+
+  int? get hideDownload;
+  set hideDownload(int? hideDownload);
+
+  String? get id;
+  set id(String? id);
+
+  int? get itemMtime;
+  set itemMtime(int? itemMtime);
+
+  int? get itemPermissions;
+  set itemPermissions(int? itemPermissions);
+
+  FilesSharingShare_ItemSizeBuilder get itemSize;
+  set itemSize(FilesSharingShare_ItemSizeBuilder? itemSize);
+
+  int? get itemSource;
+  set itemSource(int? itemSource);
+
+  FilesSharingShare_ItemType? get itemType;
+  set itemType(FilesSharingShare_ItemType? itemType);
+
+  String? get label;
+  set label(String? label);
+
+  int? get mailSend;
+  set mailSend(int? mailSend);
+
+  String? get mimetype;
+  set mimetype(String? mimetype);
+
+  String? get note;
+  set note(String? note);
+
+  JsonObject? get parent;
+  set parent(JsonObject? parent);
+
+  String? get password;
+  set password(String? password);
+
+  String? get passwordExpirationTime;
+  set passwordExpirationTime(String? passwordExpirationTime);
+
+  String? get path;
+  set path(String? path);
+
+  int? get permissions;
+  set permissions(int? permissions);
+
+  bool? get sendPasswordByTalk;
+  set sendPasswordByTalk(bool? sendPasswordByTalk);
+
+  int? get shareType;
+  set shareType(int? shareType);
+
+  String? get shareWith;
+  set shareWith(String? shareWith);
+
+  String? get shareWithAvatar;
+  set shareWithAvatar(String? shareWithAvatar);
+
+  String? get shareWithDisplayname;
+  set shareWithDisplayname(String? shareWithDisplayname);
+
+  String? get shareWithDisplaynameUnique;
+  set shareWithDisplaynameUnique(String? shareWithDisplaynameUnique);
+
+  String? get shareWithLink;
+  set shareWithLink(String? shareWithLink);
+
+  FilesSharingShare_StatusBuilder get status;
+  set status(FilesSharingShare_StatusBuilder? status);
+
+  int? get stime;
+  set stime(int? stime);
+
+  int? get storage;
+  set storage(int? storage);
+
+  String? get storageId;
+  set storageId(String? storageId);
+
+  String? get token;
+  set token(String? token);
+
+  String? get uidFileOwner;
+  set uidFileOwner(String? uidFileOwner);
+
+  String? get uidOwner;
+  set uidOwner(String? uidOwner);
+
+  String? get url;
+  set url(String? url);
 }
 
 class _$FilesSharingShare extends FilesSharingShare {
@@ -8090,173 +8691,177 @@ class _$FilesSharingShare extends FilesSharingShare {
   }
 }
 
-class FilesSharingShareBuilder implements Builder<FilesSharingShare, FilesSharingShareBuilder> {
+class FilesSharingShareBuilder
+    implements Builder<FilesSharingShare, FilesSharingShareBuilder>, FilesSharingShareInterfaceBuilder {
   _$FilesSharingShare? _$v;
 
   String? _attributes;
   String? get attributes => _$this._attributes;
-  set attributes(String? attributes) => _$this._attributes = attributes;
+  set attributes(covariant String? attributes) => _$this._attributes = attributes;
 
   bool? _canDelete;
   bool? get canDelete => _$this._canDelete;
-  set canDelete(bool? canDelete) => _$this._canDelete = canDelete;
+  set canDelete(covariant bool? canDelete) => _$this._canDelete = canDelete;
 
   bool? _canEdit;
   bool? get canEdit => _$this._canEdit;
-  set canEdit(bool? canEdit) => _$this._canEdit = canEdit;
+  set canEdit(covariant bool? canEdit) => _$this._canEdit = canEdit;
 
   String? _displaynameFileOwner;
   String? get displaynameFileOwner => _$this._displaynameFileOwner;
-  set displaynameFileOwner(String? displaynameFileOwner) => _$this._displaynameFileOwner = displaynameFileOwner;
+  set displaynameFileOwner(covariant String? displaynameFileOwner) =>
+      _$this._displaynameFileOwner = displaynameFileOwner;
 
   String? _displaynameOwner;
   String? get displaynameOwner => _$this._displaynameOwner;
-  set displaynameOwner(String? displaynameOwner) => _$this._displaynameOwner = displaynameOwner;
+  set displaynameOwner(covariant String? displaynameOwner) => _$this._displaynameOwner = displaynameOwner;
 
   String? _expiration;
   String? get expiration => _$this._expiration;
-  set expiration(String? expiration) => _$this._expiration = expiration;
+  set expiration(covariant String? expiration) => _$this._expiration = expiration;
 
   int? _fileParent;
   int? get fileParent => _$this._fileParent;
-  set fileParent(int? fileParent) => _$this._fileParent = fileParent;
+  set fileParent(covariant int? fileParent) => _$this._fileParent = fileParent;
 
   int? _fileSource;
   int? get fileSource => _$this._fileSource;
-  set fileSource(int? fileSource) => _$this._fileSource = fileSource;
+  set fileSource(covariant int? fileSource) => _$this._fileSource = fileSource;
 
   String? _fileTarget;
   String? get fileTarget => _$this._fileTarget;
-  set fileTarget(String? fileTarget) => _$this._fileTarget = fileTarget;
+  set fileTarget(covariant String? fileTarget) => _$this._fileTarget = fileTarget;
 
   bool? _hasPreview;
   bool? get hasPreview => _$this._hasPreview;
-  set hasPreview(bool? hasPreview) => _$this._hasPreview = hasPreview;
+  set hasPreview(covariant bool? hasPreview) => _$this._hasPreview = hasPreview;
 
   int? _hideDownload;
   int? get hideDownload => _$this._hideDownload;
-  set hideDownload(int? hideDownload) => _$this._hideDownload = hideDownload;
+  set hideDownload(covariant int? hideDownload) => _$this._hideDownload = hideDownload;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   int? _itemMtime;
   int? get itemMtime => _$this._itemMtime;
-  set itemMtime(int? itemMtime) => _$this._itemMtime = itemMtime;
+  set itemMtime(covariant int? itemMtime) => _$this._itemMtime = itemMtime;
 
   int? _itemPermissions;
   int? get itemPermissions => _$this._itemPermissions;
-  set itemPermissions(int? itemPermissions) => _$this._itemPermissions = itemPermissions;
+  set itemPermissions(covariant int? itemPermissions) => _$this._itemPermissions = itemPermissions;
 
   FilesSharingShare_ItemSizeBuilder? _itemSize;
   FilesSharingShare_ItemSizeBuilder get itemSize => _$this._itemSize ??= FilesSharingShare_ItemSizeBuilder();
-  set itemSize(FilesSharingShare_ItemSizeBuilder? itemSize) => _$this._itemSize = itemSize;
+  set itemSize(covariant FilesSharingShare_ItemSizeBuilder? itemSize) => _$this._itemSize = itemSize;
 
   int? _itemSource;
   int? get itemSource => _$this._itemSource;
-  set itemSource(int? itemSource) => _$this._itemSource = itemSource;
+  set itemSource(covariant int? itemSource) => _$this._itemSource = itemSource;
 
   FilesSharingShare_ItemType? _itemType;
   FilesSharingShare_ItemType? get itemType => _$this._itemType;
-  set itemType(FilesSharingShare_ItemType? itemType) => _$this._itemType = itemType;
+  set itemType(covariant FilesSharingShare_ItemType? itemType) => _$this._itemType = itemType;
 
   String? _label;
   String? get label => _$this._label;
-  set label(String? label) => _$this._label = label;
+  set label(covariant String? label) => _$this._label = label;
 
   int? _mailSend;
   int? get mailSend => _$this._mailSend;
-  set mailSend(int? mailSend) => _$this._mailSend = mailSend;
+  set mailSend(covariant int? mailSend) => _$this._mailSend = mailSend;
 
   String? _mimetype;
   String? get mimetype => _$this._mimetype;
-  set mimetype(String? mimetype) => _$this._mimetype = mimetype;
+  set mimetype(covariant String? mimetype) => _$this._mimetype = mimetype;
 
   String? _note;
   String? get note => _$this._note;
-  set note(String? note) => _$this._note = note;
+  set note(covariant String? note) => _$this._note = note;
 
   JsonObject? _parent;
   JsonObject? get parent => _$this._parent;
-  set parent(JsonObject? parent) => _$this._parent = parent;
+  set parent(covariant JsonObject? parent) => _$this._parent = parent;
 
   String? _password;
   String? get password => _$this._password;
-  set password(String? password) => _$this._password = password;
+  set password(covariant String? password) => _$this._password = password;
 
   String? _passwordExpirationTime;
   String? get passwordExpirationTime => _$this._passwordExpirationTime;
-  set passwordExpirationTime(String? passwordExpirationTime) => _$this._passwordExpirationTime = passwordExpirationTime;
+  set passwordExpirationTime(covariant String? passwordExpirationTime) =>
+      _$this._passwordExpirationTime = passwordExpirationTime;
 
   String? _path;
   String? get path => _$this._path;
-  set path(String? path) => _$this._path = path;
+  set path(covariant String? path) => _$this._path = path;
 
   int? _permissions;
   int? get permissions => _$this._permissions;
-  set permissions(int? permissions) => _$this._permissions = permissions;
+  set permissions(covariant int? permissions) => _$this._permissions = permissions;
 
   bool? _sendPasswordByTalk;
   bool? get sendPasswordByTalk => _$this._sendPasswordByTalk;
-  set sendPasswordByTalk(bool? sendPasswordByTalk) => _$this._sendPasswordByTalk = sendPasswordByTalk;
+  set sendPasswordByTalk(covariant bool? sendPasswordByTalk) => _$this._sendPasswordByTalk = sendPasswordByTalk;
 
   int? _shareType;
   int? get shareType => _$this._shareType;
-  set shareType(int? shareType) => _$this._shareType = shareType;
+  set shareType(covariant int? shareType) => _$this._shareType = shareType;
 
   String? _shareWith;
   String? get shareWith => _$this._shareWith;
-  set shareWith(String? shareWith) => _$this._shareWith = shareWith;
+  set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
   String? _shareWithAvatar;
   String? get shareWithAvatar => _$this._shareWithAvatar;
-  set shareWithAvatar(String? shareWithAvatar) => _$this._shareWithAvatar = shareWithAvatar;
+  set shareWithAvatar(covariant String? shareWithAvatar) => _$this._shareWithAvatar = shareWithAvatar;
 
   String? _shareWithDisplayname;
   String? get shareWithDisplayname => _$this._shareWithDisplayname;
-  set shareWithDisplayname(String? shareWithDisplayname) => _$this._shareWithDisplayname = shareWithDisplayname;
+  set shareWithDisplayname(covariant String? shareWithDisplayname) =>
+      _$this._shareWithDisplayname = shareWithDisplayname;
 
   String? _shareWithDisplaynameUnique;
   String? get shareWithDisplaynameUnique => _$this._shareWithDisplaynameUnique;
-  set shareWithDisplaynameUnique(String? shareWithDisplaynameUnique) =>
+  set shareWithDisplaynameUnique(covariant String? shareWithDisplaynameUnique) =>
       _$this._shareWithDisplaynameUnique = shareWithDisplaynameUnique;
 
   String? _shareWithLink;
   String? get shareWithLink => _$this._shareWithLink;
-  set shareWithLink(String? shareWithLink) => _$this._shareWithLink = shareWithLink;
+  set shareWithLink(covariant String? shareWithLink) => _$this._shareWithLink = shareWithLink;
 
   FilesSharingShare_StatusBuilder? _status;
   FilesSharingShare_StatusBuilder get status => _$this._status ??= FilesSharingShare_StatusBuilder();
-  set status(FilesSharingShare_StatusBuilder? status) => _$this._status = status;
+  set status(covariant FilesSharingShare_StatusBuilder? status) => _$this._status = status;
 
   int? _stime;
   int? get stime => _$this._stime;
-  set stime(int? stime) => _$this._stime = stime;
+  set stime(covariant int? stime) => _$this._stime = stime;
 
   int? _storage;
   int? get storage => _$this._storage;
-  set storage(int? storage) => _$this._storage = storage;
+  set storage(covariant int? storage) => _$this._storage = storage;
 
   String? _storageId;
   String? get storageId => _$this._storageId;
-  set storageId(String? storageId) => _$this._storageId = storageId;
+  set storageId(covariant String? storageId) => _$this._storageId = storageId;
 
   String? _token;
   String? get token => _$this._token;
-  set token(String? token) => _$this._token = token;
+  set token(covariant String? token) => _$this._token = token;
 
   String? _uidFileOwner;
   String? get uidFileOwner => _$this._uidFileOwner;
-  set uidFileOwner(String? uidFileOwner) => _$this._uidFileOwner = uidFileOwner;
+  set uidFileOwner(covariant String? uidFileOwner) => _$this._uidFileOwner = uidFileOwner;
 
   String? _uidOwner;
   String? get uidOwner => _$this._uidOwner;
-  set uidOwner(String? uidOwner) => _$this._uidOwner = uidOwner;
+  set uidOwner(covariant String? uidOwner) => _$this._uidOwner = uidOwner;
 
   String? _url;
   String? get url => _$this._url;
-  set url(String? url) => _$this._url = url;
+  set url(covariant String? url) => _$this._url = url;
 
   FilesSharingShareBuilder();
 
@@ -8310,7 +8915,7 @@ class FilesSharingShareBuilder implements Builder<FilesSharingShare, FilesSharin
   }
 
   @override
-  void replace(FilesSharingShare other) {
+  void replace(covariant FilesSharingShare other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShare;
   }
@@ -8389,6 +8994,16 @@ class FilesSharingShareBuilder implements Builder<FilesSharingShare, FilesSharin
   }
 }
 
+abstract mixin class FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  ListBuilder<FilesSharingShare> get data;
+  set data(ListBuilder<FilesSharingShare>? data);
+}
+
 class _$FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs
     extends FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs {
   @override
@@ -8444,16 +9059,17 @@ class _$FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs
 class FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs,
-            FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<FilesSharingShare>? _data;
   ListBuilder<FilesSharingShare> get data => _$this._data ??= ListBuilder<FilesSharingShare>();
-  set data(ListBuilder<FilesSharingShare>? data) => _$this._data = data;
+  set data(covariant ListBuilder<FilesSharingShare>? data) => _$this._data = data;
 
   FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder();
 
@@ -8468,7 +9084,7 @@ class FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiGetSharesResponse200ApplicationJson_Ocs;
   }
@@ -8502,6 +9118,13 @@ class FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiGetSharesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingShareapiGetSharesResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingShareapiGetSharesResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingShareapiGetSharesResponse200ApplicationJson
@@ -8550,13 +9173,14 @@ class _$FilesSharingShareapiGetSharesResponse200ApplicationJson
 class FilesSharingShareapiGetSharesResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingShareapiGetSharesResponse200ApplicationJson,
-            FilesSharingShareapiGetSharesResponse200ApplicationJsonBuilder> {
+            FilesSharingShareapiGetSharesResponse200ApplicationJsonBuilder>,
+        FilesSharingShareapiGetSharesResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingShareapiGetSharesResponse200ApplicationJson? _$v;
 
   FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingShareapiGetSharesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingShareapiGetSharesResponse200ApplicationJsonBuilder();
 
@@ -8570,7 +9194,7 @@ class FilesSharingShareapiGetSharesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiGetSharesResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingShareapiGetSharesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiGetSharesResponse200ApplicationJson;
   }
@@ -8601,6 +9225,16 @@ class FilesSharingShareapiGetSharesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  FilesSharingShareBuilder get data;
+  set data(FilesSharingShareBuilder? data);
 }
 
 class _$FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs
@@ -8660,16 +9294,17 @@ class _$FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs
 class FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs,
-            FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesSharingShareBuilder? _data;
   FilesSharingShareBuilder get data => _$this._data ??= FilesSharingShareBuilder();
-  set data(FilesSharingShareBuilder? data) => _$this._data = data;
+  set data(covariant FilesSharingShareBuilder? data) => _$this._data = data;
 
   FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder();
 
@@ -8684,7 +9319,7 @@ class FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiCreateShareResponse200ApplicationJson_Ocs;
   }
@@ -8718,6 +9353,13 @@ class FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiCreateShareResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingShareapiCreateShareResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingShareapiCreateShareResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingShareapiCreateShareResponse200ApplicationJson
@@ -8766,13 +9408,14 @@ class _$FilesSharingShareapiCreateShareResponse200ApplicationJson
 class FilesSharingShareapiCreateShareResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingShareapiCreateShareResponse200ApplicationJson,
-            FilesSharingShareapiCreateShareResponse200ApplicationJsonBuilder> {
+            FilesSharingShareapiCreateShareResponse200ApplicationJsonBuilder>,
+        FilesSharingShareapiCreateShareResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingShareapiCreateShareResponse200ApplicationJson? _$v;
 
   FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingShareapiCreateShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingShareapiCreateShareResponse200ApplicationJsonBuilder();
 
@@ -8786,7 +9429,7 @@ class FilesSharingShareapiCreateShareResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiCreateShareResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingShareapiCreateShareResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiCreateShareResponse200ApplicationJson;
   }
@@ -8817,6 +9460,17 @@ class FilesSharingShareapiCreateShareResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  ListBuilder<FilesSharingShare> get data;
+  set data(ListBuilder<FilesSharingShare>? data);
 }
 
 class _$FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs
@@ -8876,16 +9530,17 @@ class _$FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs
 class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs,
-            FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<FilesSharingShare>? _data;
   ListBuilder<FilesSharingShare> get data => _$this._data ??= ListBuilder<FilesSharingShare>();
-  set data(ListBuilder<FilesSharingShare>? data) => _$this._data = data;
+  set data(covariant ListBuilder<FilesSharingShare>? data) => _$this._data = data;
 
   FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder();
 
@@ -8900,7 +9555,7 @@ class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilde
   }
 
   @override
-  void replace(FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_Ocs;
   }
@@ -8935,6 +9590,13 @@ class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson
@@ -8985,13 +9647,15 @@ class _$FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson
 class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson,
-            FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonBuilder> {
+            FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonBuilder>,
+        FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson? _$v;
 
   FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonBuilder();
 
@@ -9005,7 +9669,7 @@ class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiGetInheritedSharesResponse200ApplicationJson;
   }
@@ -9036,6 +9700,16 @@ class FilesSharingShareapiGetInheritedSharesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  ListBuilder<FilesSharingShare> get data;
+  set data(ListBuilder<FilesSharingShare>? data);
 }
 
 class _$FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs
@@ -9095,16 +9769,17 @@ class _$FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs
 class FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs,
-            FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<FilesSharingShare>? _data;
   ListBuilder<FilesSharingShare> get data => _$this._data ??= ListBuilder<FilesSharingShare>();
-  set data(ListBuilder<FilesSharingShare>? data) => _$this._data = data;
+  set data(covariant ListBuilder<FilesSharingShare>? data) => _$this._data = data;
 
   FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder();
 
@@ -9119,7 +9794,7 @@ class FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiPendingSharesResponse200ApplicationJson_Ocs;
   }
@@ -9153,6 +9828,13 @@ class FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiPendingSharesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingShareapiPendingSharesResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingShareapiPendingSharesResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingShareapiPendingSharesResponse200ApplicationJson
@@ -9202,13 +9884,14 @@ class _$FilesSharingShareapiPendingSharesResponse200ApplicationJson
 class FilesSharingShareapiPendingSharesResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingShareapiPendingSharesResponse200ApplicationJson,
-            FilesSharingShareapiPendingSharesResponse200ApplicationJsonBuilder> {
+            FilesSharingShareapiPendingSharesResponse200ApplicationJsonBuilder>,
+        FilesSharingShareapiPendingSharesResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingShareapiPendingSharesResponse200ApplicationJson? _$v;
 
   FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingShareapiPendingSharesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingShareapiPendingSharesResponse200ApplicationJsonBuilder();
 
@@ -9222,7 +9905,7 @@ class FilesSharingShareapiPendingSharesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiPendingSharesResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingShareapiPendingSharesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiPendingSharesResponse200ApplicationJson;
   }
@@ -9253,6 +9936,16 @@ class FilesSharingShareapiPendingSharesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiGetShareResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingShareapiGetShareResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingShareapiGetShareResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  FilesSharingShareBuilder get data;
+  set data(FilesSharingShareBuilder? data);
 }
 
 class _$FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs
@@ -9309,16 +10002,17 @@ class _$FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs
 class FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs,
-            FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingShareapiGetShareResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesSharingShareBuilder? _data;
   FilesSharingShareBuilder get data => _$this._data ??= FilesSharingShareBuilder();
-  set data(FilesSharingShareBuilder? data) => _$this._data = data;
+  set data(covariant FilesSharingShareBuilder? data) => _$this._data = data;
 
   FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder();
 
@@ -9333,7 +10027,7 @@ class FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiGetShareResponse200ApplicationJson_Ocs;
   }
@@ -9367,6 +10061,13 @@ class FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiGetShareResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingShareapiGetShareResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingShareapiGetShareResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingShareapiGetShareResponse200ApplicationJson
@@ -9415,13 +10116,14 @@ class _$FilesSharingShareapiGetShareResponse200ApplicationJson
 class FilesSharingShareapiGetShareResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingShareapiGetShareResponse200ApplicationJson,
-            FilesSharingShareapiGetShareResponse200ApplicationJsonBuilder> {
+            FilesSharingShareapiGetShareResponse200ApplicationJsonBuilder>,
+        FilesSharingShareapiGetShareResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingShareapiGetShareResponse200ApplicationJson? _$v;
 
   FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingShareapiGetShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingShareapiGetShareResponse200ApplicationJsonBuilder();
 
@@ -9435,7 +10137,7 @@ class FilesSharingShareapiGetShareResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiGetShareResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingShareapiGetShareResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiGetShareResponse200ApplicationJson;
   }
@@ -9466,6 +10168,16 @@ class FilesSharingShareapiGetShareResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  FilesSharingShareBuilder get data;
+  set data(FilesSharingShareBuilder? data);
 }
 
 class _$FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs
@@ -9525,16 +10237,17 @@ class _$FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs
 class FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs,
-            FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesSharingShareBuilder? _data;
   FilesSharingShareBuilder get data => _$this._data ??= FilesSharingShareBuilder();
-  set data(FilesSharingShareBuilder? data) => _$this._data = data;
+  set data(covariant FilesSharingShareBuilder? data) => _$this._data = data;
 
   FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder();
 
@@ -9549,7 +10262,7 @@ class FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiUpdateShareResponse200ApplicationJson_Ocs;
   }
@@ -9583,6 +10296,13 @@ class FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiUpdateShareResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingShareapiUpdateShareResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingShareapiUpdateShareResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingShareapiUpdateShareResponse200ApplicationJson
@@ -9631,13 +10351,14 @@ class _$FilesSharingShareapiUpdateShareResponse200ApplicationJson
 class FilesSharingShareapiUpdateShareResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingShareapiUpdateShareResponse200ApplicationJson,
-            FilesSharingShareapiUpdateShareResponse200ApplicationJsonBuilder> {
+            FilesSharingShareapiUpdateShareResponse200ApplicationJsonBuilder>,
+        FilesSharingShareapiUpdateShareResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingShareapiUpdateShareResponse200ApplicationJson? _$v;
 
   FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingShareapiUpdateShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingShareapiUpdateShareResponse200ApplicationJsonBuilder();
 
@@ -9651,7 +10372,7 @@ class FilesSharingShareapiUpdateShareResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiUpdateShareResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingShareapiUpdateShareResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiUpdateShareResponse200ApplicationJson;
   }
@@ -9682,6 +10403,16 @@ class FilesSharingShareapiUpdateShareResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs
@@ -9741,16 +10472,17 @@ class _$FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs
 class FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs,
-            FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder();
 
@@ -9765,7 +10497,7 @@ class FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiDeleteShareResponse200ApplicationJson_Ocs;
   }
@@ -9800,6 +10532,13 @@ class FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiDeleteShareResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingShareapiDeleteShareResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingShareapiDeleteShareResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingShareapiDeleteShareResponse200ApplicationJson
@@ -9848,13 +10587,14 @@ class _$FilesSharingShareapiDeleteShareResponse200ApplicationJson
 class FilesSharingShareapiDeleteShareResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingShareapiDeleteShareResponse200ApplicationJson,
-            FilesSharingShareapiDeleteShareResponse200ApplicationJsonBuilder> {
+            FilesSharingShareapiDeleteShareResponse200ApplicationJsonBuilder>,
+        FilesSharingShareapiDeleteShareResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingShareapiDeleteShareResponse200ApplicationJson? _$v;
 
   FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingShareapiDeleteShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingShareapiDeleteShareResponse200ApplicationJsonBuilder();
 
@@ -9868,7 +10608,7 @@ class FilesSharingShareapiDeleteShareResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiDeleteShareResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingShareapiDeleteShareResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiDeleteShareResponse200ApplicationJson;
   }
@@ -9899,6 +10639,16 @@ class FilesSharingShareapiDeleteShareResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs
@@ -9958,16 +10708,17 @@ class _$FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs
 class FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs,
-            FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder();
 
@@ -9982,7 +10733,7 @@ class FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiAcceptShareResponse200ApplicationJson_Ocs;
   }
@@ -10017,6 +10768,13 @@ class FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareapiAcceptShareResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingShareapiAcceptShareResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingShareapiAcceptShareResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingShareapiAcceptShareResponse200ApplicationJson
@@ -10065,13 +10823,14 @@ class _$FilesSharingShareapiAcceptShareResponse200ApplicationJson
 class FilesSharingShareapiAcceptShareResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingShareapiAcceptShareResponse200ApplicationJson,
-            FilesSharingShareapiAcceptShareResponse200ApplicationJsonBuilder> {
+            FilesSharingShareapiAcceptShareResponse200ApplicationJsonBuilder>,
+        FilesSharingShareapiAcceptShareResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingShareapiAcceptShareResponse200ApplicationJson? _$v;
 
   FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingShareapiAcceptShareResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingShareapiAcceptShareResponse200ApplicationJsonBuilder();
 
@@ -10085,7 +10844,7 @@ class FilesSharingShareapiAcceptShareResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingShareapiAcceptShareResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingShareapiAcceptShareResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareapiAcceptShareResponse200ApplicationJson;
   }
@@ -10237,6 +10996,13 @@ class FilesSharingShareesapiSearchShareTypeBuilder
   }
 }
 
+abstract mixin class FilesSharingShareesapiShareesapiSearchHeadersInterfaceBuilder {
+  void replace(FilesSharingShareesapiShareesapiSearchHeadersInterface other);
+  void update(void Function(FilesSharingShareesapiShareesapiSearchHeadersInterfaceBuilder) updates);
+  String? get link;
+  set link(String? link);
+}
+
 class _$FilesSharingShareesapiShareesapiSearchHeaders extends FilesSharingShareesapiShareesapiSearchHeaders {
   @override
   final String? link;
@@ -10279,12 +11045,13 @@ class _$FilesSharingShareesapiShareesapiSearchHeaders extends FilesSharingSharee
 
 class FilesSharingShareesapiShareesapiSearchHeadersBuilder
     implements
-        Builder<FilesSharingShareesapiShareesapiSearchHeaders, FilesSharingShareesapiShareesapiSearchHeadersBuilder> {
+        Builder<FilesSharingShareesapiShareesapiSearchHeaders, FilesSharingShareesapiShareesapiSearchHeadersBuilder>,
+        FilesSharingShareesapiShareesapiSearchHeadersInterfaceBuilder {
   _$FilesSharingShareesapiShareesapiSearchHeaders? _$v;
 
   String? _link;
   String? get link => _$this._link;
-  set link(String? link) => _$this._link = link;
+  set link(covariant String? link) => _$this._link = link;
 
   FilesSharingShareesapiShareesapiSearchHeadersBuilder();
 
@@ -10298,7 +11065,7 @@ class FilesSharingShareesapiShareesapiSearchHeadersBuilder
   }
 
   @override
-  void replace(FilesSharingShareesapiShareesapiSearchHeaders other) {
+  void replace(covariant FilesSharingShareesapiShareesapiSearchHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareesapiShareesapiSearchHeaders;
   }
@@ -10316,6 +11083,16 @@ class FilesSharingShareesapiShareesapiSearchHeadersBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareeInterfaceBuilder {
+  void replace(FilesSharingShareeInterface other);
+  void update(void Function(FilesSharingShareeInterfaceBuilder) updates);
+  int? get count;
+  set count(int? count);
+
+  String? get label;
+  set label(String? label);
 }
 
 class _$FilesSharingSharee extends FilesSharingSharee {
@@ -10362,16 +11139,17 @@ class _$FilesSharingSharee extends FilesSharingSharee {
   }
 }
 
-class FilesSharingShareeBuilder implements Builder<FilesSharingSharee, FilesSharingShareeBuilder> {
+class FilesSharingShareeBuilder
+    implements Builder<FilesSharingSharee, FilesSharingShareeBuilder>, FilesSharingShareeInterfaceBuilder {
   _$FilesSharingSharee? _$v;
 
   int? _count;
   int? get count => _$this._count;
-  set count(int? count) => _$this._count = count;
+  set count(covariant int? count) => _$this._count = count;
 
   String? _label;
   String? get label => _$this._label;
-  set label(String? label) => _$this._label = label;
+  set label(covariant String? label) => _$this._label = label;
 
   FilesSharingShareeBuilder();
 
@@ -10386,7 +11164,7 @@ class FilesSharingShareeBuilder implements Builder<FilesSharingSharee, FilesShar
   }
 
   @override
-  void replace(FilesSharingSharee other) {
+  void replace(covariant FilesSharingSharee other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingSharee;
   }
@@ -10406,6 +11184,16 @@ class FilesSharingShareeBuilder implements Builder<FilesSharingSharee, FilesShar
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareeValueInterfaceBuilder {
+  void replace(FilesSharingShareeValueInterface other);
+  void update(void Function(FilesSharingShareeValueInterfaceBuilder) updates);
+  int? get shareType;
+  set shareType(int? shareType);
+
+  String? get shareWith;
+  set shareWith(String? shareWith);
 }
 
 class _$FilesSharingShareeValue extends FilesSharingShareeValue {
@@ -10453,16 +11241,19 @@ class _$FilesSharingShareeValue extends FilesSharingShareeValue {
   }
 }
 
-class FilesSharingShareeValueBuilder implements Builder<FilesSharingShareeValue, FilesSharingShareeValueBuilder> {
+class FilesSharingShareeValueBuilder
+    implements
+        Builder<FilesSharingShareeValue, FilesSharingShareeValueBuilder>,
+        FilesSharingShareeValueInterfaceBuilder {
   _$FilesSharingShareeValue? _$v;
 
   int? _shareType;
   int? get shareType => _$this._shareType;
-  set shareType(int? shareType) => _$this._shareType = shareType;
+  set shareType(covariant int? shareType) => _$this._shareType = shareType;
 
   String? _shareWith;
   String? get shareWith => _$this._shareWith;
-  set shareWith(String? shareWith) => _$this._shareWith = shareWith;
+  set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
   FilesSharingShareeValueBuilder();
 
@@ -10477,7 +11268,7 @@ class FilesSharingShareeValueBuilder implements Builder<FilesSharingShareeValue,
   }
 
   @override
-  void replace(FilesSharingShareeValue other) {
+  void replace(covariant FilesSharingShareeValue other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareeValue;
   }
@@ -10500,33 +11291,52 @@ class FilesSharingShareeValueBuilder implements Builder<FilesSharingShareeValue,
   }
 }
 
-class _$FilesSharingShareeCircle1_Value1 extends FilesSharingShareeCircle1_Value1 {
+abstract mixin class FilesSharingShareeCircle_1_Value_1InterfaceBuilder {
+  void replace(FilesSharingShareeCircle_1_Value_1Interface other);
+  void update(void Function(FilesSharingShareeCircle_1_Value_1InterfaceBuilder) updates);
+  String? get circle;
+  set circle(String? circle);
+}
+
+class _$FilesSharingShareeCircle_1_Value extends FilesSharingShareeCircle_1_Value {
+  @override
+  final int shareType;
+  @override
+  final String shareWith;
   @override
   final String circle;
 
-  factory _$FilesSharingShareeCircle1_Value1([void Function(FilesSharingShareeCircle1_Value1Builder)? updates]) =>
-      (FilesSharingShareeCircle1_Value1Builder()..update(updates))._build();
+  factory _$FilesSharingShareeCircle_1_Value([void Function(FilesSharingShareeCircle_1_ValueBuilder)? updates]) =>
+      (FilesSharingShareeCircle_1_ValueBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeCircle1_Value1._({required this.circle}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(circle, r'FilesSharingShareeCircle1_Value1', 'circle');
+  _$FilesSharingShareeCircle_1_Value._({required this.shareType, required this.shareWith, required this.circle})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(shareType, r'FilesSharingShareeCircle_1_Value', 'shareType');
+    BuiltValueNullFieldError.checkNotNull(shareWith, r'FilesSharingShareeCircle_1_Value', 'shareWith');
+    BuiltValueNullFieldError.checkNotNull(circle, r'FilesSharingShareeCircle_1_Value', 'circle');
   }
 
   @override
-  FilesSharingShareeCircle1_Value1 rebuild(void Function(FilesSharingShareeCircle1_Value1Builder) updates) =>
+  FilesSharingShareeCircle_1_Value rebuild(void Function(FilesSharingShareeCircle_1_ValueBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  FilesSharingShareeCircle1_Value1Builder toBuilder() => FilesSharingShareeCircle1_Value1Builder()..replace(this);
+  FilesSharingShareeCircle_1_ValueBuilder toBuilder() => FilesSharingShareeCircle_1_ValueBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is FilesSharingShareeCircle1_Value1 && circle == other.circle;
+    return other is FilesSharingShareeCircle_1_Value &&
+        shareType == other.shareType &&
+        shareWith == other.shareWith &&
+        circle == other.circle;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, shareType.hashCode);
+    _$hash = $jc(_$hash, shareWith.hashCode);
     _$hash = $jc(_$hash, circle.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
@@ -10534,23 +11344,40 @@ class _$FilesSharingShareeCircle1_Value1 extends FilesSharingShareeCircle1_Value
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeCircle1_Value1')..add('circle', circle)).toString();
+    return (newBuiltValueToStringHelper(r'FilesSharingShareeCircle_1_Value')
+          ..add('shareType', shareType)
+          ..add('shareWith', shareWith)
+          ..add('circle', circle))
+        .toString();
   }
 }
 
-class FilesSharingShareeCircle1_Value1Builder
-    implements Builder<FilesSharingShareeCircle1_Value1, FilesSharingShareeCircle1_Value1Builder> {
-  _$FilesSharingShareeCircle1_Value1? _$v;
+class FilesSharingShareeCircle_1_ValueBuilder
+    implements
+        Builder<FilesSharingShareeCircle_1_Value, FilesSharingShareeCircle_1_ValueBuilder>,
+        FilesSharingShareeValueInterfaceBuilder,
+        FilesSharingShareeCircle_1_Value_1InterfaceBuilder {
+  _$FilesSharingShareeCircle_1_Value? _$v;
+
+  int? _shareType;
+  int? get shareType => _$this._shareType;
+  set shareType(covariant int? shareType) => _$this._shareType = shareType;
+
+  String? _shareWith;
+  String? get shareWith => _$this._shareWith;
+  set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
   String? _circle;
   String? get circle => _$this._circle;
-  set circle(String? circle) => _$this._circle = circle;
+  set circle(covariant String? circle) => _$this._circle = circle;
 
-  FilesSharingShareeCircle1_Value1Builder();
+  FilesSharingShareeCircle_1_ValueBuilder();
 
-  FilesSharingShareeCircle1_Value1Builder get _$this {
+  FilesSharingShareeCircle_1_ValueBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _shareType = $v.shareType;
+      _shareWith = $v.shareWith;
       _circle = $v.circle;
       _$v = null;
     }
@@ -10558,276 +11385,62 @@ class FilesSharingShareeCircle1_Value1Builder
   }
 
   @override
-  void replace(FilesSharingShareeCircle1_Value1 other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant FilesSharingShareeCircle_1_Value other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeCircle1_Value1;
+    _$v = other as _$FilesSharingShareeCircle_1_Value;
   }
 
   @override
-  void update(void Function(FilesSharingShareeCircle1_Value1Builder)? updates) {
+  void update(void Function(FilesSharingShareeCircle_1_ValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  FilesSharingShareeCircle1_Value1 build() => _build();
+  FilesSharingShareeCircle_1_Value build() => _build();
 
-  _$FilesSharingShareeCircle1_Value1 _build() {
+  _$FilesSharingShareeCircle_1_Value _build() {
     final _$result = _$v ??
-        _$FilesSharingShareeCircle1_Value1._(
-            circle: BuiltValueNullFieldError.checkNotNull(circle, r'FilesSharingShareeCircle1_Value1', 'circle'));
+        _$FilesSharingShareeCircle_1_Value._(
+            shareType:
+                BuiltValueNullFieldError.checkNotNull(shareType, r'FilesSharingShareeCircle_1_Value', 'shareType'),
+            shareWith:
+                BuiltValueNullFieldError.checkNotNull(shareWith, r'FilesSharingShareeCircle_1_Value', 'shareWith'),
+            circle: BuiltValueNullFieldError.checkNotNull(circle, r'FilesSharingShareeCircle_1_Value', 'circle'));
     replace(_$result);
     return _$result;
   }
 }
 
-class _$FilesSharingShareeCircle1_Value extends FilesSharingShareeCircle1_Value {
-  @override
-  final JsonObject data;
-  @override
-  final FilesSharingShareeValue shareeValue;
-  @override
-  final FilesSharingShareeCircle1_Value1 shareeCircle1Value1;
+abstract mixin class FilesSharingShareeCircle_1InterfaceBuilder {
+  void replace(FilesSharingShareeCircle_1Interface other);
+  void update(void Function(FilesSharingShareeCircle_1InterfaceBuilder) updates);
+  String? get shareWithDescription;
+  set shareWithDescription(String? shareWithDescription);
 
-  factory _$FilesSharingShareeCircle1_Value([void Function(FilesSharingShareeCircle1_ValueBuilder)? updates]) =>
-      (FilesSharingShareeCircle1_ValueBuilder()..update(updates))._build();
-
-  _$FilesSharingShareeCircle1_Value._(
-      {required this.data, required this.shareeValue, required this.shareeCircle1Value1})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeCircle1_Value', 'data');
-    BuiltValueNullFieldError.checkNotNull(shareeValue, r'FilesSharingShareeCircle1_Value', 'shareeValue');
-    BuiltValueNullFieldError.checkNotNull(
-        shareeCircle1Value1, r'FilesSharingShareeCircle1_Value', 'shareeCircle1Value1');
-  }
-
-  @override
-  FilesSharingShareeCircle1_Value rebuild(void Function(FilesSharingShareeCircle1_ValueBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  FilesSharingShareeCircle1_ValueBuilder toBuilder() => FilesSharingShareeCircle1_ValueBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is FilesSharingShareeCircle1_Value &&
-        data == other.data &&
-        shareeValue == other.shareeValue &&
-        shareeCircle1Value1 == other.shareeCircle1Value1;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, shareeValue.hashCode);
-    _$hash = $jc(_$hash, shareeCircle1Value1.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeCircle1_Value')
-          ..add('data', data)
-          ..add('shareeValue', shareeValue)
-          ..add('shareeCircle1Value1', shareeCircle1Value1))
-        .toString();
-  }
-}
-
-class FilesSharingShareeCircle1_ValueBuilder
-    implements Builder<FilesSharingShareeCircle1_Value, FilesSharingShareeCircle1_ValueBuilder> {
-  _$FilesSharingShareeCircle1_Value? _$v;
-
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
-
-  FilesSharingShareeValueBuilder? _shareeValue;
-  FilesSharingShareeValueBuilder get shareeValue => _$this._shareeValue ??= FilesSharingShareeValueBuilder();
-  set shareeValue(FilesSharingShareeValueBuilder? shareeValue) => _$this._shareeValue = shareeValue;
-
-  FilesSharingShareeCircle1_Value1Builder? _shareeCircle1Value1;
-  FilesSharingShareeCircle1_Value1Builder get shareeCircle1Value1 =>
-      _$this._shareeCircle1Value1 ??= FilesSharingShareeCircle1_Value1Builder();
-  set shareeCircle1Value1(FilesSharingShareeCircle1_Value1Builder? shareeCircle1Value1) =>
-      _$this._shareeCircle1Value1 = shareeCircle1Value1;
-
-  FilesSharingShareeCircle1_ValueBuilder();
-
-  FilesSharingShareeCircle1_ValueBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _data = $v.data;
-      _shareeValue = $v.shareeValue.toBuilder();
-      _shareeCircle1Value1 = $v.shareeCircle1Value1.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(FilesSharingShareeCircle1_Value other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeCircle1_Value;
-  }
-
-  @override
-  void update(void Function(FilesSharingShareeCircle1_ValueBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  FilesSharingShareeCircle1_Value build() => _build();
-
-  _$FilesSharingShareeCircle1_Value _build() {
-    _$FilesSharingShareeCircle1_Value _$result;
-    try {
-      _$result = _$v ??
-          _$FilesSharingShareeCircle1_Value._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeCircle1_Value', 'data'),
-              shareeValue: shareeValue.build(),
-              shareeCircle1Value1: shareeCircle1Value1.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'shareeValue';
-        shareeValue.build();
-        _$failedField = 'shareeCircle1Value1';
-        shareeCircle1Value1.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeCircle1_Value', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
-class _$FilesSharingShareeCircle1 extends FilesSharingShareeCircle1 {
-  @override
-  final String shareWithDescription;
-  @override
-  final FilesSharingShareeCircle1_Value value;
-
-  factory _$FilesSharingShareeCircle1([void Function(FilesSharingShareeCircle1Builder)? updates]) =>
-      (FilesSharingShareeCircle1Builder()..update(updates))._build();
-
-  _$FilesSharingShareeCircle1._({required this.shareWithDescription, required this.value}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(shareWithDescription, r'FilesSharingShareeCircle1', 'shareWithDescription');
-    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeCircle1', 'value');
-  }
-
-  @override
-  FilesSharingShareeCircle1 rebuild(void Function(FilesSharingShareeCircle1Builder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  FilesSharingShareeCircle1Builder toBuilder() => FilesSharingShareeCircle1Builder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is FilesSharingShareeCircle1 &&
-        shareWithDescription == other.shareWithDescription &&
-        value == other.value;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, shareWithDescription.hashCode);
-    _$hash = $jc(_$hash, value.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeCircle1')
-          ..add('shareWithDescription', shareWithDescription)
-          ..add('value', value))
-        .toString();
-  }
-}
-
-class FilesSharingShareeCircle1Builder implements Builder<FilesSharingShareeCircle1, FilesSharingShareeCircle1Builder> {
-  _$FilesSharingShareeCircle1? _$v;
-
-  String? _shareWithDescription;
-  String? get shareWithDescription => _$this._shareWithDescription;
-  set shareWithDescription(String? shareWithDescription) => _$this._shareWithDescription = shareWithDescription;
-
-  FilesSharingShareeCircle1_ValueBuilder? _value;
-  FilesSharingShareeCircle1_ValueBuilder get value => _$this._value ??= FilesSharingShareeCircle1_ValueBuilder();
-  set value(FilesSharingShareeCircle1_ValueBuilder? value) => _$this._value = value;
-
-  FilesSharingShareeCircle1Builder();
-
-  FilesSharingShareeCircle1Builder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _shareWithDescription = $v.shareWithDescription;
-      _value = $v.value.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(FilesSharingShareeCircle1 other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeCircle1;
-  }
-
-  @override
-  void update(void Function(FilesSharingShareeCircle1Builder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  FilesSharingShareeCircle1 build() => _build();
-
-  _$FilesSharingShareeCircle1 _build() {
-    _$FilesSharingShareeCircle1 _$result;
-    try {
-      _$result = _$v ??
-          _$FilesSharingShareeCircle1._(
-              shareWithDescription: BuiltValueNullFieldError.checkNotNull(
-                  shareWithDescription, r'FilesSharingShareeCircle1', 'shareWithDescription'),
-              value: value.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'value';
-        value.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeCircle1', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
+  FilesSharingShareeCircle_1_ValueBuilder get value;
+  set value(FilesSharingShareeCircle_1_ValueBuilder? value);
 }
 
 class _$FilesSharingShareeCircle extends FilesSharingShareeCircle {
   @override
-  final JsonObject data;
+  final int? count;
   @override
-  final FilesSharingSharee sharee;
+  final String label;
   @override
-  final FilesSharingShareeCircle1 shareeCircle1;
+  final String shareWithDescription;
+  @override
+  final FilesSharingShareeCircle_1_Value value;
 
   factory _$FilesSharingShareeCircle([void Function(FilesSharingShareeCircleBuilder)? updates]) =>
       (FilesSharingShareeCircleBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeCircle._({required this.data, required this.sharee, required this.shareeCircle1}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeCircle', 'data');
-    BuiltValueNullFieldError.checkNotNull(sharee, r'FilesSharingShareeCircle', 'sharee');
-    BuiltValueNullFieldError.checkNotNull(shareeCircle1, r'FilesSharingShareeCircle', 'shareeCircle1');
+  _$FilesSharingShareeCircle._(
+      {this.count, required this.label, required this.shareWithDescription, required this.value})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeCircle', 'label');
+    BuiltValueNullFieldError.checkNotNull(shareWithDescription, r'FilesSharingShareeCircle', 'shareWithDescription');
+    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeCircle', 'value');
   }
 
   @override
@@ -10841,17 +11454,19 @@ class _$FilesSharingShareeCircle extends FilesSharingShareeCircle {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is FilesSharingShareeCircle &&
-        data == other.data &&
-        sharee == other.sharee &&
-        shareeCircle1 == other.shareeCircle1;
+        count == other.count &&
+        label == other.label &&
+        shareWithDescription == other.shareWithDescription &&
+        value == other.value;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, sharee.hashCode);
-    _$hash = $jc(_$hash, shareeCircle1.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
+    _$hash = $jc(_$hash, shareWithDescription.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -10859,43 +11474,55 @@ class _$FilesSharingShareeCircle extends FilesSharingShareeCircle {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'FilesSharingShareeCircle')
-          ..add('data', data)
-          ..add('sharee', sharee)
-          ..add('shareeCircle1', shareeCircle1))
+          ..add('count', count)
+          ..add('label', label)
+          ..add('shareWithDescription', shareWithDescription)
+          ..add('value', value))
         .toString();
   }
 }
 
-class FilesSharingShareeCircleBuilder implements Builder<FilesSharingShareeCircle, FilesSharingShareeCircleBuilder> {
+class FilesSharingShareeCircleBuilder
+    implements
+        Builder<FilesSharingShareeCircle, FilesSharingShareeCircleBuilder>,
+        FilesSharingShareeInterfaceBuilder,
+        FilesSharingShareeCircle_1InterfaceBuilder {
   _$FilesSharingShareeCircle? _$v;
 
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  int? _count;
+  int? get count => _$this._count;
+  set count(covariant int? count) => _$this._count = count;
 
-  FilesSharingShareeBuilder? _sharee;
-  FilesSharingShareeBuilder get sharee => _$this._sharee ??= FilesSharingShareeBuilder();
-  set sharee(FilesSharingShareeBuilder? sharee) => _$this._sharee = sharee;
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
 
-  FilesSharingShareeCircle1Builder? _shareeCircle1;
-  FilesSharingShareeCircle1Builder get shareeCircle1 => _$this._shareeCircle1 ??= FilesSharingShareeCircle1Builder();
-  set shareeCircle1(FilesSharingShareeCircle1Builder? shareeCircle1) => _$this._shareeCircle1 = shareeCircle1;
+  String? _shareWithDescription;
+  String? get shareWithDescription => _$this._shareWithDescription;
+  set shareWithDescription(covariant String? shareWithDescription) =>
+      _$this._shareWithDescription = shareWithDescription;
+
+  FilesSharingShareeCircle_1_ValueBuilder? _value;
+  FilesSharingShareeCircle_1_ValueBuilder get value => _$this._value ??= FilesSharingShareeCircle_1_ValueBuilder();
+  set value(covariant FilesSharingShareeCircle_1_ValueBuilder? value) => _$this._value = value;
 
   FilesSharingShareeCircleBuilder();
 
   FilesSharingShareeCircleBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _data = $v.data;
-      _sharee = $v.sharee.toBuilder();
-      _shareeCircle1 = $v.shareeCircle1.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
+      _shareWithDescription = $v.shareWithDescription;
+      _value = $v.value.toBuilder();
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(FilesSharingShareeCircle other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant FilesSharingShareeCircle other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareeCircle;
   }
@@ -10913,16 +11540,16 @@ class FilesSharingShareeCircleBuilder implements Builder<FilesSharingShareeCircl
     try {
       _$result = _$v ??
           _$FilesSharingShareeCircle._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeCircle', 'data'),
-              sharee: sharee.build(),
-              shareeCircle1: shareeCircle1.build());
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeCircle', 'label'),
+              shareWithDescription: BuiltValueNullFieldError.checkNotNull(
+                  shareWithDescription, r'FilesSharingShareeCircle', 'shareWithDescription'),
+              value: value.build());
     } catch (_) {
       late String _$failedField;
       try {
-        _$failedField = 'sharee';
-        sharee.build();
-        _$failedField = 'shareeCircle1';
-        shareeCircle1.build();
+        _$failedField = 'value';
+        value.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'FilesSharingShareeCircle', _$failedField, e.toString());
       }
@@ -10933,7 +11560,30 @@ class FilesSharingShareeCircleBuilder implements Builder<FilesSharingShareeCircl
   }
 }
 
-class _$FilesSharingShareeEmail1 extends FilesSharingShareeEmail1 {
+abstract mixin class FilesSharingShareeEmail_1InterfaceBuilder {
+  void replace(FilesSharingShareeEmail_1Interface other);
+  void update(void Function(FilesSharingShareeEmail_1InterfaceBuilder) updates);
+  String? get uuid;
+  set uuid(String? uuid);
+
+  String? get name;
+  set name(String? name);
+
+  String? get type;
+  set type(String? type);
+
+  String? get shareWithDisplayNameUnique;
+  set shareWithDisplayNameUnique(String? shareWithDisplayNameUnique);
+
+  FilesSharingShareeValueBuilder get value;
+  set value(FilesSharingShareeValueBuilder? value);
+}
+
+class _$FilesSharingShareeEmail extends FilesSharingShareeEmail {
+  @override
+  final int? count;
+  @override
+  final String label;
   @override
   final String uuid;
   @override
@@ -10945,160 +11595,25 @@ class _$FilesSharingShareeEmail1 extends FilesSharingShareeEmail1 {
   @override
   final FilesSharingShareeValue value;
 
-  factory _$FilesSharingShareeEmail1([void Function(FilesSharingShareeEmail1Builder)? updates]) =>
-      (FilesSharingShareeEmail1Builder()..update(updates))._build();
+  factory _$FilesSharingShareeEmail([void Function(FilesSharingShareeEmailBuilder)? updates]) =>
+      (FilesSharingShareeEmailBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeEmail1._(
-      {required this.uuid,
+  _$FilesSharingShareeEmail._(
+      {this.count,
+      required this.label,
+      required this.uuid,
       required this.name,
       required this.type,
       required this.shareWithDisplayNameUnique,
       required this.value})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(uuid, r'FilesSharingShareeEmail1', 'uuid');
-    BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeEmail1', 'name');
-    BuiltValueNullFieldError.checkNotNull(type, r'FilesSharingShareeEmail1', 'type');
+    BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeEmail', 'label');
+    BuiltValueNullFieldError.checkNotNull(uuid, r'FilesSharingShareeEmail', 'uuid');
+    BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeEmail', 'name');
+    BuiltValueNullFieldError.checkNotNull(type, r'FilesSharingShareeEmail', 'type');
     BuiltValueNullFieldError.checkNotNull(
-        shareWithDisplayNameUnique, r'FilesSharingShareeEmail1', 'shareWithDisplayNameUnique');
-    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeEmail1', 'value');
-  }
-
-  @override
-  FilesSharingShareeEmail1 rebuild(void Function(FilesSharingShareeEmail1Builder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  FilesSharingShareeEmail1Builder toBuilder() => FilesSharingShareeEmail1Builder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is FilesSharingShareeEmail1 &&
-        uuid == other.uuid &&
-        name == other.name &&
-        type == other.type &&
-        shareWithDisplayNameUnique == other.shareWithDisplayNameUnique &&
-        value == other.value;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, uuid.hashCode);
-    _$hash = $jc(_$hash, name.hashCode);
-    _$hash = $jc(_$hash, type.hashCode);
-    _$hash = $jc(_$hash, shareWithDisplayNameUnique.hashCode);
-    _$hash = $jc(_$hash, value.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeEmail1')
-          ..add('uuid', uuid)
-          ..add('name', name)
-          ..add('type', type)
-          ..add('shareWithDisplayNameUnique', shareWithDisplayNameUnique)
-          ..add('value', value))
-        .toString();
-  }
-}
-
-class FilesSharingShareeEmail1Builder implements Builder<FilesSharingShareeEmail1, FilesSharingShareeEmail1Builder> {
-  _$FilesSharingShareeEmail1? _$v;
-
-  String? _uuid;
-  String? get uuid => _$this._uuid;
-  set uuid(String? uuid) => _$this._uuid = uuid;
-
-  String? _name;
-  String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
-
-  String? _type;
-  String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
-
-  String? _shareWithDisplayNameUnique;
-  String? get shareWithDisplayNameUnique => _$this._shareWithDisplayNameUnique;
-  set shareWithDisplayNameUnique(String? shareWithDisplayNameUnique) =>
-      _$this._shareWithDisplayNameUnique = shareWithDisplayNameUnique;
-
-  FilesSharingShareeValueBuilder? _value;
-  FilesSharingShareeValueBuilder get value => _$this._value ??= FilesSharingShareeValueBuilder();
-  set value(FilesSharingShareeValueBuilder? value) => _$this._value = value;
-
-  FilesSharingShareeEmail1Builder();
-
-  FilesSharingShareeEmail1Builder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _uuid = $v.uuid;
-      _name = $v.name;
-      _type = $v.type;
-      _shareWithDisplayNameUnique = $v.shareWithDisplayNameUnique;
-      _value = $v.value.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(FilesSharingShareeEmail1 other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeEmail1;
-  }
-
-  @override
-  void update(void Function(FilesSharingShareeEmail1Builder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  FilesSharingShareeEmail1 build() => _build();
-
-  _$FilesSharingShareeEmail1 _build() {
-    _$FilesSharingShareeEmail1 _$result;
-    try {
-      _$result = _$v ??
-          _$FilesSharingShareeEmail1._(
-              uuid: BuiltValueNullFieldError.checkNotNull(uuid, r'FilesSharingShareeEmail1', 'uuid'),
-              name: BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeEmail1', 'name'),
-              type: BuiltValueNullFieldError.checkNotNull(type, r'FilesSharingShareeEmail1', 'type'),
-              shareWithDisplayNameUnique: BuiltValueNullFieldError.checkNotNull(
-                  shareWithDisplayNameUnique, r'FilesSharingShareeEmail1', 'shareWithDisplayNameUnique'),
-              value: value.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'value';
-        value.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeEmail1', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
-class _$FilesSharingShareeEmail extends FilesSharingShareeEmail {
-  @override
-  final JsonObject data;
-  @override
-  final FilesSharingSharee sharee;
-  @override
-  final FilesSharingShareeEmail1 shareeEmail1;
-
-  factory _$FilesSharingShareeEmail([void Function(FilesSharingShareeEmailBuilder)? updates]) =>
-      (FilesSharingShareeEmailBuilder()..update(updates))._build();
-
-  _$FilesSharingShareeEmail._({required this.data, required this.sharee, required this.shareeEmail1}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeEmail', 'data');
-    BuiltValueNullFieldError.checkNotNull(sharee, r'FilesSharingShareeEmail', 'sharee');
-    BuiltValueNullFieldError.checkNotNull(shareeEmail1, r'FilesSharingShareeEmail', 'shareeEmail1');
+        shareWithDisplayNameUnique, r'FilesSharingShareeEmail', 'shareWithDisplayNameUnique');
+    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeEmail', 'value');
   }
 
   @override
@@ -11112,17 +11627,25 @@ class _$FilesSharingShareeEmail extends FilesSharingShareeEmail {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is FilesSharingShareeEmail &&
-        data == other.data &&
-        sharee == other.sharee &&
-        shareeEmail1 == other.shareeEmail1;
+        count == other.count &&
+        label == other.label &&
+        uuid == other.uuid &&
+        name == other.name &&
+        type == other.type &&
+        shareWithDisplayNameUnique == other.shareWithDisplayNameUnique &&
+        value == other.value;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, sharee.hashCode);
-    _$hash = $jc(_$hash, shareeEmail1.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
+    _$hash = $jc(_$hash, uuid.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, type.hashCode);
+    _$hash = $jc(_$hash, shareWithDisplayNameUnique.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -11130,43 +11653,73 @@ class _$FilesSharingShareeEmail extends FilesSharingShareeEmail {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'FilesSharingShareeEmail')
-          ..add('data', data)
-          ..add('sharee', sharee)
-          ..add('shareeEmail1', shareeEmail1))
+          ..add('count', count)
+          ..add('label', label)
+          ..add('uuid', uuid)
+          ..add('name', name)
+          ..add('type', type)
+          ..add('shareWithDisplayNameUnique', shareWithDisplayNameUnique)
+          ..add('value', value))
         .toString();
   }
 }
 
-class FilesSharingShareeEmailBuilder implements Builder<FilesSharingShareeEmail, FilesSharingShareeEmailBuilder> {
+class FilesSharingShareeEmailBuilder
+    implements
+        Builder<FilesSharingShareeEmail, FilesSharingShareeEmailBuilder>,
+        FilesSharingShareeInterfaceBuilder,
+        FilesSharingShareeEmail_1InterfaceBuilder {
   _$FilesSharingShareeEmail? _$v;
 
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  int? _count;
+  int? get count => _$this._count;
+  set count(covariant int? count) => _$this._count = count;
 
-  FilesSharingShareeBuilder? _sharee;
-  FilesSharingShareeBuilder get sharee => _$this._sharee ??= FilesSharingShareeBuilder();
-  set sharee(FilesSharingShareeBuilder? sharee) => _$this._sharee = sharee;
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
 
-  FilesSharingShareeEmail1Builder? _shareeEmail1;
-  FilesSharingShareeEmail1Builder get shareeEmail1 => _$this._shareeEmail1 ??= FilesSharingShareeEmail1Builder();
-  set shareeEmail1(FilesSharingShareeEmail1Builder? shareeEmail1) => _$this._shareeEmail1 = shareeEmail1;
+  String? _uuid;
+  String? get uuid => _$this._uuid;
+  set uuid(covariant String? uuid) => _$this._uuid = uuid;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  String? _type;
+  String? get type => _$this._type;
+  set type(covariant String? type) => _$this._type = type;
+
+  String? _shareWithDisplayNameUnique;
+  String? get shareWithDisplayNameUnique => _$this._shareWithDisplayNameUnique;
+  set shareWithDisplayNameUnique(covariant String? shareWithDisplayNameUnique) =>
+      _$this._shareWithDisplayNameUnique = shareWithDisplayNameUnique;
+
+  FilesSharingShareeValueBuilder? _value;
+  FilesSharingShareeValueBuilder get value => _$this._value ??= FilesSharingShareeValueBuilder();
+  set value(covariant FilesSharingShareeValueBuilder? value) => _$this._value = value;
 
   FilesSharingShareeEmailBuilder();
 
   FilesSharingShareeEmailBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _data = $v.data;
-      _sharee = $v.sharee.toBuilder();
-      _shareeEmail1 = $v.shareeEmail1.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
+      _uuid = $v.uuid;
+      _name = $v.name;
+      _type = $v.type;
+      _shareWithDisplayNameUnique = $v.shareWithDisplayNameUnique;
+      _value = $v.value.toBuilder();
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(FilesSharingShareeEmail other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant FilesSharingShareeEmail other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareeEmail;
   }
@@ -11184,16 +11737,19 @@ class FilesSharingShareeEmailBuilder implements Builder<FilesSharingShareeEmail,
     try {
       _$result = _$v ??
           _$FilesSharingShareeEmail._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeEmail', 'data'),
-              sharee: sharee.build(),
-              shareeEmail1: shareeEmail1.build());
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeEmail', 'label'),
+              uuid: BuiltValueNullFieldError.checkNotNull(uuid, r'FilesSharingShareeEmail', 'uuid'),
+              name: BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeEmail', 'name'),
+              type: BuiltValueNullFieldError.checkNotNull(type, r'FilesSharingShareeEmail', 'type'),
+              shareWithDisplayNameUnique: BuiltValueNullFieldError.checkNotNull(
+                  shareWithDisplayNameUnique, r'FilesSharingShareeEmail', 'shareWithDisplayNameUnique'),
+              value: value.build());
     } catch (_) {
       late String _$failedField;
       try {
-        _$failedField = 'sharee';
-        sharee.build();
-        _$failedField = 'shareeEmail1';
-        shareeEmail1.build();
+        _$failedField = 'value';
+        value.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'FilesSharingShareeEmail', _$failedField, e.toString());
       }
@@ -11204,35 +11760,54 @@ class FilesSharingShareeEmailBuilder implements Builder<FilesSharingShareeEmail,
   }
 }
 
-class _$FilesSharingShareeRemoteGroup1_Value1 extends FilesSharingShareeRemoteGroup1_Value1 {
+abstract mixin class FilesSharingShareeRemoteGroup_1_Value_1InterfaceBuilder {
+  void replace(FilesSharingShareeRemoteGroup_1_Value_1Interface other);
+  void update(void Function(FilesSharingShareeRemoteGroup_1_Value_1InterfaceBuilder) updates);
+  String? get server;
+  set server(String? server);
+}
+
+class _$FilesSharingShareeRemoteGroup_1_Value extends FilesSharingShareeRemoteGroup_1_Value {
+  @override
+  final int shareType;
+  @override
+  final String shareWith;
   @override
   final String server;
 
-  factory _$FilesSharingShareeRemoteGroup1_Value1(
-          [void Function(FilesSharingShareeRemoteGroup1_Value1Builder)? updates]) =>
-      (FilesSharingShareeRemoteGroup1_Value1Builder()..update(updates))._build();
+  factory _$FilesSharingShareeRemoteGroup_1_Value(
+          [void Function(FilesSharingShareeRemoteGroup_1_ValueBuilder)? updates]) =>
+      (FilesSharingShareeRemoteGroup_1_ValueBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeRemoteGroup1_Value1._({required this.server}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(server, r'FilesSharingShareeRemoteGroup1_Value1', 'server');
+  _$FilesSharingShareeRemoteGroup_1_Value._({required this.shareType, required this.shareWith, required this.server})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(shareType, r'FilesSharingShareeRemoteGroup_1_Value', 'shareType');
+    BuiltValueNullFieldError.checkNotNull(shareWith, r'FilesSharingShareeRemoteGroup_1_Value', 'shareWith');
+    BuiltValueNullFieldError.checkNotNull(server, r'FilesSharingShareeRemoteGroup_1_Value', 'server');
   }
 
   @override
-  FilesSharingShareeRemoteGroup1_Value1 rebuild(void Function(FilesSharingShareeRemoteGroup1_Value1Builder) updates) =>
+  FilesSharingShareeRemoteGroup_1_Value rebuild(void Function(FilesSharingShareeRemoteGroup_1_ValueBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  FilesSharingShareeRemoteGroup1_Value1Builder toBuilder() =>
-      FilesSharingShareeRemoteGroup1_Value1Builder()..replace(this);
+  FilesSharingShareeRemoteGroup_1_ValueBuilder toBuilder() =>
+      FilesSharingShareeRemoteGroup_1_ValueBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is FilesSharingShareeRemoteGroup1_Value1 && server == other.server;
+    return other is FilesSharingShareeRemoteGroup_1_Value &&
+        shareType == other.shareType &&
+        shareWith == other.shareWith &&
+        server == other.server;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, shareType.hashCode);
+    _$hash = $jc(_$hash, shareWith.hashCode);
     _$hash = $jc(_$hash, server.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
@@ -11240,23 +11815,40 @@ class _$FilesSharingShareeRemoteGroup1_Value1 extends FilesSharingShareeRemoteGr
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeRemoteGroup1_Value1')..add('server', server)).toString();
+    return (newBuiltValueToStringHelper(r'FilesSharingShareeRemoteGroup_1_Value')
+          ..add('shareType', shareType)
+          ..add('shareWith', shareWith)
+          ..add('server', server))
+        .toString();
   }
 }
 
-class FilesSharingShareeRemoteGroup1_Value1Builder
-    implements Builder<FilesSharingShareeRemoteGroup1_Value1, FilesSharingShareeRemoteGroup1_Value1Builder> {
-  _$FilesSharingShareeRemoteGroup1_Value1? _$v;
+class FilesSharingShareeRemoteGroup_1_ValueBuilder
+    implements
+        Builder<FilesSharingShareeRemoteGroup_1_Value, FilesSharingShareeRemoteGroup_1_ValueBuilder>,
+        FilesSharingShareeValueInterfaceBuilder,
+        FilesSharingShareeRemoteGroup_1_Value_1InterfaceBuilder {
+  _$FilesSharingShareeRemoteGroup_1_Value? _$v;
+
+  int? _shareType;
+  int? get shareType => _$this._shareType;
+  set shareType(covariant int? shareType) => _$this._shareType = shareType;
+
+  String? _shareWith;
+  String? get shareWith => _$this._shareWith;
+  set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
   String? _server;
   String? get server => _$this._server;
-  set server(String? server) => _$this._server = server;
+  set server(covariant String? server) => _$this._server = server;
 
-  FilesSharingShareeRemoteGroup1_Value1Builder();
+  FilesSharingShareeRemoteGroup_1_ValueBuilder();
 
-  FilesSharingShareeRemoteGroup1_Value1Builder get _$this {
+  FilesSharingShareeRemoteGroup_1_ValueBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _shareType = $v.shareType;
+      _shareWith = $v.shareWith;
       _server = $v.server;
       _$v = null;
     }
@@ -11264,289 +11856,68 @@ class FilesSharingShareeRemoteGroup1_Value1Builder
   }
 
   @override
-  void replace(FilesSharingShareeRemoteGroup1_Value1 other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant FilesSharingShareeRemoteGroup_1_Value other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeRemoteGroup1_Value1;
+    _$v = other as _$FilesSharingShareeRemoteGroup_1_Value;
   }
 
   @override
-  void update(void Function(FilesSharingShareeRemoteGroup1_Value1Builder)? updates) {
+  void update(void Function(FilesSharingShareeRemoteGroup_1_ValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  FilesSharingShareeRemoteGroup1_Value1 build() => _build();
+  FilesSharingShareeRemoteGroup_1_Value build() => _build();
 
-  _$FilesSharingShareeRemoteGroup1_Value1 _build() {
+  _$FilesSharingShareeRemoteGroup_1_Value _build() {
     final _$result = _$v ??
-        _$FilesSharingShareeRemoteGroup1_Value1._(
-            server: BuiltValueNullFieldError.checkNotNull(server, r'FilesSharingShareeRemoteGroup1_Value1', 'server'));
+        _$FilesSharingShareeRemoteGroup_1_Value._(
+            shareType:
+                BuiltValueNullFieldError.checkNotNull(shareType, r'FilesSharingShareeRemoteGroup_1_Value', 'shareType'),
+            shareWith:
+                BuiltValueNullFieldError.checkNotNull(shareWith, r'FilesSharingShareeRemoteGroup_1_Value', 'shareWith'),
+            server: BuiltValueNullFieldError.checkNotNull(server, r'FilesSharingShareeRemoteGroup_1_Value', 'server'));
     replace(_$result);
     return _$result;
   }
 }
 
-class _$FilesSharingShareeRemoteGroup1_Value extends FilesSharingShareeRemoteGroup1_Value {
-  @override
-  final JsonObject data;
-  @override
-  final FilesSharingShareeValue shareeValue;
-  @override
-  final FilesSharingShareeRemoteGroup1_Value1 shareeRemoteGroup1Value1;
+abstract mixin class FilesSharingShareeRemoteGroup_1InterfaceBuilder {
+  void replace(FilesSharingShareeRemoteGroup_1Interface other);
+  void update(void Function(FilesSharingShareeRemoteGroup_1InterfaceBuilder) updates);
+  String? get guid;
+  set guid(String? guid);
 
-  factory _$FilesSharingShareeRemoteGroup1_Value(
-          [void Function(FilesSharingShareeRemoteGroup1_ValueBuilder)? updates]) =>
-      (FilesSharingShareeRemoteGroup1_ValueBuilder()..update(updates))._build();
+  String? get name;
+  set name(String? name);
 
-  _$FilesSharingShareeRemoteGroup1_Value._(
-      {required this.data, required this.shareeValue, required this.shareeRemoteGroup1Value1})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeRemoteGroup1_Value', 'data');
-    BuiltValueNullFieldError.checkNotNull(shareeValue, r'FilesSharingShareeRemoteGroup1_Value', 'shareeValue');
-    BuiltValueNullFieldError.checkNotNull(
-        shareeRemoteGroup1Value1, r'FilesSharingShareeRemoteGroup1_Value', 'shareeRemoteGroup1Value1');
-  }
-
-  @override
-  FilesSharingShareeRemoteGroup1_Value rebuild(void Function(FilesSharingShareeRemoteGroup1_ValueBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  FilesSharingShareeRemoteGroup1_ValueBuilder toBuilder() =>
-      FilesSharingShareeRemoteGroup1_ValueBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is FilesSharingShareeRemoteGroup1_Value &&
-        data == other.data &&
-        shareeValue == other.shareeValue &&
-        shareeRemoteGroup1Value1 == other.shareeRemoteGroup1Value1;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, shareeValue.hashCode);
-    _$hash = $jc(_$hash, shareeRemoteGroup1Value1.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeRemoteGroup1_Value')
-          ..add('data', data)
-          ..add('shareeValue', shareeValue)
-          ..add('shareeRemoteGroup1Value1', shareeRemoteGroup1Value1))
-        .toString();
-  }
+  FilesSharingShareeRemoteGroup_1_ValueBuilder get value;
+  set value(FilesSharingShareeRemoteGroup_1_ValueBuilder? value);
 }
 
-class FilesSharingShareeRemoteGroup1_ValueBuilder
-    implements Builder<FilesSharingShareeRemoteGroup1_Value, FilesSharingShareeRemoteGroup1_ValueBuilder> {
-  _$FilesSharingShareeRemoteGroup1_Value? _$v;
-
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
-
-  FilesSharingShareeValueBuilder? _shareeValue;
-  FilesSharingShareeValueBuilder get shareeValue => _$this._shareeValue ??= FilesSharingShareeValueBuilder();
-  set shareeValue(FilesSharingShareeValueBuilder? shareeValue) => _$this._shareeValue = shareeValue;
-
-  FilesSharingShareeRemoteGroup1_Value1Builder? _shareeRemoteGroup1Value1;
-  FilesSharingShareeRemoteGroup1_Value1Builder get shareeRemoteGroup1Value1 =>
-      _$this._shareeRemoteGroup1Value1 ??= FilesSharingShareeRemoteGroup1_Value1Builder();
-  set shareeRemoteGroup1Value1(FilesSharingShareeRemoteGroup1_Value1Builder? shareeRemoteGroup1Value1) =>
-      _$this._shareeRemoteGroup1Value1 = shareeRemoteGroup1Value1;
-
-  FilesSharingShareeRemoteGroup1_ValueBuilder();
-
-  FilesSharingShareeRemoteGroup1_ValueBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _data = $v.data;
-      _shareeValue = $v.shareeValue.toBuilder();
-      _shareeRemoteGroup1Value1 = $v.shareeRemoteGroup1Value1.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
+class _$FilesSharingShareeRemoteGroup extends FilesSharingShareeRemoteGroup {
   @override
-  void replace(FilesSharingShareeRemoteGroup1_Value other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeRemoteGroup1_Value;
-  }
-
+  final int? count;
   @override
-  void update(void Function(FilesSharingShareeRemoteGroup1_ValueBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  FilesSharingShareeRemoteGroup1_Value build() => _build();
-
-  _$FilesSharingShareeRemoteGroup1_Value _build() {
-    _$FilesSharingShareeRemoteGroup1_Value _$result;
-    try {
-      _$result = _$v ??
-          _$FilesSharingShareeRemoteGroup1_Value._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeRemoteGroup1_Value', 'data'),
-              shareeValue: shareeValue.build(),
-              shareeRemoteGroup1Value1: shareeRemoteGroup1Value1.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'shareeValue';
-        shareeValue.build();
-        _$failedField = 'shareeRemoteGroup1Value1';
-        shareeRemoteGroup1Value1.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeRemoteGroup1_Value', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
-class _$FilesSharingShareeRemoteGroup1 extends FilesSharingShareeRemoteGroup1 {
+  final String label;
   @override
   final String guid;
   @override
   final String name;
   @override
-  final FilesSharingShareeRemoteGroup1_Value value;
-
-  factory _$FilesSharingShareeRemoteGroup1([void Function(FilesSharingShareeRemoteGroup1Builder)? updates]) =>
-      (FilesSharingShareeRemoteGroup1Builder()..update(updates))._build();
-
-  _$FilesSharingShareeRemoteGroup1._({required this.guid, required this.name, required this.value}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(guid, r'FilesSharingShareeRemoteGroup1', 'guid');
-    BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeRemoteGroup1', 'name');
-    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeRemoteGroup1', 'value');
-  }
-
-  @override
-  FilesSharingShareeRemoteGroup1 rebuild(void Function(FilesSharingShareeRemoteGroup1Builder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  FilesSharingShareeRemoteGroup1Builder toBuilder() => FilesSharingShareeRemoteGroup1Builder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is FilesSharingShareeRemoteGroup1 && guid == other.guid && name == other.name && value == other.value;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, guid.hashCode);
-    _$hash = $jc(_$hash, name.hashCode);
-    _$hash = $jc(_$hash, value.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeRemoteGroup1')
-          ..add('guid', guid)
-          ..add('name', name)
-          ..add('value', value))
-        .toString();
-  }
-}
-
-class FilesSharingShareeRemoteGroup1Builder
-    implements Builder<FilesSharingShareeRemoteGroup1, FilesSharingShareeRemoteGroup1Builder> {
-  _$FilesSharingShareeRemoteGroup1? _$v;
-
-  String? _guid;
-  String? get guid => _$this._guid;
-  set guid(String? guid) => _$this._guid = guid;
-
-  String? _name;
-  String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
-
-  FilesSharingShareeRemoteGroup1_ValueBuilder? _value;
-  FilesSharingShareeRemoteGroup1_ValueBuilder get value =>
-      _$this._value ??= FilesSharingShareeRemoteGroup1_ValueBuilder();
-  set value(FilesSharingShareeRemoteGroup1_ValueBuilder? value) => _$this._value = value;
-
-  FilesSharingShareeRemoteGroup1Builder();
-
-  FilesSharingShareeRemoteGroup1Builder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _guid = $v.guid;
-      _name = $v.name;
-      _value = $v.value.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(FilesSharingShareeRemoteGroup1 other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeRemoteGroup1;
-  }
-
-  @override
-  void update(void Function(FilesSharingShareeRemoteGroup1Builder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  FilesSharingShareeRemoteGroup1 build() => _build();
-
-  _$FilesSharingShareeRemoteGroup1 _build() {
-    _$FilesSharingShareeRemoteGroup1 _$result;
-    try {
-      _$result = _$v ??
-          _$FilesSharingShareeRemoteGroup1._(
-              guid: BuiltValueNullFieldError.checkNotNull(guid, r'FilesSharingShareeRemoteGroup1', 'guid'),
-              name: BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeRemoteGroup1', 'name'),
-              value: value.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'value';
-        value.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeRemoteGroup1', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
-class _$FilesSharingShareeRemoteGroup extends FilesSharingShareeRemoteGroup {
-  @override
-  final JsonObject data;
-  @override
-  final FilesSharingSharee sharee;
-  @override
-  final FilesSharingShareeRemoteGroup1 shareeRemoteGroup1;
+  final FilesSharingShareeRemoteGroup_1_Value value;
 
   factory _$FilesSharingShareeRemoteGroup([void Function(FilesSharingShareeRemoteGroupBuilder)? updates]) =>
       (FilesSharingShareeRemoteGroupBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeRemoteGroup._({required this.data, required this.sharee, required this.shareeRemoteGroup1})
+  _$FilesSharingShareeRemoteGroup._(
+      {this.count, required this.label, required this.guid, required this.name, required this.value})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeRemoteGroup', 'data');
-    BuiltValueNullFieldError.checkNotNull(sharee, r'FilesSharingShareeRemoteGroup', 'sharee');
-    BuiltValueNullFieldError.checkNotNull(shareeRemoteGroup1, r'FilesSharingShareeRemoteGroup', 'shareeRemoteGroup1');
+    BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeRemoteGroup', 'label');
+    BuiltValueNullFieldError.checkNotNull(guid, r'FilesSharingShareeRemoteGroup', 'guid');
+    BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeRemoteGroup', 'name');
+    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeRemoteGroup', 'value');
   }
 
   @override
@@ -11560,17 +11931,21 @@ class _$FilesSharingShareeRemoteGroup extends FilesSharingShareeRemoteGroup {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is FilesSharingShareeRemoteGroup &&
-        data == other.data &&
-        sharee == other.sharee &&
-        shareeRemoteGroup1 == other.shareeRemoteGroup1;
+        count == other.count &&
+        label == other.label &&
+        guid == other.guid &&
+        name == other.name &&
+        value == other.value;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, sharee.hashCode);
-    _$hash = $jc(_$hash, shareeRemoteGroup1.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
+    _$hash = $jc(_$hash, guid.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -11578,46 +11953,61 @@ class _$FilesSharingShareeRemoteGroup extends FilesSharingShareeRemoteGroup {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'FilesSharingShareeRemoteGroup')
-          ..add('data', data)
-          ..add('sharee', sharee)
-          ..add('shareeRemoteGroup1', shareeRemoteGroup1))
+          ..add('count', count)
+          ..add('label', label)
+          ..add('guid', guid)
+          ..add('name', name)
+          ..add('value', value))
         .toString();
   }
 }
 
 class FilesSharingShareeRemoteGroupBuilder
-    implements Builder<FilesSharingShareeRemoteGroup, FilesSharingShareeRemoteGroupBuilder> {
+    implements
+        Builder<FilesSharingShareeRemoteGroup, FilesSharingShareeRemoteGroupBuilder>,
+        FilesSharingShareeInterfaceBuilder,
+        FilesSharingShareeRemoteGroup_1InterfaceBuilder {
   _$FilesSharingShareeRemoteGroup? _$v;
 
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  int? _count;
+  int? get count => _$this._count;
+  set count(covariant int? count) => _$this._count = count;
 
-  FilesSharingShareeBuilder? _sharee;
-  FilesSharingShareeBuilder get sharee => _$this._sharee ??= FilesSharingShareeBuilder();
-  set sharee(FilesSharingShareeBuilder? sharee) => _$this._sharee = sharee;
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
 
-  FilesSharingShareeRemoteGroup1Builder? _shareeRemoteGroup1;
-  FilesSharingShareeRemoteGroup1Builder get shareeRemoteGroup1 =>
-      _$this._shareeRemoteGroup1 ??= FilesSharingShareeRemoteGroup1Builder();
-  set shareeRemoteGroup1(FilesSharingShareeRemoteGroup1Builder? shareeRemoteGroup1) =>
-      _$this._shareeRemoteGroup1 = shareeRemoteGroup1;
+  String? _guid;
+  String? get guid => _$this._guid;
+  set guid(covariant String? guid) => _$this._guid = guid;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  FilesSharingShareeRemoteGroup_1_ValueBuilder? _value;
+  FilesSharingShareeRemoteGroup_1_ValueBuilder get value =>
+      _$this._value ??= FilesSharingShareeRemoteGroup_1_ValueBuilder();
+  set value(covariant FilesSharingShareeRemoteGroup_1_ValueBuilder? value) => _$this._value = value;
 
   FilesSharingShareeRemoteGroupBuilder();
 
   FilesSharingShareeRemoteGroupBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _data = $v.data;
-      _sharee = $v.sharee.toBuilder();
-      _shareeRemoteGroup1 = $v.shareeRemoteGroup1.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
+      _guid = $v.guid;
+      _name = $v.name;
+      _value = $v.value.toBuilder();
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(FilesSharingShareeRemoteGroup other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant FilesSharingShareeRemoteGroup other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareeRemoteGroup;
   }
@@ -11635,16 +12025,16 @@ class FilesSharingShareeRemoteGroupBuilder
     try {
       _$result = _$v ??
           _$FilesSharingShareeRemoteGroup._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeRemoteGroup', 'data'),
-              sharee: sharee.build(),
-              shareeRemoteGroup1: shareeRemoteGroup1.build());
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeRemoteGroup', 'label'),
+              guid: BuiltValueNullFieldError.checkNotNull(guid, r'FilesSharingShareeRemoteGroup', 'guid'),
+              name: BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeRemoteGroup', 'name'),
+              value: value.build());
     } catch (_) {
       late String _$failedField;
       try {
-        _$failedField = 'sharee';
-        sharee.build();
-        _$failedField = 'shareeRemoteGroup1';
-        shareeRemoteGroup1.build();
+        _$failedField = 'value';
+        value.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'FilesSharingShareeRemoteGroup', _$failedField, e.toString());
       }
@@ -11655,33 +12045,52 @@ class FilesSharingShareeRemoteGroupBuilder
   }
 }
 
-class _$FilesSharingShareeRemote1_Value1 extends FilesSharingShareeRemote1_Value1 {
+abstract mixin class FilesSharingShareeRemote_1_Value_1InterfaceBuilder {
+  void replace(FilesSharingShareeRemote_1_Value_1Interface other);
+  void update(void Function(FilesSharingShareeRemote_1_Value_1InterfaceBuilder) updates);
+  String? get server;
+  set server(String? server);
+}
+
+class _$FilesSharingShareeRemote_1_Value extends FilesSharingShareeRemote_1_Value {
+  @override
+  final int shareType;
+  @override
+  final String shareWith;
   @override
   final String server;
 
-  factory _$FilesSharingShareeRemote1_Value1([void Function(FilesSharingShareeRemote1_Value1Builder)? updates]) =>
-      (FilesSharingShareeRemote1_Value1Builder()..update(updates))._build();
+  factory _$FilesSharingShareeRemote_1_Value([void Function(FilesSharingShareeRemote_1_ValueBuilder)? updates]) =>
+      (FilesSharingShareeRemote_1_ValueBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeRemote1_Value1._({required this.server}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(server, r'FilesSharingShareeRemote1_Value1', 'server');
+  _$FilesSharingShareeRemote_1_Value._({required this.shareType, required this.shareWith, required this.server})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(shareType, r'FilesSharingShareeRemote_1_Value', 'shareType');
+    BuiltValueNullFieldError.checkNotNull(shareWith, r'FilesSharingShareeRemote_1_Value', 'shareWith');
+    BuiltValueNullFieldError.checkNotNull(server, r'FilesSharingShareeRemote_1_Value', 'server');
   }
 
   @override
-  FilesSharingShareeRemote1_Value1 rebuild(void Function(FilesSharingShareeRemote1_Value1Builder) updates) =>
+  FilesSharingShareeRemote_1_Value rebuild(void Function(FilesSharingShareeRemote_1_ValueBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  FilesSharingShareeRemote1_Value1Builder toBuilder() => FilesSharingShareeRemote1_Value1Builder()..replace(this);
+  FilesSharingShareeRemote_1_ValueBuilder toBuilder() => FilesSharingShareeRemote_1_ValueBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is FilesSharingShareeRemote1_Value1 && server == other.server;
+    return other is FilesSharingShareeRemote_1_Value &&
+        shareType == other.shareType &&
+        shareWith == other.shareWith &&
+        server == other.server;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, shareType.hashCode);
+    _$hash = $jc(_$hash, shareWith.hashCode);
     _$hash = $jc(_$hash, server.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
@@ -11689,23 +12098,40 @@ class _$FilesSharingShareeRemote1_Value1 extends FilesSharingShareeRemote1_Value
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeRemote1_Value1')..add('server', server)).toString();
+    return (newBuiltValueToStringHelper(r'FilesSharingShareeRemote_1_Value')
+          ..add('shareType', shareType)
+          ..add('shareWith', shareWith)
+          ..add('server', server))
+        .toString();
   }
 }
 
-class FilesSharingShareeRemote1_Value1Builder
-    implements Builder<FilesSharingShareeRemote1_Value1, FilesSharingShareeRemote1_Value1Builder> {
-  _$FilesSharingShareeRemote1_Value1? _$v;
+class FilesSharingShareeRemote_1_ValueBuilder
+    implements
+        Builder<FilesSharingShareeRemote_1_Value, FilesSharingShareeRemote_1_ValueBuilder>,
+        FilesSharingShareeValueInterfaceBuilder,
+        FilesSharingShareeRemote_1_Value_1InterfaceBuilder {
+  _$FilesSharingShareeRemote_1_Value? _$v;
+
+  int? _shareType;
+  int? get shareType => _$this._shareType;
+  set shareType(covariant int? shareType) => _$this._shareType = shareType;
+
+  String? _shareWith;
+  String? get shareWith => _$this._shareWith;
+  set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
   String? _server;
   String? get server => _$this._server;
-  set server(String? server) => _$this._server = server;
+  set server(covariant String? server) => _$this._server = server;
 
-  FilesSharingShareeRemote1_Value1Builder();
+  FilesSharingShareeRemote_1_ValueBuilder();
 
-  FilesSharingShareeRemote1_Value1Builder get _$this {
+  FilesSharingShareeRemote_1_ValueBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _shareType = $v.shareType;
+      _shareWith = $v.shareWith;
       _server = $v.server;
       _$v = null;
     }
@@ -11713,155 +12139,54 @@ class FilesSharingShareeRemote1_Value1Builder
   }
 
   @override
-  void replace(FilesSharingShareeRemote1_Value1 other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant FilesSharingShareeRemote_1_Value other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeRemote1_Value1;
+    _$v = other as _$FilesSharingShareeRemote_1_Value;
   }
 
   @override
-  void update(void Function(FilesSharingShareeRemote1_Value1Builder)? updates) {
+  void update(void Function(FilesSharingShareeRemote_1_ValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  FilesSharingShareeRemote1_Value1 build() => _build();
+  FilesSharingShareeRemote_1_Value build() => _build();
 
-  _$FilesSharingShareeRemote1_Value1 _build() {
+  _$FilesSharingShareeRemote_1_Value _build() {
     final _$result = _$v ??
-        _$FilesSharingShareeRemote1_Value1._(
-            server: BuiltValueNullFieldError.checkNotNull(server, r'FilesSharingShareeRemote1_Value1', 'server'));
+        _$FilesSharingShareeRemote_1_Value._(
+            shareType:
+                BuiltValueNullFieldError.checkNotNull(shareType, r'FilesSharingShareeRemote_1_Value', 'shareType'),
+            shareWith:
+                BuiltValueNullFieldError.checkNotNull(shareWith, r'FilesSharingShareeRemote_1_Value', 'shareWith'),
+            server: BuiltValueNullFieldError.checkNotNull(server, r'FilesSharingShareeRemote_1_Value', 'server'));
     replace(_$result);
     return _$result;
   }
 }
 
-class _$FilesSharingShareeRemote1_Value extends FilesSharingShareeRemote1_Value {
-  @override
-  final JsonObject data;
-  @override
-  final FilesSharingShareeValue shareeValue;
-  @override
-  final FilesSharingShareeRemote1_Value1 shareeRemote1Value1;
+abstract mixin class FilesSharingShareeRemote_1InterfaceBuilder {
+  void replace(FilesSharingShareeRemote_1Interface other);
+  void update(void Function(FilesSharingShareeRemote_1InterfaceBuilder) updates);
+  String? get uuid;
+  set uuid(String? uuid);
 
-  factory _$FilesSharingShareeRemote1_Value([void Function(FilesSharingShareeRemote1_ValueBuilder)? updates]) =>
-      (FilesSharingShareeRemote1_ValueBuilder()..update(updates))._build();
+  String? get name;
+  set name(String? name);
 
-  _$FilesSharingShareeRemote1_Value._(
-      {required this.data, required this.shareeValue, required this.shareeRemote1Value1})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeRemote1_Value', 'data');
-    BuiltValueNullFieldError.checkNotNull(shareeValue, r'FilesSharingShareeRemote1_Value', 'shareeValue');
-    BuiltValueNullFieldError.checkNotNull(
-        shareeRemote1Value1, r'FilesSharingShareeRemote1_Value', 'shareeRemote1Value1');
-  }
+  String? get type;
+  set type(String? type);
 
-  @override
-  FilesSharingShareeRemote1_Value rebuild(void Function(FilesSharingShareeRemote1_ValueBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  FilesSharingShareeRemote1_ValueBuilder toBuilder() => FilesSharingShareeRemote1_ValueBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is FilesSharingShareeRemote1_Value &&
-        data == other.data &&
-        shareeValue == other.shareeValue &&
-        shareeRemote1Value1 == other.shareeRemote1Value1;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, shareeValue.hashCode);
-    _$hash = $jc(_$hash, shareeRemote1Value1.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeRemote1_Value')
-          ..add('data', data)
-          ..add('shareeValue', shareeValue)
-          ..add('shareeRemote1Value1', shareeRemote1Value1))
-        .toString();
-  }
+  FilesSharingShareeRemote_1_ValueBuilder get value;
+  set value(FilesSharingShareeRemote_1_ValueBuilder? value);
 }
 
-class FilesSharingShareeRemote1_ValueBuilder
-    implements Builder<FilesSharingShareeRemote1_Value, FilesSharingShareeRemote1_ValueBuilder> {
-  _$FilesSharingShareeRemote1_Value? _$v;
-
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
-
-  FilesSharingShareeValueBuilder? _shareeValue;
-  FilesSharingShareeValueBuilder get shareeValue => _$this._shareeValue ??= FilesSharingShareeValueBuilder();
-  set shareeValue(FilesSharingShareeValueBuilder? shareeValue) => _$this._shareeValue = shareeValue;
-
-  FilesSharingShareeRemote1_Value1Builder? _shareeRemote1Value1;
-  FilesSharingShareeRemote1_Value1Builder get shareeRemote1Value1 =>
-      _$this._shareeRemote1Value1 ??= FilesSharingShareeRemote1_Value1Builder();
-  set shareeRemote1Value1(FilesSharingShareeRemote1_Value1Builder? shareeRemote1Value1) =>
-      _$this._shareeRemote1Value1 = shareeRemote1Value1;
-
-  FilesSharingShareeRemote1_ValueBuilder();
-
-  FilesSharingShareeRemote1_ValueBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _data = $v.data;
-      _shareeValue = $v.shareeValue.toBuilder();
-      _shareeRemote1Value1 = $v.shareeRemote1Value1.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
+class _$FilesSharingShareeRemote extends FilesSharingShareeRemote {
   @override
-  void replace(FilesSharingShareeRemote1_Value other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeRemote1_Value;
-  }
-
+  final int? count;
   @override
-  void update(void Function(FilesSharingShareeRemote1_ValueBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  FilesSharingShareeRemote1_Value build() => _build();
-
-  _$FilesSharingShareeRemote1_Value _build() {
-    _$FilesSharingShareeRemote1_Value _$result;
-    try {
-      _$result = _$v ??
-          _$FilesSharingShareeRemote1_Value._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeRemote1_Value', 'data'),
-              shareeValue: shareeValue.build(),
-              shareeRemote1Value1: shareeRemote1Value1.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'shareeValue';
-        shareeValue.build();
-        _$failedField = 'shareeRemote1Value1';
-        shareeRemote1Value1.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeRemote1_Value', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
-class _$FilesSharingShareeRemote1 extends FilesSharingShareeRemote1 {
+  final String label;
   @override
   final String uuid;
   @override
@@ -11869,144 +12194,24 @@ class _$FilesSharingShareeRemote1 extends FilesSharingShareeRemote1 {
   @override
   final String type;
   @override
-  final FilesSharingShareeRemote1_Value value;
-
-  factory _$FilesSharingShareeRemote1([void Function(FilesSharingShareeRemote1Builder)? updates]) =>
-      (FilesSharingShareeRemote1Builder()..update(updates))._build();
-
-  _$FilesSharingShareeRemote1._({required this.uuid, required this.name, required this.type, required this.value})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(uuid, r'FilesSharingShareeRemote1', 'uuid');
-    BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeRemote1', 'name');
-    BuiltValueNullFieldError.checkNotNull(type, r'FilesSharingShareeRemote1', 'type');
-    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeRemote1', 'value');
-  }
-
-  @override
-  FilesSharingShareeRemote1 rebuild(void Function(FilesSharingShareeRemote1Builder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  FilesSharingShareeRemote1Builder toBuilder() => FilesSharingShareeRemote1Builder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is FilesSharingShareeRemote1 &&
-        uuid == other.uuid &&
-        name == other.name &&
-        type == other.type &&
-        value == other.value;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, uuid.hashCode);
-    _$hash = $jc(_$hash, name.hashCode);
-    _$hash = $jc(_$hash, type.hashCode);
-    _$hash = $jc(_$hash, value.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeRemote1')
-          ..add('uuid', uuid)
-          ..add('name', name)
-          ..add('type', type)
-          ..add('value', value))
-        .toString();
-  }
-}
-
-class FilesSharingShareeRemote1Builder implements Builder<FilesSharingShareeRemote1, FilesSharingShareeRemote1Builder> {
-  _$FilesSharingShareeRemote1? _$v;
-
-  String? _uuid;
-  String? get uuid => _$this._uuid;
-  set uuid(String? uuid) => _$this._uuid = uuid;
-
-  String? _name;
-  String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
-
-  String? _type;
-  String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
-
-  FilesSharingShareeRemote1_ValueBuilder? _value;
-  FilesSharingShareeRemote1_ValueBuilder get value => _$this._value ??= FilesSharingShareeRemote1_ValueBuilder();
-  set value(FilesSharingShareeRemote1_ValueBuilder? value) => _$this._value = value;
-
-  FilesSharingShareeRemote1Builder();
-
-  FilesSharingShareeRemote1Builder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _uuid = $v.uuid;
-      _name = $v.name;
-      _type = $v.type;
-      _value = $v.value.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(FilesSharingShareeRemote1 other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeRemote1;
-  }
-
-  @override
-  void update(void Function(FilesSharingShareeRemote1Builder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  FilesSharingShareeRemote1 build() => _build();
-
-  _$FilesSharingShareeRemote1 _build() {
-    _$FilesSharingShareeRemote1 _$result;
-    try {
-      _$result = _$v ??
-          _$FilesSharingShareeRemote1._(
-              uuid: BuiltValueNullFieldError.checkNotNull(uuid, r'FilesSharingShareeRemote1', 'uuid'),
-              name: BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeRemote1', 'name'),
-              type: BuiltValueNullFieldError.checkNotNull(type, r'FilesSharingShareeRemote1', 'type'),
-              value: value.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'value';
-        value.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeRemote1', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
-class _$FilesSharingShareeRemote extends FilesSharingShareeRemote {
-  @override
-  final JsonObject data;
-  @override
-  final FilesSharingSharee sharee;
-  @override
-  final FilesSharingShareeRemote1 shareeRemote1;
+  final FilesSharingShareeRemote_1_Value value;
 
   factory _$FilesSharingShareeRemote([void Function(FilesSharingShareeRemoteBuilder)? updates]) =>
       (FilesSharingShareeRemoteBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeRemote._({required this.data, required this.sharee, required this.shareeRemote1}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeRemote', 'data');
-    BuiltValueNullFieldError.checkNotNull(sharee, r'FilesSharingShareeRemote', 'sharee');
-    BuiltValueNullFieldError.checkNotNull(shareeRemote1, r'FilesSharingShareeRemote', 'shareeRemote1');
+  _$FilesSharingShareeRemote._(
+      {this.count,
+      required this.label,
+      required this.uuid,
+      required this.name,
+      required this.type,
+      required this.value})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeRemote', 'label');
+    BuiltValueNullFieldError.checkNotNull(uuid, r'FilesSharingShareeRemote', 'uuid');
+    BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeRemote', 'name');
+    BuiltValueNullFieldError.checkNotNull(type, r'FilesSharingShareeRemote', 'type');
+    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeRemote', 'value');
   }
 
   @override
@@ -12020,17 +12225,23 @@ class _$FilesSharingShareeRemote extends FilesSharingShareeRemote {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is FilesSharingShareeRemote &&
-        data == other.data &&
-        sharee == other.sharee &&
-        shareeRemote1 == other.shareeRemote1;
+        count == other.count &&
+        label == other.label &&
+        uuid == other.uuid &&
+        name == other.name &&
+        type == other.type &&
+        value == other.value;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, sharee.hashCode);
-    _$hash = $jc(_$hash, shareeRemote1.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
+    _$hash = $jc(_$hash, uuid.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, type.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -12038,43 +12249,66 @@ class _$FilesSharingShareeRemote extends FilesSharingShareeRemote {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'FilesSharingShareeRemote')
-          ..add('data', data)
-          ..add('sharee', sharee)
-          ..add('shareeRemote1', shareeRemote1))
+          ..add('count', count)
+          ..add('label', label)
+          ..add('uuid', uuid)
+          ..add('name', name)
+          ..add('type', type)
+          ..add('value', value))
         .toString();
   }
 }
 
-class FilesSharingShareeRemoteBuilder implements Builder<FilesSharingShareeRemote, FilesSharingShareeRemoteBuilder> {
+class FilesSharingShareeRemoteBuilder
+    implements
+        Builder<FilesSharingShareeRemote, FilesSharingShareeRemoteBuilder>,
+        FilesSharingShareeInterfaceBuilder,
+        FilesSharingShareeRemote_1InterfaceBuilder {
   _$FilesSharingShareeRemote? _$v;
 
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  int? _count;
+  int? get count => _$this._count;
+  set count(covariant int? count) => _$this._count = count;
 
-  FilesSharingShareeBuilder? _sharee;
-  FilesSharingShareeBuilder get sharee => _$this._sharee ??= FilesSharingShareeBuilder();
-  set sharee(FilesSharingShareeBuilder? sharee) => _$this._sharee = sharee;
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
 
-  FilesSharingShareeRemote1Builder? _shareeRemote1;
-  FilesSharingShareeRemote1Builder get shareeRemote1 => _$this._shareeRemote1 ??= FilesSharingShareeRemote1Builder();
-  set shareeRemote1(FilesSharingShareeRemote1Builder? shareeRemote1) => _$this._shareeRemote1 = shareeRemote1;
+  String? _uuid;
+  String? get uuid => _$this._uuid;
+  set uuid(covariant String? uuid) => _$this._uuid = uuid;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  String? _type;
+  String? get type => _$this._type;
+  set type(covariant String? type) => _$this._type = type;
+
+  FilesSharingShareeRemote_1_ValueBuilder? _value;
+  FilesSharingShareeRemote_1_ValueBuilder get value => _$this._value ??= FilesSharingShareeRemote_1_ValueBuilder();
+  set value(covariant FilesSharingShareeRemote_1_ValueBuilder? value) => _$this._value = value;
 
   FilesSharingShareeRemoteBuilder();
 
   FilesSharingShareeRemoteBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _data = $v.data;
-      _sharee = $v.sharee.toBuilder();
-      _shareeRemote1 = $v.shareeRemote1.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
+      _uuid = $v.uuid;
+      _name = $v.name;
+      _type = $v.type;
+      _value = $v.value.toBuilder();
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(FilesSharingShareeRemote other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant FilesSharingShareeRemote other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareeRemote;
   }
@@ -12092,16 +12326,17 @@ class FilesSharingShareeRemoteBuilder implements Builder<FilesSharingShareeRemot
     try {
       _$result = _$v ??
           _$FilesSharingShareeRemote._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeRemote', 'data'),
-              sharee: sharee.build(),
-              shareeRemote1: shareeRemote1.build());
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeRemote', 'label'),
+              uuid: BuiltValueNullFieldError.checkNotNull(uuid, r'FilesSharingShareeRemote', 'uuid'),
+              name: BuiltValueNullFieldError.checkNotNull(name, r'FilesSharingShareeRemote', 'name'),
+              type: BuiltValueNullFieldError.checkNotNull(type, r'FilesSharingShareeRemote', 'type'),
+              value: value.build());
     } catch (_) {
       late String _$failedField;
       try {
-        _$failedField = 'sharee';
-        sharee.build();
-        _$failedField = 'shareeRemote1';
-        shareeRemote1.build();
+        _$failedField = 'value';
+        value.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'FilesSharingShareeRemote', _$failedField, e.toString());
       }
@@ -12112,7 +12347,23 @@ class FilesSharingShareeRemoteBuilder implements Builder<FilesSharingShareeRemot
   }
 }
 
-class _$FilesSharingShareeUser1_Status extends FilesSharingShareeUser1_Status {
+abstract mixin class FilesSharingShareeUser_1_StatusInterfaceBuilder {
+  void replace(FilesSharingShareeUser_1_StatusInterface other);
+  void update(void Function(FilesSharingShareeUser_1_StatusInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  String? get message;
+  set message(String? message);
+
+  String? get icon;
+  set icon(String? icon);
+
+  int? get clearAt;
+  set clearAt(int? clearAt);
+}
+
+class _$FilesSharingShareeUser_1_Status extends FilesSharingShareeUser_1_Status {
   @override
   final String status;
   @override
@@ -12122,27 +12373,27 @@ class _$FilesSharingShareeUser1_Status extends FilesSharingShareeUser1_Status {
   @override
   final int? clearAt;
 
-  factory _$FilesSharingShareeUser1_Status([void Function(FilesSharingShareeUser1_StatusBuilder)? updates]) =>
-      (FilesSharingShareeUser1_StatusBuilder()..update(updates))._build();
+  factory _$FilesSharingShareeUser_1_Status([void Function(FilesSharingShareeUser_1_StatusBuilder)? updates]) =>
+      (FilesSharingShareeUser_1_StatusBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeUser1_Status._({required this.status, required this.message, required this.icon, this.clearAt})
+  _$FilesSharingShareeUser_1_Status._({required this.status, required this.message, required this.icon, this.clearAt})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(status, r'FilesSharingShareeUser1_Status', 'status');
-    BuiltValueNullFieldError.checkNotNull(message, r'FilesSharingShareeUser1_Status', 'message');
-    BuiltValueNullFieldError.checkNotNull(icon, r'FilesSharingShareeUser1_Status', 'icon');
+    BuiltValueNullFieldError.checkNotNull(status, r'FilesSharingShareeUser_1_Status', 'status');
+    BuiltValueNullFieldError.checkNotNull(message, r'FilesSharingShareeUser_1_Status', 'message');
+    BuiltValueNullFieldError.checkNotNull(icon, r'FilesSharingShareeUser_1_Status', 'icon');
   }
 
   @override
-  FilesSharingShareeUser1_Status rebuild(void Function(FilesSharingShareeUser1_StatusBuilder) updates) =>
+  FilesSharingShareeUser_1_Status rebuild(void Function(FilesSharingShareeUser_1_StatusBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  FilesSharingShareeUser1_StatusBuilder toBuilder() => FilesSharingShareeUser1_StatusBuilder()..replace(this);
+  FilesSharingShareeUser_1_StatusBuilder toBuilder() => FilesSharingShareeUser_1_StatusBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is FilesSharingShareeUser1_Status &&
+    return other is FilesSharingShareeUser_1_Status &&
         status == other.status &&
         message == other.message &&
         icon == other.icon &&
@@ -12162,7 +12413,7 @@ class _$FilesSharingShareeUser1_Status extends FilesSharingShareeUser1_Status {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeUser1_Status')
+    return (newBuiltValueToStringHelper(r'FilesSharingShareeUser_1_Status')
           ..add('status', status)
           ..add('message', message)
           ..add('icon', icon)
@@ -12171,29 +12422,31 @@ class _$FilesSharingShareeUser1_Status extends FilesSharingShareeUser1_Status {
   }
 }
 
-class FilesSharingShareeUser1_StatusBuilder
-    implements Builder<FilesSharingShareeUser1_Status, FilesSharingShareeUser1_StatusBuilder> {
-  _$FilesSharingShareeUser1_Status? _$v;
+class FilesSharingShareeUser_1_StatusBuilder
+    implements
+        Builder<FilesSharingShareeUser_1_Status, FilesSharingShareeUser_1_StatusBuilder>,
+        FilesSharingShareeUser_1_StatusInterfaceBuilder {
+  _$FilesSharingShareeUser_1_Status? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _icon;
   String? get icon => _$this._icon;
-  set icon(String? icon) => _$this._icon = icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
 
   int? _clearAt;
   int? get clearAt => _$this._clearAt;
-  set clearAt(int? clearAt) => _$this._clearAt = clearAt;
+  set clearAt(covariant int? clearAt) => _$this._clearAt = clearAt;
 
-  FilesSharingShareeUser1_StatusBuilder();
+  FilesSharingShareeUser_1_StatusBuilder();
 
-  FilesSharingShareeUser1_StatusBuilder get _$this {
+  FilesSharingShareeUser_1_StatusBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _status = $v.status;
@@ -12206,32 +12459,55 @@ class FilesSharingShareeUser1_StatusBuilder
   }
 
   @override
-  void replace(FilesSharingShareeUser1_Status other) {
+  void replace(covariant FilesSharingShareeUser_1_Status other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeUser1_Status;
+    _$v = other as _$FilesSharingShareeUser_1_Status;
   }
 
   @override
-  void update(void Function(FilesSharingShareeUser1_StatusBuilder)? updates) {
+  void update(void Function(FilesSharingShareeUser_1_StatusBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  FilesSharingShareeUser1_Status build() => _build();
+  FilesSharingShareeUser_1_Status build() => _build();
 
-  _$FilesSharingShareeUser1_Status _build() {
+  _$FilesSharingShareeUser_1_Status _build() {
     final _$result = _$v ??
-        _$FilesSharingShareeUser1_Status._(
-            status: BuiltValueNullFieldError.checkNotNull(status, r'FilesSharingShareeUser1_Status', 'status'),
-            message: BuiltValueNullFieldError.checkNotNull(message, r'FilesSharingShareeUser1_Status', 'message'),
-            icon: BuiltValueNullFieldError.checkNotNull(icon, r'FilesSharingShareeUser1_Status', 'icon'),
+        _$FilesSharingShareeUser_1_Status._(
+            status: BuiltValueNullFieldError.checkNotNull(status, r'FilesSharingShareeUser_1_Status', 'status'),
+            message: BuiltValueNullFieldError.checkNotNull(message, r'FilesSharingShareeUser_1_Status', 'message'),
+            icon: BuiltValueNullFieldError.checkNotNull(icon, r'FilesSharingShareeUser_1_Status', 'icon'),
             clearAt: clearAt);
     replace(_$result);
     return _$result;
   }
 }
 
-class _$FilesSharingShareeUser1 extends FilesSharingShareeUser1 {
+abstract mixin class FilesSharingShareeUser_1InterfaceBuilder {
+  void replace(FilesSharingShareeUser_1Interface other);
+  void update(void Function(FilesSharingShareeUser_1InterfaceBuilder) updates);
+  String? get subline;
+  set subline(String? subline);
+
+  String? get icon;
+  set icon(String? icon);
+
+  String? get shareWithDisplayNameUnique;
+  set shareWithDisplayNameUnique(String? shareWithDisplayNameUnique);
+
+  FilesSharingShareeUser_1_StatusBuilder get status;
+  set status(FilesSharingShareeUser_1_StatusBuilder? status);
+
+  FilesSharingShareeValueBuilder get value;
+  set value(FilesSharingShareeValueBuilder? value);
+}
+
+class _$FilesSharingShareeUser extends FilesSharingShareeUser {
+  @override
+  final int? count;
+  @override
+  final String label;
   @override
   final String subline;
   @override
@@ -12239,166 +12515,29 @@ class _$FilesSharingShareeUser1 extends FilesSharingShareeUser1 {
   @override
   final String shareWithDisplayNameUnique;
   @override
-  final FilesSharingShareeUser1_Status status;
+  final FilesSharingShareeUser_1_Status status;
   @override
   final FilesSharingShareeValue value;
 
-  factory _$FilesSharingShareeUser1([void Function(FilesSharingShareeUser1Builder)? updates]) =>
-      (FilesSharingShareeUser1Builder()..update(updates))._build();
+  factory _$FilesSharingShareeUser([void Function(FilesSharingShareeUserBuilder)? updates]) =>
+      (FilesSharingShareeUserBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeUser1._(
-      {required this.subline,
+  _$FilesSharingShareeUser._(
+      {this.count,
+      required this.label,
+      required this.subline,
       required this.icon,
       required this.shareWithDisplayNameUnique,
       required this.status,
       required this.value})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(subline, r'FilesSharingShareeUser1', 'subline');
-    BuiltValueNullFieldError.checkNotNull(icon, r'FilesSharingShareeUser1', 'icon');
+    BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeUser', 'label');
+    BuiltValueNullFieldError.checkNotNull(subline, r'FilesSharingShareeUser', 'subline');
+    BuiltValueNullFieldError.checkNotNull(icon, r'FilesSharingShareeUser', 'icon');
     BuiltValueNullFieldError.checkNotNull(
-        shareWithDisplayNameUnique, r'FilesSharingShareeUser1', 'shareWithDisplayNameUnique');
-    BuiltValueNullFieldError.checkNotNull(status, r'FilesSharingShareeUser1', 'status');
-    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeUser1', 'value');
-  }
-
-  @override
-  FilesSharingShareeUser1 rebuild(void Function(FilesSharingShareeUser1Builder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  FilesSharingShareeUser1Builder toBuilder() => FilesSharingShareeUser1Builder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is FilesSharingShareeUser1 &&
-        subline == other.subline &&
-        icon == other.icon &&
-        shareWithDisplayNameUnique == other.shareWithDisplayNameUnique &&
-        status == other.status &&
-        value == other.value;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, subline.hashCode);
-    _$hash = $jc(_$hash, icon.hashCode);
-    _$hash = $jc(_$hash, shareWithDisplayNameUnique.hashCode);
-    _$hash = $jc(_$hash, status.hashCode);
-    _$hash = $jc(_$hash, value.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeUser1')
-          ..add('subline', subline)
-          ..add('icon', icon)
-          ..add('shareWithDisplayNameUnique', shareWithDisplayNameUnique)
-          ..add('status', status)
-          ..add('value', value))
-        .toString();
-  }
-}
-
-class FilesSharingShareeUser1Builder implements Builder<FilesSharingShareeUser1, FilesSharingShareeUser1Builder> {
-  _$FilesSharingShareeUser1? _$v;
-
-  String? _subline;
-  String? get subline => _$this._subline;
-  set subline(String? subline) => _$this._subline = subline;
-
-  String? _icon;
-  String? get icon => _$this._icon;
-  set icon(String? icon) => _$this._icon = icon;
-
-  String? _shareWithDisplayNameUnique;
-  String? get shareWithDisplayNameUnique => _$this._shareWithDisplayNameUnique;
-  set shareWithDisplayNameUnique(String? shareWithDisplayNameUnique) =>
-      _$this._shareWithDisplayNameUnique = shareWithDisplayNameUnique;
-
-  FilesSharingShareeUser1_StatusBuilder? _status;
-  FilesSharingShareeUser1_StatusBuilder get status => _$this._status ??= FilesSharingShareeUser1_StatusBuilder();
-  set status(FilesSharingShareeUser1_StatusBuilder? status) => _$this._status = status;
-
-  FilesSharingShareeValueBuilder? _value;
-  FilesSharingShareeValueBuilder get value => _$this._value ??= FilesSharingShareeValueBuilder();
-  set value(FilesSharingShareeValueBuilder? value) => _$this._value = value;
-
-  FilesSharingShareeUser1Builder();
-
-  FilesSharingShareeUser1Builder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _subline = $v.subline;
-      _icon = $v.icon;
-      _shareWithDisplayNameUnique = $v.shareWithDisplayNameUnique;
-      _status = $v.status.toBuilder();
-      _value = $v.value.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(FilesSharingShareeUser1 other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeUser1;
-  }
-
-  @override
-  void update(void Function(FilesSharingShareeUser1Builder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  FilesSharingShareeUser1 build() => _build();
-
-  _$FilesSharingShareeUser1 _build() {
-    _$FilesSharingShareeUser1 _$result;
-    try {
-      _$result = _$v ??
-          _$FilesSharingShareeUser1._(
-              subline: BuiltValueNullFieldError.checkNotNull(subline, r'FilesSharingShareeUser1', 'subline'),
-              icon: BuiltValueNullFieldError.checkNotNull(icon, r'FilesSharingShareeUser1', 'icon'),
-              shareWithDisplayNameUnique: BuiltValueNullFieldError.checkNotNull(
-                  shareWithDisplayNameUnique, r'FilesSharingShareeUser1', 'shareWithDisplayNameUnique'),
-              status: status.build(),
-              value: value.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'status';
-        status.build();
-        _$failedField = 'value';
-        value.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeUser1', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
-class _$FilesSharingShareeUser extends FilesSharingShareeUser {
-  @override
-  final JsonObject data;
-  @override
-  final FilesSharingSharee sharee;
-  @override
-  final FilesSharingShareeUser1 shareeUser1;
-
-  factory _$FilesSharingShareeUser([void Function(FilesSharingShareeUserBuilder)? updates]) =>
-      (FilesSharingShareeUserBuilder()..update(updates))._build();
-
-  _$FilesSharingShareeUser._({required this.data, required this.sharee, required this.shareeUser1}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeUser', 'data');
-    BuiltValueNullFieldError.checkNotNull(sharee, r'FilesSharingShareeUser', 'sharee');
-    BuiltValueNullFieldError.checkNotNull(shareeUser1, r'FilesSharingShareeUser', 'shareeUser1');
+        shareWithDisplayNameUnique, r'FilesSharingShareeUser', 'shareWithDisplayNameUnique');
+    BuiltValueNullFieldError.checkNotNull(status, r'FilesSharingShareeUser', 'status');
+    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeUser', 'value');
   }
 
   @override
@@ -12412,17 +12551,25 @@ class _$FilesSharingShareeUser extends FilesSharingShareeUser {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is FilesSharingShareeUser &&
-        data == other.data &&
-        sharee == other.sharee &&
-        shareeUser1 == other.shareeUser1;
+        count == other.count &&
+        label == other.label &&
+        subline == other.subline &&
+        icon == other.icon &&
+        shareWithDisplayNameUnique == other.shareWithDisplayNameUnique &&
+        status == other.status &&
+        value == other.value;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, sharee.hashCode);
-    _$hash = $jc(_$hash, shareeUser1.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
+    _$hash = $jc(_$hash, subline.hashCode);
+    _$hash = $jc(_$hash, icon.hashCode);
+    _$hash = $jc(_$hash, shareWithDisplayNameUnique.hashCode);
+    _$hash = $jc(_$hash, status.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -12430,43 +12577,73 @@ class _$FilesSharingShareeUser extends FilesSharingShareeUser {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'FilesSharingShareeUser')
-          ..add('data', data)
-          ..add('sharee', sharee)
-          ..add('shareeUser1', shareeUser1))
+          ..add('count', count)
+          ..add('label', label)
+          ..add('subline', subline)
+          ..add('icon', icon)
+          ..add('shareWithDisplayNameUnique', shareWithDisplayNameUnique)
+          ..add('status', status)
+          ..add('value', value))
         .toString();
   }
 }
 
-class FilesSharingShareeUserBuilder implements Builder<FilesSharingShareeUser, FilesSharingShareeUserBuilder> {
+class FilesSharingShareeUserBuilder
+    implements
+        Builder<FilesSharingShareeUser, FilesSharingShareeUserBuilder>,
+        FilesSharingShareeInterfaceBuilder,
+        FilesSharingShareeUser_1InterfaceBuilder {
   _$FilesSharingShareeUser? _$v;
 
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  int? _count;
+  int? get count => _$this._count;
+  set count(covariant int? count) => _$this._count = count;
 
-  FilesSharingShareeBuilder? _sharee;
-  FilesSharingShareeBuilder get sharee => _$this._sharee ??= FilesSharingShareeBuilder();
-  set sharee(FilesSharingShareeBuilder? sharee) => _$this._sharee = sharee;
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
 
-  FilesSharingShareeUser1Builder? _shareeUser1;
-  FilesSharingShareeUser1Builder get shareeUser1 => _$this._shareeUser1 ??= FilesSharingShareeUser1Builder();
-  set shareeUser1(FilesSharingShareeUser1Builder? shareeUser1) => _$this._shareeUser1 = shareeUser1;
+  String? _subline;
+  String? get subline => _$this._subline;
+  set subline(covariant String? subline) => _$this._subline = subline;
+
+  String? _icon;
+  String? get icon => _$this._icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
+
+  String? _shareWithDisplayNameUnique;
+  String? get shareWithDisplayNameUnique => _$this._shareWithDisplayNameUnique;
+  set shareWithDisplayNameUnique(covariant String? shareWithDisplayNameUnique) =>
+      _$this._shareWithDisplayNameUnique = shareWithDisplayNameUnique;
+
+  FilesSharingShareeUser_1_StatusBuilder? _status;
+  FilesSharingShareeUser_1_StatusBuilder get status => _$this._status ??= FilesSharingShareeUser_1_StatusBuilder();
+  set status(covariant FilesSharingShareeUser_1_StatusBuilder? status) => _$this._status = status;
+
+  FilesSharingShareeValueBuilder? _value;
+  FilesSharingShareeValueBuilder get value => _$this._value ??= FilesSharingShareeValueBuilder();
+  set value(covariant FilesSharingShareeValueBuilder? value) => _$this._value = value;
 
   FilesSharingShareeUserBuilder();
 
   FilesSharingShareeUserBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _data = $v.data;
-      _sharee = $v.sharee.toBuilder();
-      _shareeUser1 = $v.shareeUser1.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
+      _subline = $v.subline;
+      _icon = $v.icon;
+      _shareWithDisplayNameUnique = $v.shareWithDisplayNameUnique;
+      _status = $v.status.toBuilder();
+      _value = $v.value.toBuilder();
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(FilesSharingShareeUser other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant FilesSharingShareeUser other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareeUser;
   }
@@ -12484,16 +12661,21 @@ class FilesSharingShareeUserBuilder implements Builder<FilesSharingShareeUser, F
     try {
       _$result = _$v ??
           _$FilesSharingShareeUser._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeUser', 'data'),
-              sharee: sharee.build(),
-              shareeUser1: shareeUser1.build());
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeUser', 'label'),
+              subline: BuiltValueNullFieldError.checkNotNull(subline, r'FilesSharingShareeUser', 'subline'),
+              icon: BuiltValueNullFieldError.checkNotNull(icon, r'FilesSharingShareeUser', 'icon'),
+              shareWithDisplayNameUnique: BuiltValueNullFieldError.checkNotNull(
+                  shareWithDisplayNameUnique, r'FilesSharingShareeUser', 'shareWithDisplayNameUnique'),
+              status: status.build(),
+              value: value.build());
     } catch (_) {
       late String _$failedField;
       try {
-        _$failedField = 'sharee';
-        sharee.build();
-        _$failedField = 'shareeUser1';
-        shareeUser1.build();
+        _$failedField = 'status';
+        status.build();
+        _$failedField = 'value';
+        value.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'FilesSharingShareeUser', _$failedField, e.toString());
       }
@@ -12502,6 +12684,31 @@ class FilesSharingShareeUserBuilder implements Builder<FilesSharingShareeUser, F
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareesSearchResult_ExactInterfaceBuilder {
+  void replace(FilesSharingShareesSearchResult_ExactInterface other);
+  void update(void Function(FilesSharingShareesSearchResult_ExactInterfaceBuilder) updates);
+  ListBuilder<FilesSharingShareeCircle> get circles;
+  set circles(ListBuilder<FilesSharingShareeCircle>? circles);
+
+  ListBuilder<FilesSharingShareeEmail> get emails;
+  set emails(ListBuilder<FilesSharingShareeEmail>? emails);
+
+  ListBuilder<FilesSharingSharee> get groups;
+  set groups(ListBuilder<FilesSharingSharee>? groups);
+
+  ListBuilder<FilesSharingShareeRemoteGroup> get remoteGroups;
+  set remoteGroups(ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups);
+
+  ListBuilder<FilesSharingShareeRemote> get remotes;
+  set remotes(ListBuilder<FilesSharingShareeRemote>? remotes);
+
+  ListBuilder<FilesSharingSharee> get rooms;
+  set rooms(ListBuilder<FilesSharingSharee>? rooms);
+
+  ListBuilder<FilesSharingShareeUser> get users;
+  set users(ListBuilder<FilesSharingShareeUser>? users);
 }
 
 class _$FilesSharingShareesSearchResult_Exact extends FilesSharingShareesSearchResult_Exact {
@@ -12592,37 +12799,40 @@ class _$FilesSharingShareesSearchResult_Exact extends FilesSharingShareesSearchR
 }
 
 class FilesSharingShareesSearchResult_ExactBuilder
-    implements Builder<FilesSharingShareesSearchResult_Exact, FilesSharingShareesSearchResult_ExactBuilder> {
+    implements
+        Builder<FilesSharingShareesSearchResult_Exact, FilesSharingShareesSearchResult_ExactBuilder>,
+        FilesSharingShareesSearchResult_ExactInterfaceBuilder {
   _$FilesSharingShareesSearchResult_Exact? _$v;
 
   ListBuilder<FilesSharingShareeCircle>? _circles;
   ListBuilder<FilesSharingShareeCircle> get circles => _$this._circles ??= ListBuilder<FilesSharingShareeCircle>();
-  set circles(ListBuilder<FilesSharingShareeCircle>? circles) => _$this._circles = circles;
+  set circles(covariant ListBuilder<FilesSharingShareeCircle>? circles) => _$this._circles = circles;
 
   ListBuilder<FilesSharingShareeEmail>? _emails;
   ListBuilder<FilesSharingShareeEmail> get emails => _$this._emails ??= ListBuilder<FilesSharingShareeEmail>();
-  set emails(ListBuilder<FilesSharingShareeEmail>? emails) => _$this._emails = emails;
+  set emails(covariant ListBuilder<FilesSharingShareeEmail>? emails) => _$this._emails = emails;
 
   ListBuilder<FilesSharingSharee>? _groups;
   ListBuilder<FilesSharingSharee> get groups => _$this._groups ??= ListBuilder<FilesSharingSharee>();
-  set groups(ListBuilder<FilesSharingSharee>? groups) => _$this._groups = groups;
+  set groups(covariant ListBuilder<FilesSharingSharee>? groups) => _$this._groups = groups;
 
   ListBuilder<FilesSharingShareeRemoteGroup>? _remoteGroups;
   ListBuilder<FilesSharingShareeRemoteGroup> get remoteGroups =>
       _$this._remoteGroups ??= ListBuilder<FilesSharingShareeRemoteGroup>();
-  set remoteGroups(ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups) => _$this._remoteGroups = remoteGroups;
+  set remoteGroups(covariant ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups) =>
+      _$this._remoteGroups = remoteGroups;
 
   ListBuilder<FilesSharingShareeRemote>? _remotes;
   ListBuilder<FilesSharingShareeRemote> get remotes => _$this._remotes ??= ListBuilder<FilesSharingShareeRemote>();
-  set remotes(ListBuilder<FilesSharingShareeRemote>? remotes) => _$this._remotes = remotes;
+  set remotes(covariant ListBuilder<FilesSharingShareeRemote>? remotes) => _$this._remotes = remotes;
 
   ListBuilder<FilesSharingSharee>? _rooms;
   ListBuilder<FilesSharingSharee> get rooms => _$this._rooms ??= ListBuilder<FilesSharingSharee>();
-  set rooms(ListBuilder<FilesSharingSharee>? rooms) => _$this._rooms = rooms;
+  set rooms(covariant ListBuilder<FilesSharingSharee>? rooms) => _$this._rooms = rooms;
 
   ListBuilder<FilesSharingShareeUser>? _users;
   ListBuilder<FilesSharingShareeUser> get users => _$this._users ??= ListBuilder<FilesSharingShareeUser>();
-  set users(ListBuilder<FilesSharingShareeUser>? users) => _$this._users = users;
+  set users(covariant ListBuilder<FilesSharingShareeUser>? users) => _$this._users = users;
 
   FilesSharingShareesSearchResult_ExactBuilder();
 
@@ -12642,7 +12852,7 @@ class FilesSharingShareesSearchResult_ExactBuilder
   }
 
   @override
-  void replace(FilesSharingShareesSearchResult_Exact other) {
+  void replace(covariant FilesSharingShareesSearchResult_Exact other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareesSearchResult_Exact;
   }
@@ -12694,6 +12904,16 @@ class FilesSharingShareesSearchResult_ExactBuilder
   }
 }
 
+abstract mixin class FilesSharingLookupInterfaceBuilder {
+  void replace(FilesSharingLookupInterface other);
+  void update(void Function(FilesSharingLookupInterfaceBuilder) updates);
+  String? get value;
+  set value(String? value);
+
+  int? get verified;
+  set verified(int? verified);
+}
+
 class _$FilesSharingLookup extends FilesSharingLookup {
   @override
   final String value;
@@ -12739,16 +12959,17 @@ class _$FilesSharingLookup extends FilesSharingLookup {
   }
 }
 
-class FilesSharingLookupBuilder implements Builder<FilesSharingLookup, FilesSharingLookupBuilder> {
+class FilesSharingLookupBuilder
+    implements Builder<FilesSharingLookup, FilesSharingLookupBuilder>, FilesSharingLookupInterfaceBuilder {
   _$FilesSharingLookup? _$v;
 
   String? _value;
   String? get value => _$this._value;
-  set value(String? value) => _$this._value = value;
+  set value(covariant String? value) => _$this._value = value;
 
   int? _verified;
   int? get verified => _$this._verified;
-  set verified(int? verified) => _$this._verified = verified;
+  set verified(covariant int? verified) => _$this._verified = verified;
 
   FilesSharingLookupBuilder();
 
@@ -12763,7 +12984,7 @@ class FilesSharingLookupBuilder implements Builder<FilesSharingLookup, FilesShar
   }
 
   @override
-  void replace(FilesSharingLookup other) {
+  void replace(covariant FilesSharingLookup other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingLookup;
   }
@@ -12786,7 +13007,41 @@ class FilesSharingLookupBuilder implements Builder<FilesSharingLookup, FilesShar
   }
 }
 
-class _$FilesSharingShareeLookup1_Extra extends FilesSharingShareeLookup1_Extra {
+abstract mixin class FilesSharingShareeLookup_1_ExtraInterfaceBuilder {
+  void replace(FilesSharingShareeLookup_1_ExtraInterface other);
+  void update(void Function(FilesSharingShareeLookup_1_ExtraInterfaceBuilder) updates);
+  String? get federationId;
+  set federationId(String? federationId);
+
+  FilesSharingLookupBuilder get name;
+  set name(FilesSharingLookupBuilder? name);
+
+  FilesSharingLookupBuilder get email;
+  set email(FilesSharingLookupBuilder? email);
+
+  FilesSharingLookupBuilder get address;
+  set address(FilesSharingLookupBuilder? address);
+
+  FilesSharingLookupBuilder get website;
+  set website(FilesSharingLookupBuilder? website);
+
+  FilesSharingLookupBuilder get twitter;
+  set twitter(FilesSharingLookupBuilder? twitter);
+
+  FilesSharingLookupBuilder get phone;
+  set phone(FilesSharingLookupBuilder? phone);
+
+  FilesSharingLookupBuilder get twitterSignature;
+  set twitterSignature(FilesSharingLookupBuilder? twitterSignature);
+
+  FilesSharingLookupBuilder get websiteSignature;
+  set websiteSignature(FilesSharingLookupBuilder? websiteSignature);
+
+  FilesSharingLookupBuilder get userid;
+  set userid(FilesSharingLookupBuilder? userid);
+}
+
+class _$FilesSharingShareeLookup_1_Extra extends FilesSharingShareeLookup_1_Extra {
   @override
   final String federationId;
   @override
@@ -12808,10 +13063,10 @@ class _$FilesSharingShareeLookup1_Extra extends FilesSharingShareeLookup1_Extra 
   @override
   final FilesSharingLookup? userid;
 
-  factory _$FilesSharingShareeLookup1_Extra([void Function(FilesSharingShareeLookup1_ExtraBuilder)? updates]) =>
-      (FilesSharingShareeLookup1_ExtraBuilder()..update(updates))._build();
+  factory _$FilesSharingShareeLookup_1_Extra([void Function(FilesSharingShareeLookup_1_ExtraBuilder)? updates]) =>
+      (FilesSharingShareeLookup_1_ExtraBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeLookup1_Extra._(
+  _$FilesSharingShareeLookup_1_Extra._(
       {required this.federationId,
       this.name,
       this.email,
@@ -12823,20 +13078,20 @@ class _$FilesSharingShareeLookup1_Extra extends FilesSharingShareeLookup1_Extra 
       this.websiteSignature,
       this.userid})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(federationId, r'FilesSharingShareeLookup1_Extra', 'federationId');
+    BuiltValueNullFieldError.checkNotNull(federationId, r'FilesSharingShareeLookup_1_Extra', 'federationId');
   }
 
   @override
-  FilesSharingShareeLookup1_Extra rebuild(void Function(FilesSharingShareeLookup1_ExtraBuilder) updates) =>
+  FilesSharingShareeLookup_1_Extra rebuild(void Function(FilesSharingShareeLookup_1_ExtraBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  FilesSharingShareeLookup1_ExtraBuilder toBuilder() => FilesSharingShareeLookup1_ExtraBuilder()..replace(this);
+  FilesSharingShareeLookup_1_ExtraBuilder toBuilder() => FilesSharingShareeLookup_1_ExtraBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is FilesSharingShareeLookup1_Extra &&
+    return other is FilesSharingShareeLookup_1_Extra &&
         federationId == other.federationId &&
         name == other.name &&
         email == other.email &&
@@ -12868,7 +13123,7 @@ class _$FilesSharingShareeLookup1_Extra extends FilesSharingShareeLookup1_Extra 
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeLookup1_Extra')
+    return (newBuiltValueToStringHelper(r'FilesSharingShareeLookup_1_Extra')
           ..add('federationId', federationId)
           ..add('name', name)
           ..add('email', email)
@@ -12883,53 +13138,57 @@ class _$FilesSharingShareeLookup1_Extra extends FilesSharingShareeLookup1_Extra 
   }
 }
 
-class FilesSharingShareeLookup1_ExtraBuilder
-    implements Builder<FilesSharingShareeLookup1_Extra, FilesSharingShareeLookup1_ExtraBuilder> {
-  _$FilesSharingShareeLookup1_Extra? _$v;
+class FilesSharingShareeLookup_1_ExtraBuilder
+    implements
+        Builder<FilesSharingShareeLookup_1_Extra, FilesSharingShareeLookup_1_ExtraBuilder>,
+        FilesSharingShareeLookup_1_ExtraInterfaceBuilder {
+  _$FilesSharingShareeLookup_1_Extra? _$v;
 
   String? _federationId;
   String? get federationId => _$this._federationId;
-  set federationId(String? federationId) => _$this._federationId = federationId;
+  set federationId(covariant String? federationId) => _$this._federationId = federationId;
 
   FilesSharingLookupBuilder? _name;
   FilesSharingLookupBuilder get name => _$this._name ??= FilesSharingLookupBuilder();
-  set name(FilesSharingLookupBuilder? name) => _$this._name = name;
+  set name(covariant FilesSharingLookupBuilder? name) => _$this._name = name;
 
   FilesSharingLookupBuilder? _email;
   FilesSharingLookupBuilder get email => _$this._email ??= FilesSharingLookupBuilder();
-  set email(FilesSharingLookupBuilder? email) => _$this._email = email;
+  set email(covariant FilesSharingLookupBuilder? email) => _$this._email = email;
 
   FilesSharingLookupBuilder? _address;
   FilesSharingLookupBuilder get address => _$this._address ??= FilesSharingLookupBuilder();
-  set address(FilesSharingLookupBuilder? address) => _$this._address = address;
+  set address(covariant FilesSharingLookupBuilder? address) => _$this._address = address;
 
   FilesSharingLookupBuilder? _website;
   FilesSharingLookupBuilder get website => _$this._website ??= FilesSharingLookupBuilder();
-  set website(FilesSharingLookupBuilder? website) => _$this._website = website;
+  set website(covariant FilesSharingLookupBuilder? website) => _$this._website = website;
 
   FilesSharingLookupBuilder? _twitter;
   FilesSharingLookupBuilder get twitter => _$this._twitter ??= FilesSharingLookupBuilder();
-  set twitter(FilesSharingLookupBuilder? twitter) => _$this._twitter = twitter;
+  set twitter(covariant FilesSharingLookupBuilder? twitter) => _$this._twitter = twitter;
 
   FilesSharingLookupBuilder? _phone;
   FilesSharingLookupBuilder get phone => _$this._phone ??= FilesSharingLookupBuilder();
-  set phone(FilesSharingLookupBuilder? phone) => _$this._phone = phone;
+  set phone(covariant FilesSharingLookupBuilder? phone) => _$this._phone = phone;
 
   FilesSharingLookupBuilder? _twitterSignature;
   FilesSharingLookupBuilder get twitterSignature => _$this._twitterSignature ??= FilesSharingLookupBuilder();
-  set twitterSignature(FilesSharingLookupBuilder? twitterSignature) => _$this._twitterSignature = twitterSignature;
+  set twitterSignature(covariant FilesSharingLookupBuilder? twitterSignature) =>
+      _$this._twitterSignature = twitterSignature;
 
   FilesSharingLookupBuilder? _websiteSignature;
   FilesSharingLookupBuilder get websiteSignature => _$this._websiteSignature ??= FilesSharingLookupBuilder();
-  set websiteSignature(FilesSharingLookupBuilder? websiteSignature) => _$this._websiteSignature = websiteSignature;
+  set websiteSignature(covariant FilesSharingLookupBuilder? websiteSignature) =>
+      _$this._websiteSignature = websiteSignature;
 
   FilesSharingLookupBuilder? _userid;
   FilesSharingLookupBuilder get userid => _$this._userid ??= FilesSharingLookupBuilder();
-  set userid(FilesSharingLookupBuilder? userid) => _$this._userid = userid;
+  set userid(covariant FilesSharingLookupBuilder? userid) => _$this._userid = userid;
 
-  FilesSharingShareeLookup1_ExtraBuilder();
+  FilesSharingShareeLookup_1_ExtraBuilder();
 
-  FilesSharingShareeLookup1_ExtraBuilder get _$this {
+  FilesSharingShareeLookup_1_ExtraBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _federationId = $v.federationId;
@@ -12948,26 +13207,26 @@ class FilesSharingShareeLookup1_ExtraBuilder
   }
 
   @override
-  void replace(FilesSharingShareeLookup1_Extra other) {
+  void replace(covariant FilesSharingShareeLookup_1_Extra other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeLookup1_Extra;
+    _$v = other as _$FilesSharingShareeLookup_1_Extra;
   }
 
   @override
-  void update(void Function(FilesSharingShareeLookup1_ExtraBuilder)? updates) {
+  void update(void Function(FilesSharingShareeLookup_1_ExtraBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  FilesSharingShareeLookup1_Extra build() => _build();
+  FilesSharingShareeLookup_1_Extra build() => _build();
 
-  _$FilesSharingShareeLookup1_Extra _build() {
-    _$FilesSharingShareeLookup1_Extra _$result;
+  _$FilesSharingShareeLookup_1_Extra _build() {
+    _$FilesSharingShareeLookup_1_Extra _$result;
     try {
       _$result = _$v ??
-          _$FilesSharingShareeLookup1_Extra._(
+          _$FilesSharingShareeLookup_1_Extra._(
               federationId: BuiltValueNullFieldError.checkNotNull(
-                  federationId, r'FilesSharingShareeLookup1_Extra', 'federationId'),
+                  federationId, r'FilesSharingShareeLookup_1_Extra', 'federationId'),
               name: _name?.build(),
               email: _email?.build(),
               address: _address?.build(),
@@ -12999,7 +13258,7 @@ class FilesSharingShareeLookup1_ExtraBuilder
         _$failedField = 'userid';
         _userid?.build();
       } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeLookup1_Extra', _$failedField, e.toString());
+        throw BuiltValueNestedFieldError(r'FilesSharingShareeLookup_1_Extra', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -13008,33 +13267,52 @@ class FilesSharingShareeLookup1_ExtraBuilder
   }
 }
 
-class _$FilesSharingShareeLookup1_Value1 extends FilesSharingShareeLookup1_Value1 {
+abstract mixin class FilesSharingShareeLookup_1_Value_1InterfaceBuilder {
+  void replace(FilesSharingShareeLookup_1_Value_1Interface other);
+  void update(void Function(FilesSharingShareeLookup_1_Value_1InterfaceBuilder) updates);
+  bool? get globalScale;
+  set globalScale(bool? globalScale);
+}
+
+class _$FilesSharingShareeLookup_1_Value extends FilesSharingShareeLookup_1_Value {
+  @override
+  final int shareType;
+  @override
+  final String shareWith;
   @override
   final bool globalScale;
 
-  factory _$FilesSharingShareeLookup1_Value1([void Function(FilesSharingShareeLookup1_Value1Builder)? updates]) =>
-      (FilesSharingShareeLookup1_Value1Builder()..update(updates))._build();
+  factory _$FilesSharingShareeLookup_1_Value([void Function(FilesSharingShareeLookup_1_ValueBuilder)? updates]) =>
+      (FilesSharingShareeLookup_1_ValueBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeLookup1_Value1._({required this.globalScale}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(globalScale, r'FilesSharingShareeLookup1_Value1', 'globalScale');
+  _$FilesSharingShareeLookup_1_Value._({required this.shareType, required this.shareWith, required this.globalScale})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(shareType, r'FilesSharingShareeLookup_1_Value', 'shareType');
+    BuiltValueNullFieldError.checkNotNull(shareWith, r'FilesSharingShareeLookup_1_Value', 'shareWith');
+    BuiltValueNullFieldError.checkNotNull(globalScale, r'FilesSharingShareeLookup_1_Value', 'globalScale');
   }
 
   @override
-  FilesSharingShareeLookup1_Value1 rebuild(void Function(FilesSharingShareeLookup1_Value1Builder) updates) =>
+  FilesSharingShareeLookup_1_Value rebuild(void Function(FilesSharingShareeLookup_1_ValueBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  FilesSharingShareeLookup1_Value1Builder toBuilder() => FilesSharingShareeLookup1_Value1Builder()..replace(this);
+  FilesSharingShareeLookup_1_ValueBuilder toBuilder() => FilesSharingShareeLookup_1_ValueBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is FilesSharingShareeLookup1_Value1 && globalScale == other.globalScale;
+    return other is FilesSharingShareeLookup_1_Value &&
+        shareType == other.shareType &&
+        shareWith == other.shareWith &&
+        globalScale == other.globalScale;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, shareType.hashCode);
+    _$hash = $jc(_$hash, shareWith.hashCode);
     _$hash = $jc(_$hash, globalScale.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
@@ -13042,24 +13320,40 @@ class _$FilesSharingShareeLookup1_Value1 extends FilesSharingShareeLookup1_Value
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeLookup1_Value1')..add('globalScale', globalScale))
+    return (newBuiltValueToStringHelper(r'FilesSharingShareeLookup_1_Value')
+          ..add('shareType', shareType)
+          ..add('shareWith', shareWith)
+          ..add('globalScale', globalScale))
         .toString();
   }
 }
 
-class FilesSharingShareeLookup1_Value1Builder
-    implements Builder<FilesSharingShareeLookup1_Value1, FilesSharingShareeLookup1_Value1Builder> {
-  _$FilesSharingShareeLookup1_Value1? _$v;
+class FilesSharingShareeLookup_1_ValueBuilder
+    implements
+        Builder<FilesSharingShareeLookup_1_Value, FilesSharingShareeLookup_1_ValueBuilder>,
+        FilesSharingShareeValueInterfaceBuilder,
+        FilesSharingShareeLookup_1_Value_1InterfaceBuilder {
+  _$FilesSharingShareeLookup_1_Value? _$v;
+
+  int? _shareType;
+  int? get shareType => _$this._shareType;
+  set shareType(covariant int? shareType) => _$this._shareType = shareType;
+
+  String? _shareWith;
+  String? get shareWith => _$this._shareWith;
+  set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
   bool? _globalScale;
   bool? get globalScale => _$this._globalScale;
-  set globalScale(bool? globalScale) => _$this._globalScale = globalScale;
+  set globalScale(covariant bool? globalScale) => _$this._globalScale = globalScale;
 
-  FilesSharingShareeLookup1_Value1Builder();
+  FilesSharingShareeLookup_1_ValueBuilder();
 
-  FilesSharingShareeLookup1_Value1Builder get _$this {
+  FilesSharingShareeLookup_1_ValueBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _shareType = $v.shareType;
+      _shareWith = $v.shareWith;
       _globalScale = $v.globalScale;
       _$v = null;
     }
@@ -13067,273 +13361,62 @@ class FilesSharingShareeLookup1_Value1Builder
   }
 
   @override
-  void replace(FilesSharingShareeLookup1_Value1 other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant FilesSharingShareeLookup_1_Value other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeLookup1_Value1;
+    _$v = other as _$FilesSharingShareeLookup_1_Value;
   }
 
   @override
-  void update(void Function(FilesSharingShareeLookup1_Value1Builder)? updates) {
+  void update(void Function(FilesSharingShareeLookup_1_ValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  FilesSharingShareeLookup1_Value1 build() => _build();
+  FilesSharingShareeLookup_1_Value build() => _build();
 
-  _$FilesSharingShareeLookup1_Value1 _build() {
+  _$FilesSharingShareeLookup_1_Value _build() {
     final _$result = _$v ??
-        _$FilesSharingShareeLookup1_Value1._(
+        _$FilesSharingShareeLookup_1_Value._(
+            shareType:
+                BuiltValueNullFieldError.checkNotNull(shareType, r'FilesSharingShareeLookup_1_Value', 'shareType'),
+            shareWith:
+                BuiltValueNullFieldError.checkNotNull(shareWith, r'FilesSharingShareeLookup_1_Value', 'shareWith'),
             globalScale:
-                BuiltValueNullFieldError.checkNotNull(globalScale, r'FilesSharingShareeLookup1_Value1', 'globalScale'));
+                BuiltValueNullFieldError.checkNotNull(globalScale, r'FilesSharingShareeLookup_1_Value', 'globalScale'));
     replace(_$result);
     return _$result;
   }
 }
 
-class _$FilesSharingShareeLookup1_Value extends FilesSharingShareeLookup1_Value {
-  @override
-  final JsonObject data;
-  @override
-  final FilesSharingShareeValue shareeValue;
-  @override
-  final FilesSharingShareeLookup1_Value1 shareeLookup1Value1;
+abstract mixin class FilesSharingShareeLookup_1InterfaceBuilder {
+  void replace(FilesSharingShareeLookup_1Interface other);
+  void update(void Function(FilesSharingShareeLookup_1InterfaceBuilder) updates);
+  FilesSharingShareeLookup_1_ExtraBuilder get extra;
+  set extra(FilesSharingShareeLookup_1_ExtraBuilder? extra);
 
-  factory _$FilesSharingShareeLookup1_Value([void Function(FilesSharingShareeLookup1_ValueBuilder)? updates]) =>
-      (FilesSharingShareeLookup1_ValueBuilder()..update(updates))._build();
-
-  _$FilesSharingShareeLookup1_Value._(
-      {required this.data, required this.shareeValue, required this.shareeLookup1Value1})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeLookup1_Value', 'data');
-    BuiltValueNullFieldError.checkNotNull(shareeValue, r'FilesSharingShareeLookup1_Value', 'shareeValue');
-    BuiltValueNullFieldError.checkNotNull(
-        shareeLookup1Value1, r'FilesSharingShareeLookup1_Value', 'shareeLookup1Value1');
-  }
-
-  @override
-  FilesSharingShareeLookup1_Value rebuild(void Function(FilesSharingShareeLookup1_ValueBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  FilesSharingShareeLookup1_ValueBuilder toBuilder() => FilesSharingShareeLookup1_ValueBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is FilesSharingShareeLookup1_Value &&
-        data == other.data &&
-        shareeValue == other.shareeValue &&
-        shareeLookup1Value1 == other.shareeLookup1Value1;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, shareeValue.hashCode);
-    _$hash = $jc(_$hash, shareeLookup1Value1.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeLookup1_Value')
-          ..add('data', data)
-          ..add('shareeValue', shareeValue)
-          ..add('shareeLookup1Value1', shareeLookup1Value1))
-        .toString();
-  }
-}
-
-class FilesSharingShareeLookup1_ValueBuilder
-    implements Builder<FilesSharingShareeLookup1_Value, FilesSharingShareeLookup1_ValueBuilder> {
-  _$FilesSharingShareeLookup1_Value? _$v;
-
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
-
-  FilesSharingShareeValueBuilder? _shareeValue;
-  FilesSharingShareeValueBuilder get shareeValue => _$this._shareeValue ??= FilesSharingShareeValueBuilder();
-  set shareeValue(FilesSharingShareeValueBuilder? shareeValue) => _$this._shareeValue = shareeValue;
-
-  FilesSharingShareeLookup1_Value1Builder? _shareeLookup1Value1;
-  FilesSharingShareeLookup1_Value1Builder get shareeLookup1Value1 =>
-      _$this._shareeLookup1Value1 ??= FilesSharingShareeLookup1_Value1Builder();
-  set shareeLookup1Value1(FilesSharingShareeLookup1_Value1Builder? shareeLookup1Value1) =>
-      _$this._shareeLookup1Value1 = shareeLookup1Value1;
-
-  FilesSharingShareeLookup1_ValueBuilder();
-
-  FilesSharingShareeLookup1_ValueBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _data = $v.data;
-      _shareeValue = $v.shareeValue.toBuilder();
-      _shareeLookup1Value1 = $v.shareeLookup1Value1.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(FilesSharingShareeLookup1_Value other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeLookup1_Value;
-  }
-
-  @override
-  void update(void Function(FilesSharingShareeLookup1_ValueBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  FilesSharingShareeLookup1_Value build() => _build();
-
-  _$FilesSharingShareeLookup1_Value _build() {
-    _$FilesSharingShareeLookup1_Value _$result;
-    try {
-      _$result = _$v ??
-          _$FilesSharingShareeLookup1_Value._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeLookup1_Value', 'data'),
-              shareeValue: shareeValue.build(),
-              shareeLookup1Value1: shareeLookup1Value1.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'shareeValue';
-        shareeValue.build();
-        _$failedField = 'shareeLookup1Value1';
-        shareeLookup1Value1.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeLookup1_Value', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
-class _$FilesSharingShareeLookup1 extends FilesSharingShareeLookup1 {
-  @override
-  final FilesSharingShareeLookup1_Extra extra;
-  @override
-  final FilesSharingShareeLookup1_Value value;
-
-  factory _$FilesSharingShareeLookup1([void Function(FilesSharingShareeLookup1Builder)? updates]) =>
-      (FilesSharingShareeLookup1Builder()..update(updates))._build();
-
-  _$FilesSharingShareeLookup1._({required this.extra, required this.value}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(extra, r'FilesSharingShareeLookup1', 'extra');
-    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeLookup1', 'value');
-  }
-
-  @override
-  FilesSharingShareeLookup1 rebuild(void Function(FilesSharingShareeLookup1Builder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  FilesSharingShareeLookup1Builder toBuilder() => FilesSharingShareeLookup1Builder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is FilesSharingShareeLookup1 && extra == other.extra && value == other.value;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, extra.hashCode);
-    _$hash = $jc(_$hash, value.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'FilesSharingShareeLookup1')
-          ..add('extra', extra)
-          ..add('value', value))
-        .toString();
-  }
-}
-
-class FilesSharingShareeLookup1Builder implements Builder<FilesSharingShareeLookup1, FilesSharingShareeLookup1Builder> {
-  _$FilesSharingShareeLookup1? _$v;
-
-  FilesSharingShareeLookup1_ExtraBuilder? _extra;
-  FilesSharingShareeLookup1_ExtraBuilder get extra => _$this._extra ??= FilesSharingShareeLookup1_ExtraBuilder();
-  set extra(FilesSharingShareeLookup1_ExtraBuilder? extra) => _$this._extra = extra;
-
-  FilesSharingShareeLookup1_ValueBuilder? _value;
-  FilesSharingShareeLookup1_ValueBuilder get value => _$this._value ??= FilesSharingShareeLookup1_ValueBuilder();
-  set value(FilesSharingShareeLookup1_ValueBuilder? value) => _$this._value = value;
-
-  FilesSharingShareeLookup1Builder();
-
-  FilesSharingShareeLookup1Builder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _extra = $v.extra.toBuilder();
-      _value = $v.value.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(FilesSharingShareeLookup1 other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$FilesSharingShareeLookup1;
-  }
-
-  @override
-  void update(void Function(FilesSharingShareeLookup1Builder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  FilesSharingShareeLookup1 build() => _build();
-
-  _$FilesSharingShareeLookup1 _build() {
-    _$FilesSharingShareeLookup1 _$result;
-    try {
-      _$result = _$v ?? _$FilesSharingShareeLookup1._(extra: extra.build(), value: value.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'extra';
-        extra.build();
-        _$failedField = 'value';
-        value.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'FilesSharingShareeLookup1', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
+  FilesSharingShareeLookup_1_ValueBuilder get value;
+  set value(FilesSharingShareeLookup_1_ValueBuilder? value);
 }
 
 class _$FilesSharingShareeLookup extends FilesSharingShareeLookup {
   @override
-  final JsonObject data;
+  final int? count;
   @override
-  final FilesSharingSharee sharee;
+  final String label;
   @override
-  final FilesSharingShareeLookup1 shareeLookup1;
+  final FilesSharingShareeLookup_1_Extra extra;
+  @override
+  final FilesSharingShareeLookup_1_Value value;
 
   factory _$FilesSharingShareeLookup([void Function(FilesSharingShareeLookupBuilder)? updates]) =>
       (FilesSharingShareeLookupBuilder()..update(updates))._build();
 
-  _$FilesSharingShareeLookup._({required this.data, required this.sharee, required this.shareeLookup1}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeLookup', 'data');
-    BuiltValueNullFieldError.checkNotNull(sharee, r'FilesSharingShareeLookup', 'sharee');
-    BuiltValueNullFieldError.checkNotNull(shareeLookup1, r'FilesSharingShareeLookup', 'shareeLookup1');
+  _$FilesSharingShareeLookup._({this.count, required this.label, required this.extra, required this.value})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeLookup', 'label');
+    BuiltValueNullFieldError.checkNotNull(extra, r'FilesSharingShareeLookup', 'extra');
+    BuiltValueNullFieldError.checkNotNull(value, r'FilesSharingShareeLookup', 'value');
   }
 
   @override
@@ -13347,17 +13430,19 @@ class _$FilesSharingShareeLookup extends FilesSharingShareeLookup {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is FilesSharingShareeLookup &&
-        data == other.data &&
-        sharee == other.sharee &&
-        shareeLookup1 == other.shareeLookup1;
+        count == other.count &&
+        label == other.label &&
+        extra == other.extra &&
+        value == other.value;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, sharee.hashCode);
-    _$hash = $jc(_$hash, shareeLookup1.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
+    _$hash = $jc(_$hash, extra.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -13365,43 +13450,54 @@ class _$FilesSharingShareeLookup extends FilesSharingShareeLookup {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'FilesSharingShareeLookup')
-          ..add('data', data)
-          ..add('sharee', sharee)
-          ..add('shareeLookup1', shareeLookup1))
+          ..add('count', count)
+          ..add('label', label)
+          ..add('extra', extra)
+          ..add('value', value))
         .toString();
   }
 }
 
-class FilesSharingShareeLookupBuilder implements Builder<FilesSharingShareeLookup, FilesSharingShareeLookupBuilder> {
+class FilesSharingShareeLookupBuilder
+    implements
+        Builder<FilesSharingShareeLookup, FilesSharingShareeLookupBuilder>,
+        FilesSharingShareeInterfaceBuilder,
+        FilesSharingShareeLookup_1InterfaceBuilder {
   _$FilesSharingShareeLookup? _$v;
 
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  int? _count;
+  int? get count => _$this._count;
+  set count(covariant int? count) => _$this._count = count;
 
-  FilesSharingShareeBuilder? _sharee;
-  FilesSharingShareeBuilder get sharee => _$this._sharee ??= FilesSharingShareeBuilder();
-  set sharee(FilesSharingShareeBuilder? sharee) => _$this._sharee = sharee;
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
 
-  FilesSharingShareeLookup1Builder? _shareeLookup1;
-  FilesSharingShareeLookup1Builder get shareeLookup1 => _$this._shareeLookup1 ??= FilesSharingShareeLookup1Builder();
-  set shareeLookup1(FilesSharingShareeLookup1Builder? shareeLookup1) => _$this._shareeLookup1 = shareeLookup1;
+  FilesSharingShareeLookup_1_ExtraBuilder? _extra;
+  FilesSharingShareeLookup_1_ExtraBuilder get extra => _$this._extra ??= FilesSharingShareeLookup_1_ExtraBuilder();
+  set extra(covariant FilesSharingShareeLookup_1_ExtraBuilder? extra) => _$this._extra = extra;
+
+  FilesSharingShareeLookup_1_ValueBuilder? _value;
+  FilesSharingShareeLookup_1_ValueBuilder get value => _$this._value ??= FilesSharingShareeLookup_1_ValueBuilder();
+  set value(covariant FilesSharingShareeLookup_1_ValueBuilder? value) => _$this._value = value;
 
   FilesSharingShareeLookupBuilder();
 
   FilesSharingShareeLookupBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _data = $v.data;
-      _sharee = $v.sharee.toBuilder();
-      _shareeLookup1 = $v.shareeLookup1.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
+      _extra = $v.extra.toBuilder();
+      _value = $v.value.toBuilder();
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(FilesSharingShareeLookup other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant FilesSharingShareeLookup other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareeLookup;
   }
@@ -13419,16 +13515,17 @@ class FilesSharingShareeLookupBuilder implements Builder<FilesSharingShareeLooku
     try {
       _$result = _$v ??
           _$FilesSharingShareeLookup._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'FilesSharingShareeLookup', 'data'),
-              sharee: sharee.build(),
-              shareeLookup1: shareeLookup1.build());
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'FilesSharingShareeLookup', 'label'),
+              extra: extra.build(),
+              value: value.build());
     } catch (_) {
       late String _$failedField;
       try {
-        _$failedField = 'sharee';
-        sharee.build();
-        _$failedField = 'shareeLookup1';
-        shareeLookup1.build();
+        _$failedField = 'extra';
+        extra.build();
+        _$failedField = 'value';
+        value.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'FilesSharingShareeLookup', _$failedField, e.toString());
       }
@@ -13437,6 +13534,40 @@ class FilesSharingShareeLookupBuilder implements Builder<FilesSharingShareeLooku
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareesSearchResultInterfaceBuilder {
+  void replace(FilesSharingShareesSearchResultInterface other);
+  void update(void Function(FilesSharingShareesSearchResultInterfaceBuilder) updates);
+  FilesSharingShareesSearchResult_ExactBuilder get exact;
+  set exact(FilesSharingShareesSearchResult_ExactBuilder? exact);
+
+  ListBuilder<FilesSharingShareeCircle> get circles;
+  set circles(ListBuilder<FilesSharingShareeCircle>? circles);
+
+  ListBuilder<FilesSharingShareeEmail> get emails;
+  set emails(ListBuilder<FilesSharingShareeEmail>? emails);
+
+  ListBuilder<FilesSharingSharee> get groups;
+  set groups(ListBuilder<FilesSharingSharee>? groups);
+
+  ListBuilder<FilesSharingShareeLookup> get lookup;
+  set lookup(ListBuilder<FilesSharingShareeLookup>? lookup);
+
+  ListBuilder<FilesSharingShareeRemoteGroup> get remoteGroups;
+  set remoteGroups(ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups);
+
+  ListBuilder<FilesSharingShareeRemote> get remotes;
+  set remotes(ListBuilder<FilesSharingShareeRemote>? remotes);
+
+  ListBuilder<FilesSharingSharee> get rooms;
+  set rooms(ListBuilder<FilesSharingSharee>? rooms);
+
+  ListBuilder<FilesSharingShareeUser> get users;
+  set users(ListBuilder<FilesSharingShareeUser>? users);
+
+  bool? get lookupEnabled;
+  set lookupEnabled(bool? lookupEnabled);
 }
 
 class _$FilesSharingShareesSearchResult extends FilesSharingShareesSearchResult {
@@ -13546,50 +13677,53 @@ class _$FilesSharingShareesSearchResult extends FilesSharingShareesSearchResult 
 }
 
 class FilesSharingShareesSearchResultBuilder
-    implements Builder<FilesSharingShareesSearchResult, FilesSharingShareesSearchResultBuilder> {
+    implements
+        Builder<FilesSharingShareesSearchResult, FilesSharingShareesSearchResultBuilder>,
+        FilesSharingShareesSearchResultInterfaceBuilder {
   _$FilesSharingShareesSearchResult? _$v;
 
   FilesSharingShareesSearchResult_ExactBuilder? _exact;
   FilesSharingShareesSearchResult_ExactBuilder get exact =>
       _$this._exact ??= FilesSharingShareesSearchResult_ExactBuilder();
-  set exact(FilesSharingShareesSearchResult_ExactBuilder? exact) => _$this._exact = exact;
+  set exact(covariant FilesSharingShareesSearchResult_ExactBuilder? exact) => _$this._exact = exact;
 
   ListBuilder<FilesSharingShareeCircle>? _circles;
   ListBuilder<FilesSharingShareeCircle> get circles => _$this._circles ??= ListBuilder<FilesSharingShareeCircle>();
-  set circles(ListBuilder<FilesSharingShareeCircle>? circles) => _$this._circles = circles;
+  set circles(covariant ListBuilder<FilesSharingShareeCircle>? circles) => _$this._circles = circles;
 
   ListBuilder<FilesSharingShareeEmail>? _emails;
   ListBuilder<FilesSharingShareeEmail> get emails => _$this._emails ??= ListBuilder<FilesSharingShareeEmail>();
-  set emails(ListBuilder<FilesSharingShareeEmail>? emails) => _$this._emails = emails;
+  set emails(covariant ListBuilder<FilesSharingShareeEmail>? emails) => _$this._emails = emails;
 
   ListBuilder<FilesSharingSharee>? _groups;
   ListBuilder<FilesSharingSharee> get groups => _$this._groups ??= ListBuilder<FilesSharingSharee>();
-  set groups(ListBuilder<FilesSharingSharee>? groups) => _$this._groups = groups;
+  set groups(covariant ListBuilder<FilesSharingSharee>? groups) => _$this._groups = groups;
 
   ListBuilder<FilesSharingShareeLookup>? _lookup;
   ListBuilder<FilesSharingShareeLookup> get lookup => _$this._lookup ??= ListBuilder<FilesSharingShareeLookup>();
-  set lookup(ListBuilder<FilesSharingShareeLookup>? lookup) => _$this._lookup = lookup;
+  set lookup(covariant ListBuilder<FilesSharingShareeLookup>? lookup) => _$this._lookup = lookup;
 
   ListBuilder<FilesSharingShareeRemoteGroup>? _remoteGroups;
   ListBuilder<FilesSharingShareeRemoteGroup> get remoteGroups =>
       _$this._remoteGroups ??= ListBuilder<FilesSharingShareeRemoteGroup>();
-  set remoteGroups(ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups) => _$this._remoteGroups = remoteGroups;
+  set remoteGroups(covariant ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups) =>
+      _$this._remoteGroups = remoteGroups;
 
   ListBuilder<FilesSharingShareeRemote>? _remotes;
   ListBuilder<FilesSharingShareeRemote> get remotes => _$this._remotes ??= ListBuilder<FilesSharingShareeRemote>();
-  set remotes(ListBuilder<FilesSharingShareeRemote>? remotes) => _$this._remotes = remotes;
+  set remotes(covariant ListBuilder<FilesSharingShareeRemote>? remotes) => _$this._remotes = remotes;
 
   ListBuilder<FilesSharingSharee>? _rooms;
   ListBuilder<FilesSharingSharee> get rooms => _$this._rooms ??= ListBuilder<FilesSharingSharee>();
-  set rooms(ListBuilder<FilesSharingSharee>? rooms) => _$this._rooms = rooms;
+  set rooms(covariant ListBuilder<FilesSharingSharee>? rooms) => _$this._rooms = rooms;
 
   ListBuilder<FilesSharingShareeUser>? _users;
   ListBuilder<FilesSharingShareeUser> get users => _$this._users ??= ListBuilder<FilesSharingShareeUser>();
-  set users(ListBuilder<FilesSharingShareeUser>? users) => _$this._users = users;
+  set users(covariant ListBuilder<FilesSharingShareeUser>? users) => _$this._users = users;
 
   bool? _lookupEnabled;
   bool? get lookupEnabled => _$this._lookupEnabled;
-  set lookupEnabled(bool? lookupEnabled) => _$this._lookupEnabled = lookupEnabled;
+  set lookupEnabled(covariant bool? lookupEnabled) => _$this._lookupEnabled = lookupEnabled;
 
   FilesSharingShareesSearchResultBuilder();
 
@@ -13612,7 +13746,7 @@ class FilesSharingShareesSearchResultBuilder
   }
 
   @override
-  void replace(FilesSharingShareesSearchResult other) {
+  void replace(covariant FilesSharingShareesSearchResult other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareesSearchResult;
   }
@@ -13672,6 +13806,16 @@ class FilesSharingShareesSearchResultBuilder
   }
 }
 
+abstract mixin class FilesSharingShareesapiSearchResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingShareesapiSearchResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(FilesSharingShareesapiSearchResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  FilesSharingShareesSearchResultBuilder get data;
+  set data(FilesSharingShareesSearchResultBuilder? data);
+}
+
 class _$FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs
     extends FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs {
   @override
@@ -13726,16 +13870,17 @@ class _$FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs
 class FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs,
-            FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingShareesapiSearchResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesSharingShareesSearchResultBuilder? _data;
   FilesSharingShareesSearchResultBuilder get data => _$this._data ??= FilesSharingShareesSearchResultBuilder();
-  set data(FilesSharingShareesSearchResultBuilder? data) => _$this._data = data;
+  set data(covariant FilesSharingShareesSearchResultBuilder? data) => _$this._data = data;
 
   FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder();
 
@@ -13750,7 +13895,7 @@ class FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareesapiSearchResponse200ApplicationJson_Ocs;
   }
@@ -13784,6 +13929,13 @@ class FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareesapiSearchResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingShareesapiSearchResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingShareesapiSearchResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingShareesapiSearchResponse200ApplicationJson
@@ -13832,13 +13984,14 @@ class _$FilesSharingShareesapiSearchResponse200ApplicationJson
 class FilesSharingShareesapiSearchResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingShareesapiSearchResponse200ApplicationJson,
-            FilesSharingShareesapiSearchResponse200ApplicationJsonBuilder> {
+            FilesSharingShareesapiSearchResponse200ApplicationJsonBuilder>,
+        FilesSharingShareesapiSearchResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingShareesapiSearchResponse200ApplicationJson? _$v;
 
   FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingShareesapiSearchResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   FilesSharingShareesapiSearchResponse200ApplicationJsonBuilder();
 
@@ -13852,7 +14005,7 @@ class FilesSharingShareesapiSearchResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingShareesapiSearchResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingShareesapiSearchResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareesapiSearchResponse200ApplicationJson;
   }
@@ -14008,6 +14161,25 @@ class FilesSharingShareesapiFindRecommendedShareTypeBuilder
   }
 }
 
+abstract mixin class FilesSharingShareesRecommendedResult_ExactInterfaceBuilder {
+  void replace(FilesSharingShareesRecommendedResult_ExactInterface other);
+  void update(void Function(FilesSharingShareesRecommendedResult_ExactInterfaceBuilder) updates);
+  ListBuilder<FilesSharingShareeEmail> get emails;
+  set emails(ListBuilder<FilesSharingShareeEmail>? emails);
+
+  ListBuilder<FilesSharingSharee> get groups;
+  set groups(ListBuilder<FilesSharingSharee>? groups);
+
+  ListBuilder<FilesSharingShareeRemoteGroup> get remoteGroups;
+  set remoteGroups(ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups);
+
+  ListBuilder<FilesSharingShareeRemote> get remotes;
+  set remotes(ListBuilder<FilesSharingShareeRemote>? remotes);
+
+  ListBuilder<FilesSharingShareeUser> get users;
+  set users(ListBuilder<FilesSharingShareeUser>? users);
+}
+
 class _$FilesSharingShareesRecommendedResult_Exact extends FilesSharingShareesRecommendedResult_Exact {
   @override
   final BuiltList<FilesSharingShareeEmail> emails;
@@ -14083,29 +14255,32 @@ class _$FilesSharingShareesRecommendedResult_Exact extends FilesSharingShareesRe
 }
 
 class FilesSharingShareesRecommendedResult_ExactBuilder
-    implements Builder<FilesSharingShareesRecommendedResult_Exact, FilesSharingShareesRecommendedResult_ExactBuilder> {
+    implements
+        Builder<FilesSharingShareesRecommendedResult_Exact, FilesSharingShareesRecommendedResult_ExactBuilder>,
+        FilesSharingShareesRecommendedResult_ExactInterfaceBuilder {
   _$FilesSharingShareesRecommendedResult_Exact? _$v;
 
   ListBuilder<FilesSharingShareeEmail>? _emails;
   ListBuilder<FilesSharingShareeEmail> get emails => _$this._emails ??= ListBuilder<FilesSharingShareeEmail>();
-  set emails(ListBuilder<FilesSharingShareeEmail>? emails) => _$this._emails = emails;
+  set emails(covariant ListBuilder<FilesSharingShareeEmail>? emails) => _$this._emails = emails;
 
   ListBuilder<FilesSharingSharee>? _groups;
   ListBuilder<FilesSharingSharee> get groups => _$this._groups ??= ListBuilder<FilesSharingSharee>();
-  set groups(ListBuilder<FilesSharingSharee>? groups) => _$this._groups = groups;
+  set groups(covariant ListBuilder<FilesSharingSharee>? groups) => _$this._groups = groups;
 
   ListBuilder<FilesSharingShareeRemoteGroup>? _remoteGroups;
   ListBuilder<FilesSharingShareeRemoteGroup> get remoteGroups =>
       _$this._remoteGroups ??= ListBuilder<FilesSharingShareeRemoteGroup>();
-  set remoteGroups(ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups) => _$this._remoteGroups = remoteGroups;
+  set remoteGroups(covariant ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups) =>
+      _$this._remoteGroups = remoteGroups;
 
   ListBuilder<FilesSharingShareeRemote>? _remotes;
   ListBuilder<FilesSharingShareeRemote> get remotes => _$this._remotes ??= ListBuilder<FilesSharingShareeRemote>();
-  set remotes(ListBuilder<FilesSharingShareeRemote>? remotes) => _$this._remotes = remotes;
+  set remotes(covariant ListBuilder<FilesSharingShareeRemote>? remotes) => _$this._remotes = remotes;
 
   ListBuilder<FilesSharingShareeUser>? _users;
   ListBuilder<FilesSharingShareeUser> get users => _$this._users ??= ListBuilder<FilesSharingShareeUser>();
-  set users(ListBuilder<FilesSharingShareeUser>? users) => _$this._users = users;
+  set users(covariant ListBuilder<FilesSharingShareeUser>? users) => _$this._users = users;
 
   FilesSharingShareesRecommendedResult_ExactBuilder();
 
@@ -14123,7 +14298,7 @@ class FilesSharingShareesRecommendedResult_ExactBuilder
   }
 
   @override
-  void replace(FilesSharingShareesRecommendedResult_Exact other) {
+  void replace(covariant FilesSharingShareesRecommendedResult_Exact other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareesRecommendedResult_Exact;
   }
@@ -14167,6 +14342,28 @@ class FilesSharingShareesRecommendedResult_ExactBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareesRecommendedResultInterfaceBuilder {
+  void replace(FilesSharingShareesRecommendedResultInterface other);
+  void update(void Function(FilesSharingShareesRecommendedResultInterfaceBuilder) updates);
+  FilesSharingShareesRecommendedResult_ExactBuilder get exact;
+  set exact(FilesSharingShareesRecommendedResult_ExactBuilder? exact);
+
+  ListBuilder<FilesSharingShareeEmail> get emails;
+  set emails(ListBuilder<FilesSharingShareeEmail>? emails);
+
+  ListBuilder<FilesSharingSharee> get groups;
+  set groups(ListBuilder<FilesSharingSharee>? groups);
+
+  ListBuilder<FilesSharingShareeRemoteGroup> get remoteGroups;
+  set remoteGroups(ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups);
+
+  ListBuilder<FilesSharingShareeRemote> get remotes;
+  set remotes(ListBuilder<FilesSharingShareeRemote>? remotes);
+
+  ListBuilder<FilesSharingShareeUser> get users;
+  set users(ListBuilder<FilesSharingShareeUser>? users);
 }
 
 class _$FilesSharingShareesRecommendedResult extends FilesSharingShareesRecommendedResult {
@@ -14250,34 +14447,37 @@ class _$FilesSharingShareesRecommendedResult extends FilesSharingShareesRecommen
 }
 
 class FilesSharingShareesRecommendedResultBuilder
-    implements Builder<FilesSharingShareesRecommendedResult, FilesSharingShareesRecommendedResultBuilder> {
+    implements
+        Builder<FilesSharingShareesRecommendedResult, FilesSharingShareesRecommendedResultBuilder>,
+        FilesSharingShareesRecommendedResultInterfaceBuilder {
   _$FilesSharingShareesRecommendedResult? _$v;
 
   FilesSharingShareesRecommendedResult_ExactBuilder? _exact;
   FilesSharingShareesRecommendedResult_ExactBuilder get exact =>
       _$this._exact ??= FilesSharingShareesRecommendedResult_ExactBuilder();
-  set exact(FilesSharingShareesRecommendedResult_ExactBuilder? exact) => _$this._exact = exact;
+  set exact(covariant FilesSharingShareesRecommendedResult_ExactBuilder? exact) => _$this._exact = exact;
 
   ListBuilder<FilesSharingShareeEmail>? _emails;
   ListBuilder<FilesSharingShareeEmail> get emails => _$this._emails ??= ListBuilder<FilesSharingShareeEmail>();
-  set emails(ListBuilder<FilesSharingShareeEmail>? emails) => _$this._emails = emails;
+  set emails(covariant ListBuilder<FilesSharingShareeEmail>? emails) => _$this._emails = emails;
 
   ListBuilder<FilesSharingSharee>? _groups;
   ListBuilder<FilesSharingSharee> get groups => _$this._groups ??= ListBuilder<FilesSharingSharee>();
-  set groups(ListBuilder<FilesSharingSharee>? groups) => _$this._groups = groups;
+  set groups(covariant ListBuilder<FilesSharingSharee>? groups) => _$this._groups = groups;
 
   ListBuilder<FilesSharingShareeRemoteGroup>? _remoteGroups;
   ListBuilder<FilesSharingShareeRemoteGroup> get remoteGroups =>
       _$this._remoteGroups ??= ListBuilder<FilesSharingShareeRemoteGroup>();
-  set remoteGroups(ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups) => _$this._remoteGroups = remoteGroups;
+  set remoteGroups(covariant ListBuilder<FilesSharingShareeRemoteGroup>? remoteGroups) =>
+      _$this._remoteGroups = remoteGroups;
 
   ListBuilder<FilesSharingShareeRemote>? _remotes;
   ListBuilder<FilesSharingShareeRemote> get remotes => _$this._remotes ??= ListBuilder<FilesSharingShareeRemote>();
-  set remotes(ListBuilder<FilesSharingShareeRemote>? remotes) => _$this._remotes = remotes;
+  set remotes(covariant ListBuilder<FilesSharingShareeRemote>? remotes) => _$this._remotes = remotes;
 
   ListBuilder<FilesSharingShareeUser>? _users;
   ListBuilder<FilesSharingShareeUser> get users => _$this._users ??= ListBuilder<FilesSharingShareeUser>();
-  set users(ListBuilder<FilesSharingShareeUser>? users) => _$this._users = users;
+  set users(covariant ListBuilder<FilesSharingShareeUser>? users) => _$this._users = users;
 
   FilesSharingShareesRecommendedResultBuilder();
 
@@ -14296,7 +14496,7 @@ class FilesSharingShareesRecommendedResultBuilder
   }
 
   @override
-  void replace(FilesSharingShareesRecommendedResult other) {
+  void replace(covariant FilesSharingShareesRecommendedResult other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareesRecommendedResult;
   }
@@ -14343,6 +14543,17 @@ class FilesSharingShareesRecommendedResultBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  FilesSharingOCSMetaBuilder get meta;
+  set meta(FilesSharingOCSMetaBuilder? meta);
+
+  FilesSharingShareesRecommendedResultBuilder get data;
+  set data(FilesSharingShareesRecommendedResultBuilder? data);
 }
 
 class _$FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs
@@ -14402,17 +14613,18 @@ class _$FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs
 class FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder
     implements
         Builder<FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs,
-            FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder> {
+            FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder>,
+        FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsInterfaceBuilder {
   _$FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs? _$v;
 
   FilesSharingOCSMetaBuilder? _meta;
   FilesSharingOCSMetaBuilder get meta => _$this._meta ??= FilesSharingOCSMetaBuilder();
-  set meta(FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant FilesSharingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   FilesSharingShareesRecommendedResultBuilder? _data;
   FilesSharingShareesRecommendedResultBuilder get data =>
       _$this._data ??= FilesSharingShareesRecommendedResultBuilder();
-  set data(FilesSharingShareesRecommendedResultBuilder? data) => _$this._data = data;
+  set data(covariant FilesSharingShareesRecommendedResultBuilder? data) => _$this._data = data;
 
   FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder();
 
@@ -14427,7 +14639,7 @@ class FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs other) {
+  void replace(covariant FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_Ocs;
   }
@@ -14462,6 +14674,13 @@ class FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonInterfaceBuilder {
+  void replace(FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonInterface other);
+  void update(void Function(FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonInterfaceBuilder) updates);
+  FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$FilesSharingShareesapiFindRecommendedResponse200ApplicationJson
@@ -14512,13 +14731,15 @@ class _$FilesSharingShareesapiFindRecommendedResponse200ApplicationJson
 class FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonBuilder
     implements
         Builder<FilesSharingShareesapiFindRecommendedResponse200ApplicationJson,
-            FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonBuilder> {
+            FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonBuilder>,
+        FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonInterfaceBuilder {
   _$FilesSharingShareesapiFindRecommendedResponse200ApplicationJson? _$v;
 
   FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder? _ocs;
   FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder();
-  set ocs(FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant FilesSharingShareesapiFindRecommendedResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonBuilder();
 
@@ -14532,7 +14753,7 @@ class FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(FilesSharingShareesapiFindRecommendedResponse200ApplicationJson other) {
+  void replace(covariant FilesSharingShareesapiFindRecommendedResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingShareesapiFindRecommendedResponse200ApplicationJson;
   }
@@ -14563,6 +14784,16 @@ class FilesSharingShareesapiFindRecommendedResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_Public_PasswordInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder) updates);
+  bool? get enforced;
+  set enforced(bool? enforced);
+
+  bool? get askForOptionalPassword;
+  set askForOptionalPassword(bool? askForOptionalPassword);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Public_Password
@@ -14623,16 +14854,18 @@ class _$FilesSharingCapabilities_FilesSharing_Public_Password
 class FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder
     implements
         Builder<FilesSharingCapabilities_FilesSharing_Public_Password,
-            FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder> {
+            FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder>,
+        FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Public_Password? _$v;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   bool? _askForOptionalPassword;
   bool? get askForOptionalPassword => _$this._askForOptionalPassword;
-  set askForOptionalPassword(bool? askForOptionalPassword) => _$this._askForOptionalPassword = askForOptionalPassword;
+  set askForOptionalPassword(covariant bool? askForOptionalPassword) =>
+      _$this._askForOptionalPassword = askForOptionalPassword;
 
   FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder();
 
@@ -14647,7 +14880,7 @@ class FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Public_Password other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Public_Password other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Public_Password;
   }
@@ -14670,6 +14903,19 @@ class FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  int? get days;
+  set days(int? days);
+
+  bool? get enforced;
+  set enforced(bool? enforced);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Public_ExpireDate
@@ -14732,20 +14978,21 @@ class _$FilesSharingCapabilities_FilesSharing_Public_ExpireDate
 class FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder
     implements
         Builder<FilesSharingCapabilities_FilesSharing_Public_ExpireDate,
-            FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder> {
+            FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder>,
+        FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Public_ExpireDate? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   int? _days;
   int? get days => _$this._days;
-  set days(int? days) => _$this._days = days;
+  set days(covariant int? days) => _$this._days = days;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder();
 
@@ -14761,7 +15008,7 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Public_ExpireDate other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Public_ExpireDate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Public_ExpireDate;
   }
@@ -14784,6 +15031,19 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  int? get days;
+  set days(int? days);
+
+  bool? get enforced;
+  set enforced(bool? enforced);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
@@ -14846,20 +15106,21 @@ class _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
 class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder
     implements
         Builder<FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal,
-            FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder> {
+            FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder>,
+        FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   int? _days;
   int? get days => _$this._days;
-  set days(int? days) => _$this._days = days;
+  set days(covariant int? days) => _$this._days = days;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder();
 
@@ -14875,7 +15136,7 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal;
   }
@@ -14898,6 +15159,19 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  int? get days;
+  set days(int? days);
+
+  bool? get enforced;
+  set enforced(bool? enforced);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
@@ -14960,20 +15234,21 @@ class _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
 class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder
     implements
         Builder<FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote,
-            FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder> {
+            FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder>,
+        FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   int? _days;
   int? get days => _$this._days;
-  set days(int? days) => _$this._days = days;
+  set days(covariant int? days) => _$this._days = days;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder();
 
@@ -14989,7 +15264,7 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote;
   }
@@ -15012,6 +15287,37 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_PublicInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder get password;
+  set password(FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder? password);
+
+  bool? get multipleLinks;
+  set multipleLinks(bool? multipleLinks);
+
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder get expireDate;
+  set expireDate(FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder? expireDate);
+
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder get expireDateInternal;
+  set expireDateInternal(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder? expireDateInternal);
+
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder get expireDateRemote;
+  set expireDateRemote(FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder? expireDateRemote);
+
+  bool? get sendMail;
+  set sendMail(bool? sendMail);
+
+  bool? get upload;
+  set upload(bool? upload);
+
+  bool? get uploadFilesDrop;
+  set uploadFilesDrop(bool? uploadFilesDrop);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Public extends FilesSharingCapabilities_FilesSharing_Public {
@@ -15110,51 +15416,55 @@ class _$FilesSharingCapabilities_FilesSharing_Public extends FilesSharingCapabil
 
 class FilesSharingCapabilities_FilesSharing_PublicBuilder
     implements
-        Builder<FilesSharingCapabilities_FilesSharing_Public, FilesSharingCapabilities_FilesSharing_PublicBuilder> {
+        Builder<FilesSharingCapabilities_FilesSharing_Public, FilesSharingCapabilities_FilesSharing_PublicBuilder>,
+        FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Public? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder? _password;
   FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder get password =>
       _$this._password ??= FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder();
-  set password(FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder? password) => _$this._password = password;
+  set password(covariant FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder? password) =>
+      _$this._password = password;
 
   bool? _multipleLinks;
   bool? get multipleLinks => _$this._multipleLinks;
-  set multipleLinks(bool? multipleLinks) => _$this._multipleLinks = multipleLinks;
+  set multipleLinks(covariant bool? multipleLinks) => _$this._multipleLinks = multipleLinks;
 
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder? _expireDate;
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder get expireDate =>
       _$this._expireDate ??= FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder();
-  set expireDate(FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder? expireDate) =>
+  set expireDate(covariant FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder? _expireDateInternal;
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder get expireDateInternal =>
       _$this._expireDateInternal ??= FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder();
-  set expireDateInternal(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder? expireDateInternal) =>
+  set expireDateInternal(
+          covariant FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder? expireDateInternal) =>
       _$this._expireDateInternal = expireDateInternal;
 
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder? _expireDateRemote;
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder get expireDateRemote =>
       _$this._expireDateRemote ??= FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder();
-  set expireDateRemote(FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder? expireDateRemote) =>
+  set expireDateRemote(
+          covariant FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder? expireDateRemote) =>
       _$this._expireDateRemote = expireDateRemote;
 
   bool? _sendMail;
   bool? get sendMail => _$this._sendMail;
-  set sendMail(bool? sendMail) => _$this._sendMail = sendMail;
+  set sendMail(covariant bool? sendMail) => _$this._sendMail = sendMail;
 
   bool? _upload;
   bool? get upload => _$this._upload;
-  set upload(bool? upload) => _$this._upload = upload;
+  set upload(covariant bool? upload) => _$this._upload = upload;
 
   bool? _uploadFilesDrop;
   bool? get uploadFilesDrop => _$this._uploadFilesDrop;
-  set uploadFilesDrop(bool? uploadFilesDrop) => _$this._uploadFilesDrop = uploadFilesDrop;
+  set uploadFilesDrop(covariant bool? uploadFilesDrop) => _$this._uploadFilesDrop = uploadFilesDrop;
 
   FilesSharingCapabilities_FilesSharing_PublicBuilder();
 
@@ -15176,7 +15486,7 @@ class FilesSharingCapabilities_FilesSharing_PublicBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Public other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Public other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Public;
   }
@@ -15226,6 +15536,13 @@ class FilesSharingCapabilities_FilesSharing_PublicBuilder
   }
 }
 
+abstract mixin class FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_User_ExpireDateInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+}
+
 class _$FilesSharingCapabilities_FilesSharing_User_ExpireDate
     extends FilesSharingCapabilities_FilesSharing_User_ExpireDate {
   @override
@@ -15273,12 +15590,13 @@ class _$FilesSharingCapabilities_FilesSharing_User_ExpireDate
 class FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder
     implements
         Builder<FilesSharingCapabilities_FilesSharing_User_ExpireDate,
-            FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder> {
+            FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder>,
+        FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_User_ExpireDate? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder();
 
@@ -15292,7 +15610,7 @@ class FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_User_ExpireDate other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_User_ExpireDate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_User_ExpireDate;
   }
@@ -15313,6 +15631,16 @@ class FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_UserInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder) updates);
+  bool? get sendMail;
+  set sendMail(bool? sendMail);
+
+  FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder get expireDate;
+  set expireDate(FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder? expireDate);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_User extends FilesSharingCapabilities_FilesSharing_User {
@@ -15365,17 +15693,19 @@ class _$FilesSharingCapabilities_FilesSharing_User extends FilesSharingCapabilit
 }
 
 class FilesSharingCapabilities_FilesSharing_UserBuilder
-    implements Builder<FilesSharingCapabilities_FilesSharing_User, FilesSharingCapabilities_FilesSharing_UserBuilder> {
+    implements
+        Builder<FilesSharingCapabilities_FilesSharing_User, FilesSharingCapabilities_FilesSharing_UserBuilder>,
+        FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_User? _$v;
 
   bool? _sendMail;
   bool? get sendMail => _$this._sendMail;
-  set sendMail(bool? sendMail) => _$this._sendMail = sendMail;
+  set sendMail(covariant bool? sendMail) => _$this._sendMail = sendMail;
 
   FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder? _expireDate;
   FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder get expireDate =>
       _$this._expireDate ??= FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder();
-  set expireDate(FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder? expireDate) =>
+  set expireDate(covariant FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
   FilesSharingCapabilities_FilesSharing_UserBuilder();
@@ -15391,7 +15721,7 @@ class FilesSharingCapabilities_FilesSharing_UserBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_User other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_User other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_User;
   }
@@ -15425,6 +15755,13 @@ class FilesSharingCapabilities_FilesSharing_UserBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Group_ExpireDate
@@ -15475,12 +15812,13 @@ class _$FilesSharingCapabilities_FilesSharing_Group_ExpireDate
 class FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder
     implements
         Builder<FilesSharingCapabilities_FilesSharing_Group_ExpireDate,
-            FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder> {
+            FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder>,
+        FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Group_ExpireDate? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder();
 
@@ -15494,7 +15832,7 @@ class FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Group_ExpireDate other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Group_ExpireDate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Group_ExpireDate;
   }
@@ -15515,6 +15853,16 @@ class FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_GroupInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder get expireDate;
+  set expireDate(FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder? expireDate);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Group extends FilesSharingCapabilities_FilesSharing_Group {
@@ -15568,17 +15916,18 @@ class _$FilesSharingCapabilities_FilesSharing_Group extends FilesSharingCapabili
 
 class FilesSharingCapabilities_FilesSharing_GroupBuilder
     implements
-        Builder<FilesSharingCapabilities_FilesSharing_Group, FilesSharingCapabilities_FilesSharing_GroupBuilder> {
+        Builder<FilesSharingCapabilities_FilesSharing_Group, FilesSharingCapabilities_FilesSharing_GroupBuilder>,
+        FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Group? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder? _expireDate;
   FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder get expireDate =>
       _$this._expireDate ??= FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder();
-  set expireDate(FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder? expireDate) =>
+  set expireDate(covariant FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
   FilesSharingCapabilities_FilesSharing_GroupBuilder();
@@ -15594,7 +15943,7 @@ class FilesSharingCapabilities_FilesSharing_GroupBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Group other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Group other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Group;
   }
@@ -15628,6 +15977,13 @@ class FilesSharingCapabilities_FilesSharing_GroupBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDate
@@ -15678,12 +16034,13 @@ class _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDate
 class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder
     implements
         Builder<FilesSharingCapabilities_FilesSharing_Federation_ExpireDate,
-            FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder> {
+            FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder>,
+        FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDate? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder();
 
@@ -15697,7 +16054,7 @@ class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Federation_ExpireDate other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Federation_ExpireDate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDate;
   }
@@ -15718,6 +16075,14 @@ class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface other);
+  void update(
+      void Function(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported
@@ -15768,12 +16133,13 @@ class _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported
 class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder
     implements
         Builder<FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported,
-            FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder> {
+            FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder>,
+        FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder();
 
@@ -15787,7 +16153,7 @@ class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilde
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported;
   }
@@ -15808,6 +16174,23 @@ class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_FederationInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder) updates);
+  bool? get outgoing;
+  set outgoing(bool? outgoing);
+
+  bool? get incoming;
+  set incoming(bool? incoming);
+
+  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder get expireDate;
+  set expireDate(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder? expireDate);
+
+  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder get expireDateSupported;
+  set expireDateSupported(
+      FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder? expireDateSupported);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Federation extends FilesSharingCapabilities_FilesSharing_Federation {
@@ -15879,28 +16262,29 @@ class _$FilesSharingCapabilities_FilesSharing_Federation extends FilesSharingCap
 class FilesSharingCapabilities_FilesSharing_FederationBuilder
     implements
         Builder<FilesSharingCapabilities_FilesSharing_Federation,
-            FilesSharingCapabilities_FilesSharing_FederationBuilder> {
+            FilesSharingCapabilities_FilesSharing_FederationBuilder>,
+        FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Federation? _$v;
 
   bool? _outgoing;
   bool? get outgoing => _$this._outgoing;
-  set outgoing(bool? outgoing) => _$this._outgoing = outgoing;
+  set outgoing(covariant bool? outgoing) => _$this._outgoing = outgoing;
 
   bool? _incoming;
   bool? get incoming => _$this._incoming;
-  set incoming(bool? incoming) => _$this._incoming = incoming;
+  set incoming(covariant bool? incoming) => _$this._incoming = incoming;
 
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder? _expireDate;
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder get expireDate =>
       _$this._expireDate ??= FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder();
-  set expireDate(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder? expireDate) =>
+  set expireDate(covariant FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder? _expireDateSupported;
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder get expireDateSupported =>
       _$this._expireDateSupported ??= FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder();
   set expireDateSupported(
-          FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder? expireDateSupported) =>
+          covariant FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder? expireDateSupported) =>
       _$this._expireDateSupported = expireDateSupported;
 
   FilesSharingCapabilities_FilesSharing_FederationBuilder();
@@ -15918,7 +16302,7 @@ class FilesSharingCapabilities_FilesSharing_FederationBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Federation other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Federation other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Federation;
   }
@@ -15958,6 +16342,16 @@ class FilesSharingCapabilities_FilesSharing_FederationBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharing_ShareeInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder) updates);
+  bool? get queryLookupDefault;
+  set queryLookupDefault(bool? queryLookupDefault);
+
+  bool? get alwaysShowUnique;
+  set alwaysShowUnique(bool? alwaysShowUnique);
 }
 
 class _$FilesSharingCapabilities_FilesSharing_Sharee extends FilesSharingCapabilities_FilesSharing_Sharee {
@@ -16015,16 +16409,17 @@ class _$FilesSharingCapabilities_FilesSharing_Sharee extends FilesSharingCapabil
 
 class FilesSharingCapabilities_FilesSharing_ShareeBuilder
     implements
-        Builder<FilesSharingCapabilities_FilesSharing_Sharee, FilesSharingCapabilities_FilesSharing_ShareeBuilder> {
+        Builder<FilesSharingCapabilities_FilesSharing_Sharee, FilesSharingCapabilities_FilesSharing_ShareeBuilder>,
+        FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing_Sharee? _$v;
 
   bool? _queryLookupDefault;
   bool? get queryLookupDefault => _$this._queryLookupDefault;
-  set queryLookupDefault(bool? queryLookupDefault) => _$this._queryLookupDefault = queryLookupDefault;
+  set queryLookupDefault(covariant bool? queryLookupDefault) => _$this._queryLookupDefault = queryLookupDefault;
 
   bool? _alwaysShowUnique;
   bool? get alwaysShowUnique => _$this._alwaysShowUnique;
-  set alwaysShowUnique(bool? alwaysShowUnique) => _$this._alwaysShowUnique = alwaysShowUnique;
+  set alwaysShowUnique(covariant bool? alwaysShowUnique) => _$this._alwaysShowUnique = alwaysShowUnique;
 
   FilesSharingCapabilities_FilesSharing_ShareeBuilder();
 
@@ -16039,7 +16434,7 @@ class FilesSharingCapabilities_FilesSharing_ShareeBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing_Sharee other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing_Sharee other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing_Sharee;
   }
@@ -16062,6 +16457,37 @@ class FilesSharingCapabilities_FilesSharing_ShareeBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesSharingCapabilities_FilesSharingInterfaceBuilder {
+  void replace(FilesSharingCapabilities_FilesSharingInterface other);
+  void update(void Function(FilesSharingCapabilities_FilesSharingInterfaceBuilder) updates);
+  bool? get apiEnabled;
+  set apiEnabled(bool? apiEnabled);
+
+  FilesSharingCapabilities_FilesSharing_PublicBuilder get public;
+  set public(FilesSharingCapabilities_FilesSharing_PublicBuilder? public);
+
+  FilesSharingCapabilities_FilesSharing_UserBuilder get user;
+  set user(FilesSharingCapabilities_FilesSharing_UserBuilder? user);
+
+  bool? get resharing;
+  set resharing(bool? resharing);
+
+  bool? get groupSharing;
+  set groupSharing(bool? groupSharing);
+
+  FilesSharingCapabilities_FilesSharing_GroupBuilder get group;
+  set group(FilesSharingCapabilities_FilesSharing_GroupBuilder? group);
+
+  int? get defaultPermissions;
+  set defaultPermissions(int? defaultPermissions);
+
+  FilesSharingCapabilities_FilesSharing_FederationBuilder get federation;
+  set federation(FilesSharingCapabilities_FilesSharing_FederationBuilder? federation);
+
+  FilesSharingCapabilities_FilesSharing_ShareeBuilder get sharee;
+  set sharee(FilesSharingCapabilities_FilesSharing_ShareeBuilder? sharee);
 }
 
 class _$FilesSharingCapabilities_FilesSharing extends FilesSharingCapabilities_FilesSharing {
@@ -16163,50 +16589,52 @@ class _$FilesSharingCapabilities_FilesSharing extends FilesSharingCapabilities_F
 }
 
 class FilesSharingCapabilities_FilesSharingBuilder
-    implements Builder<FilesSharingCapabilities_FilesSharing, FilesSharingCapabilities_FilesSharingBuilder> {
+    implements
+        Builder<FilesSharingCapabilities_FilesSharing, FilesSharingCapabilities_FilesSharingBuilder>,
+        FilesSharingCapabilities_FilesSharingInterfaceBuilder {
   _$FilesSharingCapabilities_FilesSharing? _$v;
 
   bool? _apiEnabled;
   bool? get apiEnabled => _$this._apiEnabled;
-  set apiEnabled(bool? apiEnabled) => _$this._apiEnabled = apiEnabled;
+  set apiEnabled(covariant bool? apiEnabled) => _$this._apiEnabled = apiEnabled;
 
   FilesSharingCapabilities_FilesSharing_PublicBuilder? _public;
   FilesSharingCapabilities_FilesSharing_PublicBuilder get public =>
       _$this._public ??= FilesSharingCapabilities_FilesSharing_PublicBuilder();
-  set public(FilesSharingCapabilities_FilesSharing_PublicBuilder? public) => _$this._public = public;
+  set public(covariant FilesSharingCapabilities_FilesSharing_PublicBuilder? public) => _$this._public = public;
 
   FilesSharingCapabilities_FilesSharing_UserBuilder? _user;
   FilesSharingCapabilities_FilesSharing_UserBuilder get user =>
       _$this._user ??= FilesSharingCapabilities_FilesSharing_UserBuilder();
-  set user(FilesSharingCapabilities_FilesSharing_UserBuilder? user) => _$this._user = user;
+  set user(covariant FilesSharingCapabilities_FilesSharing_UserBuilder? user) => _$this._user = user;
 
   bool? _resharing;
   bool? get resharing => _$this._resharing;
-  set resharing(bool? resharing) => _$this._resharing = resharing;
+  set resharing(covariant bool? resharing) => _$this._resharing = resharing;
 
   bool? _groupSharing;
   bool? get groupSharing => _$this._groupSharing;
-  set groupSharing(bool? groupSharing) => _$this._groupSharing = groupSharing;
+  set groupSharing(covariant bool? groupSharing) => _$this._groupSharing = groupSharing;
 
   FilesSharingCapabilities_FilesSharing_GroupBuilder? _group;
   FilesSharingCapabilities_FilesSharing_GroupBuilder get group =>
       _$this._group ??= FilesSharingCapabilities_FilesSharing_GroupBuilder();
-  set group(FilesSharingCapabilities_FilesSharing_GroupBuilder? group) => _$this._group = group;
+  set group(covariant FilesSharingCapabilities_FilesSharing_GroupBuilder? group) => _$this._group = group;
 
   int? _defaultPermissions;
   int? get defaultPermissions => _$this._defaultPermissions;
-  set defaultPermissions(int? defaultPermissions) => _$this._defaultPermissions = defaultPermissions;
+  set defaultPermissions(covariant int? defaultPermissions) => _$this._defaultPermissions = defaultPermissions;
 
   FilesSharingCapabilities_FilesSharing_FederationBuilder? _federation;
   FilesSharingCapabilities_FilesSharing_FederationBuilder get federation =>
       _$this._federation ??= FilesSharingCapabilities_FilesSharing_FederationBuilder();
-  set federation(FilesSharingCapabilities_FilesSharing_FederationBuilder? federation) =>
+  set federation(covariant FilesSharingCapabilities_FilesSharing_FederationBuilder? federation) =>
       _$this._federation = federation;
 
   FilesSharingCapabilities_FilesSharing_ShareeBuilder? _sharee;
   FilesSharingCapabilities_FilesSharing_ShareeBuilder get sharee =>
       _$this._sharee ??= FilesSharingCapabilities_FilesSharing_ShareeBuilder();
-  set sharee(FilesSharingCapabilities_FilesSharing_ShareeBuilder? sharee) => _$this._sharee = sharee;
+  set sharee(covariant FilesSharingCapabilities_FilesSharing_ShareeBuilder? sharee) => _$this._sharee = sharee;
 
   FilesSharingCapabilities_FilesSharingBuilder();
 
@@ -16228,7 +16656,7 @@ class FilesSharingCapabilities_FilesSharingBuilder
   }
 
   @override
-  void replace(FilesSharingCapabilities_FilesSharing other) {
+  void replace(covariant FilesSharingCapabilities_FilesSharing other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities_FilesSharing;
   }
@@ -16282,6 +16710,13 @@ class FilesSharingCapabilities_FilesSharingBuilder
   }
 }
 
+abstract mixin class FilesSharingCapabilitiesInterfaceBuilder {
+  void replace(FilesSharingCapabilitiesInterface other);
+  void update(void Function(FilesSharingCapabilitiesInterfaceBuilder) updates);
+  FilesSharingCapabilities_FilesSharingBuilder get filesSharing;
+  set filesSharing(FilesSharingCapabilities_FilesSharingBuilder? filesSharing);
+}
+
 class _$FilesSharingCapabilities extends FilesSharingCapabilities {
   @override
   final FilesSharingCapabilities_FilesSharing filesSharing;
@@ -16320,13 +16755,17 @@ class _$FilesSharingCapabilities extends FilesSharingCapabilities {
   }
 }
 
-class FilesSharingCapabilitiesBuilder implements Builder<FilesSharingCapabilities, FilesSharingCapabilitiesBuilder> {
+class FilesSharingCapabilitiesBuilder
+    implements
+        Builder<FilesSharingCapabilities, FilesSharingCapabilitiesBuilder>,
+        FilesSharingCapabilitiesInterfaceBuilder {
   _$FilesSharingCapabilities? _$v;
 
   FilesSharingCapabilities_FilesSharingBuilder? _filesSharing;
   FilesSharingCapabilities_FilesSharingBuilder get filesSharing =>
       _$this._filesSharing ??= FilesSharingCapabilities_FilesSharingBuilder();
-  set filesSharing(FilesSharingCapabilities_FilesSharingBuilder? filesSharing) => _$this._filesSharing = filesSharing;
+  set filesSharing(covariant FilesSharingCapabilities_FilesSharingBuilder? filesSharing) =>
+      _$this._filesSharing = filesSharing;
 
   FilesSharingCapabilitiesBuilder();
 
@@ -16340,7 +16779,7 @@ class FilesSharingCapabilitiesBuilder implements Builder<FilesSharingCapabilitie
   }
 
   @override
-  void replace(FilesSharingCapabilities other) {
+  void replace(covariant FilesSharingCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesSharingCapabilities;
   }

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -127,8 +127,19 @@ class FilesTrashbinPreviewClient {
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesTrashbinCapabilities_FilesInterface {
+  bool get undelete;
+  FilesTrashbinCapabilities_FilesInterface rebuild(
+    final void Function(FilesTrashbinCapabilities_FilesInterfaceBuilder) updates,
+  );
+  FilesTrashbinCapabilities_FilesInterfaceBuilder toBuilder();
+}
+
 abstract class FilesTrashbinCapabilities_Files
-    implements Built<FilesTrashbinCapabilities_Files, FilesTrashbinCapabilities_FilesBuilder> {
+    implements
+        FilesTrashbinCapabilities_FilesInterface,
+        Built<FilesTrashbinCapabilities_Files, FilesTrashbinCapabilities_FilesBuilder> {
   factory FilesTrashbinCapabilities_Files([final void Function(FilesTrashbinCapabilities_FilesBuilder)? b]) =
       _$FilesTrashbinCapabilities_Files;
 
@@ -144,11 +155,18 @@ abstract class FilesTrashbinCapabilities_Files
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get undelete;
   static Serializer<FilesTrashbinCapabilities_Files> get serializer => _$filesTrashbinCapabilitiesFilesSerializer;
 }
 
-abstract class FilesTrashbinCapabilities implements Built<FilesTrashbinCapabilities, FilesTrashbinCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesTrashbinCapabilitiesInterface {
+  FilesTrashbinCapabilities_Files get files;
+  FilesTrashbinCapabilitiesInterface rebuild(final void Function(FilesTrashbinCapabilitiesInterfaceBuilder) updates);
+  FilesTrashbinCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class FilesTrashbinCapabilities
+    implements FilesTrashbinCapabilitiesInterface, Built<FilesTrashbinCapabilities, FilesTrashbinCapabilitiesBuilder> {
   factory FilesTrashbinCapabilities([final void Function(FilesTrashbinCapabilitiesBuilder)? b]) =
       _$FilesTrashbinCapabilities;
 
@@ -164,7 +182,6 @@ abstract class FilesTrashbinCapabilities implements Built<FilesTrashbinCapabilit
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesTrashbinCapabilities_Files get files;
   static Serializer<FilesTrashbinCapabilities> get serializer => _$filesTrashbinCapabilitiesSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.g.dart
@@ -87,6 +87,13 @@ class _$FilesTrashbinCapabilitiesSerializer implements StructuredSerializer<File
   }
 }
 
+abstract mixin class FilesTrashbinCapabilities_FilesInterfaceBuilder {
+  void replace(FilesTrashbinCapabilities_FilesInterface other);
+  void update(void Function(FilesTrashbinCapabilities_FilesInterfaceBuilder) updates);
+  bool? get undelete;
+  set undelete(bool? undelete);
+}
+
 class _$FilesTrashbinCapabilities_Files extends FilesTrashbinCapabilities_Files {
   @override
   final bool undelete;
@@ -126,12 +133,14 @@ class _$FilesTrashbinCapabilities_Files extends FilesTrashbinCapabilities_Files 
 }
 
 class FilesTrashbinCapabilities_FilesBuilder
-    implements Builder<FilesTrashbinCapabilities_Files, FilesTrashbinCapabilities_FilesBuilder> {
+    implements
+        Builder<FilesTrashbinCapabilities_Files, FilesTrashbinCapabilities_FilesBuilder>,
+        FilesTrashbinCapabilities_FilesInterfaceBuilder {
   _$FilesTrashbinCapabilities_Files? _$v;
 
   bool? _undelete;
   bool? get undelete => _$this._undelete;
-  set undelete(bool? undelete) => _$this._undelete = undelete;
+  set undelete(covariant bool? undelete) => _$this._undelete = undelete;
 
   FilesTrashbinCapabilities_FilesBuilder();
 
@@ -145,7 +154,7 @@ class FilesTrashbinCapabilities_FilesBuilder
   }
 
   @override
-  void replace(FilesTrashbinCapabilities_Files other) {
+  void replace(covariant FilesTrashbinCapabilities_Files other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTrashbinCapabilities_Files;
   }
@@ -165,6 +174,13 @@ class FilesTrashbinCapabilities_FilesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesTrashbinCapabilitiesInterfaceBuilder {
+  void replace(FilesTrashbinCapabilitiesInterface other);
+  void update(void Function(FilesTrashbinCapabilitiesInterfaceBuilder) updates);
+  FilesTrashbinCapabilities_FilesBuilder get files;
+  set files(FilesTrashbinCapabilities_FilesBuilder? files);
 }
 
 class _$FilesTrashbinCapabilities extends FilesTrashbinCapabilities {
@@ -205,12 +221,15 @@ class _$FilesTrashbinCapabilities extends FilesTrashbinCapabilities {
   }
 }
 
-class FilesTrashbinCapabilitiesBuilder implements Builder<FilesTrashbinCapabilities, FilesTrashbinCapabilitiesBuilder> {
+class FilesTrashbinCapabilitiesBuilder
+    implements
+        Builder<FilesTrashbinCapabilities, FilesTrashbinCapabilitiesBuilder>,
+        FilesTrashbinCapabilitiesInterfaceBuilder {
   _$FilesTrashbinCapabilities? _$v;
 
   FilesTrashbinCapabilities_FilesBuilder? _files;
   FilesTrashbinCapabilities_FilesBuilder get files => _$this._files ??= FilesTrashbinCapabilities_FilesBuilder();
-  set files(FilesTrashbinCapabilities_FilesBuilder? files) => _$this._files = files;
+  set files(covariant FilesTrashbinCapabilities_FilesBuilder? files) => _$this._files = files;
 
   FilesTrashbinCapabilitiesBuilder();
 
@@ -224,7 +243,7 @@ class FilesTrashbinCapabilitiesBuilder implements Builder<FilesTrashbinCapabilit
   }
 
   @override
-  void replace(FilesTrashbinCapabilities other) {
+  void replace(covariant FilesTrashbinCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesTrashbinCapabilities;
   }

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.dart
@@ -127,8 +127,23 @@ class FilesVersionsPreviewClient {
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class FilesVersionsCapabilities_FilesInterface {
+  bool get versioning;
+  @BuiltValueField(wireName: 'version_labeling')
+  bool get versionLabeling;
+  @BuiltValueField(wireName: 'version_deletion')
+  bool get versionDeletion;
+  FilesVersionsCapabilities_FilesInterface rebuild(
+    final void Function(FilesVersionsCapabilities_FilesInterfaceBuilder) updates,
+  );
+  FilesVersionsCapabilities_FilesInterfaceBuilder toBuilder();
+}
+
 abstract class FilesVersionsCapabilities_Files
-    implements Built<FilesVersionsCapabilities_Files, FilesVersionsCapabilities_FilesBuilder> {
+    implements
+        FilesVersionsCapabilities_FilesInterface,
+        Built<FilesVersionsCapabilities_Files, FilesVersionsCapabilities_FilesBuilder> {
   factory FilesVersionsCapabilities_Files([final void Function(FilesVersionsCapabilities_FilesBuilder)? b]) =
       _$FilesVersionsCapabilities_Files;
 
@@ -144,15 +159,18 @@ abstract class FilesVersionsCapabilities_Files
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get versioning;
-  @BuiltValueField(wireName: 'version_labeling')
-  bool get versionLabeling;
-  @BuiltValueField(wireName: 'version_deletion')
-  bool get versionDeletion;
   static Serializer<FilesVersionsCapabilities_Files> get serializer => _$filesVersionsCapabilitiesFilesSerializer;
 }
 
-abstract class FilesVersionsCapabilities implements Built<FilesVersionsCapabilities, FilesVersionsCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class FilesVersionsCapabilitiesInterface {
+  FilesVersionsCapabilities_Files get files;
+  FilesVersionsCapabilitiesInterface rebuild(final void Function(FilesVersionsCapabilitiesInterfaceBuilder) updates);
+  FilesVersionsCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class FilesVersionsCapabilities
+    implements FilesVersionsCapabilitiesInterface, Built<FilesVersionsCapabilities, FilesVersionsCapabilitiesBuilder> {
   factory FilesVersionsCapabilities([final void Function(FilesVersionsCapabilitiesBuilder)? b]) =
       _$FilesVersionsCapabilities;
 
@@ -168,7 +186,6 @@ abstract class FilesVersionsCapabilities implements Built<FilesVersionsCapabilit
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  FilesVersionsCapabilities_Files get files;
   static Serializer<FilesVersionsCapabilities> get serializer => _$filesVersionsCapabilitiesSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.g.dart
@@ -97,6 +97,19 @@ class _$FilesVersionsCapabilitiesSerializer implements StructuredSerializer<File
   }
 }
 
+abstract mixin class FilesVersionsCapabilities_FilesInterfaceBuilder {
+  void replace(FilesVersionsCapabilities_FilesInterface other);
+  void update(void Function(FilesVersionsCapabilities_FilesInterfaceBuilder) updates);
+  bool? get versioning;
+  set versioning(bool? versioning);
+
+  bool? get versionLabeling;
+  set versionLabeling(bool? versionLabeling);
+
+  bool? get versionDeletion;
+  set versionDeletion(bool? versionDeletion);
+}
+
 class _$FilesVersionsCapabilities_Files extends FilesVersionsCapabilities_Files {
   @override
   final bool versioning;
@@ -153,20 +166,22 @@ class _$FilesVersionsCapabilities_Files extends FilesVersionsCapabilities_Files 
 }
 
 class FilesVersionsCapabilities_FilesBuilder
-    implements Builder<FilesVersionsCapabilities_Files, FilesVersionsCapabilities_FilesBuilder> {
+    implements
+        Builder<FilesVersionsCapabilities_Files, FilesVersionsCapabilities_FilesBuilder>,
+        FilesVersionsCapabilities_FilesInterfaceBuilder {
   _$FilesVersionsCapabilities_Files? _$v;
 
   bool? _versioning;
   bool? get versioning => _$this._versioning;
-  set versioning(bool? versioning) => _$this._versioning = versioning;
+  set versioning(covariant bool? versioning) => _$this._versioning = versioning;
 
   bool? _versionLabeling;
   bool? get versionLabeling => _$this._versionLabeling;
-  set versionLabeling(bool? versionLabeling) => _$this._versionLabeling = versionLabeling;
+  set versionLabeling(covariant bool? versionLabeling) => _$this._versionLabeling = versionLabeling;
 
   bool? _versionDeletion;
   bool? get versionDeletion => _$this._versionDeletion;
-  set versionDeletion(bool? versionDeletion) => _$this._versionDeletion = versionDeletion;
+  set versionDeletion(covariant bool? versionDeletion) => _$this._versionDeletion = versionDeletion;
 
   FilesVersionsCapabilities_FilesBuilder();
 
@@ -182,7 +197,7 @@ class FilesVersionsCapabilities_FilesBuilder
   }
 
   @override
-  void replace(FilesVersionsCapabilities_Files other) {
+  void replace(covariant FilesVersionsCapabilities_Files other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesVersionsCapabilities_Files;
   }
@@ -207,6 +222,13 @@ class FilesVersionsCapabilities_FilesBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class FilesVersionsCapabilitiesInterfaceBuilder {
+  void replace(FilesVersionsCapabilitiesInterface other);
+  void update(void Function(FilesVersionsCapabilitiesInterfaceBuilder) updates);
+  FilesVersionsCapabilities_FilesBuilder get files;
+  set files(FilesVersionsCapabilities_FilesBuilder? files);
 }
 
 class _$FilesVersionsCapabilities extends FilesVersionsCapabilities {
@@ -247,12 +269,15 @@ class _$FilesVersionsCapabilities extends FilesVersionsCapabilities {
   }
 }
 
-class FilesVersionsCapabilitiesBuilder implements Builder<FilesVersionsCapabilities, FilesVersionsCapabilitiesBuilder> {
+class FilesVersionsCapabilitiesBuilder
+    implements
+        Builder<FilesVersionsCapabilities, FilesVersionsCapabilitiesBuilder>,
+        FilesVersionsCapabilitiesInterfaceBuilder {
   _$FilesVersionsCapabilities? _$v;
 
   FilesVersionsCapabilities_FilesBuilder? _files;
   FilesVersionsCapabilities_FilesBuilder get files => _$this._files ??= FilesVersionsCapabilities_FilesBuilder();
-  set files(FilesVersionsCapabilities_FilesBuilder? files) => _$this._files = files;
+  set files(covariant FilesVersionsCapabilities_FilesBuilder? files) => _$this._files = files;
 
   FilesVersionsCapabilitiesBuilder();
 
@@ -266,7 +291,7 @@ class FilesVersionsCapabilitiesBuilder implements Builder<FilesVersionsCapabilit
   }
 
   @override
-  void replace(FilesVersionsCapabilities other) {
+  void replace(covariant FilesVersionsCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FilesVersionsCapabilities;
   }

--- a/packages/nextcloud/lib/src/api/news.openapi.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.dart
@@ -605,7 +605,15 @@ class NewsClient extends DynamiteClient {
   }
 }
 
-abstract class NewsSupportedAPIVersions implements Built<NewsSupportedAPIVersions, NewsSupportedAPIVersionsBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NewsSupportedAPIVersionsInterface {
+  BuiltList<String>? get apiLevels;
+  NewsSupportedAPIVersionsInterface rebuild(final void Function(NewsSupportedAPIVersionsInterfaceBuilder) updates);
+  NewsSupportedAPIVersionsInterfaceBuilder toBuilder();
+}
+
+abstract class NewsSupportedAPIVersions
+    implements NewsSupportedAPIVersionsInterface, Built<NewsSupportedAPIVersions, NewsSupportedAPIVersionsBuilder> {
   factory NewsSupportedAPIVersions([final void Function(NewsSupportedAPIVersionsBuilder)? b]) =
       _$NewsSupportedAPIVersions;
 
@@ -621,24 +629,11 @@ abstract class NewsSupportedAPIVersions implements Built<NewsSupportedAPIVersion
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String>? get apiLevels;
   static Serializer<NewsSupportedAPIVersions> get serializer => _$newsSupportedAPIVersionsSerializer;
 }
 
-abstract class NewsArticle implements Built<NewsArticle, NewsArticleBuilder> {
-  factory NewsArticle([final void Function(NewsArticleBuilder)? b]) = _$NewsArticle;
-
-  // coverage:ignore-start
-  const NewsArticle._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory NewsArticle.fromJson(final Map<String, dynamic> json) => _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class NewsArticleInterface {
   int get id;
   String get guid;
   String get guidHash;
@@ -659,23 +654,29 @@ abstract class NewsArticle implements Built<NewsArticle, NewsArticleBuilder> {
   bool get rtl;
   String get fingerprint;
   String get contentHash;
-  static Serializer<NewsArticle> get serializer => _$newsArticleSerializer;
+  NewsArticleInterface rebuild(final void Function(NewsArticleInterfaceBuilder) updates);
+  NewsArticleInterfaceBuilder toBuilder();
 }
 
-abstract class NewsFeed implements Built<NewsFeed, NewsFeedBuilder> {
-  factory NewsFeed([final void Function(NewsFeedBuilder)? b]) = _$NewsFeed;
+abstract class NewsArticle implements NewsArticleInterface, Built<NewsArticle, NewsArticleBuilder> {
+  factory NewsArticle([final void Function(NewsArticleBuilder)? b]) = _$NewsArticle;
 
   // coverage:ignore-start
-  const NewsFeed._();
+  const NewsArticle._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NewsFeed.fromJson(final Map<String, dynamic> json) => _jsonSerializers.deserializeWith(serializer, json)!;
+  factory NewsArticle.fromJson(final Map<String, dynamic> json) => _jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
+  static Serializer<NewsArticle> get serializer => _$newsArticleSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class NewsFeedInterface {
   int get id;
   String get url;
   String get title;
@@ -689,10 +690,40 @@ abstract class NewsFeed implements Built<NewsFeed, NewsFeedBuilder> {
   int get updateErrorCount;
   String? get lastUpdateError;
   BuiltList<NewsArticle> get items;
+  NewsFeedInterface rebuild(final void Function(NewsFeedInterfaceBuilder) updates);
+  NewsFeedInterfaceBuilder toBuilder();
+}
+
+abstract class NewsFeed implements NewsFeedInterface, Built<NewsFeed, NewsFeedBuilder> {
+  factory NewsFeed([final void Function(NewsFeedBuilder)? b]) = _$NewsFeed;
+
+  // coverage:ignore-start
+  const NewsFeed._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory NewsFeed.fromJson(final Map<String, dynamic> json) => _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<NewsFeed> get serializer => _$newsFeedSerializer;
 }
 
-abstract class NewsFolder implements Built<NewsFolder, NewsFolderBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NewsFolderInterface {
+  int get id;
+  String get name;
+  bool get opened;
+
+  /// This seems to be broken. In testing it is always empty
+  BuiltList<NewsFeed> get feeds;
+  NewsFolderInterface rebuild(final void Function(NewsFolderInterfaceBuilder) updates);
+  NewsFolderInterfaceBuilder toBuilder();
+}
+
+abstract class NewsFolder implements NewsFolderInterface, Built<NewsFolder, NewsFolderBuilder> {
   factory NewsFolder([final void Function(NewsFolderBuilder)? b]) = _$NewsFolder;
 
   // coverage:ignore-start
@@ -706,16 +737,17 @@ abstract class NewsFolder implements Built<NewsFolder, NewsFolderBuilder> {
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int get id;
-  String get name;
-  bool get opened;
-
-  /// This seems to be broken. In testing it is always empty
-  BuiltList<NewsFeed> get feeds;
   static Serializer<NewsFolder> get serializer => _$newsFolderSerializer;
 }
 
-abstract class NewsListFolders implements Built<NewsListFolders, NewsListFoldersBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NewsListFoldersInterface {
+  BuiltList<NewsFolder> get folders;
+  NewsListFoldersInterface rebuild(final void Function(NewsListFoldersInterfaceBuilder) updates);
+  NewsListFoldersInterfaceBuilder toBuilder();
+}
+
+abstract class NewsListFolders implements NewsListFoldersInterface, Built<NewsListFolders, NewsListFoldersBuilder> {
   factory NewsListFolders([final void Function(NewsListFoldersBuilder)? b]) = _$NewsListFolders;
 
   // coverage:ignore-start
@@ -730,11 +762,19 @@ abstract class NewsListFolders implements Built<NewsListFolders, NewsListFolders
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<NewsFolder> get folders;
   static Serializer<NewsListFolders> get serializer => _$newsListFoldersSerializer;
 }
 
-abstract class NewsListFeeds implements Built<NewsListFeeds, NewsListFeedsBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NewsListFeedsInterface {
+  int? get starredCount;
+  int? get newestItemId;
+  BuiltList<NewsFeed> get feeds;
+  NewsListFeedsInterface rebuild(final void Function(NewsListFeedsInterfaceBuilder) updates);
+  NewsListFeedsInterfaceBuilder toBuilder();
+}
+
+abstract class NewsListFeeds implements NewsListFeedsInterface, Built<NewsListFeeds, NewsListFeedsBuilder> {
   factory NewsListFeeds([final void Function(NewsListFeedsBuilder)? b]) = _$NewsListFeeds;
 
   // coverage:ignore-start
@@ -749,13 +789,17 @@ abstract class NewsListFeeds implements Built<NewsListFeeds, NewsListFeedsBuilde
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int? get starredCount;
-  int? get newestItemId;
-  BuiltList<NewsFeed> get feeds;
   static Serializer<NewsListFeeds> get serializer => _$newsListFeedsSerializer;
 }
 
-abstract class NewsListArticles implements Built<NewsListArticles, NewsListArticlesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NewsListArticlesInterface {
+  BuiltList<NewsArticle> get items;
+  NewsListArticlesInterface rebuild(final void Function(NewsListArticlesInterfaceBuilder) updates);
+  NewsListArticlesInterfaceBuilder toBuilder();
+}
+
+abstract class NewsListArticles implements NewsListArticlesInterface, Built<NewsListArticles, NewsListArticlesBuilder> {
   factory NewsListArticles([final void Function(NewsListArticlesBuilder)? b]) = _$NewsListArticles;
 
   // coverage:ignore-start
@@ -770,11 +814,21 @@ abstract class NewsListArticles implements Built<NewsListArticles, NewsListArtic
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<NewsArticle> get items;
   static Serializer<NewsListArticles> get serializer => _$newsListArticlesSerializer;
 }
 
-abstract class NewsOCSMeta implements Built<NewsOCSMeta, NewsOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NewsOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  NewsOCSMetaInterface rebuild(final void Function(NewsOCSMetaInterfaceBuilder) updates);
+  NewsOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class NewsOCSMeta implements NewsOCSMetaInterface, Built<NewsOCSMeta, NewsOCSMetaBuilder> {
   factory NewsOCSMeta([final void Function(NewsOCSMetaBuilder)? b]) = _$NewsOCSMeta;
 
   // coverage:ignore-start
@@ -788,15 +842,18 @@ abstract class NewsOCSMeta implements Built<NewsOCSMeta, NewsOCSMetaBuilder> {
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<NewsOCSMeta> get serializer => _$newsOCSMetaSerializer;
 }
 
-abstract class NewsEmptyOCS_Ocs implements Built<NewsEmptyOCS_Ocs, NewsEmptyOCS_OcsBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NewsEmptyOCS_OcsInterface {
+  NewsOCSMeta get meta;
+  BuiltList<JsonObject> get data;
+  NewsEmptyOCS_OcsInterface rebuild(final void Function(NewsEmptyOCS_OcsInterfaceBuilder) updates);
+  NewsEmptyOCS_OcsInterfaceBuilder toBuilder();
+}
+
+abstract class NewsEmptyOCS_Ocs implements NewsEmptyOCS_OcsInterface, Built<NewsEmptyOCS_Ocs, NewsEmptyOCS_OcsBuilder> {
   factory NewsEmptyOCS_Ocs([final void Function(NewsEmptyOCS_OcsBuilder)? b]) = _$NewsEmptyOCS_Ocs;
 
   // coverage:ignore-start
@@ -811,12 +868,17 @@ abstract class NewsEmptyOCS_Ocs implements Built<NewsEmptyOCS_Ocs, NewsEmptyOCS_
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NewsOCSMeta get meta;
-  BuiltList<JsonObject> get data;
   static Serializer<NewsEmptyOCS_Ocs> get serializer => _$newsEmptyOCSOcsSerializer;
 }
 
-abstract class NewsEmptyOCS implements Built<NewsEmptyOCS, NewsEmptyOCSBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NewsEmptyOCSInterface {
+  NewsEmptyOCS_Ocs get ocs;
+  NewsEmptyOCSInterface rebuild(final void Function(NewsEmptyOCSInterfaceBuilder) updates);
+  NewsEmptyOCSInterfaceBuilder toBuilder();
+}
+
+abstract class NewsEmptyOCS implements NewsEmptyOCSInterface, Built<NewsEmptyOCS, NewsEmptyOCSBuilder> {
   factory NewsEmptyOCS([final void Function(NewsEmptyOCSBuilder)? b]) = _$NewsEmptyOCS;
 
   // coverage:ignore-start
@@ -830,7 +892,6 @@ abstract class NewsEmptyOCS implements Built<NewsEmptyOCS, NewsEmptyOCSBuilder> 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NewsEmptyOCS_Ocs get ocs;
   static Serializer<NewsEmptyOCS> get serializer => _$newsEmptyOCSSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/news.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.g.dart
@@ -682,6 +682,13 @@ class _$NewsEmptyOCSSerializer implements StructuredSerializer<NewsEmptyOCS> {
   }
 }
 
+abstract mixin class NewsSupportedAPIVersionsInterfaceBuilder {
+  void replace(NewsSupportedAPIVersionsInterface other);
+  void update(void Function(NewsSupportedAPIVersionsInterfaceBuilder) updates);
+  ListBuilder<String> get apiLevels;
+  set apiLevels(ListBuilder<String>? apiLevels);
+}
+
 class _$NewsSupportedAPIVersions extends NewsSupportedAPIVersions {
   @override
   final BuiltList<String>? apiLevels;
@@ -718,12 +725,15 @@ class _$NewsSupportedAPIVersions extends NewsSupportedAPIVersions {
   }
 }
 
-class NewsSupportedAPIVersionsBuilder implements Builder<NewsSupportedAPIVersions, NewsSupportedAPIVersionsBuilder> {
+class NewsSupportedAPIVersionsBuilder
+    implements
+        Builder<NewsSupportedAPIVersions, NewsSupportedAPIVersionsBuilder>,
+        NewsSupportedAPIVersionsInterfaceBuilder {
   _$NewsSupportedAPIVersions? _$v;
 
   ListBuilder<String>? _apiLevels;
   ListBuilder<String> get apiLevels => _$this._apiLevels ??= ListBuilder<String>();
-  set apiLevels(ListBuilder<String>? apiLevels) => _$this._apiLevels = apiLevels;
+  set apiLevels(covariant ListBuilder<String>? apiLevels) => _$this._apiLevels = apiLevels;
 
   NewsSupportedAPIVersionsBuilder();
 
@@ -737,7 +747,7 @@ class NewsSupportedAPIVersionsBuilder implements Builder<NewsSupportedAPIVersion
   }
 
   @override
-  void replace(NewsSupportedAPIVersions other) {
+  void replace(covariant NewsSupportedAPIVersions other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NewsSupportedAPIVersions;
   }
@@ -767,6 +777,70 @@ class NewsSupportedAPIVersionsBuilder implements Builder<NewsSupportedAPIVersion
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NewsArticleInterfaceBuilder {
+  void replace(NewsArticleInterface other);
+  void update(void Function(NewsArticleInterfaceBuilder) updates);
+  int? get id;
+  set id(int? id);
+
+  String? get guid;
+  set guid(String? guid);
+
+  String? get guidHash;
+  set guidHash(String? guidHash);
+
+  String? get url;
+  set url(String? url);
+
+  String? get title;
+  set title(String? title);
+
+  String? get author;
+  set author(String? author);
+
+  int? get pubDate;
+  set pubDate(int? pubDate);
+
+  int? get updatedDate;
+  set updatedDate(int? updatedDate);
+
+  String? get body;
+  set body(String? body);
+
+  String? get enclosureMime;
+  set enclosureMime(String? enclosureMime);
+
+  String? get enclosureLink;
+  set enclosureLink(String? enclosureLink);
+
+  String? get mediaThumbnail;
+  set mediaThumbnail(String? mediaThumbnail);
+
+  String? get mediaDescription;
+  set mediaDescription(String? mediaDescription);
+
+  int? get feedId;
+  set feedId(int? feedId);
+
+  bool? get unread;
+  set unread(bool? unread);
+
+  bool? get starred;
+  set starred(bool? starred);
+
+  int? get lastModified;
+  set lastModified(int? lastModified);
+
+  bool? get rtl;
+  set rtl(bool? rtl);
+
+  String? get fingerprint;
+  set fingerprint(String? fingerprint);
+
+  String? get contentHash;
+  set contentHash(String? contentHash);
 }
 
 class _$NewsArticle extends NewsArticle {
@@ -937,88 +1011,88 @@ class _$NewsArticle extends NewsArticle {
   }
 }
 
-class NewsArticleBuilder implements Builder<NewsArticle, NewsArticleBuilder> {
+class NewsArticleBuilder implements Builder<NewsArticle, NewsArticleBuilder>, NewsArticleInterfaceBuilder {
   _$NewsArticle? _$v;
 
   int? _id;
   int? get id => _$this._id;
-  set id(int? id) => _$this._id = id;
+  set id(covariant int? id) => _$this._id = id;
 
   String? _guid;
   String? get guid => _$this._guid;
-  set guid(String? guid) => _$this._guid = guid;
+  set guid(covariant String? guid) => _$this._guid = guid;
 
   String? _guidHash;
   String? get guidHash => _$this._guidHash;
-  set guidHash(String? guidHash) => _$this._guidHash = guidHash;
+  set guidHash(covariant String? guidHash) => _$this._guidHash = guidHash;
 
   String? _url;
   String? get url => _$this._url;
-  set url(String? url) => _$this._url = url;
+  set url(covariant String? url) => _$this._url = url;
 
   String? _title;
   String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
+  set title(covariant String? title) => _$this._title = title;
 
   String? _author;
   String? get author => _$this._author;
-  set author(String? author) => _$this._author = author;
+  set author(covariant String? author) => _$this._author = author;
 
   int? _pubDate;
   int? get pubDate => _$this._pubDate;
-  set pubDate(int? pubDate) => _$this._pubDate = pubDate;
+  set pubDate(covariant int? pubDate) => _$this._pubDate = pubDate;
 
   int? _updatedDate;
   int? get updatedDate => _$this._updatedDate;
-  set updatedDate(int? updatedDate) => _$this._updatedDate = updatedDate;
+  set updatedDate(covariant int? updatedDate) => _$this._updatedDate = updatedDate;
 
   String? _body;
   String? get body => _$this._body;
-  set body(String? body) => _$this._body = body;
+  set body(covariant String? body) => _$this._body = body;
 
   String? _enclosureMime;
   String? get enclosureMime => _$this._enclosureMime;
-  set enclosureMime(String? enclosureMime) => _$this._enclosureMime = enclosureMime;
+  set enclosureMime(covariant String? enclosureMime) => _$this._enclosureMime = enclosureMime;
 
   String? _enclosureLink;
   String? get enclosureLink => _$this._enclosureLink;
-  set enclosureLink(String? enclosureLink) => _$this._enclosureLink = enclosureLink;
+  set enclosureLink(covariant String? enclosureLink) => _$this._enclosureLink = enclosureLink;
 
   String? _mediaThumbnail;
   String? get mediaThumbnail => _$this._mediaThumbnail;
-  set mediaThumbnail(String? mediaThumbnail) => _$this._mediaThumbnail = mediaThumbnail;
+  set mediaThumbnail(covariant String? mediaThumbnail) => _$this._mediaThumbnail = mediaThumbnail;
 
   String? _mediaDescription;
   String? get mediaDescription => _$this._mediaDescription;
-  set mediaDescription(String? mediaDescription) => _$this._mediaDescription = mediaDescription;
+  set mediaDescription(covariant String? mediaDescription) => _$this._mediaDescription = mediaDescription;
 
   int? _feedId;
   int? get feedId => _$this._feedId;
-  set feedId(int? feedId) => _$this._feedId = feedId;
+  set feedId(covariant int? feedId) => _$this._feedId = feedId;
 
   bool? _unread;
   bool? get unread => _$this._unread;
-  set unread(bool? unread) => _$this._unread = unread;
+  set unread(covariant bool? unread) => _$this._unread = unread;
 
   bool? _starred;
   bool? get starred => _$this._starred;
-  set starred(bool? starred) => _$this._starred = starred;
+  set starred(covariant bool? starred) => _$this._starred = starred;
 
   int? _lastModified;
   int? get lastModified => _$this._lastModified;
-  set lastModified(int? lastModified) => _$this._lastModified = lastModified;
+  set lastModified(covariant int? lastModified) => _$this._lastModified = lastModified;
 
   bool? _rtl;
   bool? get rtl => _$this._rtl;
-  set rtl(bool? rtl) => _$this._rtl = rtl;
+  set rtl(covariant bool? rtl) => _$this._rtl = rtl;
 
   String? _fingerprint;
   String? get fingerprint => _$this._fingerprint;
-  set fingerprint(String? fingerprint) => _$this._fingerprint = fingerprint;
+  set fingerprint(covariant String? fingerprint) => _$this._fingerprint = fingerprint;
 
   String? _contentHash;
   String? get contentHash => _$this._contentHash;
-  set contentHash(String? contentHash) => _$this._contentHash = contentHash;
+  set contentHash(covariant String? contentHash) => _$this._contentHash = contentHash;
 
   NewsArticleBuilder();
 
@@ -1051,7 +1125,7 @@ class NewsArticleBuilder implements Builder<NewsArticle, NewsArticleBuilder> {
   }
 
   @override
-  void replace(NewsArticle other) {
+  void replace(covariant NewsArticle other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NewsArticle;
   }
@@ -1090,6 +1164,49 @@ class NewsArticleBuilder implements Builder<NewsArticle, NewsArticleBuilder> {
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NewsFeedInterfaceBuilder {
+  void replace(NewsFeedInterface other);
+  void update(void Function(NewsFeedInterfaceBuilder) updates);
+  int? get id;
+  set id(int? id);
+
+  String? get url;
+  set url(String? url);
+
+  String? get title;
+  set title(String? title);
+
+  String? get faviconLink;
+  set faviconLink(String? faviconLink);
+
+  int? get added;
+  set added(int? added);
+
+  int? get folderId;
+  set folderId(int? folderId);
+
+  int? get unreadCount;
+  set unreadCount(int? unreadCount);
+
+  int? get ordering;
+  set ordering(int? ordering);
+
+  String? get link;
+  set link(String? link);
+
+  bool? get pinned;
+  set pinned(bool? pinned);
+
+  int? get updateErrorCount;
+  set updateErrorCount(int? updateErrorCount);
+
+  String? get lastUpdateError;
+  set lastUpdateError(String? lastUpdateError);
+
+  ListBuilder<NewsArticle> get items;
+  set items(ListBuilder<NewsArticle>? items);
 }
 
 class _$NewsFeed extends NewsFeed {
@@ -1212,60 +1329,60 @@ class _$NewsFeed extends NewsFeed {
   }
 }
 
-class NewsFeedBuilder implements Builder<NewsFeed, NewsFeedBuilder> {
+class NewsFeedBuilder implements Builder<NewsFeed, NewsFeedBuilder>, NewsFeedInterfaceBuilder {
   _$NewsFeed? _$v;
 
   int? _id;
   int? get id => _$this._id;
-  set id(int? id) => _$this._id = id;
+  set id(covariant int? id) => _$this._id = id;
 
   String? _url;
   String? get url => _$this._url;
-  set url(String? url) => _$this._url = url;
+  set url(covariant String? url) => _$this._url = url;
 
   String? _title;
   String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
+  set title(covariant String? title) => _$this._title = title;
 
   String? _faviconLink;
   String? get faviconLink => _$this._faviconLink;
-  set faviconLink(String? faviconLink) => _$this._faviconLink = faviconLink;
+  set faviconLink(covariant String? faviconLink) => _$this._faviconLink = faviconLink;
 
   int? _added;
   int? get added => _$this._added;
-  set added(int? added) => _$this._added = added;
+  set added(covariant int? added) => _$this._added = added;
 
   int? _folderId;
   int? get folderId => _$this._folderId;
-  set folderId(int? folderId) => _$this._folderId = folderId;
+  set folderId(covariant int? folderId) => _$this._folderId = folderId;
 
   int? _unreadCount;
   int? get unreadCount => _$this._unreadCount;
-  set unreadCount(int? unreadCount) => _$this._unreadCount = unreadCount;
+  set unreadCount(covariant int? unreadCount) => _$this._unreadCount = unreadCount;
 
   int? _ordering;
   int? get ordering => _$this._ordering;
-  set ordering(int? ordering) => _$this._ordering = ordering;
+  set ordering(covariant int? ordering) => _$this._ordering = ordering;
 
   String? _link;
   String? get link => _$this._link;
-  set link(String? link) => _$this._link = link;
+  set link(covariant String? link) => _$this._link = link;
 
   bool? _pinned;
   bool? get pinned => _$this._pinned;
-  set pinned(bool? pinned) => _$this._pinned = pinned;
+  set pinned(covariant bool? pinned) => _$this._pinned = pinned;
 
   int? _updateErrorCount;
   int? get updateErrorCount => _$this._updateErrorCount;
-  set updateErrorCount(int? updateErrorCount) => _$this._updateErrorCount = updateErrorCount;
+  set updateErrorCount(covariant int? updateErrorCount) => _$this._updateErrorCount = updateErrorCount;
 
   String? _lastUpdateError;
   String? get lastUpdateError => _$this._lastUpdateError;
-  set lastUpdateError(String? lastUpdateError) => _$this._lastUpdateError = lastUpdateError;
+  set lastUpdateError(covariant String? lastUpdateError) => _$this._lastUpdateError = lastUpdateError;
 
   ListBuilder<NewsArticle>? _items;
   ListBuilder<NewsArticle> get items => _$this._items ??= ListBuilder<NewsArticle>();
-  set items(ListBuilder<NewsArticle>? items) => _$this._items = items;
+  set items(covariant ListBuilder<NewsArticle>? items) => _$this._items = items;
 
   NewsFeedBuilder();
 
@@ -1291,7 +1408,7 @@ class NewsFeedBuilder implements Builder<NewsFeed, NewsFeedBuilder> {
   }
 
   @override
-  void replace(NewsFeed other) {
+  void replace(covariant NewsFeed other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NewsFeed;
   }
@@ -1336,6 +1453,22 @@ class NewsFeedBuilder implements Builder<NewsFeed, NewsFeedBuilder> {
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NewsFolderInterfaceBuilder {
+  void replace(NewsFolderInterface other);
+  void update(void Function(NewsFolderInterfaceBuilder) updates);
+  int? get id;
+  set id(int? id);
+
+  String? get name;
+  set name(String? name);
+
+  bool? get opened;
+  set opened(bool? opened);
+
+  ListBuilder<NewsFeed> get feeds;
+  set feeds(ListBuilder<NewsFeed>? feeds);
 }
 
 class _$NewsFolder extends NewsFolder {
@@ -1395,24 +1528,24 @@ class _$NewsFolder extends NewsFolder {
   }
 }
 
-class NewsFolderBuilder implements Builder<NewsFolder, NewsFolderBuilder> {
+class NewsFolderBuilder implements Builder<NewsFolder, NewsFolderBuilder>, NewsFolderInterfaceBuilder {
   _$NewsFolder? _$v;
 
   int? _id;
   int? get id => _$this._id;
-  set id(int? id) => _$this._id = id;
+  set id(covariant int? id) => _$this._id = id;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   bool? _opened;
   bool? get opened => _$this._opened;
-  set opened(bool? opened) => _$this._opened = opened;
+  set opened(covariant bool? opened) => _$this._opened = opened;
 
   ListBuilder<NewsFeed>? _feeds;
   ListBuilder<NewsFeed> get feeds => _$this._feeds ??= ListBuilder<NewsFeed>();
-  set feeds(ListBuilder<NewsFeed>? feeds) => _$this._feeds = feeds;
+  set feeds(covariant ListBuilder<NewsFeed>? feeds) => _$this._feeds = feeds;
 
   NewsFolderBuilder();
 
@@ -1429,7 +1562,7 @@ class NewsFolderBuilder implements Builder<NewsFolder, NewsFolderBuilder> {
   }
 
   @override
-  void replace(NewsFolder other) {
+  void replace(covariant NewsFolder other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NewsFolder;
   }
@@ -1464,6 +1597,13 @@ class NewsFolderBuilder implements Builder<NewsFolder, NewsFolderBuilder> {
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NewsListFoldersInterfaceBuilder {
+  void replace(NewsListFoldersInterface other);
+  void update(void Function(NewsListFoldersInterfaceBuilder) updates);
+  ListBuilder<NewsFolder> get folders;
+  set folders(ListBuilder<NewsFolder>? folders);
 }
 
 class _$NewsListFolders extends NewsListFolders {
@@ -1503,12 +1643,13 @@ class _$NewsListFolders extends NewsListFolders {
   }
 }
 
-class NewsListFoldersBuilder implements Builder<NewsListFolders, NewsListFoldersBuilder> {
+class NewsListFoldersBuilder
+    implements Builder<NewsListFolders, NewsListFoldersBuilder>, NewsListFoldersInterfaceBuilder {
   _$NewsListFolders? _$v;
 
   ListBuilder<NewsFolder>? _folders;
   ListBuilder<NewsFolder> get folders => _$this._folders ??= ListBuilder<NewsFolder>();
-  set folders(ListBuilder<NewsFolder>? folders) => _$this._folders = folders;
+  set folders(covariant ListBuilder<NewsFolder>? folders) => _$this._folders = folders;
 
   NewsListFoldersBuilder();
 
@@ -1522,7 +1663,7 @@ class NewsListFoldersBuilder implements Builder<NewsListFolders, NewsListFolders
   }
 
   @override
-  void replace(NewsListFolders other) {
+  void replace(covariant NewsListFolders other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NewsListFolders;
   }
@@ -1552,6 +1693,19 @@ class NewsListFoldersBuilder implements Builder<NewsListFolders, NewsListFolders
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NewsListFeedsInterfaceBuilder {
+  void replace(NewsListFeedsInterface other);
+  void update(void Function(NewsListFeedsInterfaceBuilder) updates);
+  int? get starredCount;
+  set starredCount(int? starredCount);
+
+  int? get newestItemId;
+  set newestItemId(int? newestItemId);
+
+  ListBuilder<NewsFeed> get feeds;
+  set feeds(ListBuilder<NewsFeed>? feeds);
 }
 
 class _$NewsListFeeds extends NewsListFeeds {
@@ -1604,20 +1758,20 @@ class _$NewsListFeeds extends NewsListFeeds {
   }
 }
 
-class NewsListFeedsBuilder implements Builder<NewsListFeeds, NewsListFeedsBuilder> {
+class NewsListFeedsBuilder implements Builder<NewsListFeeds, NewsListFeedsBuilder>, NewsListFeedsInterfaceBuilder {
   _$NewsListFeeds? _$v;
 
   int? _starredCount;
   int? get starredCount => _$this._starredCount;
-  set starredCount(int? starredCount) => _$this._starredCount = starredCount;
+  set starredCount(covariant int? starredCount) => _$this._starredCount = starredCount;
 
   int? _newestItemId;
   int? get newestItemId => _$this._newestItemId;
-  set newestItemId(int? newestItemId) => _$this._newestItemId = newestItemId;
+  set newestItemId(covariant int? newestItemId) => _$this._newestItemId = newestItemId;
 
   ListBuilder<NewsFeed>? _feeds;
   ListBuilder<NewsFeed> get feeds => _$this._feeds ??= ListBuilder<NewsFeed>();
-  set feeds(ListBuilder<NewsFeed>? feeds) => _$this._feeds = feeds;
+  set feeds(covariant ListBuilder<NewsFeed>? feeds) => _$this._feeds = feeds;
 
   NewsListFeedsBuilder();
 
@@ -1633,7 +1787,7 @@ class NewsListFeedsBuilder implements Builder<NewsListFeeds, NewsListFeedsBuilde
   }
 
   @override
-  void replace(NewsListFeeds other) {
+  void replace(covariant NewsListFeeds other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NewsListFeeds;
   }
@@ -1663,6 +1817,13 @@ class NewsListFeedsBuilder implements Builder<NewsListFeeds, NewsListFeedsBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NewsListArticlesInterfaceBuilder {
+  void replace(NewsListArticlesInterface other);
+  void update(void Function(NewsListArticlesInterfaceBuilder) updates);
+  ListBuilder<NewsArticle> get items;
+  set items(ListBuilder<NewsArticle>? items);
 }
 
 class _$NewsListArticles extends NewsListArticles {
@@ -1702,12 +1863,13 @@ class _$NewsListArticles extends NewsListArticles {
   }
 }
 
-class NewsListArticlesBuilder implements Builder<NewsListArticles, NewsListArticlesBuilder> {
+class NewsListArticlesBuilder
+    implements Builder<NewsListArticles, NewsListArticlesBuilder>, NewsListArticlesInterfaceBuilder {
   _$NewsListArticles? _$v;
 
   ListBuilder<NewsArticle>? _items;
   ListBuilder<NewsArticle> get items => _$this._items ??= ListBuilder<NewsArticle>();
-  set items(ListBuilder<NewsArticle>? items) => _$this._items = items;
+  set items(covariant ListBuilder<NewsArticle>? items) => _$this._items = items;
 
   NewsListArticlesBuilder();
 
@@ -1721,7 +1883,7 @@ class NewsListArticlesBuilder implements Builder<NewsListArticles, NewsListArtic
   }
 
   @override
-  void replace(NewsListArticles other) {
+  void replace(covariant NewsListArticles other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NewsListArticles;
   }
@@ -1751,6 +1913,25 @@ class NewsListArticlesBuilder implements Builder<NewsListArticles, NewsListArtic
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NewsOCSMetaInterfaceBuilder {
+  void replace(NewsOCSMetaInterface other);
+  void update(void Function(NewsOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
 }
 
 class _$NewsOCSMeta extends NewsOCSMeta {
@@ -1815,28 +1996,28 @@ class _$NewsOCSMeta extends NewsOCSMeta {
   }
 }
 
-class NewsOCSMetaBuilder implements Builder<NewsOCSMeta, NewsOCSMetaBuilder> {
+class NewsOCSMetaBuilder implements Builder<NewsOCSMeta, NewsOCSMetaBuilder>, NewsOCSMetaInterfaceBuilder {
   _$NewsOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   NewsOCSMetaBuilder();
 
@@ -1854,7 +2035,7 @@ class NewsOCSMetaBuilder implements Builder<NewsOCSMeta, NewsOCSMetaBuilder> {
   }
 
   @override
-  void replace(NewsOCSMeta other) {
+  void replace(covariant NewsOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NewsOCSMeta;
   }
@@ -1878,6 +2059,16 @@ class NewsOCSMetaBuilder implements Builder<NewsOCSMeta, NewsOCSMetaBuilder> {
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NewsEmptyOCS_OcsInterfaceBuilder {
+  void replace(NewsEmptyOCS_OcsInterface other);
+  void update(void Function(NewsEmptyOCS_OcsInterfaceBuilder) updates);
+  NewsOCSMetaBuilder get meta;
+  set meta(NewsOCSMetaBuilder? meta);
+
+  ListBuilder<JsonObject> get data;
+  set data(ListBuilder<JsonObject>? data);
 }
 
 class _$NewsEmptyOCS_Ocs extends NewsEmptyOCS_Ocs {
@@ -1924,16 +2115,17 @@ class _$NewsEmptyOCS_Ocs extends NewsEmptyOCS_Ocs {
   }
 }
 
-class NewsEmptyOCS_OcsBuilder implements Builder<NewsEmptyOCS_Ocs, NewsEmptyOCS_OcsBuilder> {
+class NewsEmptyOCS_OcsBuilder
+    implements Builder<NewsEmptyOCS_Ocs, NewsEmptyOCS_OcsBuilder>, NewsEmptyOCS_OcsInterfaceBuilder {
   _$NewsEmptyOCS_Ocs? _$v;
 
   NewsOCSMetaBuilder? _meta;
   NewsOCSMetaBuilder get meta => _$this._meta ??= NewsOCSMetaBuilder();
-  set meta(NewsOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant NewsOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<JsonObject>? _data;
   ListBuilder<JsonObject> get data => _$this._data ??= ListBuilder<JsonObject>();
-  set data(ListBuilder<JsonObject>? data) => _$this._data = data;
+  set data(covariant ListBuilder<JsonObject>? data) => _$this._data = data;
 
   NewsEmptyOCS_OcsBuilder();
 
@@ -1948,7 +2140,7 @@ class NewsEmptyOCS_OcsBuilder implements Builder<NewsEmptyOCS_Ocs, NewsEmptyOCS_
   }
 
   @override
-  void replace(NewsEmptyOCS_Ocs other) {
+  void replace(covariant NewsEmptyOCS_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NewsEmptyOCS_Ocs;
   }
@@ -1980,6 +2172,13 @@ class NewsEmptyOCS_OcsBuilder implements Builder<NewsEmptyOCS_Ocs, NewsEmptyOCS_
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NewsEmptyOCSInterfaceBuilder {
+  void replace(NewsEmptyOCSInterface other);
+  void update(void Function(NewsEmptyOCSInterfaceBuilder) updates);
+  NewsEmptyOCS_OcsBuilder get ocs;
+  set ocs(NewsEmptyOCS_OcsBuilder? ocs);
 }
 
 class _$NewsEmptyOCS extends NewsEmptyOCS {
@@ -2019,12 +2218,12 @@ class _$NewsEmptyOCS extends NewsEmptyOCS {
   }
 }
 
-class NewsEmptyOCSBuilder implements Builder<NewsEmptyOCS, NewsEmptyOCSBuilder> {
+class NewsEmptyOCSBuilder implements Builder<NewsEmptyOCS, NewsEmptyOCSBuilder>, NewsEmptyOCSInterfaceBuilder {
   _$NewsEmptyOCS? _$v;
 
   NewsEmptyOCS_OcsBuilder? _ocs;
   NewsEmptyOCS_OcsBuilder get ocs => _$this._ocs ??= NewsEmptyOCS_OcsBuilder();
-  set ocs(NewsEmptyOCS_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant NewsEmptyOCS_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   NewsEmptyOCSBuilder();
 
@@ -2038,7 +2237,7 @@ class NewsEmptyOCSBuilder implements Builder<NewsEmptyOCS, NewsEmptyOCSBuilder> 
   }
 
   @override
-  void replace(NewsEmptyOCS other) {
+  void replace(covariant NewsEmptyOCS other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NewsEmptyOCS;
   }

--- a/packages/nextcloud/lib/src/api/notes.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.dart
@@ -350,7 +350,23 @@ class NotesClient extends DynamiteClient {
   }
 }
 
-abstract class NotesNote implements Built<NotesNote, NotesNoteBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotesNoteInterface {
+  int get id;
+  String get etag;
+  bool get readonly;
+  String get content;
+  String get title;
+  String get category;
+  bool get favorite;
+  int get modified;
+  bool get error;
+  String get errorType;
+  NotesNoteInterface rebuild(final void Function(NotesNoteInterfaceBuilder) updates);
+  NotesNoteInterfaceBuilder toBuilder();
+}
+
+abstract class NotesNote implements NotesNoteInterface, Built<NotesNote, NotesNoteBuilder> {
   factory NotesNote([final void Function(NotesNoteBuilder)? b]) = _$NotesNote;
 
   // coverage:ignore-start
@@ -364,16 +380,6 @@ abstract class NotesNote implements Built<NotesNote, NotesNoteBuilder> {
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int get id;
-  String get etag;
-  bool get readonly;
-  String get content;
-  String get title;
-  String get category;
-  bool get favorite;
-  int get modified;
-  bool get error;
-  String get errorType;
   static Serializer<NotesNote> get serializer => _$notesNoteSerializer;
 }
 
@@ -393,7 +399,16 @@ class NotesSettings_NoteMode extends EnumClass {
   static Serializer<NotesSettings_NoteMode> get serializer => _$notesSettingsNoteModeSerializer;
 }
 
-abstract class NotesSettings implements Built<NotesSettings, NotesSettingsBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotesSettingsInterface {
+  String get notesPath;
+  String get fileSuffix;
+  NotesSettings_NoteMode get noteMode;
+  NotesSettingsInterface rebuild(final void Function(NotesSettingsInterfaceBuilder) updates);
+  NotesSettingsInterfaceBuilder toBuilder();
+}
+
+abstract class NotesSettings implements NotesSettingsInterface, Built<NotesSettings, NotesSettingsBuilder> {
   factory NotesSettings([final void Function(NotesSettingsBuilder)? b]) = _$NotesSettings;
 
   // coverage:ignore-start
@@ -408,13 +423,20 @@ abstract class NotesSettings implements Built<NotesSettings, NotesSettingsBuilde
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get notesPath;
-  String get fileSuffix;
-  NotesSettings_NoteMode get noteMode;
   static Serializer<NotesSettings> get serializer => _$notesSettingsSerializer;
 }
 
-abstract class NotesCapabilities_Notes implements Built<NotesCapabilities_Notes, NotesCapabilities_NotesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotesCapabilities_NotesInterface {
+  @BuiltValueField(wireName: 'api_version')
+  BuiltList<String>? get apiVersion;
+  String? get version;
+  NotesCapabilities_NotesInterface rebuild(final void Function(NotesCapabilities_NotesInterfaceBuilder) updates);
+  NotesCapabilities_NotesInterfaceBuilder toBuilder();
+}
+
+abstract class NotesCapabilities_Notes
+    implements NotesCapabilities_NotesInterface, Built<NotesCapabilities_Notes, NotesCapabilities_NotesBuilder> {
   factory NotesCapabilities_Notes([final void Function(NotesCapabilities_NotesBuilder)? b]) = _$NotesCapabilities_Notes;
 
   // coverage:ignore-start
@@ -429,13 +451,18 @@ abstract class NotesCapabilities_Notes implements Built<NotesCapabilities_Notes,
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'api_version')
-  BuiltList<String>? get apiVersion;
-  String? get version;
   static Serializer<NotesCapabilities_Notes> get serializer => _$notesCapabilitiesNotesSerializer;
 }
 
-abstract class NotesCapabilities implements Built<NotesCapabilities, NotesCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotesCapabilitiesInterface {
+  NotesCapabilities_Notes get notes;
+  NotesCapabilitiesInterface rebuild(final void Function(NotesCapabilitiesInterfaceBuilder) updates);
+  NotesCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class NotesCapabilities
+    implements NotesCapabilitiesInterface, Built<NotesCapabilities, NotesCapabilitiesBuilder> {
   factory NotesCapabilities([final void Function(NotesCapabilitiesBuilder)? b]) = _$NotesCapabilities;
 
   // coverage:ignore-start
@@ -450,11 +477,21 @@ abstract class NotesCapabilities implements Built<NotesCapabilities, NotesCapabi
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotesCapabilities_Notes get notes;
   static Serializer<NotesCapabilities> get serializer => _$notesCapabilitiesSerializer;
 }
 
-abstract class NotesOCSMeta implements Built<NotesOCSMeta, NotesOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotesOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  NotesOCSMetaInterface rebuild(final void Function(NotesOCSMetaInterfaceBuilder) updates);
+  NotesOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class NotesOCSMeta implements NotesOCSMetaInterface, Built<NotesOCSMeta, NotesOCSMetaBuilder> {
   factory NotesOCSMeta([final void Function(NotesOCSMetaBuilder)? b]) = _$NotesOCSMeta;
 
   // coverage:ignore-start
@@ -468,15 +505,19 @@ abstract class NotesOCSMeta implements Built<NotesOCSMeta, NotesOCSMetaBuilder> 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<NotesOCSMeta> get serializer => _$notesOCSMetaSerializer;
 }
 
-abstract class NotesEmptyOCS_Ocs implements Built<NotesEmptyOCS_Ocs, NotesEmptyOCS_OcsBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotesEmptyOCS_OcsInterface {
+  NotesOCSMeta get meta;
+  BuiltList<JsonObject> get data;
+  NotesEmptyOCS_OcsInterface rebuild(final void Function(NotesEmptyOCS_OcsInterfaceBuilder) updates);
+  NotesEmptyOCS_OcsInterfaceBuilder toBuilder();
+}
+
+abstract class NotesEmptyOCS_Ocs
+    implements NotesEmptyOCS_OcsInterface, Built<NotesEmptyOCS_Ocs, NotesEmptyOCS_OcsBuilder> {
   factory NotesEmptyOCS_Ocs([final void Function(NotesEmptyOCS_OcsBuilder)? b]) = _$NotesEmptyOCS_Ocs;
 
   // coverage:ignore-start
@@ -491,12 +532,17 @@ abstract class NotesEmptyOCS_Ocs implements Built<NotesEmptyOCS_Ocs, NotesEmptyO
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotesOCSMeta get meta;
-  BuiltList<JsonObject> get data;
   static Serializer<NotesEmptyOCS_Ocs> get serializer => _$notesEmptyOCSOcsSerializer;
 }
 
-abstract class NotesEmptyOCS implements Built<NotesEmptyOCS, NotesEmptyOCSBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotesEmptyOCSInterface {
+  NotesEmptyOCS_Ocs get ocs;
+  NotesEmptyOCSInterface rebuild(final void Function(NotesEmptyOCSInterfaceBuilder) updates);
+  NotesEmptyOCSInterfaceBuilder toBuilder();
+}
+
+abstract class NotesEmptyOCS implements NotesEmptyOCSInterface, Built<NotesEmptyOCS, NotesEmptyOCSBuilder> {
   factory NotesEmptyOCS([final void Function(NotesEmptyOCSBuilder)? b]) = _$NotesEmptyOCS;
 
   // coverage:ignore-start
@@ -511,7 +557,6 @@ abstract class NotesEmptyOCS implements Built<NotesEmptyOCS, NotesEmptyOCSBuilde
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotesEmptyOCS_Ocs get ocs;
   static Serializer<NotesEmptyOCS> get serializer => _$notesEmptyOCSSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/notes.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.g.dart
@@ -432,6 +432,40 @@ class _$NotesEmptyOCSSerializer implements StructuredSerializer<NotesEmptyOCS> {
   }
 }
 
+abstract mixin class NotesNoteInterfaceBuilder {
+  void replace(NotesNoteInterface other);
+  void update(void Function(NotesNoteInterfaceBuilder) updates);
+  int? get id;
+  set id(int? id);
+
+  String? get etag;
+  set etag(String? etag);
+
+  bool? get readonly;
+  set readonly(bool? readonly);
+
+  String? get content;
+  set content(String? content);
+
+  String? get title;
+  set title(String? title);
+
+  String? get category;
+  set category(String? category);
+
+  bool? get favorite;
+  set favorite(bool? favorite);
+
+  int? get modified;
+  set modified(int? modified);
+
+  bool? get error;
+  set error(bool? error);
+
+  String? get errorType;
+  set errorType(String? errorType);
+}
+
 class _$NotesNote extends NotesNote {
   @override
   final int id;
@@ -536,48 +570,48 @@ class _$NotesNote extends NotesNote {
   }
 }
 
-class NotesNoteBuilder implements Builder<NotesNote, NotesNoteBuilder> {
+class NotesNoteBuilder implements Builder<NotesNote, NotesNoteBuilder>, NotesNoteInterfaceBuilder {
   _$NotesNote? _$v;
 
   int? _id;
   int? get id => _$this._id;
-  set id(int? id) => _$this._id = id;
+  set id(covariant int? id) => _$this._id = id;
 
   String? _etag;
   String? get etag => _$this._etag;
-  set etag(String? etag) => _$this._etag = etag;
+  set etag(covariant String? etag) => _$this._etag = etag;
 
   bool? _readonly;
   bool? get readonly => _$this._readonly;
-  set readonly(bool? readonly) => _$this._readonly = readonly;
+  set readonly(covariant bool? readonly) => _$this._readonly = readonly;
 
   String? _content;
   String? get content => _$this._content;
-  set content(String? content) => _$this._content = content;
+  set content(covariant String? content) => _$this._content = content;
 
   String? _title;
   String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
+  set title(covariant String? title) => _$this._title = title;
 
   String? _category;
   String? get category => _$this._category;
-  set category(String? category) => _$this._category = category;
+  set category(covariant String? category) => _$this._category = category;
 
   bool? _favorite;
   bool? get favorite => _$this._favorite;
-  set favorite(bool? favorite) => _$this._favorite = favorite;
+  set favorite(covariant bool? favorite) => _$this._favorite = favorite;
 
   int? _modified;
   int? get modified => _$this._modified;
-  set modified(int? modified) => _$this._modified = modified;
+  set modified(covariant int? modified) => _$this._modified = modified;
 
   bool? _error;
   bool? get error => _$this._error;
-  set error(bool? error) => _$this._error = error;
+  set error(covariant bool? error) => _$this._error = error;
 
   String? _errorType;
   String? get errorType => _$this._errorType;
-  set errorType(String? errorType) => _$this._errorType = errorType;
+  set errorType(covariant String? errorType) => _$this._errorType = errorType;
 
   NotesNoteBuilder();
 
@@ -600,7 +634,7 @@ class NotesNoteBuilder implements Builder<NotesNote, NotesNoteBuilder> {
   }
 
   @override
-  void replace(NotesNote other) {
+  void replace(covariant NotesNote other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotesNote;
   }
@@ -629,6 +663,19 @@ class NotesNoteBuilder implements Builder<NotesNote, NotesNoteBuilder> {
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotesSettingsInterfaceBuilder {
+  void replace(NotesSettingsInterface other);
+  void update(void Function(NotesSettingsInterfaceBuilder) updates);
+  String? get notesPath;
+  set notesPath(String? notesPath);
+
+  String? get fileSuffix;
+  set fileSuffix(String? fileSuffix);
+
+  NotesSettings_NoteMode? get noteMode;
+  set noteMode(NotesSettings_NoteMode? noteMode);
 }
 
 class _$NotesSettings extends NotesSettings {
@@ -683,20 +730,20 @@ class _$NotesSettings extends NotesSettings {
   }
 }
 
-class NotesSettingsBuilder implements Builder<NotesSettings, NotesSettingsBuilder> {
+class NotesSettingsBuilder implements Builder<NotesSettings, NotesSettingsBuilder>, NotesSettingsInterfaceBuilder {
   _$NotesSettings? _$v;
 
   String? _notesPath;
   String? get notesPath => _$this._notesPath;
-  set notesPath(String? notesPath) => _$this._notesPath = notesPath;
+  set notesPath(covariant String? notesPath) => _$this._notesPath = notesPath;
 
   String? _fileSuffix;
   String? get fileSuffix => _$this._fileSuffix;
-  set fileSuffix(String? fileSuffix) => _$this._fileSuffix = fileSuffix;
+  set fileSuffix(covariant String? fileSuffix) => _$this._fileSuffix = fileSuffix;
 
   NotesSettings_NoteMode? _noteMode;
   NotesSettings_NoteMode? get noteMode => _$this._noteMode;
-  set noteMode(NotesSettings_NoteMode? noteMode) => _$this._noteMode = noteMode;
+  set noteMode(covariant NotesSettings_NoteMode? noteMode) => _$this._noteMode = noteMode;
 
   NotesSettingsBuilder();
 
@@ -712,7 +759,7 @@ class NotesSettingsBuilder implements Builder<NotesSettings, NotesSettingsBuilde
   }
 
   @override
-  void replace(NotesSettings other) {
+  void replace(covariant NotesSettings other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotesSettings;
   }
@@ -734,6 +781,16 @@ class NotesSettingsBuilder implements Builder<NotesSettings, NotesSettingsBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotesCapabilities_NotesInterfaceBuilder {
+  void replace(NotesCapabilities_NotesInterface other);
+  void update(void Function(NotesCapabilities_NotesInterfaceBuilder) updates);
+  ListBuilder<String> get apiVersion;
+  set apiVersion(ListBuilder<String>? apiVersion);
+
+  String? get version;
+  set version(String? version);
 }
 
 class _$NotesCapabilities_Notes extends NotesCapabilities_Notes {
@@ -778,16 +835,19 @@ class _$NotesCapabilities_Notes extends NotesCapabilities_Notes {
   }
 }
 
-class NotesCapabilities_NotesBuilder implements Builder<NotesCapabilities_Notes, NotesCapabilities_NotesBuilder> {
+class NotesCapabilities_NotesBuilder
+    implements
+        Builder<NotesCapabilities_Notes, NotesCapabilities_NotesBuilder>,
+        NotesCapabilities_NotesInterfaceBuilder {
   _$NotesCapabilities_Notes? _$v;
 
   ListBuilder<String>? _apiVersion;
   ListBuilder<String> get apiVersion => _$this._apiVersion ??= ListBuilder<String>();
-  set apiVersion(ListBuilder<String>? apiVersion) => _$this._apiVersion = apiVersion;
+  set apiVersion(covariant ListBuilder<String>? apiVersion) => _$this._apiVersion = apiVersion;
 
   String? _version;
   String? get version => _$this._version;
-  set version(String? version) => _$this._version = version;
+  set version(covariant String? version) => _$this._version = version;
 
   NotesCapabilities_NotesBuilder();
 
@@ -802,7 +862,7 @@ class NotesCapabilities_NotesBuilder implements Builder<NotesCapabilities_Notes,
   }
 
   @override
-  void replace(NotesCapabilities_Notes other) {
+  void replace(covariant NotesCapabilities_Notes other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotesCapabilities_Notes;
   }
@@ -832,6 +892,13 @@ class NotesCapabilities_NotesBuilder implements Builder<NotesCapabilities_Notes,
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotesCapabilitiesInterfaceBuilder {
+  void replace(NotesCapabilitiesInterface other);
+  void update(void Function(NotesCapabilitiesInterfaceBuilder) updates);
+  NotesCapabilities_NotesBuilder get notes;
+  set notes(NotesCapabilities_NotesBuilder? notes);
 }
 
 class _$NotesCapabilities extends NotesCapabilities {
@@ -871,12 +938,13 @@ class _$NotesCapabilities extends NotesCapabilities {
   }
 }
 
-class NotesCapabilitiesBuilder implements Builder<NotesCapabilities, NotesCapabilitiesBuilder> {
+class NotesCapabilitiesBuilder
+    implements Builder<NotesCapabilities, NotesCapabilitiesBuilder>, NotesCapabilitiesInterfaceBuilder {
   _$NotesCapabilities? _$v;
 
   NotesCapabilities_NotesBuilder? _notes;
   NotesCapabilities_NotesBuilder get notes => _$this._notes ??= NotesCapabilities_NotesBuilder();
-  set notes(NotesCapabilities_NotesBuilder? notes) => _$this._notes = notes;
+  set notes(covariant NotesCapabilities_NotesBuilder? notes) => _$this._notes = notes;
 
   NotesCapabilitiesBuilder();
 
@@ -890,7 +958,7 @@ class NotesCapabilitiesBuilder implements Builder<NotesCapabilities, NotesCapabi
   }
 
   @override
-  void replace(NotesCapabilities other) {
+  void replace(covariant NotesCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotesCapabilities;
   }
@@ -920,6 +988,25 @@ class NotesCapabilitiesBuilder implements Builder<NotesCapabilities, NotesCapabi
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotesOCSMetaInterfaceBuilder {
+  void replace(NotesOCSMetaInterface other);
+  void update(void Function(NotesOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
 }
 
 class _$NotesOCSMeta extends NotesOCSMeta {
@@ -984,28 +1071,28 @@ class _$NotesOCSMeta extends NotesOCSMeta {
   }
 }
 
-class NotesOCSMetaBuilder implements Builder<NotesOCSMeta, NotesOCSMetaBuilder> {
+class NotesOCSMetaBuilder implements Builder<NotesOCSMeta, NotesOCSMetaBuilder>, NotesOCSMetaInterfaceBuilder {
   _$NotesOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   NotesOCSMetaBuilder();
 
@@ -1023,7 +1110,7 @@ class NotesOCSMetaBuilder implements Builder<NotesOCSMeta, NotesOCSMetaBuilder> 
   }
 
   @override
-  void replace(NotesOCSMeta other) {
+  void replace(covariant NotesOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotesOCSMeta;
   }
@@ -1047,6 +1134,16 @@ class NotesOCSMetaBuilder implements Builder<NotesOCSMeta, NotesOCSMetaBuilder> 
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotesEmptyOCS_OcsInterfaceBuilder {
+  void replace(NotesEmptyOCS_OcsInterface other);
+  void update(void Function(NotesEmptyOCS_OcsInterfaceBuilder) updates);
+  NotesOCSMetaBuilder get meta;
+  set meta(NotesOCSMetaBuilder? meta);
+
+  ListBuilder<JsonObject> get data;
+  set data(ListBuilder<JsonObject>? data);
 }
 
 class _$NotesEmptyOCS_Ocs extends NotesEmptyOCS_Ocs {
@@ -1093,16 +1190,17 @@ class _$NotesEmptyOCS_Ocs extends NotesEmptyOCS_Ocs {
   }
 }
 
-class NotesEmptyOCS_OcsBuilder implements Builder<NotesEmptyOCS_Ocs, NotesEmptyOCS_OcsBuilder> {
+class NotesEmptyOCS_OcsBuilder
+    implements Builder<NotesEmptyOCS_Ocs, NotesEmptyOCS_OcsBuilder>, NotesEmptyOCS_OcsInterfaceBuilder {
   _$NotesEmptyOCS_Ocs? _$v;
 
   NotesOCSMetaBuilder? _meta;
   NotesOCSMetaBuilder get meta => _$this._meta ??= NotesOCSMetaBuilder();
-  set meta(NotesOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant NotesOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<JsonObject>? _data;
   ListBuilder<JsonObject> get data => _$this._data ??= ListBuilder<JsonObject>();
-  set data(ListBuilder<JsonObject>? data) => _$this._data = data;
+  set data(covariant ListBuilder<JsonObject>? data) => _$this._data = data;
 
   NotesEmptyOCS_OcsBuilder();
 
@@ -1117,7 +1215,7 @@ class NotesEmptyOCS_OcsBuilder implements Builder<NotesEmptyOCS_Ocs, NotesEmptyO
   }
 
   @override
-  void replace(NotesEmptyOCS_Ocs other) {
+  void replace(covariant NotesEmptyOCS_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotesEmptyOCS_Ocs;
   }
@@ -1149,6 +1247,13 @@ class NotesEmptyOCS_OcsBuilder implements Builder<NotesEmptyOCS_Ocs, NotesEmptyO
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotesEmptyOCSInterfaceBuilder {
+  void replace(NotesEmptyOCSInterface other);
+  void update(void Function(NotesEmptyOCSInterfaceBuilder) updates);
+  NotesEmptyOCS_OcsBuilder get ocs;
+  set ocs(NotesEmptyOCS_OcsBuilder? ocs);
 }
 
 class _$NotesEmptyOCS extends NotesEmptyOCS {
@@ -1188,12 +1293,12 @@ class _$NotesEmptyOCS extends NotesEmptyOCS {
   }
 }
 
-class NotesEmptyOCSBuilder implements Builder<NotesEmptyOCS, NotesEmptyOCSBuilder> {
+class NotesEmptyOCSBuilder implements Builder<NotesEmptyOCS, NotesEmptyOCSBuilder>, NotesEmptyOCSInterfaceBuilder {
   _$NotesEmptyOCS? _$v;
 
   NotesEmptyOCS_OcsBuilder? _ocs;
   NotesEmptyOCS_OcsBuilder get ocs => _$this._ocs ??= NotesEmptyOCS_OcsBuilder();
-  set ocs(NotesEmptyOCS_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant NotesEmptyOCS_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   NotesEmptyOCSBuilder();
 
@@ -1207,7 +1312,7 @@ class NotesEmptyOCSBuilder implements Builder<NotesEmptyOCS, NotesEmptyOCSBuilde
   }
 
   @override
-  void replace(NotesEmptyOCS other) {
+  void replace(covariant NotesEmptyOCS other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotesEmptyOCS;
   }

--- a/packages/nextcloud/lib/src/api/notifications.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.dart
@@ -290,7 +290,19 @@ class NotificationsClient extends DynamiteClient {
   }
 }
 
-abstract class NotificationsOCSMeta implements Built<NotificationsOCSMeta, NotificationsOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  NotificationsOCSMetaInterface rebuild(final void Function(NotificationsOCSMetaInterfaceBuilder) updates);
+  NotificationsOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class NotificationsOCSMeta
+    implements NotificationsOCSMetaInterface, Built<NotificationsOCSMeta, NotificationsOCSMetaBuilder> {
   factory NotificationsOCSMeta([final void Function(NotificationsOCSMetaBuilder)? b]) = _$NotificationsOCSMeta;
 
   // coverage:ignore-start
@@ -305,16 +317,25 @@ abstract class NotificationsOCSMeta implements Built<NotificationsOCSMeta, Notif
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<NotificationsOCSMeta> get serializer => _$notificationsOCSMetaSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsNotificationActionInterface {
+  String get label;
+  String get link;
+  String get type;
+  bool? get primary;
+  NotificationsNotificationActionInterface rebuild(
+    final void Function(NotificationsNotificationActionInterfaceBuilder) updates,
+  );
+  NotificationsNotificationActionInterfaceBuilder toBuilder();
+}
+
 abstract class NotificationsNotificationAction
-    implements Built<NotificationsNotificationAction, NotificationsNotificationActionBuilder> {
+    implements
+        NotificationsNotificationActionInterface,
+        Built<NotificationsNotificationAction, NotificationsNotificationActionBuilder> {
   factory NotificationsNotificationAction([final void Function(NotificationsNotificationActionBuilder)? b]) =
       _$NotificationsNotificationAction;
 
@@ -330,29 +351,11 @@ abstract class NotificationsNotificationAction
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get label;
-  String get link;
-  String get type;
-  bool? get primary;
   static Serializer<NotificationsNotificationAction> get serializer => _$notificationsNotificationActionSerializer;
 }
 
-abstract class NotificationsNotification implements Built<NotificationsNotification, NotificationsNotificationBuilder> {
-  factory NotificationsNotification([final void Function(NotificationsNotificationBuilder)? b]) =
-      _$NotificationsNotification;
-
-  // coverage:ignore-start
-  const NotificationsNotification._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory NotificationsNotification.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsNotificationInterface {
   @BuiltValueField(wireName: 'notification_id')
   int get notificationId;
   String get app;
@@ -372,11 +375,44 @@ abstract class NotificationsNotification implements Built<NotificationsNotificat
   String? get icon;
   bool? get shouldNotify;
   BuiltList<NotificationsNotificationAction> get actions;
+  NotificationsNotificationInterface rebuild(final void Function(NotificationsNotificationInterfaceBuilder) updates);
+  NotificationsNotificationInterfaceBuilder toBuilder();
+}
+
+abstract class NotificationsNotification
+    implements NotificationsNotificationInterface, Built<NotificationsNotification, NotificationsNotificationBuilder> {
+  factory NotificationsNotification([final void Function(NotificationsNotificationBuilder)? b]) =
+      _$NotificationsNotification;
+
+  // coverage:ignore-start
+  const NotificationsNotification._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory NotificationsNotification.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<NotificationsNotification> get serializer => _$notificationsNotificationSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsListNotifications_OcsInterface {
+  NotificationsOCSMeta get meta;
+  BuiltList<NotificationsNotification> get data;
+  NotificationsListNotifications_OcsInterface rebuild(
+    final void Function(NotificationsListNotifications_OcsInterfaceBuilder) updates,
+  );
+  NotificationsListNotifications_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class NotificationsListNotifications_Ocs
-    implements Built<NotificationsListNotifications_Ocs, NotificationsListNotifications_OcsBuilder> {
+    implements
+        NotificationsListNotifications_OcsInterface,
+        Built<NotificationsListNotifications_Ocs, NotificationsListNotifications_OcsBuilder> {
   factory NotificationsListNotifications_Ocs([final void Function(NotificationsListNotifications_OcsBuilder)? b]) =
       _$NotificationsListNotifications_Ocs;
 
@@ -392,13 +428,22 @@ abstract class NotificationsListNotifications_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotificationsOCSMeta get meta;
-  BuiltList<NotificationsNotification> get data;
   static Serializer<NotificationsListNotifications_Ocs> get serializer => _$notificationsListNotificationsOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsListNotificationsInterface {
+  NotificationsListNotifications_Ocs get ocs;
+  NotificationsListNotificationsInterface rebuild(
+    final void Function(NotificationsListNotificationsInterfaceBuilder) updates,
+  );
+  NotificationsListNotificationsInterfaceBuilder toBuilder();
+}
+
 abstract class NotificationsListNotifications
-    implements Built<NotificationsListNotifications, NotificationsListNotificationsBuilder> {
+    implements
+        NotificationsListNotificationsInterface,
+        Built<NotificationsListNotifications, NotificationsListNotificationsBuilder> {
   factory NotificationsListNotifications([final void Function(NotificationsListNotificationsBuilder)? b]) =
       _$NotificationsListNotifications;
 
@@ -414,12 +459,23 @@ abstract class NotificationsListNotifications
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotificationsListNotifications_Ocs get ocs;
   static Serializer<NotificationsListNotifications> get serializer => _$notificationsListNotificationsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsGetNotification_OcsInterface {
+  NotificationsOCSMeta get meta;
+  NotificationsNotification get data;
+  NotificationsGetNotification_OcsInterface rebuild(
+    final void Function(NotificationsGetNotification_OcsInterfaceBuilder) updates,
+  );
+  NotificationsGetNotification_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class NotificationsGetNotification_Ocs
-    implements Built<NotificationsGetNotification_Ocs, NotificationsGetNotification_OcsBuilder> {
+    implements
+        NotificationsGetNotification_OcsInterface,
+        Built<NotificationsGetNotification_Ocs, NotificationsGetNotification_OcsBuilder> {
   factory NotificationsGetNotification_Ocs([final void Function(NotificationsGetNotification_OcsBuilder)? b]) =
       _$NotificationsGetNotification_Ocs;
 
@@ -435,13 +491,22 @@ abstract class NotificationsGetNotification_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotificationsOCSMeta get meta;
-  NotificationsNotification get data;
   static Serializer<NotificationsGetNotification_Ocs> get serializer => _$notificationsGetNotificationOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsGetNotificationInterface {
+  NotificationsGetNotification_Ocs get ocs;
+  NotificationsGetNotificationInterface rebuild(
+    final void Function(NotificationsGetNotificationInterfaceBuilder) updates,
+  );
+  NotificationsGetNotificationInterfaceBuilder toBuilder();
+}
+
 abstract class NotificationsGetNotification
-    implements Built<NotificationsGetNotification, NotificationsGetNotificationBuilder> {
+    implements
+        NotificationsGetNotificationInterface,
+        Built<NotificationsGetNotification, NotificationsGetNotificationBuilder> {
   factory NotificationsGetNotification([final void Function(NotificationsGetNotificationBuilder)? b]) =
       _$NotificationsGetNotification;
 
@@ -457,11 +522,19 @@ abstract class NotificationsGetNotification
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotificationsGetNotification_Ocs get ocs;
   static Serializer<NotificationsGetNotification> get serializer => _$notificationsGetNotificationSerializer;
 }
 
-abstract class NotificationsEmptyOCS_Ocs implements Built<NotificationsEmptyOCS_Ocs, NotificationsEmptyOCS_OcsBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsEmptyOCS_OcsInterface {
+  NotificationsOCSMeta get meta;
+  BuiltList<JsonObject> get data;
+  NotificationsEmptyOCS_OcsInterface rebuild(final void Function(NotificationsEmptyOCS_OcsInterfaceBuilder) updates);
+  NotificationsEmptyOCS_OcsInterfaceBuilder toBuilder();
+}
+
+abstract class NotificationsEmptyOCS_Ocs
+    implements NotificationsEmptyOCS_OcsInterface, Built<NotificationsEmptyOCS_Ocs, NotificationsEmptyOCS_OcsBuilder> {
   factory NotificationsEmptyOCS_Ocs([final void Function(NotificationsEmptyOCS_OcsBuilder)? b]) =
       _$NotificationsEmptyOCS_Ocs;
 
@@ -477,12 +550,18 @@ abstract class NotificationsEmptyOCS_Ocs implements Built<NotificationsEmptyOCS_
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotificationsOCSMeta get meta;
-  BuiltList<JsonObject> get data;
   static Serializer<NotificationsEmptyOCS_Ocs> get serializer => _$notificationsEmptyOCSOcsSerializer;
 }
 
-abstract class NotificationsEmptyOCS implements Built<NotificationsEmptyOCS, NotificationsEmptyOCSBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsEmptyOCSInterface {
+  NotificationsEmptyOCS_Ocs get ocs;
+  NotificationsEmptyOCSInterface rebuild(final void Function(NotificationsEmptyOCSInterfaceBuilder) updates);
+  NotificationsEmptyOCSInterfaceBuilder toBuilder();
+}
+
+abstract class NotificationsEmptyOCS
+    implements NotificationsEmptyOCSInterface, Built<NotificationsEmptyOCS, NotificationsEmptyOCSBuilder> {
   factory NotificationsEmptyOCS([final void Function(NotificationsEmptyOCSBuilder)? b]) = _$NotificationsEmptyOCS;
 
   // coverage:ignore-start
@@ -497,12 +576,25 @@ abstract class NotificationsEmptyOCS implements Built<NotificationsEmptyOCS, Not
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotificationsEmptyOCS_Ocs get ocs;
   static Serializer<NotificationsEmptyOCS> get serializer => _$notificationsEmptyOCSSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsPushServerSubscriptionInterface {
+  String get publicKey;
+  String get deviceIdentifier;
+  String get signature;
+  String? get message;
+  NotificationsPushServerSubscriptionInterface rebuild(
+    final void Function(NotificationsPushServerSubscriptionInterfaceBuilder) updates,
+  );
+  NotificationsPushServerSubscriptionInterfaceBuilder toBuilder();
+}
+
 abstract class NotificationsPushServerSubscription
-    implements Built<NotificationsPushServerSubscription, NotificationsPushServerSubscriptionBuilder> {
+    implements
+        NotificationsPushServerSubscriptionInterface,
+        Built<NotificationsPushServerSubscription, NotificationsPushServerSubscriptionBuilder> {
   factory NotificationsPushServerSubscription([final void Function(NotificationsPushServerSubscriptionBuilder)? b]) =
       _$NotificationsPushServerSubscription;
 
@@ -518,16 +610,24 @@ abstract class NotificationsPushServerSubscription
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get publicKey;
-  String get deviceIdentifier;
-  String get signature;
-  String? get message;
   static Serializer<NotificationsPushServerSubscription> get serializer =>
       _$notificationsPushServerSubscriptionSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsPushServerRegistration_OcsInterface {
+  NotificationsOCSMeta get meta;
+  NotificationsPushServerSubscription get data;
+  NotificationsPushServerRegistration_OcsInterface rebuild(
+    final void Function(NotificationsPushServerRegistration_OcsInterfaceBuilder) updates,
+  );
+  NotificationsPushServerRegistration_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class NotificationsPushServerRegistration_Ocs
-    implements Built<NotificationsPushServerRegistration_Ocs, NotificationsPushServerRegistration_OcsBuilder> {
+    implements
+        NotificationsPushServerRegistration_OcsInterface,
+        Built<NotificationsPushServerRegistration_Ocs, NotificationsPushServerRegistration_OcsBuilder> {
   factory NotificationsPushServerRegistration_Ocs([
     final void Function(NotificationsPushServerRegistration_OcsBuilder)? b,
   ]) = _$NotificationsPushServerRegistration_Ocs;
@@ -544,14 +644,23 @@ abstract class NotificationsPushServerRegistration_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotificationsOCSMeta get meta;
-  NotificationsPushServerSubscription get data;
   static Serializer<NotificationsPushServerRegistration_Ocs> get serializer =>
       _$notificationsPushServerRegistrationOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsPushServerRegistrationInterface {
+  NotificationsPushServerRegistration_Ocs get ocs;
+  NotificationsPushServerRegistrationInterface rebuild(
+    final void Function(NotificationsPushServerRegistrationInterfaceBuilder) updates,
+  );
+  NotificationsPushServerRegistrationInterfaceBuilder toBuilder();
+}
+
 abstract class NotificationsPushServerRegistration
-    implements Built<NotificationsPushServerRegistration, NotificationsPushServerRegistrationBuilder> {
+    implements
+        NotificationsPushServerRegistrationInterface,
+        Built<NotificationsPushServerRegistration, NotificationsPushServerRegistrationBuilder> {
   factory NotificationsPushServerRegistration([final void Function(NotificationsPushServerRegistrationBuilder)? b]) =
       _$NotificationsPushServerRegistration;
 
@@ -567,13 +676,27 @@ abstract class NotificationsPushServerRegistration
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotificationsPushServerRegistration_Ocs get ocs;
   static Serializer<NotificationsPushServerRegistration> get serializer =>
       _$notificationsPushServerRegistrationSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsCapabilities_NotificationsInterface {
+  @BuiltValueField(wireName: 'ocs-endpoints')
+  BuiltList<String>? get ocsEndpoints;
+  BuiltList<String>? get push;
+  @BuiltValueField(wireName: 'admin-notifications')
+  BuiltList<String>? get adminNotifications;
+  NotificationsCapabilities_NotificationsInterface rebuild(
+    final void Function(NotificationsCapabilities_NotificationsInterfaceBuilder) updates,
+  );
+  NotificationsCapabilities_NotificationsInterfaceBuilder toBuilder();
+}
+
 abstract class NotificationsCapabilities_Notifications
-    implements Built<NotificationsCapabilities_Notifications, NotificationsCapabilities_NotificationsBuilder> {
+    implements
+        NotificationsCapabilities_NotificationsInterface,
+        Built<NotificationsCapabilities_Notifications, NotificationsCapabilities_NotificationsBuilder> {
   factory NotificationsCapabilities_Notifications([
     final void Function(NotificationsCapabilities_NotificationsBuilder)? b,
   ]) = _$NotificationsCapabilities_Notifications;
@@ -590,16 +713,19 @@ abstract class NotificationsCapabilities_Notifications
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'ocs-endpoints')
-  BuiltList<String>? get ocsEndpoints;
-  BuiltList<String>? get push;
-  @BuiltValueField(wireName: 'admin-notifications')
-  BuiltList<String>? get adminNotifications;
   static Serializer<NotificationsCapabilities_Notifications> get serializer =>
       _$notificationsCapabilitiesNotificationsSerializer;
 }
 
-abstract class NotificationsCapabilities implements Built<NotificationsCapabilities, NotificationsCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsCapabilitiesInterface {
+  NotificationsCapabilities_Notifications get notifications;
+  NotificationsCapabilitiesInterface rebuild(final void Function(NotificationsCapabilitiesInterfaceBuilder) updates);
+  NotificationsCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class NotificationsCapabilities
+    implements NotificationsCapabilitiesInterface, Built<NotificationsCapabilities, NotificationsCapabilitiesBuilder> {
   factory NotificationsCapabilities([final void Function(NotificationsCapabilitiesBuilder)? b]) =
       _$NotificationsCapabilities;
 
@@ -615,12 +741,29 @@ abstract class NotificationsCapabilities implements Built<NotificationsCapabilit
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  NotificationsCapabilities_Notifications get notifications;
   static Serializer<NotificationsCapabilities> get serializer => _$notificationsCapabilitiesSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class NotificationsNotificationDecryptedSubjectInterface {
+  int? get nid;
+  String? get app;
+  String? get subject;
+  String? get type;
+  String? get id;
+  bool? get delete;
+  @BuiltValueField(wireName: 'delete-all')
+  bool? get deleteAll;
+  NotificationsNotificationDecryptedSubjectInterface rebuild(
+    final void Function(NotificationsNotificationDecryptedSubjectInterfaceBuilder) updates,
+  );
+  NotificationsNotificationDecryptedSubjectInterfaceBuilder toBuilder();
+}
+
 abstract class NotificationsNotificationDecryptedSubject
-    implements Built<NotificationsNotificationDecryptedSubject, NotificationsNotificationDecryptedSubjectBuilder> {
+    implements
+        NotificationsNotificationDecryptedSubjectInterface,
+        Built<NotificationsNotificationDecryptedSubject, NotificationsNotificationDecryptedSubjectBuilder> {
   factory NotificationsNotificationDecryptedSubject([
     final void Function(NotificationsNotificationDecryptedSubjectBuilder)? b,
   ]) = _$NotificationsNotificationDecryptedSubject;
@@ -637,14 +780,6 @@ abstract class NotificationsNotificationDecryptedSubject
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int? get nid;
-  String? get app;
-  String? get subject;
-  String? get type;
-  String? get id;
-  bool? get delete;
-  @BuiltValueField(wireName: 'delete-all')
-  bool? get deleteAll;
   static Serializer<NotificationsNotificationDecryptedSubject> get serializer =>
       _$notificationsNotificationDecryptedSubjectSerializer;
 }

--- a/packages/nextcloud/lib/src/api/notifications.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.g.dart
@@ -911,6 +911,25 @@ class _$NotificationsNotificationDecryptedSubjectSerializer
   }
 }
 
+abstract mixin class NotificationsOCSMetaInterfaceBuilder {
+  void replace(NotificationsOCSMetaInterface other);
+  void update(void Function(NotificationsOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
+}
+
 class _$NotificationsOCSMeta extends NotificationsOCSMeta {
   @override
   final String status;
@@ -975,28 +994,29 @@ class _$NotificationsOCSMeta extends NotificationsOCSMeta {
   }
 }
 
-class NotificationsOCSMetaBuilder implements Builder<NotificationsOCSMeta, NotificationsOCSMetaBuilder> {
+class NotificationsOCSMetaBuilder
+    implements Builder<NotificationsOCSMeta, NotificationsOCSMetaBuilder>, NotificationsOCSMetaInterfaceBuilder {
   _$NotificationsOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   NotificationsOCSMetaBuilder();
 
@@ -1014,7 +1034,7 @@ class NotificationsOCSMetaBuilder implements Builder<NotificationsOCSMeta, Notif
   }
 
   @override
-  void replace(NotificationsOCSMeta other) {
+  void replace(covariant NotificationsOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsOCSMeta;
   }
@@ -1038,6 +1058,22 @@ class NotificationsOCSMetaBuilder implements Builder<NotificationsOCSMeta, Notif
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsNotificationActionInterfaceBuilder {
+  void replace(NotificationsNotificationActionInterface other);
+  void update(void Function(NotificationsNotificationActionInterfaceBuilder) updates);
+  String? get label;
+  set label(String? label);
+
+  String? get link;
+  set link(String? link);
+
+  String? get type;
+  set type(String? type);
+
+  bool? get primary;
+  set primary(bool? primary);
 }
 
 class _$NotificationsNotificationAction extends NotificationsNotificationAction {
@@ -1100,24 +1136,26 @@ class _$NotificationsNotificationAction extends NotificationsNotificationAction 
 }
 
 class NotificationsNotificationActionBuilder
-    implements Builder<NotificationsNotificationAction, NotificationsNotificationActionBuilder> {
+    implements
+        Builder<NotificationsNotificationAction, NotificationsNotificationActionBuilder>,
+        NotificationsNotificationActionInterfaceBuilder {
   _$NotificationsNotificationAction? _$v;
 
   String? _label;
   String? get label => _$this._label;
-  set label(String? label) => _$this._label = label;
+  set label(covariant String? label) => _$this._label = label;
 
   String? _link;
   String? get link => _$this._link;
-  set link(String? link) => _$this._link = link;
+  set link(covariant String? link) => _$this._link = link;
 
   String? _type;
   String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
+  set type(covariant String? type) => _$this._type = type;
 
   bool? _primary;
   bool? get primary => _$this._primary;
-  set primary(bool? primary) => _$this._primary = primary;
+  set primary(covariant bool? primary) => _$this._primary = primary;
 
   NotificationsNotificationActionBuilder();
 
@@ -1134,7 +1172,7 @@ class NotificationsNotificationActionBuilder
   }
 
   @override
-  void replace(NotificationsNotificationAction other) {
+  void replace(covariant NotificationsNotificationAction other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsNotificationAction;
   }
@@ -1157,6 +1195,58 @@ class NotificationsNotificationActionBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsNotificationInterfaceBuilder {
+  void replace(NotificationsNotificationInterface other);
+  void update(void Function(NotificationsNotificationInterfaceBuilder) updates);
+  int? get notificationId;
+  set notificationId(int? notificationId);
+
+  String? get app;
+  set app(String? app);
+
+  String? get user;
+  set user(String? user);
+
+  String? get datetime;
+  set datetime(String? datetime);
+
+  String? get objectType;
+  set objectType(String? objectType);
+
+  String? get objectId;
+  set objectId(String? objectId);
+
+  String? get subject;
+  set subject(String? subject);
+
+  String? get message;
+  set message(String? message);
+
+  String? get link;
+  set link(String? link);
+
+  String? get subjectRich;
+  set subjectRich(String? subjectRich);
+
+  JsonObject? get subjectRichParameters;
+  set subjectRichParameters(JsonObject? subjectRichParameters);
+
+  String? get messageRich;
+  set messageRich(String? messageRich);
+
+  JsonObject? get messageRichParameters;
+  set messageRichParameters(JsonObject? messageRichParameters);
+
+  String? get icon;
+  set icon(String? icon);
+
+  bool? get shouldNotify;
+  set shouldNotify(bool? shouldNotify);
+
+  ListBuilder<NotificationsNotificationAction> get actions;
+  set actions(ListBuilder<NotificationsNotificationAction>? actions);
 }
 
 class _$NotificationsNotification extends NotificationsNotification {
@@ -1301,73 +1391,78 @@ class _$NotificationsNotification extends NotificationsNotification {
   }
 }
 
-class NotificationsNotificationBuilder implements Builder<NotificationsNotification, NotificationsNotificationBuilder> {
+class NotificationsNotificationBuilder
+    implements
+        Builder<NotificationsNotification, NotificationsNotificationBuilder>,
+        NotificationsNotificationInterfaceBuilder {
   _$NotificationsNotification? _$v;
 
   int? _notificationId;
   int? get notificationId => _$this._notificationId;
-  set notificationId(int? notificationId) => _$this._notificationId = notificationId;
+  set notificationId(covariant int? notificationId) => _$this._notificationId = notificationId;
 
   String? _app;
   String? get app => _$this._app;
-  set app(String? app) => _$this._app = app;
+  set app(covariant String? app) => _$this._app = app;
 
   String? _user;
   String? get user => _$this._user;
-  set user(String? user) => _$this._user = user;
+  set user(covariant String? user) => _$this._user = user;
 
   String? _datetime;
   String? get datetime => _$this._datetime;
-  set datetime(String? datetime) => _$this._datetime = datetime;
+  set datetime(covariant String? datetime) => _$this._datetime = datetime;
 
   String? _objectType;
   String? get objectType => _$this._objectType;
-  set objectType(String? objectType) => _$this._objectType = objectType;
+  set objectType(covariant String? objectType) => _$this._objectType = objectType;
 
   String? _objectId;
   String? get objectId => _$this._objectId;
-  set objectId(String? objectId) => _$this._objectId = objectId;
+  set objectId(covariant String? objectId) => _$this._objectId = objectId;
 
   String? _subject;
   String? get subject => _$this._subject;
-  set subject(String? subject) => _$this._subject = subject;
+  set subject(covariant String? subject) => _$this._subject = subject;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _link;
   String? get link => _$this._link;
-  set link(String? link) => _$this._link = link;
+  set link(covariant String? link) => _$this._link = link;
 
   String? _subjectRich;
   String? get subjectRich => _$this._subjectRich;
-  set subjectRich(String? subjectRich) => _$this._subjectRich = subjectRich;
+  set subjectRich(covariant String? subjectRich) => _$this._subjectRich = subjectRich;
 
   JsonObject? _subjectRichParameters;
   JsonObject? get subjectRichParameters => _$this._subjectRichParameters;
-  set subjectRichParameters(JsonObject? subjectRichParameters) => _$this._subjectRichParameters = subjectRichParameters;
+  set subjectRichParameters(covariant JsonObject? subjectRichParameters) =>
+      _$this._subjectRichParameters = subjectRichParameters;
 
   String? _messageRich;
   String? get messageRich => _$this._messageRich;
-  set messageRich(String? messageRich) => _$this._messageRich = messageRich;
+  set messageRich(covariant String? messageRich) => _$this._messageRich = messageRich;
 
   JsonObject? _messageRichParameters;
   JsonObject? get messageRichParameters => _$this._messageRichParameters;
-  set messageRichParameters(JsonObject? messageRichParameters) => _$this._messageRichParameters = messageRichParameters;
+  set messageRichParameters(covariant JsonObject? messageRichParameters) =>
+      _$this._messageRichParameters = messageRichParameters;
 
   String? _icon;
   String? get icon => _$this._icon;
-  set icon(String? icon) => _$this._icon = icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
 
   bool? _shouldNotify;
   bool? get shouldNotify => _$this._shouldNotify;
-  set shouldNotify(bool? shouldNotify) => _$this._shouldNotify = shouldNotify;
+  set shouldNotify(covariant bool? shouldNotify) => _$this._shouldNotify = shouldNotify;
 
   ListBuilder<NotificationsNotificationAction>? _actions;
   ListBuilder<NotificationsNotificationAction> get actions =>
       _$this._actions ??= ListBuilder<NotificationsNotificationAction>();
-  set actions(ListBuilder<NotificationsNotificationAction>? actions) => _$this._actions = actions;
+  set actions(covariant ListBuilder<NotificationsNotificationAction>? actions) => _$this._actions = actions;
 
   NotificationsNotificationBuilder();
 
@@ -1396,7 +1491,7 @@ class NotificationsNotificationBuilder implements Builder<NotificationsNotificat
   }
 
   @override
-  void replace(NotificationsNotification other) {
+  void replace(covariant NotificationsNotification other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsNotification;
   }
@@ -1446,6 +1541,16 @@ class NotificationsNotificationBuilder implements Builder<NotificationsNotificat
   }
 }
 
+abstract mixin class NotificationsListNotifications_OcsInterfaceBuilder {
+  void replace(NotificationsListNotifications_OcsInterface other);
+  void update(void Function(NotificationsListNotifications_OcsInterfaceBuilder) updates);
+  NotificationsOCSMetaBuilder get meta;
+  set meta(NotificationsOCSMetaBuilder? meta);
+
+  ListBuilder<NotificationsNotification> get data;
+  set data(ListBuilder<NotificationsNotification>? data);
+}
+
 class _$NotificationsListNotifications_Ocs extends NotificationsListNotifications_Ocs {
   @override
   final NotificationsOCSMeta meta;
@@ -1492,16 +1597,18 @@ class _$NotificationsListNotifications_Ocs extends NotificationsListNotification
 }
 
 class NotificationsListNotifications_OcsBuilder
-    implements Builder<NotificationsListNotifications_Ocs, NotificationsListNotifications_OcsBuilder> {
+    implements
+        Builder<NotificationsListNotifications_Ocs, NotificationsListNotifications_OcsBuilder>,
+        NotificationsListNotifications_OcsInterfaceBuilder {
   _$NotificationsListNotifications_Ocs? _$v;
 
   NotificationsOCSMetaBuilder? _meta;
   NotificationsOCSMetaBuilder get meta => _$this._meta ??= NotificationsOCSMetaBuilder();
-  set meta(NotificationsOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant NotificationsOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<NotificationsNotification>? _data;
   ListBuilder<NotificationsNotification> get data => _$this._data ??= ListBuilder<NotificationsNotification>();
-  set data(ListBuilder<NotificationsNotification>? data) => _$this._data = data;
+  set data(covariant ListBuilder<NotificationsNotification>? data) => _$this._data = data;
 
   NotificationsListNotifications_OcsBuilder();
 
@@ -1516,7 +1623,7 @@ class NotificationsListNotifications_OcsBuilder
   }
 
   @override
-  void replace(NotificationsListNotifications_Ocs other) {
+  void replace(covariant NotificationsListNotifications_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsListNotifications_Ocs;
   }
@@ -1548,6 +1655,13 @@ class NotificationsListNotifications_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsListNotificationsInterfaceBuilder {
+  void replace(NotificationsListNotificationsInterface other);
+  void update(void Function(NotificationsListNotificationsInterfaceBuilder) updates);
+  NotificationsListNotifications_OcsBuilder get ocs;
+  set ocs(NotificationsListNotifications_OcsBuilder? ocs);
 }
 
 class _$NotificationsListNotifications extends NotificationsListNotifications {
@@ -1589,12 +1703,14 @@ class _$NotificationsListNotifications extends NotificationsListNotifications {
 }
 
 class NotificationsListNotificationsBuilder
-    implements Builder<NotificationsListNotifications, NotificationsListNotificationsBuilder> {
+    implements
+        Builder<NotificationsListNotifications, NotificationsListNotificationsBuilder>,
+        NotificationsListNotificationsInterfaceBuilder {
   _$NotificationsListNotifications? _$v;
 
   NotificationsListNotifications_OcsBuilder? _ocs;
   NotificationsListNotifications_OcsBuilder get ocs => _$this._ocs ??= NotificationsListNotifications_OcsBuilder();
-  set ocs(NotificationsListNotifications_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant NotificationsListNotifications_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   NotificationsListNotificationsBuilder();
 
@@ -1608,7 +1724,7 @@ class NotificationsListNotificationsBuilder
   }
 
   @override
-  void replace(NotificationsListNotifications other) {
+  void replace(covariant NotificationsListNotifications other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsListNotifications;
   }
@@ -1638,6 +1754,16 @@ class NotificationsListNotificationsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsGetNotification_OcsInterfaceBuilder {
+  void replace(NotificationsGetNotification_OcsInterface other);
+  void update(void Function(NotificationsGetNotification_OcsInterfaceBuilder) updates);
+  NotificationsOCSMetaBuilder get meta;
+  set meta(NotificationsOCSMetaBuilder? meta);
+
+  NotificationsNotificationBuilder get data;
+  set data(NotificationsNotificationBuilder? data);
 }
 
 class _$NotificationsGetNotification_Ocs extends NotificationsGetNotification_Ocs {
@@ -1686,16 +1812,18 @@ class _$NotificationsGetNotification_Ocs extends NotificationsGetNotification_Oc
 }
 
 class NotificationsGetNotification_OcsBuilder
-    implements Builder<NotificationsGetNotification_Ocs, NotificationsGetNotification_OcsBuilder> {
+    implements
+        Builder<NotificationsGetNotification_Ocs, NotificationsGetNotification_OcsBuilder>,
+        NotificationsGetNotification_OcsInterfaceBuilder {
   _$NotificationsGetNotification_Ocs? _$v;
 
   NotificationsOCSMetaBuilder? _meta;
   NotificationsOCSMetaBuilder get meta => _$this._meta ??= NotificationsOCSMetaBuilder();
-  set meta(NotificationsOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant NotificationsOCSMetaBuilder? meta) => _$this._meta = meta;
 
   NotificationsNotificationBuilder? _data;
   NotificationsNotificationBuilder get data => _$this._data ??= NotificationsNotificationBuilder();
-  set data(NotificationsNotificationBuilder? data) => _$this._data = data;
+  set data(covariant NotificationsNotificationBuilder? data) => _$this._data = data;
 
   NotificationsGetNotification_OcsBuilder();
 
@@ -1710,7 +1838,7 @@ class NotificationsGetNotification_OcsBuilder
   }
 
   @override
-  void replace(NotificationsGetNotification_Ocs other) {
+  void replace(covariant NotificationsGetNotification_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsGetNotification_Ocs;
   }
@@ -1742,6 +1870,13 @@ class NotificationsGetNotification_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsGetNotificationInterfaceBuilder {
+  void replace(NotificationsGetNotificationInterface other);
+  void update(void Function(NotificationsGetNotificationInterfaceBuilder) updates);
+  NotificationsGetNotification_OcsBuilder get ocs;
+  set ocs(NotificationsGetNotification_OcsBuilder? ocs);
 }
 
 class _$NotificationsGetNotification extends NotificationsGetNotification {
@@ -1783,12 +1918,14 @@ class _$NotificationsGetNotification extends NotificationsGetNotification {
 }
 
 class NotificationsGetNotificationBuilder
-    implements Builder<NotificationsGetNotification, NotificationsGetNotificationBuilder> {
+    implements
+        Builder<NotificationsGetNotification, NotificationsGetNotificationBuilder>,
+        NotificationsGetNotificationInterfaceBuilder {
   _$NotificationsGetNotification? _$v;
 
   NotificationsGetNotification_OcsBuilder? _ocs;
   NotificationsGetNotification_OcsBuilder get ocs => _$this._ocs ??= NotificationsGetNotification_OcsBuilder();
-  set ocs(NotificationsGetNotification_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant NotificationsGetNotification_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   NotificationsGetNotificationBuilder();
 
@@ -1802,7 +1939,7 @@ class NotificationsGetNotificationBuilder
   }
 
   @override
-  void replace(NotificationsGetNotification other) {
+  void replace(covariant NotificationsGetNotification other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsGetNotification;
   }
@@ -1832,6 +1969,16 @@ class NotificationsGetNotificationBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsEmptyOCS_OcsInterfaceBuilder {
+  void replace(NotificationsEmptyOCS_OcsInterface other);
+  void update(void Function(NotificationsEmptyOCS_OcsInterfaceBuilder) updates);
+  NotificationsOCSMetaBuilder get meta;
+  set meta(NotificationsOCSMetaBuilder? meta);
+
+  ListBuilder<JsonObject> get data;
+  set data(ListBuilder<JsonObject>? data);
 }
 
 class _$NotificationsEmptyOCS_Ocs extends NotificationsEmptyOCS_Ocs {
@@ -1879,16 +2026,19 @@ class _$NotificationsEmptyOCS_Ocs extends NotificationsEmptyOCS_Ocs {
   }
 }
 
-class NotificationsEmptyOCS_OcsBuilder implements Builder<NotificationsEmptyOCS_Ocs, NotificationsEmptyOCS_OcsBuilder> {
+class NotificationsEmptyOCS_OcsBuilder
+    implements
+        Builder<NotificationsEmptyOCS_Ocs, NotificationsEmptyOCS_OcsBuilder>,
+        NotificationsEmptyOCS_OcsInterfaceBuilder {
   _$NotificationsEmptyOCS_Ocs? _$v;
 
   NotificationsOCSMetaBuilder? _meta;
   NotificationsOCSMetaBuilder get meta => _$this._meta ??= NotificationsOCSMetaBuilder();
-  set meta(NotificationsOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant NotificationsOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<JsonObject>? _data;
   ListBuilder<JsonObject> get data => _$this._data ??= ListBuilder<JsonObject>();
-  set data(ListBuilder<JsonObject>? data) => _$this._data = data;
+  set data(covariant ListBuilder<JsonObject>? data) => _$this._data = data;
 
   NotificationsEmptyOCS_OcsBuilder();
 
@@ -1903,7 +2053,7 @@ class NotificationsEmptyOCS_OcsBuilder implements Builder<NotificationsEmptyOCS_
   }
 
   @override
-  void replace(NotificationsEmptyOCS_Ocs other) {
+  void replace(covariant NotificationsEmptyOCS_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsEmptyOCS_Ocs;
   }
@@ -1935,6 +2085,13 @@ class NotificationsEmptyOCS_OcsBuilder implements Builder<NotificationsEmptyOCS_
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsEmptyOCSInterfaceBuilder {
+  void replace(NotificationsEmptyOCSInterface other);
+  void update(void Function(NotificationsEmptyOCSInterfaceBuilder) updates);
+  NotificationsEmptyOCS_OcsBuilder get ocs;
+  set ocs(NotificationsEmptyOCS_OcsBuilder? ocs);
 }
 
 class _$NotificationsEmptyOCS extends NotificationsEmptyOCS {
@@ -1975,12 +2132,13 @@ class _$NotificationsEmptyOCS extends NotificationsEmptyOCS {
   }
 }
 
-class NotificationsEmptyOCSBuilder implements Builder<NotificationsEmptyOCS, NotificationsEmptyOCSBuilder> {
+class NotificationsEmptyOCSBuilder
+    implements Builder<NotificationsEmptyOCS, NotificationsEmptyOCSBuilder>, NotificationsEmptyOCSInterfaceBuilder {
   _$NotificationsEmptyOCS? _$v;
 
   NotificationsEmptyOCS_OcsBuilder? _ocs;
   NotificationsEmptyOCS_OcsBuilder get ocs => _$this._ocs ??= NotificationsEmptyOCS_OcsBuilder();
-  set ocs(NotificationsEmptyOCS_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant NotificationsEmptyOCS_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   NotificationsEmptyOCSBuilder();
 
@@ -1994,7 +2152,7 @@ class NotificationsEmptyOCSBuilder implements Builder<NotificationsEmptyOCS, Not
   }
 
   @override
-  void replace(NotificationsEmptyOCS other) {
+  void replace(covariant NotificationsEmptyOCS other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsEmptyOCS;
   }
@@ -2024,6 +2182,22 @@ class NotificationsEmptyOCSBuilder implements Builder<NotificationsEmptyOCS, Not
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsPushServerSubscriptionInterfaceBuilder {
+  void replace(NotificationsPushServerSubscriptionInterface other);
+  void update(void Function(NotificationsPushServerSubscriptionInterfaceBuilder) updates);
+  String? get publicKey;
+  set publicKey(String? publicKey);
+
+  String? get deviceIdentifier;
+  set deviceIdentifier(String? deviceIdentifier);
+
+  String? get signature;
+  set signature(String? signature);
+
+  String? get message;
+  set message(String? message);
 }
 
 class _$NotificationsPushServerSubscription extends NotificationsPushServerSubscription {
@@ -2087,24 +2261,26 @@ class _$NotificationsPushServerSubscription extends NotificationsPushServerSubsc
 }
 
 class NotificationsPushServerSubscriptionBuilder
-    implements Builder<NotificationsPushServerSubscription, NotificationsPushServerSubscriptionBuilder> {
+    implements
+        Builder<NotificationsPushServerSubscription, NotificationsPushServerSubscriptionBuilder>,
+        NotificationsPushServerSubscriptionInterfaceBuilder {
   _$NotificationsPushServerSubscription? _$v;
 
   String? _publicKey;
   String? get publicKey => _$this._publicKey;
-  set publicKey(String? publicKey) => _$this._publicKey = publicKey;
+  set publicKey(covariant String? publicKey) => _$this._publicKey = publicKey;
 
   String? _deviceIdentifier;
   String? get deviceIdentifier => _$this._deviceIdentifier;
-  set deviceIdentifier(String? deviceIdentifier) => _$this._deviceIdentifier = deviceIdentifier;
+  set deviceIdentifier(covariant String? deviceIdentifier) => _$this._deviceIdentifier = deviceIdentifier;
 
   String? _signature;
   String? get signature => _$this._signature;
-  set signature(String? signature) => _$this._signature = signature;
+  set signature(covariant String? signature) => _$this._signature = signature;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   NotificationsPushServerSubscriptionBuilder();
 
@@ -2121,7 +2297,7 @@ class NotificationsPushServerSubscriptionBuilder
   }
 
   @override
-  void replace(NotificationsPushServerSubscription other) {
+  void replace(covariant NotificationsPushServerSubscription other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsPushServerSubscription;
   }
@@ -2147,6 +2323,16 @@ class NotificationsPushServerSubscriptionBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsPushServerRegistration_OcsInterfaceBuilder {
+  void replace(NotificationsPushServerRegistration_OcsInterface other);
+  void update(void Function(NotificationsPushServerRegistration_OcsInterfaceBuilder) updates);
+  NotificationsOCSMetaBuilder get meta;
+  set meta(NotificationsOCSMetaBuilder? meta);
+
+  NotificationsPushServerSubscriptionBuilder get data;
+  set data(NotificationsPushServerSubscriptionBuilder? data);
 }
 
 class _$NotificationsPushServerRegistration_Ocs extends NotificationsPushServerRegistration_Ocs {
@@ -2198,16 +2384,18 @@ class _$NotificationsPushServerRegistration_Ocs extends NotificationsPushServerR
 }
 
 class NotificationsPushServerRegistration_OcsBuilder
-    implements Builder<NotificationsPushServerRegistration_Ocs, NotificationsPushServerRegistration_OcsBuilder> {
+    implements
+        Builder<NotificationsPushServerRegistration_Ocs, NotificationsPushServerRegistration_OcsBuilder>,
+        NotificationsPushServerRegistration_OcsInterfaceBuilder {
   _$NotificationsPushServerRegistration_Ocs? _$v;
 
   NotificationsOCSMetaBuilder? _meta;
   NotificationsOCSMetaBuilder get meta => _$this._meta ??= NotificationsOCSMetaBuilder();
-  set meta(NotificationsOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant NotificationsOCSMetaBuilder? meta) => _$this._meta = meta;
 
   NotificationsPushServerSubscriptionBuilder? _data;
   NotificationsPushServerSubscriptionBuilder get data => _$this._data ??= NotificationsPushServerSubscriptionBuilder();
-  set data(NotificationsPushServerSubscriptionBuilder? data) => _$this._data = data;
+  set data(covariant NotificationsPushServerSubscriptionBuilder? data) => _$this._data = data;
 
   NotificationsPushServerRegistration_OcsBuilder();
 
@@ -2222,7 +2410,7 @@ class NotificationsPushServerRegistration_OcsBuilder
   }
 
   @override
-  void replace(NotificationsPushServerRegistration_Ocs other) {
+  void replace(covariant NotificationsPushServerRegistration_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsPushServerRegistration_Ocs;
   }
@@ -2254,6 +2442,13 @@ class NotificationsPushServerRegistration_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsPushServerRegistrationInterfaceBuilder {
+  void replace(NotificationsPushServerRegistrationInterface other);
+  void update(void Function(NotificationsPushServerRegistrationInterfaceBuilder) updates);
+  NotificationsPushServerRegistration_OcsBuilder get ocs;
+  set ocs(NotificationsPushServerRegistration_OcsBuilder? ocs);
 }
 
 class _$NotificationsPushServerRegistration extends NotificationsPushServerRegistration {
@@ -2295,13 +2490,15 @@ class _$NotificationsPushServerRegistration extends NotificationsPushServerRegis
 }
 
 class NotificationsPushServerRegistrationBuilder
-    implements Builder<NotificationsPushServerRegistration, NotificationsPushServerRegistrationBuilder> {
+    implements
+        Builder<NotificationsPushServerRegistration, NotificationsPushServerRegistrationBuilder>,
+        NotificationsPushServerRegistrationInterfaceBuilder {
   _$NotificationsPushServerRegistration? _$v;
 
   NotificationsPushServerRegistration_OcsBuilder? _ocs;
   NotificationsPushServerRegistration_OcsBuilder get ocs =>
       _$this._ocs ??= NotificationsPushServerRegistration_OcsBuilder();
-  set ocs(NotificationsPushServerRegistration_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant NotificationsPushServerRegistration_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   NotificationsPushServerRegistrationBuilder();
 
@@ -2315,7 +2512,7 @@ class NotificationsPushServerRegistrationBuilder
   }
 
   @override
-  void replace(NotificationsPushServerRegistration other) {
+  void replace(covariant NotificationsPushServerRegistration other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsPushServerRegistration;
   }
@@ -2345,6 +2542,19 @@ class NotificationsPushServerRegistrationBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsCapabilities_NotificationsInterfaceBuilder {
+  void replace(NotificationsCapabilities_NotificationsInterface other);
+  void update(void Function(NotificationsCapabilities_NotificationsInterfaceBuilder) updates);
+  ListBuilder<String> get ocsEndpoints;
+  set ocsEndpoints(ListBuilder<String>? ocsEndpoints);
+
+  ListBuilder<String> get push;
+  set push(ListBuilder<String>? push);
+
+  ListBuilder<String> get adminNotifications;
+  set adminNotifications(ListBuilder<String>? adminNotifications);
 }
 
 class _$NotificationsCapabilities_Notifications extends NotificationsCapabilities_Notifications {
@@ -2400,20 +2610,23 @@ class _$NotificationsCapabilities_Notifications extends NotificationsCapabilitie
 }
 
 class NotificationsCapabilities_NotificationsBuilder
-    implements Builder<NotificationsCapabilities_Notifications, NotificationsCapabilities_NotificationsBuilder> {
+    implements
+        Builder<NotificationsCapabilities_Notifications, NotificationsCapabilities_NotificationsBuilder>,
+        NotificationsCapabilities_NotificationsInterfaceBuilder {
   _$NotificationsCapabilities_Notifications? _$v;
 
   ListBuilder<String>? _ocsEndpoints;
   ListBuilder<String> get ocsEndpoints => _$this._ocsEndpoints ??= ListBuilder<String>();
-  set ocsEndpoints(ListBuilder<String>? ocsEndpoints) => _$this._ocsEndpoints = ocsEndpoints;
+  set ocsEndpoints(covariant ListBuilder<String>? ocsEndpoints) => _$this._ocsEndpoints = ocsEndpoints;
 
   ListBuilder<String>? _push;
   ListBuilder<String> get push => _$this._push ??= ListBuilder<String>();
-  set push(ListBuilder<String>? push) => _$this._push = push;
+  set push(covariant ListBuilder<String>? push) => _$this._push = push;
 
   ListBuilder<String>? _adminNotifications;
   ListBuilder<String> get adminNotifications => _$this._adminNotifications ??= ListBuilder<String>();
-  set adminNotifications(ListBuilder<String>? adminNotifications) => _$this._adminNotifications = adminNotifications;
+  set adminNotifications(covariant ListBuilder<String>? adminNotifications) =>
+      _$this._adminNotifications = adminNotifications;
 
   NotificationsCapabilities_NotificationsBuilder();
 
@@ -2429,7 +2642,7 @@ class NotificationsCapabilities_NotificationsBuilder
   }
 
   @override
-  void replace(NotificationsCapabilities_Notifications other) {
+  void replace(covariant NotificationsCapabilities_Notifications other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsCapabilities_Notifications;
   }
@@ -2467,6 +2680,13 @@ class NotificationsCapabilities_NotificationsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsCapabilitiesInterfaceBuilder {
+  void replace(NotificationsCapabilitiesInterface other);
+  void update(void Function(NotificationsCapabilitiesInterfaceBuilder) updates);
+  NotificationsCapabilities_NotificationsBuilder get notifications;
+  set notifications(NotificationsCapabilities_NotificationsBuilder? notifications);
 }
 
 class _$NotificationsCapabilities extends NotificationsCapabilities {
@@ -2507,13 +2727,16 @@ class _$NotificationsCapabilities extends NotificationsCapabilities {
   }
 }
 
-class NotificationsCapabilitiesBuilder implements Builder<NotificationsCapabilities, NotificationsCapabilitiesBuilder> {
+class NotificationsCapabilitiesBuilder
+    implements
+        Builder<NotificationsCapabilities, NotificationsCapabilitiesBuilder>,
+        NotificationsCapabilitiesInterfaceBuilder {
   _$NotificationsCapabilities? _$v;
 
   NotificationsCapabilities_NotificationsBuilder? _notifications;
   NotificationsCapabilities_NotificationsBuilder get notifications =>
       _$this._notifications ??= NotificationsCapabilities_NotificationsBuilder();
-  set notifications(NotificationsCapabilities_NotificationsBuilder? notifications) =>
+  set notifications(covariant NotificationsCapabilities_NotificationsBuilder? notifications) =>
       _$this._notifications = notifications;
 
   NotificationsCapabilitiesBuilder();
@@ -2528,7 +2751,7 @@ class NotificationsCapabilitiesBuilder implements Builder<NotificationsCapabilit
   }
 
   @override
-  void replace(NotificationsCapabilities other) {
+  void replace(covariant NotificationsCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsCapabilities;
   }
@@ -2558,6 +2781,31 @@ class NotificationsCapabilitiesBuilder implements Builder<NotificationsCapabilit
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class NotificationsNotificationDecryptedSubjectInterfaceBuilder {
+  void replace(NotificationsNotificationDecryptedSubjectInterface other);
+  void update(void Function(NotificationsNotificationDecryptedSubjectInterfaceBuilder) updates);
+  int? get nid;
+  set nid(int? nid);
+
+  String? get app;
+  set app(String? app);
+
+  String? get subject;
+  set subject(String? subject);
+
+  String? get type;
+  set type(String? type);
+
+  String? get id;
+  set id(String? id);
+
+  bool? get delete;
+  set delete(bool? delete);
+
+  bool? get deleteAll;
+  set deleteAll(bool? deleteAll);
 }
 
 class _$NotificationsNotificationDecryptedSubject extends NotificationsNotificationDecryptedSubject {
@@ -2635,36 +2883,38 @@ class _$NotificationsNotificationDecryptedSubject extends NotificationsNotificat
 }
 
 class NotificationsNotificationDecryptedSubjectBuilder
-    implements Builder<NotificationsNotificationDecryptedSubject, NotificationsNotificationDecryptedSubjectBuilder> {
+    implements
+        Builder<NotificationsNotificationDecryptedSubject, NotificationsNotificationDecryptedSubjectBuilder>,
+        NotificationsNotificationDecryptedSubjectInterfaceBuilder {
   _$NotificationsNotificationDecryptedSubject? _$v;
 
   int? _nid;
   int? get nid => _$this._nid;
-  set nid(int? nid) => _$this._nid = nid;
+  set nid(covariant int? nid) => _$this._nid = nid;
 
   String? _app;
   String? get app => _$this._app;
-  set app(String? app) => _$this._app = app;
+  set app(covariant String? app) => _$this._app = app;
 
   String? _subject;
   String? get subject => _$this._subject;
-  set subject(String? subject) => _$this._subject = subject;
+  set subject(covariant String? subject) => _$this._subject = subject;
 
   String? _type;
   String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
+  set type(covariant String? type) => _$this._type = type;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   bool? _delete;
   bool? get delete => _$this._delete;
-  set delete(bool? delete) => _$this._delete = delete;
+  set delete(covariant bool? delete) => _$this._delete = delete;
 
   bool? _deleteAll;
   bool? get deleteAll => _$this._deleteAll;
-  set deleteAll(bool? deleteAll) => _$this._deleteAll = deleteAll;
+  set deleteAll(covariant bool? deleteAll) => _$this._deleteAll = deleteAll;
 
   NotificationsNotificationDecryptedSubjectBuilder();
 
@@ -2684,7 +2934,7 @@ class NotificationsNotificationDecryptedSubjectBuilder
   }
 
   @override
-  void replace(NotificationsNotificationDecryptedSubject other) {
+  void replace(covariant NotificationsNotificationDecryptedSubject other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$NotificationsNotificationDecryptedSubject;
   }

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -2081,7 +2081,19 @@ class ProvisioningApiUsersClient {
   }
 }
 
-abstract class ProvisioningApiOCSMeta implements Built<ProvisioningApiOCSMeta, ProvisioningApiOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  ProvisioningApiOCSMetaInterface rebuild(final void Function(ProvisioningApiOCSMetaInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class ProvisioningApiOCSMeta
+    implements ProvisioningApiOCSMetaInterface, Built<ProvisioningApiOCSMeta, ProvisioningApiOCSMetaBuilder> {
   factory ProvisioningApiOCSMeta([final void Function(ProvisioningApiOCSMetaBuilder)? b]) = _$ProvisioningApiOCSMeta;
 
   // coverage:ignore-start
@@ -2096,16 +2108,21 @@ abstract class ProvisioningApiOCSMeta implements Built<ProvisioningApiOCSMeta, P
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<ProvisioningApiOCSMeta> get serializer => _$provisioningApiOCSMetaSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<String> get data;
+  ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
 }
 
 abstract class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data([
@@ -2126,13 +2143,23 @@ abstract class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Dat
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String> get data;
   static Serializer<ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiAppConfigGetAppsResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs,
             ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs([
@@ -2151,14 +2178,22 @@ abstract class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiAppConfigGetAppsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonInterface {
+  ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson
     implements
+        ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonInterface,
         Built<ProvisioningApiAppConfigGetAppsResponse200ApplicationJson,
             ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiAppConfigGetAppsResponse200ApplicationJson([
@@ -2177,13 +2212,22 @@ abstract class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiAppConfigGetAppsResponse200ApplicationJson> get serializer =>
       _$provisioningApiAppConfigGetAppsResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<String> get data;
+  ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data([
@@ -2204,13 +2248,23 @@ abstract class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Dat
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String> get data;
   static Serializer<ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiAppConfigGetKeysResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs,
             ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs([
@@ -2229,14 +2283,22 @@ abstract class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiAppConfigGetKeysResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonInterface {
+  ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson
     implements
+        ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonInterface,
         Built<ProvisioningApiAppConfigGetKeysResponse200ApplicationJson,
             ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiAppConfigGetKeysResponse200ApplicationJson([
@@ -2255,13 +2317,22 @@ abstract class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiAppConfigGetKeysResponse200ApplicationJson> get serializer =>
       _$provisioningApiAppConfigGetKeysResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataInterface {
+  String get data;
+  ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data([
@@ -2282,13 +2353,23 @@ abstract class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Da
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get data;
   static Serializer<ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiAppConfigGetValueResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs,
             ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs([
@@ -2307,14 +2388,22 @@ abstract class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiAppConfigGetValueResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigGetValueResponse200ApplicationJsonInterface {
+  ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiAppConfigGetValueResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiAppConfigGetValueResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigGetValueResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigGetValueResponse200ApplicationJson
     implements
+        ProvisioningApiAppConfigGetValueResponse200ApplicationJsonInterface,
         Built<ProvisioningApiAppConfigGetValueResponse200ApplicationJson,
             ProvisioningApiAppConfigGetValueResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiAppConfigGetValueResponse200ApplicationJson([
@@ -2333,13 +2422,23 @@ abstract class ProvisioningApiAppConfigGetValueResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiAppConfigGetValueResponse200ApplicationJson> get serializer =>
       _$provisioningApiAppConfigGetValueResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs,
             ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs([
@@ -2358,14 +2457,22 @@ abstract class ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiAppConfigSetValueResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigSetValueResponse200ApplicationJsonInterface {
+  ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiAppConfigSetValueResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiAppConfigSetValueResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigSetValueResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigSetValueResponse200ApplicationJson
     implements
+        ProvisioningApiAppConfigSetValueResponse200ApplicationJsonInterface,
         Built<ProvisioningApiAppConfigSetValueResponse200ApplicationJson,
             ProvisioningApiAppConfigSetValueResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiAppConfigSetValueResponse200ApplicationJson([
@@ -2384,13 +2491,23 @@ abstract class ProvisioningApiAppConfigSetValueResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiAppConfigSetValueResponse200ApplicationJson> get serializer =>
       _$provisioningApiAppConfigSetValueResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs,
             ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs([
@@ -2409,14 +2526,22 @@ abstract class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiAppConfigDeleteKeyResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonInterface {
+  ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson
     implements
+        ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonInterface,
         Built<ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson,
             ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson([
@@ -2435,13 +2560,22 @@ abstract class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson> get serializer =>
       _$provisioningApiAppConfigDeleteKeyResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<String> get apps;
+  ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data([
@@ -2460,13 +2594,23 @@ abstract class ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String> get apps;
   static Serializer<ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiAppsGetAppsResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs,
             ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs([
@@ -2485,14 +2629,22 @@ abstract class ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiAppsGetAppsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppsGetAppsResponse200ApplicationJsonInterface {
+  ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiAppsGetAppsResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiAppsGetAppsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppsGetAppsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppsGetAppsResponse200ApplicationJson
     implements
+        ProvisioningApiAppsGetAppsResponse200ApplicationJsonInterface,
         Built<ProvisioningApiAppsGetAppsResponse200ApplicationJson,
             ProvisioningApiAppsGetAppsResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiAppsGetAppsResponse200ApplicationJson([
@@ -2511,26 +2663,12 @@ abstract class ProvisioningApiAppsGetAppsResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiAppsGetAppsResponse200ApplicationJson> get serializer =>
       _$provisioningApiAppsGetAppsResponse200ApplicationJsonSerializer;
 }
 
-abstract class ProvisioningApiAppInfo implements Built<ProvisioningApiAppInfo, ProvisioningApiAppInfoBuilder> {
-  factory ProvisioningApiAppInfo([final void Function(ProvisioningApiAppInfoBuilder)? b]) = _$ProvisioningApiAppInfo;
-
-  // coverage:ignore-start
-  const ProvisioningApiAppInfo._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory ProvisioningApiAppInfo.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppInfoInterface {
   bool? get active;
   JsonObject? get activity;
   JsonObject? get author;
@@ -2574,11 +2712,42 @@ abstract class ProvisioningApiAppInfo implements Built<ProvisioningApiAppInfo, P
   String get version;
   JsonObject? get versions;
   JsonObject? get website;
+  ProvisioningApiAppInfoInterface rebuild(final void Function(ProvisioningApiAppInfoInterfaceBuilder) updates);
+  ProvisioningApiAppInfoInterfaceBuilder toBuilder();
+}
+
+abstract class ProvisioningApiAppInfo
+    implements ProvisioningApiAppInfoInterface, Built<ProvisioningApiAppInfo, ProvisioningApiAppInfoBuilder> {
+  factory ProvisioningApiAppInfo([final void Function(ProvisioningApiAppInfoBuilder)? b]) = _$ProvisioningApiAppInfo;
+
+  // coverage:ignore-start
+  const ProvisioningApiAppInfo._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory ProvisioningApiAppInfo.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<ProvisioningApiAppInfo> get serializer => _$provisioningApiAppInfoSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiAppInfo get data;
+  ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs,
             ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs([
@@ -2597,14 +2766,22 @@ abstract class ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiAppInfo get data;
   static Serializer<ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiAppsGetAppInfoResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonInterface {
+  ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppsGetAppInfoResponse200ApplicationJson
     implements
+        ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonInterface,
         Built<ProvisioningApiAppsGetAppInfoResponse200ApplicationJson,
             ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiAppsGetAppInfoResponse200ApplicationJson([
@@ -2623,13 +2800,23 @@ abstract class ProvisioningApiAppsGetAppInfoResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiAppsGetAppInfoResponse200ApplicationJson> get serializer =>
       _$provisioningApiAppsGetAppInfoResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppsEnableResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiAppsEnableResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiAppsEnableResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppsEnableResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiAppsEnableResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs,
             ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs([
@@ -2648,14 +2835,22 @@ abstract class ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiAppsEnableResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppsEnableResponse200ApplicationJsonInterface {
+  ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiAppsEnableResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiAppsEnableResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppsEnableResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppsEnableResponse200ApplicationJson
     implements
+        ProvisioningApiAppsEnableResponse200ApplicationJsonInterface,
         Built<ProvisioningApiAppsEnableResponse200ApplicationJson,
             ProvisioningApiAppsEnableResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiAppsEnableResponse200ApplicationJson([
@@ -2674,13 +2869,23 @@ abstract class ProvisioningApiAppsEnableResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiAppsEnableResponse200ApplicationJson> get serializer =>
       _$provisioningApiAppsEnableResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppsDisableResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiAppsDisableResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiAppsDisableResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppsDisableResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiAppsDisableResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs,
             ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs([
@@ -2699,14 +2904,22 @@ abstract class ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiAppsDisableResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiAppsDisableResponse200ApplicationJsonInterface {
+  ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiAppsDisableResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiAppsDisableResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiAppsDisableResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiAppsDisableResponse200ApplicationJson
     implements
+        ProvisioningApiAppsDisableResponse200ApplicationJsonInterface,
         Built<ProvisioningApiAppsDisableResponse200ApplicationJson,
             ProvisioningApiAppsDisableResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiAppsDisableResponse200ApplicationJson([
@@ -2725,13 +2938,22 @@ abstract class ProvisioningApiAppsDisableResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiAppsDisableResponse200ApplicationJson> get serializer =>
       _$provisioningApiAppsDisableResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<String> get groups;
+  ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data([
@@ -2750,13 +2972,23 @@ abstract class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String> get groups;
   static Serializer<ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiGroupsGetGroupsResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs,
             ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs([
@@ -2775,14 +3007,22 @@ abstract class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiGroupsGetGroupsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonInterface {
+  ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson
     implements
+        ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonInterface,
         Built<ProvisioningApiGroupsGetGroupsResponse200ApplicationJson,
             ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiGroupsGetGroupsResponse200ApplicationJson([
@@ -2801,13 +3041,23 @@ abstract class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiGroupsGetGroupsResponse200ApplicationJson> get serializer =>
       _$provisioningApiGroupsGetGroupsResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs,
             ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs([
@@ -2826,14 +3076,22 @@ abstract class ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiGroupsAddGroupResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsAddGroupResponse200ApplicationJsonInterface {
+  ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiGroupsAddGroupResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiGroupsAddGroupResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsAddGroupResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsAddGroupResponse200ApplicationJson
     implements
+        ProvisioningApiGroupsAddGroupResponse200ApplicationJsonInterface,
         Built<ProvisioningApiGroupsAddGroupResponse200ApplicationJson,
             ProvisioningApiGroupsAddGroupResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiGroupsAddGroupResponse200ApplicationJson([
@@ -2852,7 +3110,6 @@ abstract class ProvisioningApiGroupsAddGroupResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiGroupsAddGroupResponse200ApplicationJson> get serializer =>
       _$provisioningApiGroupsAddGroupResponse200ApplicationJsonSerializer;
 }
@@ -2976,8 +3233,24 @@ class _$ProvisioningApiGroupDetails_DisabledSerializer
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupDetailsInterface {
+  String get id;
+  String get displayname;
+  ProvisioningApiGroupDetails_Usercount get usercount;
+  ProvisioningApiGroupDetails_Disabled get disabled;
+  bool get canAdd;
+  bool get canRemove;
+  ProvisioningApiGroupDetailsInterface rebuild(
+    final void Function(ProvisioningApiGroupDetailsInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupDetailsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupDetails
-    implements Built<ProvisioningApiGroupDetails, ProvisioningApiGroupDetailsBuilder> {
+    implements
+        ProvisioningApiGroupDetailsInterface,
+        Built<ProvisioningApiGroupDetails, ProvisioningApiGroupDetailsBuilder> {
   factory ProvisioningApiGroupDetails([final void Function(ProvisioningApiGroupDetailsBuilder)? b]) =
       _$ProvisioningApiGroupDetails;
 
@@ -2993,17 +3266,22 @@ abstract class ProvisioningApiGroupDetails
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  String get displayname;
-  ProvisioningApiGroupDetails_Usercount get usercount;
-  ProvisioningApiGroupDetails_Disabled get disabled;
-  bool get canAdd;
-  bool get canRemove;
   static Serializer<ProvisioningApiGroupDetails> get serializer => _$provisioningApiGroupDetailsSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<ProvisioningApiGroupDetails> get groups;
+  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder)
+        updates,
+  );
+  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
 }
 
 abstract class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data([
@@ -3024,13 +3302,23 @@ abstract class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<ProvisioningApiGroupDetails> get groups;
   static Serializer<ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs,
             ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs([
@@ -3051,14 +3339,22 @@ abstract class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonInterface {
+  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson
     implements
+        ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonInterface,
         Built<ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson,
             ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson([
@@ -3077,13 +3373,22 @@ abstract class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson> get serializer =>
       _$provisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<String> get users;
+  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data([
@@ -3104,13 +3409,23 @@ abstract class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String> get users;
   static Serializer<ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiGroupsGetGroupUsersResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs,
             ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs([
@@ -3129,14 +3444,22 @@ abstract class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiGroupsGetGroupUsersResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonInterface {
+  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson
     implements
+        ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonInterface,
         Built<ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson,
             ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson([
@@ -3155,13 +3478,23 @@ abstract class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson> get serializer =>
       _$provisioningApiGroupsGetGroupUsersResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUserDetails_BackendCapabilitiesInterface {
+  bool get setDisplayName;
+  bool get setPassword;
+  ProvisioningApiUserDetails_BackendCapabilitiesInterface rebuild(
+    final void Function(ProvisioningApiUserDetails_BackendCapabilitiesInterfaceBuilder) updates,
+  );
+  ProvisioningApiUserDetails_BackendCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUserDetails_BackendCapabilities
     implements
+        ProvisioningApiUserDetails_BackendCapabilitiesInterface,
         Built<ProvisioningApiUserDetails_BackendCapabilities, ProvisioningApiUserDetails_BackendCapabilitiesBuilder> {
   factory ProvisioningApiUserDetails_BackendCapabilities([
     final void Function(ProvisioningApiUserDetails_BackendCapabilitiesBuilder)? b,
@@ -3179,8 +3512,6 @@ abstract class ProvisioningApiUserDetails_BackendCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get setDisplayName;
-  bool get setPassword;
   static Serializer<ProvisioningApiUserDetails_BackendCapabilities> get serializer =>
       _$provisioningApiUserDetailsBackendCapabilitiesSerializer;
 }
@@ -3245,8 +3576,23 @@ class _$ProvisioningApiUserDetailsQuota_QuotaSerializer
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUserDetailsQuotaInterface {
+  num? get free;
+  ProvisioningApiUserDetailsQuota_Quota? get quota;
+  num? get relative;
+  num? get total;
+  num? get used;
+  ProvisioningApiUserDetailsQuotaInterface rebuild(
+    final void Function(ProvisioningApiUserDetailsQuotaInterfaceBuilder) updates,
+  );
+  ProvisioningApiUserDetailsQuotaInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUserDetailsQuota
-    implements Built<ProvisioningApiUserDetailsQuota, ProvisioningApiUserDetailsQuotaBuilder> {
+    implements
+        ProvisioningApiUserDetailsQuotaInterface,
+        Built<ProvisioningApiUserDetailsQuota, ProvisioningApiUserDetailsQuotaBuilder> {
   factory ProvisioningApiUserDetailsQuota([final void Function(ProvisioningApiUserDetailsQuotaBuilder)? b]) =
       _$ProvisioningApiUserDetailsQuota;
 
@@ -3262,31 +3608,11 @@ abstract class ProvisioningApiUserDetailsQuota
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  num? get free;
-  ProvisioningApiUserDetailsQuota_Quota? get quota;
-  num? get relative;
-  num? get total;
-  num? get used;
   static Serializer<ProvisioningApiUserDetailsQuota> get serializer => _$provisioningApiUserDetailsQuotaSerializer;
 }
 
-abstract class ProvisioningApiUserDetails
-    implements Built<ProvisioningApiUserDetails, ProvisioningApiUserDetailsBuilder> {
-  factory ProvisioningApiUserDetails([final void Function(ProvisioningApiUserDetailsBuilder)? b]) =
-      _$ProvisioningApiUserDetails;
-
-  // coverage:ignore-start
-  const ProvisioningApiUserDetails._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory ProvisioningApiUserDetails.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUserDetailsInterface {
   @BuiltValueField(wireName: 'additional_mail')
   BuiltList<String> get additionalMail;
   @BuiltValueField(wireName: 'additional_mailScope')
@@ -3334,11 +3660,46 @@ abstract class ProvisioningApiUserDetails
   String? get twitterScope;
   String get website;
   String? get websiteScope;
+  ProvisioningApiUserDetailsInterface rebuild(final void Function(ProvisioningApiUserDetailsInterfaceBuilder) updates);
+  ProvisioningApiUserDetailsInterfaceBuilder toBuilder();
+}
+
+abstract class ProvisioningApiUserDetails
+    implements
+        ProvisioningApiUserDetailsInterface,
+        Built<ProvisioningApiUserDetails, ProvisioningApiUserDetailsBuilder> {
+  factory ProvisioningApiUserDetails([final void Function(ProvisioningApiUserDetailsBuilder)? b]) =
+      _$ProvisioningApiUserDetails;
+
+  // coverage:ignore-start
+  const ProvisioningApiUserDetails._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory ProvisioningApiUserDetails.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<ProvisioningApiUserDetails> get serializer => _$provisioningApiUserDetailsSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Interface {
+  String get id;
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Interface rebuild(
+    final void Function(
+      ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1InterfaceBuilder,
+    ) updates,
+  );
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1InterfaceBuilder toBuilder();
 }
 
 abstract class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1
     implements
+        ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Interface,
         Built<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1,
             ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Builder> {
   factory ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1([
@@ -3359,7 +3720,6 @@ abstract class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
   static Serializer<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1>
       get serializer => _$provisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonOcsDataUsers1Serializer;
 }
@@ -3449,8 +3809,19 @@ class _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltMap<String, ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users> get users;
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder)
+        updates,
+  );
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data([
@@ -3471,13 +3842,24 @@ abstract class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltMap<String, ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users> get users;
   static Serializer<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsInterfaceBuilder)
+        updates,
+  );
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs,
             ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs([
@@ -3498,14 +3880,22 @@ abstract class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonInterface {
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson
     implements
+        ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonInterface,
         Built<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson,
             ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson([
@@ -3526,13 +3916,23 @@ abstract class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson> get serializer =>
       _$provisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  BuiltList<String> get data;
+  ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs,
             ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs([
@@ -3553,14 +3953,22 @@ abstract class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  BuiltList<String> get data;
   static Serializer<ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonInterface {
+  ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson
     implements
+        ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonInterface,
         Built<ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson,
             ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson([
@@ -3581,13 +3989,22 @@ abstract class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson> get serializer =>
       _$provisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<String> get users;
+  ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data([
@@ -3606,13 +4023,23 @@ abstract class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String> get users;
   static Serializer<ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiGroupsGetGroupResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs,
             ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs([
@@ -3631,14 +4058,22 @@ abstract class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiGroupsGetGroupResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsGetGroupResponse200ApplicationJsonInterface {
+  ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiGroupsGetGroupResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiGroupsGetGroupResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsGetGroupResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsGetGroupResponse200ApplicationJson
     implements
+        ProvisioningApiGroupsGetGroupResponse200ApplicationJsonInterface,
         Built<ProvisioningApiGroupsGetGroupResponse200ApplicationJson,
             ProvisioningApiGroupsGetGroupResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiGroupsGetGroupResponse200ApplicationJson([
@@ -3657,13 +4092,23 @@ abstract class ProvisioningApiGroupsGetGroupResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiGroupsGetGroupResponse200ApplicationJson> get serializer =>
       _$provisioningApiGroupsGetGroupResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs,
             ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs([
@@ -3682,14 +4127,22 @@ abstract class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiGroupsUpdateGroupResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonInterface {
+  ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson
     implements
+        ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonInterface,
         Built<ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson,
             ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson([
@@ -3708,13 +4161,23 @@ abstract class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson> get serializer =>
       _$provisioningApiGroupsUpdateGroupResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs,
             ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs([
@@ -3733,14 +4196,22 @@ abstract class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiGroupsDeleteGroupResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonInterface {
+  ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson
     implements
+        ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonInterface,
         Built<ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson,
             ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson([
@@ -3759,13 +4230,23 @@ abstract class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson> get serializer =>
       _$provisioningApiGroupsDeleteGroupResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs,
             ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs([
@@ -3786,14 +4267,22 @@ abstract class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiPreferencesSetPreferenceResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonInterface {
+  ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson
     implements
+        ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonInterface,
         Built<ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson,
             ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson([
@@ -3812,13 +4301,24 @@ abstract class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson> get serializer =>
       _$provisioningApiPreferencesSetPreferenceResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsInterfaceBuilder)
+        updates,
+  );
+  ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs,
             ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs([
@@ -3839,14 +4339,22 @@ abstract class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJ
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonInterface {
+  ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson
     implements
+        ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonInterface,
         Built<ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson,
             ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson([
@@ -3867,13 +4375,24 @@ abstract class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJ
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson> get serializer =>
       _$provisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsInterfaceBuilder)
+        updates,
+  );
+  ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs,
             ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs([
@@ -3894,14 +4413,23 @@ abstract class ProvisioningApiPreferencesSetMultiplePreferencesResponse200Applic
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonInterface {
+  ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonInterfaceBuilder)
+        updates,
+  );
+  ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson
     implements
+        ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonInterface,
         Built<ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson,
             ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson([
@@ -3922,13 +4450,25 @@ abstract class ProvisioningApiPreferencesSetMultiplePreferencesResponse200Applic
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson> get serializer =>
       _$provisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(
+      ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsInterfaceBuilder,
+    ) updates,
+  );
+  ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs,
             ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs([
@@ -3949,14 +4489,23 @@ abstract class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200Appl
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonInterface {
+  ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonInterfaceBuilder)
+        updates,
+  );
+  ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson
     implements
+        ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonInterface,
         Built<ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson,
             ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson([
@@ -3977,13 +4526,22 @@ abstract class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200Appl
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson> get serializer =>
       _$provisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<String> get users;
+  ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data([
@@ -4002,13 +4560,23 @@ abstract class ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String> get users;
   static Serializer<ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiUsersGetUsersResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs([
@@ -4027,14 +4595,22 @@ abstract class ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersGetUsersResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUsersResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersGetUsersResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUsersResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUsersResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUsersResponse200ApplicationJson
     implements
+        ProvisioningApiUsersGetUsersResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersGetUsersResponse200ApplicationJson,
             ProvisioningApiUsersGetUsersResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersGetUsersResponse200ApplicationJson([
@@ -4053,13 +4629,22 @@ abstract class ProvisioningApiUsersGetUsersResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersGetUsersResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersGetUsersResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataInterface {
+  String get id;
+  ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data([
@@ -4078,13 +4663,23 @@ abstract class ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
   static Serializer<ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiUsersAddUserResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs([
@@ -4103,14 +4698,22 @@ abstract class ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersAddUserResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersAddUserResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersAddUserResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersAddUserResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersAddUserResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersAddUserResponse200ApplicationJson
     implements
+        ProvisioningApiUsersAddUserResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersAddUserResponse200ApplicationJson,
             ProvisioningApiUsersAddUserResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersAddUserResponse200ApplicationJson([
@@ -4129,13 +4732,23 @@ abstract class ProvisioningApiUsersAddUserResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersAddUserResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersAddUserResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Interface {
+  String get id;
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Interface rebuild(
+    final void Function(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1InterfaceBuilder)
+        updates,
+  );
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1InterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1
     implements
+        ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Interface,
         Built<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1,
             ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Builder> {
   factory ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1([
@@ -4156,7 +4769,6 @@ abstract class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
   static Serializer<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1> get serializer =>
       _$provisioningApiUsersGetUsersDetailsResponse200ApplicationJsonOcsDataUsers1Serializer;
 }
@@ -4243,8 +4855,18 @@ class _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_U
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltMap<String, ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users> get users;
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data([
@@ -4265,13 +4887,23 @@ abstract class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltMap<String, ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users> get users;
   static Serializer<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiUsersGetUsersDetailsResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs([
@@ -4290,14 +4922,22 @@ abstract class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersGetUsersDetailsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson
     implements
+        ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson,
             ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson([
@@ -4316,13 +4956,23 @@ abstract class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersGetUsersDetailsResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  BuiltMap<String, String> get data;
+  ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs([
@@ -4343,14 +4993,22 @@ abstract class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  BuiltMap<String, String> get data;
   static Serializer<ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson
     implements
+        ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson,
             ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson([
@@ -4371,13 +5029,23 @@ abstract class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiUserDetails get data;
+  ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs([
@@ -4396,14 +5064,22 @@ abstract class ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiUserDetails get data;
   static Serializer<ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersGetUserResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUserResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersGetUserResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUserResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUserResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUserResponse200ApplicationJson
     implements
+        ProvisioningApiUsersGetUserResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersGetUserResponse200ApplicationJson,
             ProvisioningApiUsersGetUserResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersGetUserResponse200ApplicationJson([
@@ -4422,13 +5098,23 @@ abstract class ProvisioningApiUsersGetUserResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersGetUserResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersGetUserResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs([
@@ -4447,14 +5133,22 @@ abstract class ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersEditUserResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersEditUserResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersEditUserResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersEditUserResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersEditUserResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersEditUserResponse200ApplicationJson
     implements
+        ProvisioningApiUsersEditUserResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersEditUserResponse200ApplicationJson,
             ProvisioningApiUsersEditUserResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersEditUserResponse200ApplicationJson([
@@ -4473,13 +5167,23 @@ abstract class ProvisioningApiUsersEditUserResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersEditUserResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersEditUserResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs([
@@ -4498,14 +5202,22 @@ abstract class ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersDeleteUserResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersDeleteUserResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersDeleteUserResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersDeleteUserResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersDeleteUserResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersDeleteUserResponse200ApplicationJson
     implements
+        ProvisioningApiUsersDeleteUserResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersDeleteUserResponse200ApplicationJson,
             ProvisioningApiUsersDeleteUserResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersDeleteUserResponse200ApplicationJson([
@@ -4524,13 +5236,23 @@ abstract class ProvisioningApiUsersDeleteUserResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersDeleteUserResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersDeleteUserResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiUserDetails get data;
+  ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs([
@@ -4549,14 +5271,22 @@ abstract class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiUserDetails get data;
   static Serializer<ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersGetCurrentUserResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson
     implements
+        ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson,
             ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson([
@@ -4575,13 +5305,23 @@ abstract class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersGetCurrentUserResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  BuiltList<String> get data;
+  ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs([
@@ -4602,14 +5342,22 @@ abstract class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  BuiltList<String> get data;
   static Serializer<ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersGetEditableFieldsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson
     implements
+        ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson,
             ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson([
@@ -4628,13 +5376,24 @@ abstract class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersGetEditableFieldsResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  BuiltList<String> get data;
+  ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsInterfaceBuilder)
+        updates,
+  );
+  ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs([
@@ -4655,14 +5414,22 @@ abstract class ProvisioningApiUsersGetEditableFieldsForUserResponse200Applicatio
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  BuiltList<String> get data;
   static Serializer<ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson
     implements
+        ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson,
             ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson([
@@ -4683,13 +5450,23 @@ abstract class ProvisioningApiUsersGetEditableFieldsForUserResponse200Applicatio
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs([
@@ -4710,14 +5487,22 @@ abstract class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersEditUserMultiValueResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson
     implements
+        ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson,
             ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson([
@@ -4736,13 +5521,23 @@ abstract class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersEditUserMultiValueResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs([
@@ -4761,14 +5556,22 @@ abstract class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersWipeUserDevicesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson
     implements
+        ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson,
             ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson([
@@ -4787,13 +5590,23 @@ abstract class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersWipeUserDevicesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs([
@@ -4812,14 +5625,22 @@ abstract class ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersEnableUserResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersEnableUserResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersEnableUserResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersEnableUserResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersEnableUserResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersEnableUserResponse200ApplicationJson
     implements
+        ProvisioningApiUsersEnableUserResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersEnableUserResponse200ApplicationJson,
             ProvisioningApiUsersEnableUserResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersEnableUserResponse200ApplicationJson([
@@ -4838,13 +5659,23 @@ abstract class ProvisioningApiUsersEnableUserResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersEnableUserResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersEnableUserResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs([
@@ -4863,14 +5694,22 @@ abstract class ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersDisableUserResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersDisableUserResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersDisableUserResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersDisableUserResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersDisableUserResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersDisableUserResponse200ApplicationJson
     implements
+        ProvisioningApiUsersDisableUserResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersDisableUserResponse200ApplicationJson,
             ProvisioningApiUsersDisableUserResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersDisableUserResponse200ApplicationJson([
@@ -4889,13 +5728,22 @@ abstract class ProvisioningApiUsersDisableUserResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersDisableUserResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersDisableUserResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<String> get groups;
+  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data
     implements
+        ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataInterface,
         Built<ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data,
             ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder> {
   factory ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data([
@@ -4916,13 +5764,23 @@ abstract class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String> get groups;
   static Serializer<ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$provisioningApiUsersGetUsersGroupsResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data get data;
+  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs([
@@ -4941,14 +5799,22 @@ abstract class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersGetUsersGroupsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson
     implements
+        ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson,
             ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson([
@@ -4967,13 +5833,23 @@ abstract class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersGetUsersGroupsResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs([
@@ -4992,14 +5868,22 @@ abstract class ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersAddToGroupResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersAddToGroupResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersAddToGroupResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersAddToGroupResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersAddToGroupResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersAddToGroupResponse200ApplicationJson
     implements
+        ProvisioningApiUsersAddToGroupResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersAddToGroupResponse200ApplicationJson,
             ProvisioningApiUsersAddToGroupResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersAddToGroupResponse200ApplicationJson([
@@ -5018,13 +5902,23 @@ abstract class ProvisioningApiUsersAddToGroupResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersAddToGroupResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersAddToGroupResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs([
@@ -5043,14 +5937,22 @@ abstract class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersRemoveFromGroupResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson
     implements
+        ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson,
             ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson([
@@ -5069,13 +5971,24 @@ abstract class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersRemoveFromGroupResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  BuiltList<String> get data;
+  ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsInterfaceBuilder)
+        updates,
+  );
+  ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs([
@@ -5096,14 +6009,22 @@ abstract class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  BuiltList<String> get data;
   static Serializer<ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson
     implements
+        ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson,
             ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson([
@@ -5124,13 +6045,23 @@ abstract class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs([
@@ -5149,14 +6080,22 @@ abstract class ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersAddSubAdminResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersAddSubAdminResponse200ApplicationJson
     implements
+        ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersAddSubAdminResponse200ApplicationJson,
             ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersAddSubAdminResponse200ApplicationJson([
@@ -5175,13 +6114,23 @@ abstract class ProvisioningApiUsersAddSubAdminResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersAddSubAdminResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersAddSubAdminResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs([
@@ -5200,14 +6149,22 @@ abstract class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersRemoveSubAdminResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson
     implements
+        ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson,
             ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson([
@@ -5226,13 +6183,23 @@ abstract class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersRemoveSubAdminResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsInterface {
+  ProvisioningApiOCSMeta get meta;
+  JsonObject get data;
+  ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs
     implements
+        ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsInterface,
         Built<ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs,
             ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder> {
   factory ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs([
@@ -5253,14 +6220,22 @@ abstract class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs> get serializer =>
       _$provisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonInterface {
+  ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs get ocs;
+  ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonInterface rebuild(
+    final void Function(ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson
     implements
+        ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonInterface,
         Built<ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson,
             ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonBuilder> {
   factory ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson([
@@ -5281,13 +6256,29 @@ abstract class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson> get serializer =>
       _$provisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiCapabilities_ProvisioningApiInterface {
+  String get version;
+  @BuiltValueField(wireName: 'AccountPropertyScopesVersion')
+  int get accountPropertyScopesVersion;
+  @BuiltValueField(wireName: 'AccountPropertyScopesFederatedEnabled')
+  bool get accountPropertyScopesFederatedEnabled;
+  @BuiltValueField(wireName: 'AccountPropertyScopesPublishedEnabled')
+  bool get accountPropertyScopesPublishedEnabled;
+  ProvisioningApiCapabilities_ProvisioningApiInterface rebuild(
+    final void Function(ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder) updates,
+  );
+  ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiCapabilities_ProvisioningApi
-    implements Built<ProvisioningApiCapabilities_ProvisioningApi, ProvisioningApiCapabilities_ProvisioningApiBuilder> {
+    implements
+        ProvisioningApiCapabilities_ProvisioningApiInterface,
+        Built<ProvisioningApiCapabilities_ProvisioningApi, ProvisioningApiCapabilities_ProvisioningApiBuilder> {
   factory ProvisioningApiCapabilities_ProvisioningApi([
     final void Function(ProvisioningApiCapabilities_ProvisioningApiBuilder)? b,
   ]) = _$ProvisioningApiCapabilities_ProvisioningApi;
@@ -5304,19 +6295,24 @@ abstract class ProvisioningApiCapabilities_ProvisioningApi
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get version;
-  @BuiltValueField(wireName: 'AccountPropertyScopesVersion')
-  int get accountPropertyScopesVersion;
-  @BuiltValueField(wireName: 'AccountPropertyScopesFederatedEnabled')
-  bool get accountPropertyScopesFederatedEnabled;
-  @BuiltValueField(wireName: 'AccountPropertyScopesPublishedEnabled')
-  bool get accountPropertyScopesPublishedEnabled;
   static Serializer<ProvisioningApiCapabilities_ProvisioningApi> get serializer =>
       _$provisioningApiCapabilitiesProvisioningApiSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ProvisioningApiCapabilitiesInterface {
+  @BuiltValueField(wireName: 'provisioning_api')
+  ProvisioningApiCapabilities_ProvisioningApi get provisioningApi;
+  ProvisioningApiCapabilitiesInterface rebuild(
+    final void Function(ProvisioningApiCapabilitiesInterfaceBuilder) updates,
+  );
+  ProvisioningApiCapabilitiesInterfaceBuilder toBuilder();
+}
+
 abstract class ProvisioningApiCapabilities
-    implements Built<ProvisioningApiCapabilities, ProvisioningApiCapabilitiesBuilder> {
+    implements
+        ProvisioningApiCapabilitiesInterface,
+        Built<ProvisioningApiCapabilities, ProvisioningApiCapabilitiesBuilder> {
   factory ProvisioningApiCapabilities([final void Function(ProvisioningApiCapabilitiesBuilder)? b]) =
       _$ProvisioningApiCapabilities;
 
@@ -5332,8 +6328,6 @@ abstract class ProvisioningApiCapabilities
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'provisioning_api')
-  ProvisioningApiCapabilities_ProvisioningApi get provisioningApi;
   static Serializer<ProvisioningApiCapabilities> get serializer => _$provisioningApiCapabilitiesSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
@@ -6272,6 +6272,25 @@ class _$ProvisioningApiCapabilitiesSerializer implements StructuredSerializer<Pr
   }
 }
 
+abstract mixin class ProvisioningApiOCSMetaInterfaceBuilder {
+  void replace(ProvisioningApiOCSMetaInterface other);
+  void update(void Function(ProvisioningApiOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
+}
+
 class _$ProvisioningApiOCSMeta extends ProvisioningApiOCSMeta {
   @override
   final String status;
@@ -6336,28 +6355,29 @@ class _$ProvisioningApiOCSMeta extends ProvisioningApiOCSMeta {
   }
 }
 
-class ProvisioningApiOCSMetaBuilder implements Builder<ProvisioningApiOCSMeta, ProvisioningApiOCSMetaBuilder> {
+class ProvisioningApiOCSMetaBuilder
+    implements Builder<ProvisioningApiOCSMeta, ProvisioningApiOCSMetaBuilder>, ProvisioningApiOCSMetaInterfaceBuilder {
   _$ProvisioningApiOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   ProvisioningApiOCSMetaBuilder();
 
@@ -6375,7 +6395,7 @@ class ProvisioningApiOCSMetaBuilder implements Builder<ProvisioningApiOCSMeta, P
   }
 
   @override
-  void replace(ProvisioningApiOCSMeta other) {
+  void replace(covariant ProvisioningApiOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiOCSMeta;
   }
@@ -6399,6 +6419,14 @@ class ProvisioningApiOCSMetaBuilder implements Builder<ProvisioningApiOCSMeta, P
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<String> get data;
+  set data(ListBuilder<String>? data);
 }
 
 class _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data
@@ -6449,12 +6477,13 @@ class _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<String>? _data;
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
-  set data(ListBuilder<String>? data) => _$this._data = data;
+  set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
   ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -6468,7 +6497,7 @@ class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_Data;
   }
@@ -6499,6 +6528,16 @@ class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs
@@ -6558,17 +6597,19 @@ class _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs
 class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs,
-            ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder();
 
@@ -6583,7 +6624,7 @@ class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_Ocs;
   }
@@ -6617,6 +6658,13 @@ class ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson
@@ -6665,13 +6713,14 @@ class _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson
 class ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiAppConfigGetAppsResponse200ApplicationJson,
-            ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonBuilder> {
+            ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonBuilder>,
+        ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson? _$v;
 
   ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiAppConfigGetAppsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonBuilder();
 
@@ -6685,7 +6734,7 @@ class ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigGetAppsResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiAppConfigGetAppsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigGetAppsResponse200ApplicationJson;
   }
@@ -6716,6 +6765,14 @@ class ProvisioningApiAppConfigGetAppsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<String> get data;
+  set data(ListBuilder<String>? data);
 }
 
 class _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data
@@ -6766,12 +6823,13 @@ class _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<String>? _data;
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
-  set data(ListBuilder<String>? data) => _$this._data = data;
+  set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
   ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -6785,7 +6843,7 @@ class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_Data;
   }
@@ -6816,6 +6874,16 @@ class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs
@@ -6875,17 +6943,19 @@ class _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs
 class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs,
-            ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder();
 
@@ -6900,7 +6970,7 @@ class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_Ocs;
   }
@@ -6934,6 +7004,13 @@ class ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson
@@ -6982,13 +7059,14 @@ class _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson
 class ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiAppConfigGetKeysResponse200ApplicationJson,
-            ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonBuilder> {
+            ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonBuilder>,
+        ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson? _$v;
 
   ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiAppConfigGetKeysResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonBuilder();
 
@@ -7002,7 +7080,7 @@ class ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigGetKeysResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiAppConfigGetKeysResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigGetKeysResponse200ApplicationJson;
   }
@@ -7033,6 +7111,14 @@ class ProvisioningApiAppConfigGetKeysResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get data;
+  set data(String? data);
 }
 
 class _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data
@@ -7083,12 +7169,13 @@ class _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _data;
   String? get data => _$this._data;
-  set data(String? data) => _$this._data = data;
+  set data(covariant String? data) => _$this._data = data;
 
   ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -7102,7 +7189,7 @@ class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_Data;
   }
@@ -7123,6 +7210,16 @@ class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs
@@ -7182,17 +7279,19 @@ class _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs
 class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs,
-            ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder();
 
@@ -7207,7 +7306,7 @@ class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson_Ocs;
   }
@@ -7241,6 +7340,13 @@ class ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigGetValueResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigGetValueResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiAppConfigGetValueResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson
@@ -7289,13 +7395,14 @@ class _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson
 class ProvisioningApiAppConfigGetValueResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiAppConfigGetValueResponse200ApplicationJson,
-            ProvisioningApiAppConfigGetValueResponse200ApplicationJsonBuilder> {
+            ProvisioningApiAppConfigGetValueResponse200ApplicationJsonBuilder>,
+        ProvisioningApiAppConfigGetValueResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson? _$v;
 
   ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiAppConfigGetValueResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiAppConfigGetValueResponse200ApplicationJsonBuilder();
 
@@ -7309,7 +7416,7 @@ class ProvisioningApiAppConfigGetValueResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigGetValueResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiAppConfigGetValueResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigGetValueResponse200ApplicationJson;
   }
@@ -7340,6 +7447,16 @@ class ProvisioningApiAppConfigGetValueResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs
@@ -7399,16 +7516,17 @@ class _$ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs
 class ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs,
-            ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder();
 
@@ -7423,7 +7541,7 @@ class ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigSetValueResponse200ApplicationJson_Ocs;
   }
@@ -7458,6 +7576,13 @@ class ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigSetValueResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigSetValueResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiAppConfigSetValueResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiAppConfigSetValueResponse200ApplicationJson
@@ -7506,13 +7631,14 @@ class _$ProvisioningApiAppConfigSetValueResponse200ApplicationJson
 class ProvisioningApiAppConfigSetValueResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiAppConfigSetValueResponse200ApplicationJson,
-            ProvisioningApiAppConfigSetValueResponse200ApplicationJsonBuilder> {
+            ProvisioningApiAppConfigSetValueResponse200ApplicationJsonBuilder>,
+        ProvisioningApiAppConfigSetValueResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiAppConfigSetValueResponse200ApplicationJson? _$v;
 
   ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiAppConfigSetValueResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiAppConfigSetValueResponse200ApplicationJsonBuilder();
 
@@ -7526,7 +7652,7 @@ class ProvisioningApiAppConfigSetValueResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigSetValueResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiAppConfigSetValueResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigSetValueResponse200ApplicationJson;
   }
@@ -7557,6 +7683,16 @@ class ProvisioningApiAppConfigSetValueResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs
@@ -7616,16 +7752,17 @@ class _$ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs
 class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs,
-            ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder();
 
@@ -7640,7 +7777,7 @@ class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_Ocs;
   }
@@ -7675,6 +7812,13 @@ class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson
@@ -7724,13 +7868,14 @@ class _$ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson
 class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson,
-            ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonBuilder> {
+            ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonBuilder>,
+        ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson? _$v;
 
   ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonBuilder();
 
@@ -7744,7 +7889,7 @@ class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJson;
   }
@@ -7775,6 +7920,13 @@ class ProvisioningApiAppConfigDeleteKeyResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<String> get apps;
+  set apps(ListBuilder<String>? apps);
 }
 
 class _$ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data
@@ -7825,12 +7977,13 @@ class _$ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<String>? _apps;
   ListBuilder<String> get apps => _$this._apps ??= ListBuilder<String>();
-  set apps(ListBuilder<String>? apps) => _$this._apps = apps;
+  set apps(covariant ListBuilder<String>? apps) => _$this._apps = apps;
 
   ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -7844,7 +7997,7 @@ class ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_Data;
   }
@@ -7875,6 +8028,16 @@ class ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs
@@ -7931,17 +8094,18 @@ class _$ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs
 class ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs,
-            ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
   ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder();
 
@@ -7956,7 +8120,7 @@ class ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppsGetAppsResponse200ApplicationJson_Ocs;
   }
@@ -7990,6 +8154,13 @@ class ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppsGetAppsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiAppsGetAppsResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiAppsGetAppsResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiAppsGetAppsResponse200ApplicationJson
@@ -8038,13 +8209,14 @@ class _$ProvisioningApiAppsGetAppsResponse200ApplicationJson
 class ProvisioningApiAppsGetAppsResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiAppsGetAppsResponse200ApplicationJson,
-            ProvisioningApiAppsGetAppsResponse200ApplicationJsonBuilder> {
+            ProvisioningApiAppsGetAppsResponse200ApplicationJsonBuilder>,
+        ProvisioningApiAppsGetAppsResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiAppsGetAppsResponse200ApplicationJson? _$v;
 
   ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiAppsGetAppsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiAppsGetAppsResponse200ApplicationJsonBuilder();
 
@@ -8058,7 +8230,7 @@ class ProvisioningApiAppsGetAppsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppsGetAppsResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiAppsGetAppsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppsGetAppsResponse200ApplicationJson;
   }
@@ -8089,6 +8261,127 @@ class ProvisioningApiAppsGetAppsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppInfoInterfaceBuilder {
+  void replace(ProvisioningApiAppInfoInterface other);
+  void update(void Function(ProvisioningApiAppInfoInterfaceBuilder) updates);
+  bool? get active;
+  set active(bool? active);
+
+  JsonObject? get activity;
+  set activity(JsonObject? activity);
+
+  JsonObject? get author;
+  set author(JsonObject? author);
+
+  JsonObject? get backgroundJobs;
+  set backgroundJobs(JsonObject? backgroundJobs);
+
+  JsonObject? get bugs;
+  set bugs(JsonObject? bugs);
+
+  JsonObject? get category;
+  set category(JsonObject? category);
+
+  JsonObject? get collaboration;
+  set collaboration(JsonObject? collaboration);
+
+  JsonObject? get commands;
+  set commands(JsonObject? commands);
+
+  JsonObject? get defaultEnable;
+  set defaultEnable(JsonObject? defaultEnable);
+
+  JsonObject? get dependencies;
+  set dependencies(JsonObject? dependencies);
+
+  String? get description;
+  set description(String? description);
+
+  JsonObject? get discussion;
+  set discussion(JsonObject? discussion);
+
+  JsonObject? get documentation;
+  set documentation(JsonObject? documentation);
+
+  JsonObject? get groups;
+  set groups(JsonObject? groups);
+
+  String? get id;
+  set id(String? id);
+
+  JsonObject? get info;
+  set info(JsonObject? info);
+
+  bool? get internal;
+  set internal(bool? internal);
+
+  int? get level;
+  set level(int? level);
+
+  JsonObject? get licence;
+  set licence(JsonObject? licence);
+
+  String? get name;
+  set name(String? name);
+
+  JsonObject? get namespace;
+  set namespace(JsonObject? namespace);
+
+  JsonObject? get navigations;
+  set navigations(JsonObject? navigations);
+
+  JsonObject? get preview;
+  set preview(JsonObject? preview);
+
+  bool? get previewAsIcon;
+  set previewAsIcon(bool? previewAsIcon);
+
+  JsonObject? get public;
+  set public(JsonObject? public);
+
+  JsonObject? get remote;
+  set remote(JsonObject? remote);
+
+  bool? get removable;
+  set removable(bool? removable);
+
+  JsonObject? get repairSteps;
+  set repairSteps(JsonObject? repairSteps);
+
+  JsonObject? get repository;
+  set repository(JsonObject? repository);
+
+  JsonObject? get sabre;
+  set sabre(JsonObject? sabre);
+
+  JsonObject? get screenshot;
+  set screenshot(JsonObject? screenshot);
+
+  JsonObject? get settings;
+  set settings(JsonObject? settings);
+
+  String? get summary;
+  set summary(String? summary);
+
+  JsonObject? get trash;
+  set trash(JsonObject? trash);
+
+  JsonObject? get twoFactorProviders;
+  set twoFactorProviders(JsonObject? twoFactorProviders);
+
+  JsonObject? get types;
+  set types(JsonObject? types);
+
+  String? get version;
+  set version(String? version);
+
+  JsonObject? get versions;
+  set versions(JsonObject? versions);
+
+  JsonObject? get website;
+  set website(JsonObject? website);
 }
 
 class _$ProvisioningApiAppInfo extends ProvisioningApiAppInfo {
@@ -8366,164 +8659,165 @@ class _$ProvisioningApiAppInfo extends ProvisioningApiAppInfo {
   }
 }
 
-class ProvisioningApiAppInfoBuilder implements Builder<ProvisioningApiAppInfo, ProvisioningApiAppInfoBuilder> {
+class ProvisioningApiAppInfoBuilder
+    implements Builder<ProvisioningApiAppInfo, ProvisioningApiAppInfoBuilder>, ProvisioningApiAppInfoInterfaceBuilder {
   _$ProvisioningApiAppInfo? _$v;
 
   bool? _active;
   bool? get active => _$this._active;
-  set active(bool? active) => _$this._active = active;
+  set active(covariant bool? active) => _$this._active = active;
 
   JsonObject? _activity;
   JsonObject? get activity => _$this._activity;
-  set activity(JsonObject? activity) => _$this._activity = activity;
+  set activity(covariant JsonObject? activity) => _$this._activity = activity;
 
   JsonObject? _author;
   JsonObject? get author => _$this._author;
-  set author(JsonObject? author) => _$this._author = author;
+  set author(covariant JsonObject? author) => _$this._author = author;
 
   JsonObject? _backgroundJobs;
   JsonObject? get backgroundJobs => _$this._backgroundJobs;
-  set backgroundJobs(JsonObject? backgroundJobs) => _$this._backgroundJobs = backgroundJobs;
+  set backgroundJobs(covariant JsonObject? backgroundJobs) => _$this._backgroundJobs = backgroundJobs;
 
   JsonObject? _bugs;
   JsonObject? get bugs => _$this._bugs;
-  set bugs(JsonObject? bugs) => _$this._bugs = bugs;
+  set bugs(covariant JsonObject? bugs) => _$this._bugs = bugs;
 
   JsonObject? _category;
   JsonObject? get category => _$this._category;
-  set category(JsonObject? category) => _$this._category = category;
+  set category(covariant JsonObject? category) => _$this._category = category;
 
   JsonObject? _collaboration;
   JsonObject? get collaboration => _$this._collaboration;
-  set collaboration(JsonObject? collaboration) => _$this._collaboration = collaboration;
+  set collaboration(covariant JsonObject? collaboration) => _$this._collaboration = collaboration;
 
   JsonObject? _commands;
   JsonObject? get commands => _$this._commands;
-  set commands(JsonObject? commands) => _$this._commands = commands;
+  set commands(covariant JsonObject? commands) => _$this._commands = commands;
 
   JsonObject? _defaultEnable;
   JsonObject? get defaultEnable => _$this._defaultEnable;
-  set defaultEnable(JsonObject? defaultEnable) => _$this._defaultEnable = defaultEnable;
+  set defaultEnable(covariant JsonObject? defaultEnable) => _$this._defaultEnable = defaultEnable;
 
   JsonObject? _dependencies;
   JsonObject? get dependencies => _$this._dependencies;
-  set dependencies(JsonObject? dependencies) => _$this._dependencies = dependencies;
+  set dependencies(covariant JsonObject? dependencies) => _$this._dependencies = dependencies;
 
   String? _description;
   String? get description => _$this._description;
-  set description(String? description) => _$this._description = description;
+  set description(covariant String? description) => _$this._description = description;
 
   JsonObject? _discussion;
   JsonObject? get discussion => _$this._discussion;
-  set discussion(JsonObject? discussion) => _$this._discussion = discussion;
+  set discussion(covariant JsonObject? discussion) => _$this._discussion = discussion;
 
   JsonObject? _documentation;
   JsonObject? get documentation => _$this._documentation;
-  set documentation(JsonObject? documentation) => _$this._documentation = documentation;
+  set documentation(covariant JsonObject? documentation) => _$this._documentation = documentation;
 
   JsonObject? _groups;
   JsonObject? get groups => _$this._groups;
-  set groups(JsonObject? groups) => _$this._groups = groups;
+  set groups(covariant JsonObject? groups) => _$this._groups = groups;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   JsonObject? _info;
   JsonObject? get info => _$this._info;
-  set info(JsonObject? info) => _$this._info = info;
+  set info(covariant JsonObject? info) => _$this._info = info;
 
   bool? _internal;
   bool? get internal => _$this._internal;
-  set internal(bool? internal) => _$this._internal = internal;
+  set internal(covariant bool? internal) => _$this._internal = internal;
 
   int? _level;
   int? get level => _$this._level;
-  set level(int? level) => _$this._level = level;
+  set level(covariant int? level) => _$this._level = level;
 
   JsonObject? _licence;
   JsonObject? get licence => _$this._licence;
-  set licence(JsonObject? licence) => _$this._licence = licence;
+  set licence(covariant JsonObject? licence) => _$this._licence = licence;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   JsonObject? _namespace;
   JsonObject? get namespace => _$this._namespace;
-  set namespace(JsonObject? namespace) => _$this._namespace = namespace;
+  set namespace(covariant JsonObject? namespace) => _$this._namespace = namespace;
 
   JsonObject? _navigations;
   JsonObject? get navigations => _$this._navigations;
-  set navigations(JsonObject? navigations) => _$this._navigations = navigations;
+  set navigations(covariant JsonObject? navigations) => _$this._navigations = navigations;
 
   JsonObject? _preview;
   JsonObject? get preview => _$this._preview;
-  set preview(JsonObject? preview) => _$this._preview = preview;
+  set preview(covariant JsonObject? preview) => _$this._preview = preview;
 
   bool? _previewAsIcon;
   bool? get previewAsIcon => _$this._previewAsIcon;
-  set previewAsIcon(bool? previewAsIcon) => _$this._previewAsIcon = previewAsIcon;
+  set previewAsIcon(covariant bool? previewAsIcon) => _$this._previewAsIcon = previewAsIcon;
 
   JsonObject? _public;
   JsonObject? get public => _$this._public;
-  set public(JsonObject? public) => _$this._public = public;
+  set public(covariant JsonObject? public) => _$this._public = public;
 
   JsonObject? _remote;
   JsonObject? get remote => _$this._remote;
-  set remote(JsonObject? remote) => _$this._remote = remote;
+  set remote(covariant JsonObject? remote) => _$this._remote = remote;
 
   bool? _removable;
   bool? get removable => _$this._removable;
-  set removable(bool? removable) => _$this._removable = removable;
+  set removable(covariant bool? removable) => _$this._removable = removable;
 
   JsonObject? _repairSteps;
   JsonObject? get repairSteps => _$this._repairSteps;
-  set repairSteps(JsonObject? repairSteps) => _$this._repairSteps = repairSteps;
+  set repairSteps(covariant JsonObject? repairSteps) => _$this._repairSteps = repairSteps;
 
   JsonObject? _repository;
   JsonObject? get repository => _$this._repository;
-  set repository(JsonObject? repository) => _$this._repository = repository;
+  set repository(covariant JsonObject? repository) => _$this._repository = repository;
 
   JsonObject? _sabre;
   JsonObject? get sabre => _$this._sabre;
-  set sabre(JsonObject? sabre) => _$this._sabre = sabre;
+  set sabre(covariant JsonObject? sabre) => _$this._sabre = sabre;
 
   JsonObject? _screenshot;
   JsonObject? get screenshot => _$this._screenshot;
-  set screenshot(JsonObject? screenshot) => _$this._screenshot = screenshot;
+  set screenshot(covariant JsonObject? screenshot) => _$this._screenshot = screenshot;
 
   JsonObject? _settings;
   JsonObject? get settings => _$this._settings;
-  set settings(JsonObject? settings) => _$this._settings = settings;
+  set settings(covariant JsonObject? settings) => _$this._settings = settings;
 
   String? _summary;
   String? get summary => _$this._summary;
-  set summary(String? summary) => _$this._summary = summary;
+  set summary(covariant String? summary) => _$this._summary = summary;
 
   JsonObject? _trash;
   JsonObject? get trash => _$this._trash;
-  set trash(JsonObject? trash) => _$this._trash = trash;
+  set trash(covariant JsonObject? trash) => _$this._trash = trash;
 
   JsonObject? _twoFactorProviders;
   JsonObject? get twoFactorProviders => _$this._twoFactorProviders;
-  set twoFactorProviders(JsonObject? twoFactorProviders) => _$this._twoFactorProviders = twoFactorProviders;
+  set twoFactorProviders(covariant JsonObject? twoFactorProviders) => _$this._twoFactorProviders = twoFactorProviders;
 
   JsonObject? _types;
   JsonObject? get types => _$this._types;
-  set types(JsonObject? types) => _$this._types = types;
+  set types(covariant JsonObject? types) => _$this._types = types;
 
   String? _version;
   String? get version => _$this._version;
-  set version(String? version) => _$this._version = version;
+  set version(covariant String? version) => _$this._version = version;
 
   JsonObject? _versions;
   JsonObject? get versions => _$this._versions;
-  set versions(JsonObject? versions) => _$this._versions = versions;
+  set versions(covariant JsonObject? versions) => _$this._versions = versions;
 
   JsonObject? _website;
   JsonObject? get website => _$this._website;
-  set website(JsonObject? website) => _$this._website = website;
+  set website(covariant JsonObject? website) => _$this._website = website;
 
   ProvisioningApiAppInfoBuilder();
 
@@ -8575,7 +8869,7 @@ class ProvisioningApiAppInfoBuilder implements Builder<ProvisioningApiAppInfo, P
   }
 
   @override
-  void replace(ProvisioningApiAppInfo other) {
+  void replace(covariant ProvisioningApiAppInfo other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppInfo;
   }
@@ -8635,6 +8929,16 @@ class ProvisioningApiAppInfoBuilder implements Builder<ProvisioningApiAppInfo, P
   }
 }
 
+abstract mixin class ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiAppInfoBuilder get data;
+  set data(ProvisioningApiAppInfoBuilder? data);
+}
+
 class _$ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs
     extends ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs {
   @override
@@ -8690,16 +8994,17 @@ class _$ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs
 class ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs,
-            ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiAppInfoBuilder? _data;
   ProvisioningApiAppInfoBuilder get data => _$this._data ??= ProvisioningApiAppInfoBuilder();
-  set data(ProvisioningApiAppInfoBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiAppInfoBuilder? data) => _$this._data = data;
 
   ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder();
 
@@ -8714,7 +9019,7 @@ class ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_Ocs;
   }
@@ -8748,6 +9053,13 @@ class ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiAppsGetAppInfoResponse200ApplicationJson
@@ -8796,13 +9108,14 @@ class _$ProvisioningApiAppsGetAppInfoResponse200ApplicationJson
 class ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiAppsGetAppInfoResponse200ApplicationJson,
-            ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonBuilder> {
+            ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonBuilder>,
+        ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiAppsGetAppInfoResponse200ApplicationJson? _$v;
 
   ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiAppsGetAppInfoResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonBuilder();
 
@@ -8816,7 +9129,7 @@ class ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppsGetAppInfoResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiAppsGetAppInfoResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppsGetAppInfoResponse200ApplicationJson;
   }
@@ -8847,6 +9160,16 @@ class ProvisioningApiAppsGetAppInfoResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppsEnableResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiAppsEnableResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiAppsEnableResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs
@@ -8901,16 +9224,17 @@ class _$ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs
 class ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs,
-            ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiAppsEnableResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder();
 
@@ -8925,7 +9249,7 @@ class ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppsEnableResponse200ApplicationJson_Ocs;
   }
@@ -8960,6 +9284,13 @@ class ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppsEnableResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiAppsEnableResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiAppsEnableResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiAppsEnableResponse200ApplicationJson
@@ -9008,13 +9339,14 @@ class _$ProvisioningApiAppsEnableResponse200ApplicationJson
 class ProvisioningApiAppsEnableResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiAppsEnableResponse200ApplicationJson,
-            ProvisioningApiAppsEnableResponse200ApplicationJsonBuilder> {
+            ProvisioningApiAppsEnableResponse200ApplicationJsonBuilder>,
+        ProvisioningApiAppsEnableResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiAppsEnableResponse200ApplicationJson? _$v;
 
   ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiAppsEnableResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiAppsEnableResponse200ApplicationJsonBuilder();
 
@@ -9028,7 +9360,7 @@ class ProvisioningApiAppsEnableResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppsEnableResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiAppsEnableResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppsEnableResponse200ApplicationJson;
   }
@@ -9059,6 +9391,16 @@ class ProvisioningApiAppsEnableResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppsDisableResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiAppsDisableResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiAppsDisableResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs
@@ -9115,16 +9457,17 @@ class _$ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs
 class ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs,
-            ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiAppsDisableResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder();
 
@@ -9139,7 +9482,7 @@ class ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppsDisableResponse200ApplicationJson_Ocs;
   }
@@ -9174,6 +9517,13 @@ class ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiAppsDisableResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiAppsDisableResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiAppsDisableResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiAppsDisableResponse200ApplicationJson
@@ -9222,13 +9572,14 @@ class _$ProvisioningApiAppsDisableResponse200ApplicationJson
 class ProvisioningApiAppsDisableResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiAppsDisableResponse200ApplicationJson,
-            ProvisioningApiAppsDisableResponse200ApplicationJsonBuilder> {
+            ProvisioningApiAppsDisableResponse200ApplicationJsonBuilder>,
+        ProvisioningApiAppsDisableResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiAppsDisableResponse200ApplicationJson? _$v;
 
   ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiAppsDisableResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiAppsDisableResponse200ApplicationJsonBuilder();
 
@@ -9242,7 +9593,7 @@ class ProvisioningApiAppsDisableResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiAppsDisableResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiAppsDisableResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiAppsDisableResponse200ApplicationJson;
   }
@@ -9273,6 +9624,13 @@ class ProvisioningApiAppsDisableResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<String> get groups;
+  set groups(ListBuilder<String>? groups);
 }
 
 class _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data
@@ -9323,12 +9681,13 @@ class _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<String>? _groups;
   ListBuilder<String> get groups => _$this._groups ??= ListBuilder<String>();
-  set groups(ListBuilder<String>? groups) => _$this._groups = groups;
+  set groups(covariant ListBuilder<String>? groups) => _$this._groups = groups;
 
   ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -9342,7 +9701,7 @@ class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_Data;
   }
@@ -9373,6 +9732,16 @@ class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs
@@ -9432,17 +9801,19 @@ class _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs
 class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs,
-            ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder();
 
@@ -9457,7 +9828,7 @@ class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_Ocs;
   }
@@ -9491,6 +9862,13 @@ class ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson
@@ -9539,13 +9917,14 @@ class _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson
 class ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupsResponse200ApplicationJson,
-            ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonBuilder> {
+            ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonBuilder>,
+        ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson? _$v;
 
   ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiGroupsGetGroupsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonBuilder();
 
@@ -9559,7 +9938,7 @@ class ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupsResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupsResponse200ApplicationJson;
   }
@@ -9590,6 +9969,16 @@ class ProvisioningApiGroupsGetGroupsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs
@@ -9647,16 +10036,17 @@ class _$ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs
 class ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs,
-            ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder();
 
@@ -9671,7 +10061,7 @@ class ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsAddGroupResponse200ApplicationJson_Ocs;
   }
@@ -9706,6 +10096,13 @@ class ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsAddGroupResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiGroupsAddGroupResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiGroupsAddGroupResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiGroupsAddGroupResponse200ApplicationJson
@@ -9754,13 +10151,14 @@ class _$ProvisioningApiGroupsAddGroupResponse200ApplicationJson
 class ProvisioningApiGroupsAddGroupResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiGroupsAddGroupResponse200ApplicationJson,
-            ProvisioningApiGroupsAddGroupResponse200ApplicationJsonBuilder> {
+            ProvisioningApiGroupsAddGroupResponse200ApplicationJsonBuilder>,
+        ProvisioningApiGroupsAddGroupResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiGroupsAddGroupResponse200ApplicationJson? _$v;
 
   ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiGroupsAddGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiGroupsAddGroupResponse200ApplicationJsonBuilder();
 
@@ -9774,7 +10172,7 @@ class ProvisioningApiGroupsAddGroupResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsAddGroupResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiGroupsAddGroupResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsAddGroupResponse200ApplicationJson;
   }
@@ -10021,6 +10419,28 @@ class ProvisioningApiGroupDetails_DisabledBuilder
   }
 }
 
+abstract mixin class ProvisioningApiGroupDetailsInterfaceBuilder {
+  void replace(ProvisioningApiGroupDetailsInterface other);
+  void update(void Function(ProvisioningApiGroupDetailsInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get displayname;
+  set displayname(String? displayname);
+
+  ProvisioningApiGroupDetails_UsercountBuilder get usercount;
+  set usercount(ProvisioningApiGroupDetails_UsercountBuilder? usercount);
+
+  ProvisioningApiGroupDetails_DisabledBuilder get disabled;
+  set disabled(ProvisioningApiGroupDetails_DisabledBuilder? disabled);
+
+  bool? get canAdd;
+  set canAdd(bool? canAdd);
+
+  bool? get canRemove;
+  set canRemove(bool? canRemove);
+}
+
 class _$ProvisioningApiGroupDetails extends ProvisioningApiGroupDetails {
   @override
   final String id;
@@ -10100,34 +10520,36 @@ class _$ProvisioningApiGroupDetails extends ProvisioningApiGroupDetails {
 }
 
 class ProvisioningApiGroupDetailsBuilder
-    implements Builder<ProvisioningApiGroupDetails, ProvisioningApiGroupDetailsBuilder> {
+    implements
+        Builder<ProvisioningApiGroupDetails, ProvisioningApiGroupDetailsBuilder>,
+        ProvisioningApiGroupDetailsInterfaceBuilder {
   _$ProvisioningApiGroupDetails? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _displayname;
   String? get displayname => _$this._displayname;
-  set displayname(String? displayname) => _$this._displayname = displayname;
+  set displayname(covariant String? displayname) => _$this._displayname = displayname;
 
   ProvisioningApiGroupDetails_UsercountBuilder? _usercount;
   ProvisioningApiGroupDetails_UsercountBuilder get usercount =>
       _$this._usercount ??= ProvisioningApiGroupDetails_UsercountBuilder();
-  set usercount(ProvisioningApiGroupDetails_UsercountBuilder? usercount) => _$this._usercount = usercount;
+  set usercount(covariant ProvisioningApiGroupDetails_UsercountBuilder? usercount) => _$this._usercount = usercount;
 
   ProvisioningApiGroupDetails_DisabledBuilder? _disabled;
   ProvisioningApiGroupDetails_DisabledBuilder get disabled =>
       _$this._disabled ??= ProvisioningApiGroupDetails_DisabledBuilder();
-  set disabled(ProvisioningApiGroupDetails_DisabledBuilder? disabled) => _$this._disabled = disabled;
+  set disabled(covariant ProvisioningApiGroupDetails_DisabledBuilder? disabled) => _$this._disabled = disabled;
 
   bool? _canAdd;
   bool? get canAdd => _$this._canAdd;
-  set canAdd(bool? canAdd) => _$this._canAdd = canAdd;
+  set canAdd(covariant bool? canAdd) => _$this._canAdd = canAdd;
 
   bool? _canRemove;
   bool? get canRemove => _$this._canRemove;
-  set canRemove(bool? canRemove) => _$this._canRemove = canRemove;
+  set canRemove(covariant bool? canRemove) => _$this._canRemove = canRemove;
 
   ProvisioningApiGroupDetailsBuilder();
 
@@ -10146,7 +10568,7 @@ class ProvisioningApiGroupDetailsBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupDetails other) {
+  void replace(covariant ProvisioningApiGroupDetails other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupDetails;
   }
@@ -10186,6 +10608,14 @@ class ProvisioningApiGroupDetailsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<ProvisioningApiGroupDetails> get groups;
+  set groups(ListBuilder<ProvisioningApiGroupDetails>? groups);
 }
 
 class _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data
@@ -10236,12 +10666,13 @@ class _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<ProvisioningApiGroupDetails>? _groups;
   ListBuilder<ProvisioningApiGroupDetails> get groups => _$this._groups ??= ListBuilder<ProvisioningApiGroupDetails>();
-  set groups(ListBuilder<ProvisioningApiGroupDetails>? groups) => _$this._groups = groups;
+  set groups(covariant ListBuilder<ProvisioningApiGroupDetails>? groups) => _$this._groups = groups;
 
   ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -10255,7 +10686,7 @@ class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBu
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_Data;
   }
@@ -10287,6 +10718,17 @@ class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBu
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs
@@ -10346,17 +10788,18 @@ class _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs
 class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs,
-            ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+  set data(covariant ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
   ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder();
@@ -10372,7 +10815,7 @@ class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_Ocs;
   }
@@ -10407,6 +10850,13 @@ class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson
@@ -10457,13 +10907,15 @@ class _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson
 class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson,
-            ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonBuilder> {
+            ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonBuilder>,
+        ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson? _$v;
 
   ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonBuilder();
 
@@ -10477,7 +10929,7 @@ class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJson;
   }
@@ -10508,6 +10960,14 @@ class ProvisioningApiGroupsGetGroupsDetailsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<String> get users;
+  set users(ListBuilder<String>? users);
 }
 
 class _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data
@@ -10558,12 +11018,13 @@ class _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<String>? _users;
   ListBuilder<String> get users => _$this._users ??= ListBuilder<String>();
-  set users(ListBuilder<String>? users) => _$this._users = users;
+  set users(covariant ListBuilder<String>? users) => _$this._users = users;
 
   ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -10577,7 +11038,7 @@ class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuild
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_Data;
   }
@@ -10608,6 +11069,16 @@ class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuild
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs
@@ -10667,17 +11138,19 @@ class _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs
 class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs,
-            ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder();
 
@@ -10692,7 +11165,7 @@ class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_Ocs;
   }
@@ -10726,6 +11199,13 @@ class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson
@@ -10775,13 +11255,14 @@ class _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson
 class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson,
-            ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonBuilder> {
+            ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonBuilder>,
+        ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson? _$v;
 
   ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonBuilder();
 
@@ -10795,7 +11276,7 @@ class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJson;
   }
@@ -10826,6 +11307,16 @@ class ProvisioningApiGroupsGetGroupUsersResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUserDetails_BackendCapabilitiesInterfaceBuilder {
+  void replace(ProvisioningApiUserDetails_BackendCapabilitiesInterface other);
+  void update(void Function(ProvisioningApiUserDetails_BackendCapabilitiesInterfaceBuilder) updates);
+  bool? get setDisplayName;
+  set setDisplayName(bool? setDisplayName);
+
+  bool? get setPassword;
+  set setPassword(bool? setPassword);
 }
 
 class _$ProvisioningApiUserDetails_BackendCapabilities extends ProvisioningApiUserDetails_BackendCapabilities {
@@ -10883,16 +11374,17 @@ class _$ProvisioningApiUserDetails_BackendCapabilities extends ProvisioningApiUs
 
 class ProvisioningApiUserDetails_BackendCapabilitiesBuilder
     implements
-        Builder<ProvisioningApiUserDetails_BackendCapabilities, ProvisioningApiUserDetails_BackendCapabilitiesBuilder> {
+        Builder<ProvisioningApiUserDetails_BackendCapabilities, ProvisioningApiUserDetails_BackendCapabilitiesBuilder>,
+        ProvisioningApiUserDetails_BackendCapabilitiesInterfaceBuilder {
   _$ProvisioningApiUserDetails_BackendCapabilities? _$v;
 
   bool? _setDisplayName;
   bool? get setDisplayName => _$this._setDisplayName;
-  set setDisplayName(bool? setDisplayName) => _$this._setDisplayName = setDisplayName;
+  set setDisplayName(covariant bool? setDisplayName) => _$this._setDisplayName = setDisplayName;
 
   bool? _setPassword;
   bool? get setPassword => _$this._setPassword;
-  set setPassword(bool? setPassword) => _$this._setPassword = setPassword;
+  set setPassword(covariant bool? setPassword) => _$this._setPassword = setPassword;
 
   ProvisioningApiUserDetails_BackendCapabilitiesBuilder();
 
@@ -10907,7 +11399,7 @@ class ProvisioningApiUserDetails_BackendCapabilitiesBuilder
   }
 
   @override
-  void replace(ProvisioningApiUserDetails_BackendCapabilities other) {
+  void replace(covariant ProvisioningApiUserDetails_BackendCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUserDetails_BackendCapabilities;
   }
@@ -11039,6 +11531,25 @@ class ProvisioningApiUserDetailsQuota_QuotaBuilder
   }
 }
 
+abstract mixin class ProvisioningApiUserDetailsQuotaInterfaceBuilder {
+  void replace(ProvisioningApiUserDetailsQuotaInterface other);
+  void update(void Function(ProvisioningApiUserDetailsQuotaInterfaceBuilder) updates);
+  num? get free;
+  set free(num? free);
+
+  ProvisioningApiUserDetailsQuota_QuotaBuilder get quota;
+  set quota(ProvisioningApiUserDetailsQuota_QuotaBuilder? quota);
+
+  num? get relative;
+  set relative(num? relative);
+
+  num? get total;
+  set total(num? total);
+
+  num? get used;
+  set used(num? used);
+}
+
 class _$ProvisioningApiUserDetailsQuota extends ProvisioningApiUserDetailsQuota {
   @override
   final num? free;
@@ -11099,29 +11610,31 @@ class _$ProvisioningApiUserDetailsQuota extends ProvisioningApiUserDetailsQuota 
 }
 
 class ProvisioningApiUserDetailsQuotaBuilder
-    implements Builder<ProvisioningApiUserDetailsQuota, ProvisioningApiUserDetailsQuotaBuilder> {
+    implements
+        Builder<ProvisioningApiUserDetailsQuota, ProvisioningApiUserDetailsQuotaBuilder>,
+        ProvisioningApiUserDetailsQuotaInterfaceBuilder {
   _$ProvisioningApiUserDetailsQuota? _$v;
 
   num? _free;
   num? get free => _$this._free;
-  set free(num? free) => _$this._free = free;
+  set free(covariant num? free) => _$this._free = free;
 
   ProvisioningApiUserDetailsQuota_QuotaBuilder? _quota;
   ProvisioningApiUserDetailsQuota_QuotaBuilder get quota =>
       _$this._quota ??= ProvisioningApiUserDetailsQuota_QuotaBuilder();
-  set quota(ProvisioningApiUserDetailsQuota_QuotaBuilder? quota) => _$this._quota = quota;
+  set quota(covariant ProvisioningApiUserDetailsQuota_QuotaBuilder? quota) => _$this._quota = quota;
 
   num? _relative;
   num? get relative => _$this._relative;
-  set relative(num? relative) => _$this._relative = relative;
+  set relative(covariant num? relative) => _$this._relative = relative;
 
   num? _total;
   num? get total => _$this._total;
-  set total(num? total) => _$this._total = total;
+  set total(covariant num? total) => _$this._total = total;
 
   num? _used;
   num? get used => _$this._used;
-  set used(num? used) => _$this._used = used;
+  set used(covariant num? used) => _$this._used = used;
 
   ProvisioningApiUserDetailsQuotaBuilder();
 
@@ -11139,7 +11652,7 @@ class ProvisioningApiUserDetailsQuotaBuilder
   }
 
   @override
-  void replace(ProvisioningApiUserDetailsQuota other) {
+  void replace(covariant ProvisioningApiUserDetailsQuota other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUserDetailsQuota;
   }
@@ -11171,6 +11684,133 @@ class ProvisioningApiUserDetailsQuotaBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUserDetailsInterfaceBuilder {
+  void replace(ProvisioningApiUserDetailsInterface other);
+  void update(void Function(ProvisioningApiUserDetailsInterfaceBuilder) updates);
+  ListBuilder<String> get additionalMail;
+  set additionalMail(ListBuilder<String>? additionalMail);
+
+  ListBuilder<String> get additionalMailScope;
+  set additionalMailScope(ListBuilder<String>? additionalMailScope);
+
+  String? get address;
+  set address(String? address);
+
+  String? get addressScope;
+  set addressScope(String? addressScope);
+
+  String? get avatarScope;
+  set avatarScope(String? avatarScope);
+
+  String? get backend;
+  set backend(String? backend);
+
+  ProvisioningApiUserDetails_BackendCapabilitiesBuilder get backendCapabilities;
+  set backendCapabilities(ProvisioningApiUserDetails_BackendCapabilitiesBuilder? backendCapabilities);
+
+  String? get biography;
+  set biography(String? biography);
+
+  String? get biographyScope;
+  set biographyScope(String? biographyScope);
+
+  String? get displayName;
+  set displayName(String? displayName);
+
+  String? get displayname;
+  set displayname(String? displayname);
+
+  String? get displaynameScope;
+  set displaynameScope(String? displaynameScope);
+
+  String? get email;
+  set email(String? email);
+
+  String? get emailScope;
+  set emailScope(String? emailScope);
+
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  String? get fediverse;
+  set fediverse(String? fediverse);
+
+  String? get fediverseScope;
+  set fediverseScope(String? fediverseScope);
+
+  ListBuilder<String> get groups;
+  set groups(ListBuilder<String>? groups);
+
+  String? get headline;
+  set headline(String? headline);
+
+  String? get headlineScope;
+  set headlineScope(String? headlineScope);
+
+  String? get id;
+  set id(String? id);
+
+  String? get language;
+  set language(String? language);
+
+  int? get lastLogin;
+  set lastLogin(int? lastLogin);
+
+  String? get locale;
+  set locale(String? locale);
+
+  String? get manager;
+  set manager(String? manager);
+
+  String? get notifyEmail;
+  set notifyEmail(String? notifyEmail);
+
+  String? get organisation;
+  set organisation(String? organisation);
+
+  String? get organisationScope;
+  set organisationScope(String? organisationScope);
+
+  String? get phone;
+  set phone(String? phone);
+
+  String? get phoneScope;
+  set phoneScope(String? phoneScope);
+
+  String? get profileEnabled;
+  set profileEnabled(String? profileEnabled);
+
+  String? get profileEnabledScope;
+  set profileEnabledScope(String? profileEnabledScope);
+
+  ProvisioningApiUserDetailsQuotaBuilder get quota;
+  set quota(ProvisioningApiUserDetailsQuotaBuilder? quota);
+
+  String? get role;
+  set role(String? role);
+
+  String? get roleScope;
+  set roleScope(String? roleScope);
+
+  String? get storageLocation;
+  set storageLocation(String? storageLocation);
+
+  ListBuilder<String> get subadmin;
+  set subadmin(ListBuilder<String>? subadmin);
+
+  String? get twitter;
+  set twitter(String? twitter);
+
+  String? get twitterScope;
+  set twitterScope(String? twitterScope);
+
+  String? get website;
+  set website(String? website);
+
+  String? get websiteScope;
+  set websiteScope(String? websiteScope);
 }
 
 class _$ProvisioningApiUserDetails extends ProvisioningApiUserDetails {
@@ -11479,175 +12119,177 @@ class _$ProvisioningApiUserDetails extends ProvisioningApiUserDetails {
 }
 
 class ProvisioningApiUserDetailsBuilder
-    implements Builder<ProvisioningApiUserDetails, ProvisioningApiUserDetailsBuilder> {
+    implements
+        Builder<ProvisioningApiUserDetails, ProvisioningApiUserDetailsBuilder>,
+        ProvisioningApiUserDetailsInterfaceBuilder {
   _$ProvisioningApiUserDetails? _$v;
 
   ListBuilder<String>? _additionalMail;
   ListBuilder<String> get additionalMail => _$this._additionalMail ??= ListBuilder<String>();
-  set additionalMail(ListBuilder<String>? additionalMail) => _$this._additionalMail = additionalMail;
+  set additionalMail(covariant ListBuilder<String>? additionalMail) => _$this._additionalMail = additionalMail;
 
   ListBuilder<String>? _additionalMailScope;
   ListBuilder<String> get additionalMailScope => _$this._additionalMailScope ??= ListBuilder<String>();
-  set additionalMailScope(ListBuilder<String>? additionalMailScope) =>
+  set additionalMailScope(covariant ListBuilder<String>? additionalMailScope) =>
       _$this._additionalMailScope = additionalMailScope;
 
   String? _address;
   String? get address => _$this._address;
-  set address(String? address) => _$this._address = address;
+  set address(covariant String? address) => _$this._address = address;
 
   String? _addressScope;
   String? get addressScope => _$this._addressScope;
-  set addressScope(String? addressScope) => _$this._addressScope = addressScope;
+  set addressScope(covariant String? addressScope) => _$this._addressScope = addressScope;
 
   String? _avatarScope;
   String? get avatarScope => _$this._avatarScope;
-  set avatarScope(String? avatarScope) => _$this._avatarScope = avatarScope;
+  set avatarScope(covariant String? avatarScope) => _$this._avatarScope = avatarScope;
 
   String? _backend;
   String? get backend => _$this._backend;
-  set backend(String? backend) => _$this._backend = backend;
+  set backend(covariant String? backend) => _$this._backend = backend;
 
   ProvisioningApiUserDetails_BackendCapabilitiesBuilder? _backendCapabilities;
   ProvisioningApiUserDetails_BackendCapabilitiesBuilder get backendCapabilities =>
       _$this._backendCapabilities ??= ProvisioningApiUserDetails_BackendCapabilitiesBuilder();
-  set backendCapabilities(ProvisioningApiUserDetails_BackendCapabilitiesBuilder? backendCapabilities) =>
+  set backendCapabilities(covariant ProvisioningApiUserDetails_BackendCapabilitiesBuilder? backendCapabilities) =>
       _$this._backendCapabilities = backendCapabilities;
 
   String? _biography;
   String? get biography => _$this._biography;
-  set biography(String? biography) => _$this._biography = biography;
+  set biography(covariant String? biography) => _$this._biography = biography;
 
   String? _biographyScope;
   String? get biographyScope => _$this._biographyScope;
-  set biographyScope(String? biographyScope) => _$this._biographyScope = biographyScope;
+  set biographyScope(covariant String? biographyScope) => _$this._biographyScope = biographyScope;
 
   String? _displayName;
   String? get displayName => _$this._displayName;
-  set displayName(String? displayName) => _$this._displayName = displayName;
+  set displayName(covariant String? displayName) => _$this._displayName = displayName;
 
   String? _displayname;
   String? get displayname => _$this._displayname;
-  set displayname(String? displayname) => _$this._displayname = displayname;
+  set displayname(covariant String? displayname) => _$this._displayname = displayname;
 
   String? _displaynameScope;
   String? get displaynameScope => _$this._displaynameScope;
-  set displaynameScope(String? displaynameScope) => _$this._displaynameScope = displaynameScope;
+  set displaynameScope(covariant String? displaynameScope) => _$this._displaynameScope = displaynameScope;
 
   String? _email;
   String? get email => _$this._email;
-  set email(String? email) => _$this._email = email;
+  set email(covariant String? email) => _$this._email = email;
 
   String? _emailScope;
   String? get emailScope => _$this._emailScope;
-  set emailScope(String? emailScope) => _$this._emailScope = emailScope;
+  set emailScope(covariant String? emailScope) => _$this._emailScope = emailScope;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   String? _fediverse;
   String? get fediverse => _$this._fediverse;
-  set fediverse(String? fediverse) => _$this._fediverse = fediverse;
+  set fediverse(covariant String? fediverse) => _$this._fediverse = fediverse;
 
   String? _fediverseScope;
   String? get fediverseScope => _$this._fediverseScope;
-  set fediverseScope(String? fediverseScope) => _$this._fediverseScope = fediverseScope;
+  set fediverseScope(covariant String? fediverseScope) => _$this._fediverseScope = fediverseScope;
 
   ListBuilder<String>? _groups;
   ListBuilder<String> get groups => _$this._groups ??= ListBuilder<String>();
-  set groups(ListBuilder<String>? groups) => _$this._groups = groups;
+  set groups(covariant ListBuilder<String>? groups) => _$this._groups = groups;
 
   String? _headline;
   String? get headline => _$this._headline;
-  set headline(String? headline) => _$this._headline = headline;
+  set headline(covariant String? headline) => _$this._headline = headline;
 
   String? _headlineScope;
   String? get headlineScope => _$this._headlineScope;
-  set headlineScope(String? headlineScope) => _$this._headlineScope = headlineScope;
+  set headlineScope(covariant String? headlineScope) => _$this._headlineScope = headlineScope;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _language;
   String? get language => _$this._language;
-  set language(String? language) => _$this._language = language;
+  set language(covariant String? language) => _$this._language = language;
 
   int? _lastLogin;
   int? get lastLogin => _$this._lastLogin;
-  set lastLogin(int? lastLogin) => _$this._lastLogin = lastLogin;
+  set lastLogin(covariant int? lastLogin) => _$this._lastLogin = lastLogin;
 
   String? _locale;
   String? get locale => _$this._locale;
-  set locale(String? locale) => _$this._locale = locale;
+  set locale(covariant String? locale) => _$this._locale = locale;
 
   String? _manager;
   String? get manager => _$this._manager;
-  set manager(String? manager) => _$this._manager = manager;
+  set manager(covariant String? manager) => _$this._manager = manager;
 
   String? _notifyEmail;
   String? get notifyEmail => _$this._notifyEmail;
-  set notifyEmail(String? notifyEmail) => _$this._notifyEmail = notifyEmail;
+  set notifyEmail(covariant String? notifyEmail) => _$this._notifyEmail = notifyEmail;
 
   String? _organisation;
   String? get organisation => _$this._organisation;
-  set organisation(String? organisation) => _$this._organisation = organisation;
+  set organisation(covariant String? organisation) => _$this._organisation = organisation;
 
   String? _organisationScope;
   String? get organisationScope => _$this._organisationScope;
-  set organisationScope(String? organisationScope) => _$this._organisationScope = organisationScope;
+  set organisationScope(covariant String? organisationScope) => _$this._organisationScope = organisationScope;
 
   String? _phone;
   String? get phone => _$this._phone;
-  set phone(String? phone) => _$this._phone = phone;
+  set phone(covariant String? phone) => _$this._phone = phone;
 
   String? _phoneScope;
   String? get phoneScope => _$this._phoneScope;
-  set phoneScope(String? phoneScope) => _$this._phoneScope = phoneScope;
+  set phoneScope(covariant String? phoneScope) => _$this._phoneScope = phoneScope;
 
   String? _profileEnabled;
   String? get profileEnabled => _$this._profileEnabled;
-  set profileEnabled(String? profileEnabled) => _$this._profileEnabled = profileEnabled;
+  set profileEnabled(covariant String? profileEnabled) => _$this._profileEnabled = profileEnabled;
 
   String? _profileEnabledScope;
   String? get profileEnabledScope => _$this._profileEnabledScope;
-  set profileEnabledScope(String? profileEnabledScope) => _$this._profileEnabledScope = profileEnabledScope;
+  set profileEnabledScope(covariant String? profileEnabledScope) => _$this._profileEnabledScope = profileEnabledScope;
 
   ProvisioningApiUserDetailsQuotaBuilder? _quota;
   ProvisioningApiUserDetailsQuotaBuilder get quota => _$this._quota ??= ProvisioningApiUserDetailsQuotaBuilder();
-  set quota(ProvisioningApiUserDetailsQuotaBuilder? quota) => _$this._quota = quota;
+  set quota(covariant ProvisioningApiUserDetailsQuotaBuilder? quota) => _$this._quota = quota;
 
   String? _role;
   String? get role => _$this._role;
-  set role(String? role) => _$this._role = role;
+  set role(covariant String? role) => _$this._role = role;
 
   String? _roleScope;
   String? get roleScope => _$this._roleScope;
-  set roleScope(String? roleScope) => _$this._roleScope = roleScope;
+  set roleScope(covariant String? roleScope) => _$this._roleScope = roleScope;
 
   String? _storageLocation;
   String? get storageLocation => _$this._storageLocation;
-  set storageLocation(String? storageLocation) => _$this._storageLocation = storageLocation;
+  set storageLocation(covariant String? storageLocation) => _$this._storageLocation = storageLocation;
 
   ListBuilder<String>? _subadmin;
   ListBuilder<String> get subadmin => _$this._subadmin ??= ListBuilder<String>();
-  set subadmin(ListBuilder<String>? subadmin) => _$this._subadmin = subadmin;
+  set subadmin(covariant ListBuilder<String>? subadmin) => _$this._subadmin = subadmin;
 
   String? _twitter;
   String? get twitter => _$this._twitter;
-  set twitter(String? twitter) => _$this._twitter = twitter;
+  set twitter(covariant String? twitter) => _$this._twitter = twitter;
 
   String? _twitterScope;
   String? get twitterScope => _$this._twitterScope;
-  set twitterScope(String? twitterScope) => _$this._twitterScope = twitterScope;
+  set twitterScope(covariant String? twitterScope) => _$this._twitterScope = twitterScope;
 
   String? _website;
   String? get website => _$this._website;
-  set website(String? website) => _$this._website = website;
+  set website(covariant String? website) => _$this._website = website;
 
   String? _websiteScope;
   String? get websiteScope => _$this._websiteScope;
-  set websiteScope(String? websiteScope) => _$this._websiteScope = websiteScope;
+  set websiteScope(covariant String? websiteScope) => _$this._websiteScope = websiteScope;
 
   ProvisioningApiUserDetailsBuilder();
 
@@ -11701,7 +12343,7 @@ class ProvisioningApiUserDetailsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUserDetails other) {
+  void replace(covariant ProvisioningApiUserDetails other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUserDetails;
   }
@@ -11793,6 +12435,15 @@ class ProvisioningApiUserDetailsBuilder
   }
 }
 
+abstract mixin class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1InterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Interface other);
+  void update(
+      void Function(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1InterfaceBuilder)
+          updates);
+  String? get id;
+  set id(String? id);
+}
+
 class _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1
     extends ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1 {
   @override
@@ -11847,12 +12498,13 @@ class _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_
 class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Builder
     implements
         Builder<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1,
-            ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Builder> {
+            ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Builder>,
+        ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1InterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Builder();
 
@@ -11866,7 +12518,7 @@ class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Da
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1 other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1 other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1;
   }
@@ -12042,6 +12694,16 @@ class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Da
   }
 }
 
+abstract mixin class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder)
+          updates);
+  MapBuilder<String, ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users> get users;
+  set users(
+      MapBuilder<String, ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users>? users);
+}
+
 class _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data
     extends ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data {
   @override
@@ -12092,7 +12754,8 @@ class _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_
 class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data? _$v;
 
   MapBuilder<String, ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users>? _users;
@@ -12100,7 +12763,8 @@ class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Da
       _$this._users ??=
           MapBuilder<String, ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users>();
   set users(
-          MapBuilder<String, ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users>?
+          covariant MapBuilder<String,
+                  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data_Users>?
               users) =>
       _$this._users = users;
 
@@ -12116,7 +12780,7 @@ class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Da
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Data;
   }
@@ -12151,6 +12815,17 @@ class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_Da
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs
@@ -12210,17 +12885,18 @@ class _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs
 class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs,
-            ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+  set data(covariant ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
   ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder();
@@ -12236,7 +12912,7 @@ class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBui
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_Ocs;
   }
@@ -12271,6 +12947,14 @@ class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBui
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson
@@ -12321,13 +13005,15 @@ class _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson
 class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson,
-            ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonBuilder> {
+            ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonBuilder>,
+        ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson? _$v;
 
   ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonBuilder();
 
@@ -12341,7 +13027,7 @@ class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJson;
   }
@@ -12372,6 +13058,17 @@ class ProvisioningApiGroupsGetGroupUsersDetailsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ListBuilder<String> get data;
+  set data(ListBuilder<String>? data);
 }
 
 class _$ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs
@@ -12431,16 +13128,17 @@ class _$ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs
 class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs,
-            ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<String>? _data;
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
-  set data(ListBuilder<String>? data) => _$this._data = data;
+  set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
   ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder();
 
@@ -12455,7 +13153,7 @@ class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuil
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_Ocs;
   }
@@ -12490,6 +13188,14 @@ class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson
@@ -12540,13 +13246,15 @@ class _$ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson
 class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson,
-            ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonBuilder> {
+            ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonBuilder>,
+        ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson? _$v;
 
   ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonBuilder();
 
@@ -12560,7 +13268,7 @@ class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJson;
   }
@@ -12591,6 +13299,13 @@ class ProvisioningApiGroupsGetSubAdminsOfGroupResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<String> get users;
+  set users(ListBuilder<String>? users);
 }
 
 class _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data
@@ -12641,12 +13356,13 @@ class _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<String>? _users;
   ListBuilder<String> get users => _$this._users ??= ListBuilder<String>();
-  set users(ListBuilder<String>? users) => _$this._users = users;
+  set users(covariant ListBuilder<String>? users) => _$this._users = users;
 
   ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -12660,7 +13376,7 @@ class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_Data;
   }
@@ -12691,6 +13407,16 @@ class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs
@@ -12748,17 +13474,19 @@ class _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs
 class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs,
-            ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder();
 
@@ -12773,7 +13501,7 @@ class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson_Ocs;
   }
@@ -12807,6 +13535,13 @@ class ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsGetGroupResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiGroupsGetGroupResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiGroupsGetGroupResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson
@@ -12855,13 +13590,14 @@ class _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson
 class ProvisioningApiGroupsGetGroupResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiGroupsGetGroupResponse200ApplicationJson,
-            ProvisioningApiGroupsGetGroupResponse200ApplicationJsonBuilder> {
+            ProvisioningApiGroupsGetGroupResponse200ApplicationJsonBuilder>,
+        ProvisioningApiGroupsGetGroupResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson? _$v;
 
   ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiGroupsGetGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiGroupsGetGroupResponse200ApplicationJsonBuilder();
 
@@ -12875,7 +13611,7 @@ class ProvisioningApiGroupsGetGroupResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsGetGroupResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiGroupsGetGroupResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsGetGroupResponse200ApplicationJson;
   }
@@ -12906,6 +13642,16 @@ class ProvisioningApiGroupsGetGroupResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs
@@ -12965,16 +13711,17 @@ class _$ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs
 class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs,
-            ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder();
 
@@ -12989,7 +13736,7 @@ class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_Ocs;
   }
@@ -13024,6 +13771,13 @@ class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson
@@ -13072,13 +13826,14 @@ class _$ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson
 class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson,
-            ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonBuilder> {
+            ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonBuilder>,
+        ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson? _$v;
 
   ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonBuilder();
 
@@ -13092,7 +13847,7 @@ class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsUpdateGroupResponse200ApplicationJson;
   }
@@ -13123,6 +13878,16 @@ class ProvisioningApiGroupsUpdateGroupResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs
@@ -13182,16 +13947,17 @@ class _$ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs
 class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs,
-            ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder();
 
@@ -13206,7 +13972,7 @@ class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_Ocs;
   }
@@ -13241,6 +14007,13 @@ class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson
@@ -13289,13 +14062,14 @@ class _$ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson
 class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson,
-            ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonBuilder> {
+            ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonBuilder>,
+        ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson? _$v;
 
   ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonBuilder();
 
@@ -13309,7 +14083,7 @@ class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiGroupsDeleteGroupResponse200ApplicationJson;
   }
@@ -13340,6 +14114,17 @@ class ProvisioningApiGroupsDeleteGroupResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs
@@ -13399,16 +14184,17 @@ class _$ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs
 class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs,
-            ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder();
 
@@ -13423,7 +14209,7 @@ class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuild
   }
 
   @override
-  void replace(ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_Ocs;
   }
@@ -13458,6 +14244,13 @@ class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuild
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson
@@ -13508,13 +14301,15 @@ class _$ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson
 class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson,
-            ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonBuilder> {
+            ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonBuilder>,
+        ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson? _$v;
 
   ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonBuilder();
 
@@ -13528,7 +14323,7 @@ class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJson;
   }
@@ -13559,6 +14354,17 @@ class ProvisioningApiPreferencesSetPreferenceResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs
@@ -13618,16 +14424,17 @@ class _$ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs
 class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs,
-            ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder();
 
@@ -13642,7 +14449,7 @@ class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBu
   }
 
   @override
-  void replace(ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_Ocs;
   }
@@ -13677,6 +14484,14 @@ class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBu
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson
@@ -13727,13 +14542,15 @@ class _$ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson
 class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson,
-            ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonBuilder> {
+            ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonBuilder>,
+        ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson? _$v;
 
   ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonBuilder();
 
@@ -13747,7 +14564,7 @@ class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonBuilde
   }
 
   @override
-  void replace(ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJson;
   }
@@ -13778,6 +14595,18 @@ class ProvisioningApiPreferencesDeletePreferenceResponse200ApplicationJsonBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsInterfaceBuilder)
+          updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs
@@ -13842,16 +14671,17 @@ class _$ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJs
 class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs,
-            ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder();
 
@@ -13866,7 +14696,7 @@ class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson
   }
 
   @override
-  void replace(ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_Ocs;
   }
@@ -13904,6 +14734,15 @@ class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonInterfaceBuilder)
+          updates);
+  ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson
@@ -13955,13 +14794,14 @@ class _$ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJs
 class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson,
-            ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonBuilder> {
+            ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonBuilder>,
+        ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson? _$v;
 
   ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder? ocs) =>
+  set ocs(covariant ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson_OcsBuilder? ocs) =>
       _$this._ocs = ocs;
 
   ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJsonBuilder();
@@ -13976,7 +14816,7 @@ class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson
   }
 
   @override
-  void replace(ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson;
   }
@@ -14009,6 +14849,18 @@ class ProvisioningApiPreferencesSetMultiplePreferencesResponse200ApplicationJson
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsInterfaceBuilder)
+          updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs
@@ -14073,16 +14925,17 @@ class _$ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200Application
 class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs,
-            ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder();
 
@@ -14097,7 +14950,7 @@ class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJs
   }
 
   @override
-  void replace(ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_Ocs;
   }
@@ -14135,6 +14988,15 @@ class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJs
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonInterfaceBuilder)
+          updates);
+  ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson
@@ -14186,13 +15048,14 @@ class _$ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200Application
 class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson,
-            ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonBuilder> {
+            ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonBuilder>,
+        ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson? _$v;
 
   ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder? ocs) =>
+  set ocs(covariant ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson_OcsBuilder? ocs) =>
       _$this._ocs = ocs;
 
   ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJsonBuilder();
@@ -14207,7 +15070,7 @@ class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJs
   }
 
   @override
-  void replace(ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJson;
   }
@@ -14242,6 +15105,13 @@ class ProvisioningApiPreferencesDeleteMultiplePreferenceResponse200ApplicationJs
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<String> get users;
+  set users(ListBuilder<String>? users);
 }
 
 class _$ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data
@@ -14292,12 +15162,13 @@ class _$ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<String>? _users;
   ListBuilder<String> get users => _$this._users ??= ListBuilder<String>();
-  set users(ListBuilder<String>? users) => _$this._users = users;
+  set users(covariant ListBuilder<String>? users) => _$this._users = users;
 
   ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -14311,7 +15182,7 @@ class ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_Data;
   }
@@ -14342,6 +15213,16 @@ class ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs
@@ -14398,17 +15279,19 @@ class _$ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder();
 
@@ -14423,7 +15306,7 @@ class ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUsersResponse200ApplicationJson_Ocs;
   }
@@ -14457,6 +15340,13 @@ class ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUsersResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUsersResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersGetUsersResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersGetUsersResponse200ApplicationJson
@@ -14505,13 +15395,14 @@ class _$ProvisioningApiUsersGetUsersResponse200ApplicationJson
 class ProvisioningApiUsersGetUsersResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersGetUsersResponse200ApplicationJson,
-            ProvisioningApiUsersGetUsersResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersGetUsersResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersGetUsersResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersGetUsersResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersGetUsersResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersGetUsersResponse200ApplicationJsonBuilder();
 
@@ -14525,7 +15416,7 @@ class ProvisioningApiUsersGetUsersResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUsersResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersGetUsersResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUsersResponse200ApplicationJson;
   }
@@ -14556,6 +15447,13 @@ class ProvisioningApiUsersGetUsersResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(void Function(ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
 }
 
 class _$ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data
@@ -14605,12 +15503,13 @@ class _$ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -14624,7 +15523,7 @@ class ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_Data;
   }
@@ -14645,6 +15544,16 @@ class ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs
@@ -14701,17 +15610,19 @@ class _$ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder();
 
@@ -14726,7 +15637,7 @@ class ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersAddUserResponse200ApplicationJson_Ocs;
   }
@@ -14760,6 +15671,13 @@ class ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersAddUserResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersAddUserResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersAddUserResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersAddUserResponse200ApplicationJson
@@ -14808,13 +15726,14 @@ class _$ProvisioningApiUsersAddUserResponse200ApplicationJson
 class ProvisioningApiUsersAddUserResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersAddUserResponse200ApplicationJson,
-            ProvisioningApiUsersAddUserResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersAddUserResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersAddUserResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersAddUserResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersAddUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersAddUserResponse200ApplicationJsonBuilder();
 
@@ -14828,7 +15747,7 @@ class ProvisioningApiUsersAddUserResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersAddUserResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersAddUserResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersAddUserResponse200ApplicationJson;
   }
@@ -14859,6 +15778,15 @@ class ProvisioningApiUsersAddUserResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1InterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Interface other);
+  void update(
+      void Function(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1InterfaceBuilder)
+          updates);
+  String? get id;
+  set id(String? id);
 }
 
 class _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1
@@ -14913,12 +15841,13 @@ class _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_U
 class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Builder
     implements
         Builder<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1,
-            ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Builder> {
+            ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Builder>,
+        ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1InterfaceBuilder {
   _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1Builder();
 
@@ -14932,7 +15861,7 @@ class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Use
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1 other) {
+  void replace(covariant ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1 other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users1;
   }
@@ -15103,6 +16032,14 @@ class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Use
   }
 }
 
+abstract mixin class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  MapBuilder<String, ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users> get users;
+  set users(MapBuilder<String, ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users>? users);
+}
+
 class _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data
     extends ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data {
   @override
@@ -15151,14 +16088,17 @@ class _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data? _$v;
 
   MapBuilder<String, ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users>? _users;
   MapBuilder<String, ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users> get users =>
       _$this._users ??=
           MapBuilder<String, ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users>();
-  set users(MapBuilder<String, ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users>? users) =>
+  set users(
+          covariant MapBuilder<String, ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data_Users>?
+              users) =>
       _$this._users = users;
 
   ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder();
@@ -15173,7 +16113,7 @@ class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuil
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_Data;
   }
@@ -15205,6 +16145,16 @@ class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs
@@ -15264,17 +16214,19 @@ class _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder();
 
@@ -15289,7 +16241,7 @@ class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_Ocs;
   }
@@ -15323,6 +16275,13 @@ class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson
@@ -15372,13 +16331,14 @@ class _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson
 class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson,
-            ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonBuilder();
 
@@ -15392,7 +16352,7 @@ class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJson;
   }
@@ -15423,6 +16383,17 @@ class ProvisioningApiUsersGetUsersDetailsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  MapBuilder<String, String> get data;
+  set data(MapBuilder<String, String>? data);
 }
 
 class _$ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs
@@ -15482,16 +16453,17 @@ class _$ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   MapBuilder<String, String>? _data;
   MapBuilder<String, String> get data => _$this._data ??= MapBuilder<String, String>();
-  set data(MapBuilder<String, String>? data) => _$this._data = data;
+  set data(covariant MapBuilder<String, String>? data) => _$this._data = data;
 
   ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder();
 
@@ -15506,7 +16478,7 @@ class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuil
   }
 
   @override
-  void replace(ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_Ocs;
   }
@@ -15541,6 +16513,14 @@ class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson
@@ -15591,13 +16571,15 @@ class _$ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson
 class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson,
-            ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonBuilder();
 
@@ -15611,7 +16593,7 @@ class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJson;
   }
@@ -15642,6 +16624,16 @@ class ProvisioningApiUsersSearchByPhoneNumbersResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiUserDetailsBuilder get data;
+  set data(ProvisioningApiUserDetailsBuilder? data);
 }
 
 class _$ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs
@@ -15698,16 +16690,17 @@ class _$ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiUserDetailsBuilder? _data;
   ProvisioningApiUserDetailsBuilder get data => _$this._data ??= ProvisioningApiUserDetailsBuilder();
-  set data(ProvisioningApiUserDetailsBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiUserDetailsBuilder? data) => _$this._data = data;
 
   ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder();
 
@@ -15722,7 +16715,7 @@ class ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUserResponse200ApplicationJson_Ocs;
   }
@@ -15756,6 +16749,13 @@ class ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUserResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUserResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersGetUserResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersGetUserResponse200ApplicationJson
@@ -15804,13 +16804,14 @@ class _$ProvisioningApiUsersGetUserResponse200ApplicationJson
 class ProvisioningApiUsersGetUserResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersGetUserResponse200ApplicationJson,
-            ProvisioningApiUsersGetUserResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersGetUserResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersGetUserResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersGetUserResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersGetUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersGetUserResponse200ApplicationJsonBuilder();
 
@@ -15824,7 +16825,7 @@ class ProvisioningApiUsersGetUserResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUserResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersGetUserResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUserResponse200ApplicationJson;
   }
@@ -15855,6 +16856,16 @@ class ProvisioningApiUsersGetUserResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs
@@ -15911,16 +16922,17 @@ class _$ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder();
 
@@ -15935,7 +16947,7 @@ class ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersEditUserResponse200ApplicationJson_Ocs;
   }
@@ -15970,6 +16982,13 @@ class ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersEditUserResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersEditUserResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersEditUserResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersEditUserResponse200ApplicationJson
@@ -16018,13 +17037,14 @@ class _$ProvisioningApiUsersEditUserResponse200ApplicationJson
 class ProvisioningApiUsersEditUserResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersEditUserResponse200ApplicationJson,
-            ProvisioningApiUsersEditUserResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersEditUserResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersEditUserResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersEditUserResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersEditUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersEditUserResponse200ApplicationJsonBuilder();
 
@@ -16038,7 +17058,7 @@ class ProvisioningApiUsersEditUserResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersEditUserResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersEditUserResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersEditUserResponse200ApplicationJson;
   }
@@ -16069,6 +17089,16 @@ class ProvisioningApiUsersEditUserResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs
@@ -16128,16 +17158,17 @@ class _$ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder();
 
@@ -16152,7 +17183,7 @@ class ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersDeleteUserResponse200ApplicationJson_Ocs;
   }
@@ -16187,6 +17218,13 @@ class ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersDeleteUserResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersDeleteUserResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersDeleteUserResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersDeleteUserResponse200ApplicationJson
@@ -16235,13 +17273,14 @@ class _$ProvisioningApiUsersDeleteUserResponse200ApplicationJson
 class ProvisioningApiUsersDeleteUserResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersDeleteUserResponse200ApplicationJson,
-            ProvisioningApiUsersDeleteUserResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersDeleteUserResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersDeleteUserResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersDeleteUserResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersDeleteUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersDeleteUserResponse200ApplicationJsonBuilder();
 
@@ -16255,7 +17294,7 @@ class ProvisioningApiUsersDeleteUserResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersDeleteUserResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersDeleteUserResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersDeleteUserResponse200ApplicationJson;
   }
@@ -16286,6 +17325,16 @@ class ProvisioningApiUsersDeleteUserResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiUserDetailsBuilder get data;
+  set data(ProvisioningApiUserDetailsBuilder? data);
 }
 
 class _$ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs
@@ -16345,16 +17394,17 @@ class _$ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiUserDetailsBuilder? _data;
   ProvisioningApiUserDetailsBuilder get data => _$this._data ??= ProvisioningApiUserDetailsBuilder();
-  set data(ProvisioningApiUserDetailsBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiUserDetailsBuilder? data) => _$this._data = data;
 
   ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder();
 
@@ -16369,7 +17419,7 @@ class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_Ocs;
   }
@@ -16403,6 +17453,13 @@ class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson
@@ -16452,13 +17509,14 @@ class _$ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson
 class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson,
-            ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonBuilder();
 
@@ -16472,7 +17530,7 @@ class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetCurrentUserResponse200ApplicationJson;
   }
@@ -16503,6 +17561,17 @@ class ProvisioningApiUsersGetCurrentUserResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ListBuilder<String> get data;
+  set data(ListBuilder<String>? data);
 }
 
 class _$ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs
@@ -16562,16 +17631,17 @@ class _$ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<String>? _data;
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
-  set data(ListBuilder<String>? data) => _$this._data = data;
+  set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
   ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder();
 
@@ -16586,7 +17656,7 @@ class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_Ocs;
   }
@@ -16621,6 +17691,13 @@ class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson
@@ -16671,13 +17748,15 @@ class _$ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson
 class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson,
-            ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonBuilder();
 
@@ -16691,7 +17770,7 @@ class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJson;
   }
@@ -16722,6 +17801,18 @@ class ProvisioningApiUsersGetEditableFieldsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsInterfaceBuilder)
+          updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ListBuilder<String> get data;
+  set data(ListBuilder<String>? data);
 }
 
 class _$ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs
@@ -16783,16 +17874,17 @@ class _$ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_O
 class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<String>? _data;
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
-  set data(ListBuilder<String>? data) => _$this._data = data;
+  set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
   ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder();
 
@@ -16807,7 +17899,7 @@ class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs
   }
 
   @override
-  void replace(ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs;
   }
@@ -16843,6 +17935,14 @@ class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_Ocs
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson
@@ -16893,13 +17993,15 @@ class _$ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson
 class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson,
-            ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonBuilder();
 
@@ -16913,7 +18015,7 @@ class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonBuil
   }
 
   @override
-  void replace(ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJson;
   }
@@ -16944,6 +18046,17 @@ class ProvisioningApiUsersGetEditableFieldsForUserResponse200ApplicationJsonBuil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs
@@ -17003,16 +18116,17 @@ class _$ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder();
 
@@ -17027,7 +18141,7 @@ class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilde
   }
 
   @override
-  void replace(ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_Ocs;
   }
@@ -17062,6 +18176,13 @@ class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson
@@ -17112,13 +18233,15 @@ class _$ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson
 class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson,
-            ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonBuilder();
 
@@ -17132,7 +18255,7 @@ class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJson;
   }
@@ -17163,6 +18286,16 @@ class ProvisioningApiUsersEditUserMultiValueResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs
@@ -17222,16 +18355,17 @@ class _$ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder();
 
@@ -17246,7 +18380,7 @@ class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_Ocs;
   }
@@ -17281,6 +18415,13 @@ class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson
@@ -17330,13 +18471,14 @@ class _$ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson
 class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson,
-            ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonBuilder();
 
@@ -17350,7 +18492,7 @@ class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJson;
   }
@@ -17381,6 +18523,16 @@ class ProvisioningApiUsersWipeUserDevicesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs
@@ -17440,16 +18592,17 @@ class _$ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder();
 
@@ -17464,7 +18617,7 @@ class ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersEnableUserResponse200ApplicationJson_Ocs;
   }
@@ -17499,6 +18652,13 @@ class ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersEnableUserResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersEnableUserResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersEnableUserResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersEnableUserResponse200ApplicationJson
@@ -17547,13 +18707,14 @@ class _$ProvisioningApiUsersEnableUserResponse200ApplicationJson
 class ProvisioningApiUsersEnableUserResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersEnableUserResponse200ApplicationJson,
-            ProvisioningApiUsersEnableUserResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersEnableUserResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersEnableUserResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersEnableUserResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersEnableUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersEnableUserResponse200ApplicationJsonBuilder();
 
@@ -17567,7 +18728,7 @@ class ProvisioningApiUsersEnableUserResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersEnableUserResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersEnableUserResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersEnableUserResponse200ApplicationJson;
   }
@@ -17598,6 +18759,16 @@ class ProvisioningApiUsersEnableUserResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs
@@ -17657,16 +18828,17 @@ class _$ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder();
 
@@ -17681,7 +18853,7 @@ class ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersDisableUserResponse200ApplicationJson_Ocs;
   }
@@ -17716,6 +18888,13 @@ class ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersDisableUserResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersDisableUserResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersDisableUserResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersDisableUserResponse200ApplicationJson
@@ -17764,13 +18943,14 @@ class _$ProvisioningApiUsersDisableUserResponse200ApplicationJson
 class ProvisioningApiUsersDisableUserResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersDisableUserResponse200ApplicationJson,
-            ProvisioningApiUsersDisableUserResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersDisableUserResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersDisableUserResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersDisableUserResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersDisableUserResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersDisableUserResponse200ApplicationJsonBuilder();
 
@@ -17784,7 +18964,7 @@ class ProvisioningApiUsersDisableUserResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersDisableUserResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersDisableUserResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersDisableUserResponse200ApplicationJson;
   }
@@ -17815,6 +18995,14 @@ class ProvisioningApiUsersDisableUserResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<String> get groups;
+  set groups(ListBuilder<String>? groups);
 }
 
 class _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data
@@ -17865,12 +19053,13 @@ class _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data
 class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data,
-            ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder> {
+            ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder>,
+        ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<String>? _groups;
   ListBuilder<String> get groups => _$this._groups ??= ListBuilder<String>();
-  set groups(ListBuilder<String>? groups) => _$this._groups = groups;
+  set groups(covariant ListBuilder<String>? groups) => _$this._groups = groups;
 
   ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -17884,7 +19073,7 @@ class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuild
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_Data;
   }
@@ -17916,6 +19105,16 @@ class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuild
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs
@@ -17975,17 +19174,19 @@ class _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder? _data;
   ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder();
 
@@ -18000,7 +19201,7 @@ class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_Ocs;
   }
@@ -18034,6 +19235,13 @@ class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson
@@ -18083,13 +19291,14 @@ class _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson
 class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson,
-            ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonBuilder();
 
@@ -18103,7 +19312,7 @@ class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJson;
   }
@@ -18134,6 +19343,16 @@ class ProvisioningApiUsersGetUsersGroupsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs
@@ -18193,16 +19412,17 @@ class _$ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder();
 
@@ -18217,7 +19437,7 @@ class ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersAddToGroupResponse200ApplicationJson_Ocs;
   }
@@ -18252,6 +19472,13 @@ class ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersAddToGroupResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersAddToGroupResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersAddToGroupResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersAddToGroupResponse200ApplicationJson
@@ -18300,13 +19527,14 @@ class _$ProvisioningApiUsersAddToGroupResponse200ApplicationJson
 class ProvisioningApiUsersAddToGroupResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersAddToGroupResponse200ApplicationJson,
-            ProvisioningApiUsersAddToGroupResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersAddToGroupResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersAddToGroupResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersAddToGroupResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersAddToGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersAddToGroupResponse200ApplicationJsonBuilder();
 
@@ -18320,7 +19548,7 @@ class ProvisioningApiUsersAddToGroupResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersAddToGroupResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersAddToGroupResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersAddToGroupResponse200ApplicationJson;
   }
@@ -18351,6 +19579,16 @@ class ProvisioningApiUsersAddToGroupResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs
@@ -18410,16 +19648,17 @@ class _$ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder();
 
@@ -18434,7 +19673,7 @@ class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_Ocs;
   }
@@ -18469,6 +19708,13 @@ class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson
@@ -18518,13 +19764,14 @@ class _$ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson
 class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson,
-            ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonBuilder();
 
@@ -18538,7 +19785,7 @@ class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJson;
   }
@@ -18569,6 +19816,17 @@ class ProvisioningApiUsersRemoveFromGroupResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  ListBuilder<String> get data;
+  set data(ListBuilder<String>? data);
 }
 
 class _$ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs
@@ -18628,16 +19886,17 @@ class _$ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<String>? _data;
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
-  set data(ListBuilder<String>? data) => _$this._data = data;
+  set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
   ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder();
 
@@ -18652,7 +19911,7 @@ class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBui
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_Ocs;
   }
@@ -18687,6 +19946,14 @@ class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBui
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson
@@ -18737,13 +20004,15 @@ class _$ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson
 class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson,
-            ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonBuilder();
 
@@ -18757,7 +20026,7 @@ class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJson;
   }
@@ -18788,6 +20057,16 @@ class ProvisioningApiUsersGetUserSubAdminGroupsResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs
@@ -18847,16 +20126,17 @@ class _$ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder();
 
@@ -18871,7 +20151,7 @@ class ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_Ocs;
   }
@@ -18906,6 +20186,13 @@ class ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersAddSubAdminResponse200ApplicationJson
@@ -18954,13 +20241,14 @@ class _$ProvisioningApiUsersAddSubAdminResponse200ApplicationJson
 class ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersAddSubAdminResponse200ApplicationJson,
-            ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersAddSubAdminResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersAddSubAdminResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonBuilder();
 
@@ -18974,7 +20262,7 @@ class ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersAddSubAdminResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersAddSubAdminResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersAddSubAdminResponse200ApplicationJson;
   }
@@ -19005,6 +20293,16 @@ class ProvisioningApiUsersAddSubAdminResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs
@@ -19064,16 +20362,17 @@ class _$ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder();
 
@@ -19088,7 +20387,7 @@ class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_Ocs;
   }
@@ -19123,6 +20422,13 @@ class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonInterface other);
+  void update(void Function(ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson
@@ -19172,13 +20478,14 @@ class _$ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson
 class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson,
-            ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonBuilder();
 
@@ -19192,7 +20499,7 @@ class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJson;
   }
@@ -19223,6 +20530,17 @@ class ProvisioningApiUsersRemoveSubAdminResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ProvisioningApiOCSMetaBuilder get meta;
+  set meta(ProvisioningApiOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs
@@ -19282,16 +20600,17 @@ class _$ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs
 class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs,
-            ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder> {
+            ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder>,
+        ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs? _$v;
 
   ProvisioningApiOCSMetaBuilder? _meta;
   ProvisioningApiOCSMetaBuilder get meta => _$this._meta ??= ProvisioningApiOCSMetaBuilder();
-  set meta(ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ProvisioningApiOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder();
 
@@ -19306,7 +20625,7 @@ class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuil
   }
 
   @override
-  void replace(ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_Ocs;
   }
@@ -19341,6 +20660,14 @@ class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonInterfaceBuilder) updates);
+  ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson
@@ -19391,13 +20718,15 @@ class _$ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson
 class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonBuilder
     implements
         Builder<ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson,
-            ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonBuilder> {
+            ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonBuilder>,
+        ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonInterfaceBuilder {
   _$ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson? _$v;
 
   ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder? _ocs;
   ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder();
-  set ocs(ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonBuilder();
 
@@ -19411,7 +20740,7 @@ class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson other) {
+  void replace(covariant ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJson;
   }
@@ -19442,6 +20771,22 @@ class ProvisioningApiUsersResendWelcomeMessageResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder {
+  void replace(ProvisioningApiCapabilities_ProvisioningApiInterface other);
+  void update(void Function(ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder) updates);
+  String? get version;
+  set version(String? version);
+
+  int? get accountPropertyScopesVersion;
+  set accountPropertyScopesVersion(int? accountPropertyScopesVersion);
+
+  bool? get accountPropertyScopesFederatedEnabled;
+  set accountPropertyScopesFederatedEnabled(bool? accountPropertyScopesFederatedEnabled);
+
+  bool? get accountPropertyScopesPublishedEnabled;
+  set accountPropertyScopesPublishedEnabled(bool? accountPropertyScopesPublishedEnabled);
 }
 
 class _$ProvisioningApiCapabilities_ProvisioningApi extends ProvisioningApiCapabilities_ProvisioningApi {
@@ -19516,26 +20861,27 @@ class _$ProvisioningApiCapabilities_ProvisioningApi extends ProvisioningApiCapab
 
 class ProvisioningApiCapabilities_ProvisioningApiBuilder
     implements
-        Builder<ProvisioningApiCapabilities_ProvisioningApi, ProvisioningApiCapabilities_ProvisioningApiBuilder> {
+        Builder<ProvisioningApiCapabilities_ProvisioningApi, ProvisioningApiCapabilities_ProvisioningApiBuilder>,
+        ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder {
   _$ProvisioningApiCapabilities_ProvisioningApi? _$v;
 
   String? _version;
   String? get version => _$this._version;
-  set version(String? version) => _$this._version = version;
+  set version(covariant String? version) => _$this._version = version;
 
   int? _accountPropertyScopesVersion;
   int? get accountPropertyScopesVersion => _$this._accountPropertyScopesVersion;
-  set accountPropertyScopesVersion(int? accountPropertyScopesVersion) =>
+  set accountPropertyScopesVersion(covariant int? accountPropertyScopesVersion) =>
       _$this._accountPropertyScopesVersion = accountPropertyScopesVersion;
 
   bool? _accountPropertyScopesFederatedEnabled;
   bool? get accountPropertyScopesFederatedEnabled => _$this._accountPropertyScopesFederatedEnabled;
-  set accountPropertyScopesFederatedEnabled(bool? accountPropertyScopesFederatedEnabled) =>
+  set accountPropertyScopesFederatedEnabled(covariant bool? accountPropertyScopesFederatedEnabled) =>
       _$this._accountPropertyScopesFederatedEnabled = accountPropertyScopesFederatedEnabled;
 
   bool? _accountPropertyScopesPublishedEnabled;
   bool? get accountPropertyScopesPublishedEnabled => _$this._accountPropertyScopesPublishedEnabled;
-  set accountPropertyScopesPublishedEnabled(bool? accountPropertyScopesPublishedEnabled) =>
+  set accountPropertyScopesPublishedEnabled(covariant bool? accountPropertyScopesPublishedEnabled) =>
       _$this._accountPropertyScopesPublishedEnabled = accountPropertyScopesPublishedEnabled;
 
   ProvisioningApiCapabilities_ProvisioningApiBuilder();
@@ -19553,7 +20899,7 @@ class ProvisioningApiCapabilities_ProvisioningApiBuilder
   }
 
   @override
-  void replace(ProvisioningApiCapabilities_ProvisioningApi other) {
+  void replace(covariant ProvisioningApiCapabilities_ProvisioningApi other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiCapabilities_ProvisioningApi;
   }
@@ -19584,6 +20930,13 @@ class ProvisioningApiCapabilities_ProvisioningApiBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ProvisioningApiCapabilitiesInterfaceBuilder {
+  void replace(ProvisioningApiCapabilitiesInterface other);
+  void update(void Function(ProvisioningApiCapabilitiesInterfaceBuilder) updates);
+  ProvisioningApiCapabilities_ProvisioningApiBuilder get provisioningApi;
+  set provisioningApi(ProvisioningApiCapabilities_ProvisioningApiBuilder? provisioningApi);
 }
 
 class _$ProvisioningApiCapabilities extends ProvisioningApiCapabilities {
@@ -19626,13 +20979,15 @@ class _$ProvisioningApiCapabilities extends ProvisioningApiCapabilities {
 }
 
 class ProvisioningApiCapabilitiesBuilder
-    implements Builder<ProvisioningApiCapabilities, ProvisioningApiCapabilitiesBuilder> {
+    implements
+        Builder<ProvisioningApiCapabilities, ProvisioningApiCapabilitiesBuilder>,
+        ProvisioningApiCapabilitiesInterfaceBuilder {
   _$ProvisioningApiCapabilities? _$v;
 
   ProvisioningApiCapabilities_ProvisioningApiBuilder? _provisioningApi;
   ProvisioningApiCapabilities_ProvisioningApiBuilder get provisioningApi =>
       _$this._provisioningApi ??= ProvisioningApiCapabilities_ProvisioningApiBuilder();
-  set provisioningApi(ProvisioningApiCapabilities_ProvisioningApiBuilder? provisioningApi) =>
+  set provisioningApi(covariant ProvisioningApiCapabilities_ProvisioningApiBuilder? provisioningApi) =>
       _$this._provisioningApi = provisioningApi;
 
   ProvisioningApiCapabilitiesBuilder();
@@ -19647,7 +21002,7 @@ class ProvisioningApiCapabilitiesBuilder
   }
 
   @override
-  void replace(ProvisioningApiCapabilities other) {
+  void replace(covariant ProvisioningApiCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ProvisioningApiCapabilities;
   }

--- a/packages/nextcloud/lib/src/api/settings.openapi.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.dart
@@ -118,8 +118,19 @@ class SettingsLogSettingsClient {
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class SettingsLogSettingsLogSettingsDownloadHeadersInterface {
+  @BuiltValueField(wireName: 'content-disposition')
+  String? get contentDisposition;
+  SettingsLogSettingsLogSettingsDownloadHeadersInterface rebuild(
+    final void Function(SettingsLogSettingsLogSettingsDownloadHeadersInterfaceBuilder) updates,
+  );
+  SettingsLogSettingsLogSettingsDownloadHeadersInterfaceBuilder toBuilder();
+}
+
 abstract class SettingsLogSettingsLogSettingsDownloadHeaders
     implements
+        SettingsLogSettingsLogSettingsDownloadHeadersInterface,
         Built<SettingsLogSettingsLogSettingsDownloadHeaders, SettingsLogSettingsLogSettingsDownloadHeadersBuilder> {
   factory SettingsLogSettingsLogSettingsDownloadHeaders([
     final void Function(SettingsLogSettingsLogSettingsDownloadHeadersBuilder)? b,
@@ -137,8 +148,6 @@ abstract class SettingsLogSettingsLogSettingsDownloadHeaders
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'content-disposition')
-  String? get contentDisposition;
   @BuiltValueSerializer(custom: true)
   static Serializer<SettingsLogSettingsLogSettingsDownloadHeaders> get serializer =>
       _$SettingsLogSettingsLogSettingsDownloadHeadersSerializer();

--- a/packages/nextcloud/lib/src/api/settings.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.g.dart
@@ -6,6 +6,13 @@ part of 'settings.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+abstract mixin class SettingsLogSettingsLogSettingsDownloadHeadersInterfaceBuilder {
+  void replace(SettingsLogSettingsLogSettingsDownloadHeadersInterface other);
+  void update(void Function(SettingsLogSettingsLogSettingsDownloadHeadersInterfaceBuilder) updates);
+  String? get contentDisposition;
+  set contentDisposition(String? contentDisposition);
+}
+
 class _$SettingsLogSettingsLogSettingsDownloadHeaders extends SettingsLogSettingsLogSettingsDownloadHeaders {
   @override
   final String? contentDisposition;
@@ -49,12 +56,13 @@ class _$SettingsLogSettingsLogSettingsDownloadHeaders extends SettingsLogSetting
 
 class SettingsLogSettingsLogSettingsDownloadHeadersBuilder
     implements
-        Builder<SettingsLogSettingsLogSettingsDownloadHeaders, SettingsLogSettingsLogSettingsDownloadHeadersBuilder> {
+        Builder<SettingsLogSettingsLogSettingsDownloadHeaders, SettingsLogSettingsLogSettingsDownloadHeadersBuilder>,
+        SettingsLogSettingsLogSettingsDownloadHeadersInterfaceBuilder {
   _$SettingsLogSettingsLogSettingsDownloadHeaders? _$v;
 
   String? _contentDisposition;
   String? get contentDisposition => _$this._contentDisposition;
-  set contentDisposition(String? contentDisposition) => _$this._contentDisposition = contentDisposition;
+  set contentDisposition(covariant String? contentDisposition) => _$this._contentDisposition = contentDisposition;
 
   SettingsLogSettingsLogSettingsDownloadHeadersBuilder();
 
@@ -68,7 +76,7 @@ class SettingsLogSettingsLogSettingsDownloadHeadersBuilder
   }
 
   @override
-  void replace(SettingsLogSettingsLogSettingsDownloadHeaders other) {
+  void replace(covariant SettingsLogSettingsLogSettingsDownloadHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$SettingsLogSettingsLogSettingsDownloadHeaders;
   }

--- a/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
+++ b/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
@@ -68,8 +68,18 @@ class SharebymailClient extends DynamiteClient {
         );
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterface {
+  bool get enabled;
+  SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterface rebuild(
+    final void Function(SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder) updates,
+  );
+  SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder toBuilder();
+}
+
 abstract class SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop
     implements
+        SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterface,
         Built<SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop,
             SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder> {
   factory SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop([
@@ -88,13 +98,23 @@ abstract class SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop> get serializer =>
       _$sharebymailCapabilitiesFilesSharingSharebymailUploadFilesDropSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class SharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterface {
+  bool get enabled;
+  bool get enforced;
+  SharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterface rebuild(
+    final void Function(SharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterfaceBuilder) updates,
+  );
+  SharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterfaceBuilder toBuilder();
+}
+
 abstract class SharebymailCapabilities_FilesSharing_Sharebymail_Password
     implements
+        SharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterface,
         Built<SharebymailCapabilities_FilesSharing_Sharebymail_Password,
             SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder> {
   factory SharebymailCapabilities_FilesSharing_Sharebymail_Password([
@@ -113,14 +133,23 @@ abstract class SharebymailCapabilities_FilesSharing_Sharebymail_Password
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  bool get enforced;
   static Serializer<SharebymailCapabilities_FilesSharing_Sharebymail_Password> get serializer =>
       _$sharebymailCapabilitiesFilesSharingSharebymailPasswordSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterface {
+  bool get enabled;
+  bool get enforced;
+  SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterface rebuild(
+    final void Function(SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder) updates,
+  );
+  SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder toBuilder();
+}
+
 abstract class SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate
     implements
+        SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterface,
         Built<SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate,
             SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder> {
   factory SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate([
@@ -139,14 +168,29 @@ abstract class SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  bool get enforced;
   static Serializer<SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate> get serializer =>
       _$sharebymailCapabilitiesFilesSharingSharebymailExpireDateSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class SharebymailCapabilities_FilesSharing_SharebymailInterface {
+  bool get enabled;
+  @BuiltValueField(wireName: 'send_password_by_mail')
+  bool get sendPasswordByMail;
+  @BuiltValueField(wireName: 'upload_files_drop')
+  SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop get uploadFilesDrop;
+  SharebymailCapabilities_FilesSharing_Sharebymail_Password get password;
+  @BuiltValueField(wireName: 'expire_date')
+  SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate get expireDate;
+  SharebymailCapabilities_FilesSharing_SharebymailInterface rebuild(
+    final void Function(SharebymailCapabilities_FilesSharing_SharebymailInterfaceBuilder) updates,
+  );
+  SharebymailCapabilities_FilesSharing_SharebymailInterfaceBuilder toBuilder();
+}
+
 abstract class SharebymailCapabilities_FilesSharing_Sharebymail
     implements
+        SharebymailCapabilities_FilesSharing_SharebymailInterface,
         Built<SharebymailCapabilities_FilesSharing_Sharebymail,
             SharebymailCapabilities_FilesSharing_SharebymailBuilder> {
   factory SharebymailCapabilities_FilesSharing_Sharebymail([
@@ -165,20 +209,23 @@ abstract class SharebymailCapabilities_FilesSharing_Sharebymail
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  @BuiltValueField(wireName: 'send_password_by_mail')
-  bool get sendPasswordByMail;
-  @BuiltValueField(wireName: 'upload_files_drop')
-  SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop get uploadFilesDrop;
-  SharebymailCapabilities_FilesSharing_Sharebymail_Password get password;
-  @BuiltValueField(wireName: 'expire_date')
-  SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate get expireDate;
   static Serializer<SharebymailCapabilities_FilesSharing_Sharebymail> get serializer =>
       _$sharebymailCapabilitiesFilesSharingSharebymailSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class SharebymailCapabilities_FilesSharingInterface {
+  SharebymailCapabilities_FilesSharing_Sharebymail get sharebymail;
+  SharebymailCapabilities_FilesSharingInterface rebuild(
+    final void Function(SharebymailCapabilities_FilesSharingInterfaceBuilder) updates,
+  );
+  SharebymailCapabilities_FilesSharingInterfaceBuilder toBuilder();
+}
+
 abstract class SharebymailCapabilities_FilesSharing
-    implements Built<SharebymailCapabilities_FilesSharing, SharebymailCapabilities_FilesSharingBuilder> {
+    implements
+        SharebymailCapabilities_FilesSharingInterface,
+        Built<SharebymailCapabilities_FilesSharing, SharebymailCapabilities_FilesSharingBuilder> {
   factory SharebymailCapabilities_FilesSharing([final void Function(SharebymailCapabilities_FilesSharingBuilder)? b]) =
       _$SharebymailCapabilities_FilesSharing;
 
@@ -194,12 +241,20 @@ abstract class SharebymailCapabilities_FilesSharing
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  SharebymailCapabilities_FilesSharing_Sharebymail get sharebymail;
   static Serializer<SharebymailCapabilities_FilesSharing> get serializer =>
       _$sharebymailCapabilitiesFilesSharingSerializer;
 }
 
-abstract class SharebymailCapabilities implements Built<SharebymailCapabilities, SharebymailCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class SharebymailCapabilitiesInterface {
+  @BuiltValueField(wireName: 'files_sharing')
+  SharebymailCapabilities_FilesSharing get filesSharing;
+  SharebymailCapabilitiesInterface rebuild(final void Function(SharebymailCapabilitiesInterfaceBuilder) updates);
+  SharebymailCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class SharebymailCapabilities
+    implements SharebymailCapabilitiesInterface, Built<SharebymailCapabilities, SharebymailCapabilitiesBuilder> {
   factory SharebymailCapabilities([final void Function(SharebymailCapabilitiesBuilder)? b]) = _$SharebymailCapabilities;
 
   // coverage:ignore-start
@@ -214,8 +269,6 @@ abstract class SharebymailCapabilities implements Built<SharebymailCapabilities,
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'files_sharing')
-  SharebymailCapabilities_FilesSharing get filesSharing;
   static Serializer<SharebymailCapabilities> get serializer => _$sharebymailCapabilitiesSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/sharebymail.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/sharebymail.openapi.g.dart
@@ -316,6 +316,13 @@ class _$SharebymailCapabilitiesSerializer implements StructuredSerializer<Shareb
   }
 }
 
+abstract mixin class SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder {
+  void replace(SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterface other);
+  void update(void Function(SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+}
+
 class _$SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop
     extends SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop {
   @override
@@ -364,12 +371,13 @@ class _$SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop
 class SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder
     implements
         Builder<SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop,
-            SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder> {
+            SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder>,
+        SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder {
   _$SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder();
 
@@ -383,7 +391,7 @@ class SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder
   }
 
   @override
-  void replace(SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop other) {
+  void replace(covariant SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDrop;
   }
@@ -404,6 +412,16 @@ class SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class SharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterfaceBuilder {
+  void replace(SharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterface other);
+  void update(void Function(SharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  bool? get enforced;
+  set enforced(bool? enforced);
 }
 
 class _$SharebymailCapabilities_FilesSharing_Sharebymail_Password
@@ -463,16 +481,17 @@ class _$SharebymailCapabilities_FilesSharing_Sharebymail_Password
 class SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder
     implements
         Builder<SharebymailCapabilities_FilesSharing_Sharebymail_Password,
-            SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder> {
+            SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder>,
+        SharebymailCapabilities_FilesSharing_Sharebymail_PasswordInterfaceBuilder {
   _$SharebymailCapabilities_FilesSharing_Sharebymail_Password? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder();
 
@@ -487,7 +506,7 @@ class SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder
   }
 
   @override
-  void replace(SharebymailCapabilities_FilesSharing_Sharebymail_Password other) {
+  void replace(covariant SharebymailCapabilities_FilesSharing_Sharebymail_Password other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$SharebymailCapabilities_FilesSharing_Sharebymail_Password;
   }
@@ -510,6 +529,16 @@ class SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder {
+  void replace(SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterface other);
+  void update(void Function(SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  bool? get enforced;
+  set enforced(bool? enforced);
 }
 
 class _$SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate
@@ -569,16 +598,17 @@ class _$SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate
 class SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder
     implements
         Builder<SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate,
-            SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder> {
+            SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder>,
+        SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder {
   _$SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   bool? _enforced;
   bool? get enforced => _$this._enforced;
-  set enforced(bool? enforced) => _$this._enforced = enforced;
+  set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
   SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder();
 
@@ -593,7 +623,7 @@ class SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder
   }
 
   @override
-  void replace(SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate other) {
+  void replace(covariant SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDate;
   }
@@ -616,6 +646,25 @@ class SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class SharebymailCapabilities_FilesSharing_SharebymailInterfaceBuilder {
+  void replace(SharebymailCapabilities_FilesSharing_SharebymailInterface other);
+  void update(void Function(SharebymailCapabilities_FilesSharing_SharebymailInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  bool? get sendPasswordByMail;
+  set sendPasswordByMail(bool? sendPasswordByMail);
+
+  SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder get uploadFilesDrop;
+  set uploadFilesDrop(SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder? uploadFilesDrop);
+
+  SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder get password;
+  set password(SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder? password);
+
+  SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder get expireDate;
+  set expireDate(SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder? expireDate);
 }
 
 class _$SharebymailCapabilities_FilesSharing_Sharebymail extends SharebymailCapabilities_FilesSharing_Sharebymail {
@@ -698,33 +747,35 @@ class _$SharebymailCapabilities_FilesSharing_Sharebymail extends SharebymailCapa
 class SharebymailCapabilities_FilesSharing_SharebymailBuilder
     implements
         Builder<SharebymailCapabilities_FilesSharing_Sharebymail,
-            SharebymailCapabilities_FilesSharing_SharebymailBuilder> {
+            SharebymailCapabilities_FilesSharing_SharebymailBuilder>,
+        SharebymailCapabilities_FilesSharing_SharebymailInterfaceBuilder {
   _$SharebymailCapabilities_FilesSharing_Sharebymail? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   bool? _sendPasswordByMail;
   bool? get sendPasswordByMail => _$this._sendPasswordByMail;
-  set sendPasswordByMail(bool? sendPasswordByMail) => _$this._sendPasswordByMail = sendPasswordByMail;
+  set sendPasswordByMail(covariant bool? sendPasswordByMail) => _$this._sendPasswordByMail = sendPasswordByMail;
 
   SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder? _uploadFilesDrop;
   SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder get uploadFilesDrop =>
       _$this._uploadFilesDrop ??= SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder();
-  set uploadFilesDrop(SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder? uploadFilesDrop) =>
+  set uploadFilesDrop(
+          covariant SharebymailCapabilities_FilesSharing_Sharebymail_UploadFilesDropBuilder? uploadFilesDrop) =>
       _$this._uploadFilesDrop = uploadFilesDrop;
 
   SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder? _password;
   SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder get password =>
       _$this._password ??= SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder();
-  set password(SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder? password) =>
+  set password(covariant SharebymailCapabilities_FilesSharing_Sharebymail_PasswordBuilder? password) =>
       _$this._password = password;
 
   SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder? _expireDate;
   SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder get expireDate =>
       _$this._expireDate ??= SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder();
-  set expireDate(SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder? expireDate) =>
+  set expireDate(covariant SharebymailCapabilities_FilesSharing_Sharebymail_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
   SharebymailCapabilities_FilesSharing_SharebymailBuilder();
@@ -743,7 +794,7 @@ class SharebymailCapabilities_FilesSharing_SharebymailBuilder
   }
 
   @override
-  void replace(SharebymailCapabilities_FilesSharing_Sharebymail other) {
+  void replace(covariant SharebymailCapabilities_FilesSharing_Sharebymail other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$SharebymailCapabilities_FilesSharing_Sharebymail;
   }
@@ -788,6 +839,13 @@ class SharebymailCapabilities_FilesSharing_SharebymailBuilder
   }
 }
 
+abstract mixin class SharebymailCapabilities_FilesSharingInterfaceBuilder {
+  void replace(SharebymailCapabilities_FilesSharingInterface other);
+  void update(void Function(SharebymailCapabilities_FilesSharingInterfaceBuilder) updates);
+  SharebymailCapabilities_FilesSharing_SharebymailBuilder get sharebymail;
+  set sharebymail(SharebymailCapabilities_FilesSharing_SharebymailBuilder? sharebymail);
+}
+
 class _$SharebymailCapabilities_FilesSharing extends SharebymailCapabilities_FilesSharing {
   @override
   final SharebymailCapabilities_FilesSharing_Sharebymail sharebymail;
@@ -830,13 +888,15 @@ class _$SharebymailCapabilities_FilesSharing extends SharebymailCapabilities_Fil
 }
 
 class SharebymailCapabilities_FilesSharingBuilder
-    implements Builder<SharebymailCapabilities_FilesSharing, SharebymailCapabilities_FilesSharingBuilder> {
+    implements
+        Builder<SharebymailCapabilities_FilesSharing, SharebymailCapabilities_FilesSharingBuilder>,
+        SharebymailCapabilities_FilesSharingInterfaceBuilder {
   _$SharebymailCapabilities_FilesSharing? _$v;
 
   SharebymailCapabilities_FilesSharing_SharebymailBuilder? _sharebymail;
   SharebymailCapabilities_FilesSharing_SharebymailBuilder get sharebymail =>
       _$this._sharebymail ??= SharebymailCapabilities_FilesSharing_SharebymailBuilder();
-  set sharebymail(SharebymailCapabilities_FilesSharing_SharebymailBuilder? sharebymail) =>
+  set sharebymail(covariant SharebymailCapabilities_FilesSharing_SharebymailBuilder? sharebymail) =>
       _$this._sharebymail = sharebymail;
 
   SharebymailCapabilities_FilesSharingBuilder();
@@ -851,7 +911,7 @@ class SharebymailCapabilities_FilesSharingBuilder
   }
 
   @override
-  void replace(SharebymailCapabilities_FilesSharing other) {
+  void replace(covariant SharebymailCapabilities_FilesSharing other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$SharebymailCapabilities_FilesSharing;
   }
@@ -881,6 +941,13 @@ class SharebymailCapabilities_FilesSharingBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class SharebymailCapabilitiesInterfaceBuilder {
+  void replace(SharebymailCapabilitiesInterface other);
+  void update(void Function(SharebymailCapabilitiesInterfaceBuilder) updates);
+  SharebymailCapabilities_FilesSharingBuilder get filesSharing;
+  set filesSharing(SharebymailCapabilities_FilesSharingBuilder? filesSharing);
 }
 
 class _$SharebymailCapabilities extends SharebymailCapabilities {
@@ -921,13 +988,17 @@ class _$SharebymailCapabilities extends SharebymailCapabilities {
   }
 }
 
-class SharebymailCapabilitiesBuilder implements Builder<SharebymailCapabilities, SharebymailCapabilitiesBuilder> {
+class SharebymailCapabilitiesBuilder
+    implements
+        Builder<SharebymailCapabilities, SharebymailCapabilitiesBuilder>,
+        SharebymailCapabilitiesInterfaceBuilder {
   _$SharebymailCapabilities? _$v;
 
   SharebymailCapabilities_FilesSharingBuilder? _filesSharing;
   SharebymailCapabilities_FilesSharingBuilder get filesSharing =>
       _$this._filesSharing ??= SharebymailCapabilities_FilesSharingBuilder();
-  set filesSharing(SharebymailCapabilities_FilesSharingBuilder? filesSharing) => _$this._filesSharing = filesSharing;
+  set filesSharing(covariant SharebymailCapabilities_FilesSharingBuilder? filesSharing) =>
+      _$this._filesSharing = filesSharing;
 
   SharebymailCapabilitiesBuilder();
 
@@ -941,7 +1012,7 @@ class SharebymailCapabilitiesBuilder implements Builder<SharebymailCapabilities,
   }
 
   @override
-  void replace(SharebymailCapabilities other) {
+  void replace(covariant SharebymailCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$SharebymailCapabilities;
   }

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -511,8 +511,20 @@ class ThemingUserThemeClient {
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ThemingThemingGetManifestResponse200ApplicationJson_IconsInterface {
+  String get src;
+  String get type;
+  String get sizes;
+  ThemingThemingGetManifestResponse200ApplicationJson_IconsInterface rebuild(
+    final void Function(ThemingThemingGetManifestResponse200ApplicationJson_IconsInterfaceBuilder) updates,
+  );
+  ThemingThemingGetManifestResponse200ApplicationJson_IconsInterfaceBuilder toBuilder();
+}
+
 abstract class ThemingThemingGetManifestResponse200ApplicationJson_Icons
     implements
+        ThemingThemingGetManifestResponse200ApplicationJson_IconsInterface,
         Built<ThemingThemingGetManifestResponse200ApplicationJson_Icons,
             ThemingThemingGetManifestResponse200ApplicationJson_IconsBuilder> {
   factory ThemingThemingGetManifestResponse200ApplicationJson_Icons([
@@ -531,15 +543,33 @@ abstract class ThemingThemingGetManifestResponse200ApplicationJson_Icons
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get src;
-  String get type;
-  String get sizes;
   static Serializer<ThemingThemingGetManifestResponse200ApplicationJson_Icons> get serializer =>
       _$themingThemingGetManifestResponse200ApplicationJsonIconsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ThemingThemingGetManifestResponse200ApplicationJsonInterface {
+  String get name;
+  @BuiltValueField(wireName: 'short_name')
+  String get shortName;
+  @BuiltValueField(wireName: 'start_url')
+  String get startUrl;
+  @BuiltValueField(wireName: 'theme_color')
+  String get themeColor;
+  @BuiltValueField(wireName: 'background_color')
+  String get backgroundColor;
+  String get description;
+  BuiltList<ThemingThemingGetManifestResponse200ApplicationJson_Icons> get icons;
+  String get display;
+  ThemingThemingGetManifestResponse200ApplicationJsonInterface rebuild(
+    final void Function(ThemingThemingGetManifestResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ThemingThemingGetManifestResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ThemingThemingGetManifestResponse200ApplicationJson
     implements
+        ThemingThemingGetManifestResponse200ApplicationJsonInterface,
         Built<ThemingThemingGetManifestResponse200ApplicationJson,
             ThemingThemingGetManifestResponse200ApplicationJsonBuilder> {
   factory ThemingThemingGetManifestResponse200ApplicationJson([
@@ -558,23 +588,21 @@ abstract class ThemingThemingGetManifestResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get name;
-  @BuiltValueField(wireName: 'short_name')
-  String get shortName;
-  @BuiltValueField(wireName: 'start_url')
-  String get startUrl;
-  @BuiltValueField(wireName: 'theme_color')
-  String get themeColor;
-  @BuiltValueField(wireName: 'background_color')
-  String get backgroundColor;
-  String get description;
-  BuiltList<ThemingThemingGetManifestResponse200ApplicationJson_Icons> get icons;
-  String get display;
   static Serializer<ThemingThemingGetManifestResponse200ApplicationJson> get serializer =>
       _$themingThemingGetManifestResponse200ApplicationJsonSerializer;
 }
 
-abstract class ThemingBackground implements Built<ThemingBackground, ThemingBackgroundBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class ThemingBackgroundInterface {
+  String? get backgroundImage;
+  String get backgroundColor;
+  int get version;
+  ThemingBackgroundInterface rebuild(final void Function(ThemingBackgroundInterfaceBuilder) updates);
+  ThemingBackgroundInterfaceBuilder toBuilder();
+}
+
+abstract class ThemingBackground
+    implements ThemingBackgroundInterface, Built<ThemingBackground, ThemingBackgroundBuilder> {
   factory ThemingBackground([final void Function(ThemingBackgroundBuilder)? b]) = _$ThemingBackground;
 
   // coverage:ignore-start
@@ -589,13 +617,21 @@ abstract class ThemingBackground implements Built<ThemingBackground, ThemingBack
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String? get backgroundImage;
-  String get backgroundColor;
-  int get version;
   static Serializer<ThemingBackground> get serializer => _$themingBackgroundSerializer;
 }
 
-abstract class ThemingOCSMeta implements Built<ThemingOCSMeta, ThemingOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class ThemingOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  ThemingOCSMetaInterface rebuild(final void Function(ThemingOCSMetaInterfaceBuilder) updates);
+  ThemingOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class ThemingOCSMeta implements ThemingOCSMetaInterface, Built<ThemingOCSMeta, ThemingOCSMetaBuilder> {
   factory ThemingOCSMeta([final void Function(ThemingOCSMetaBuilder)? b]) = _$ThemingOCSMeta;
 
   // coverage:ignore-start
@@ -610,16 +646,22 @@ abstract class ThemingOCSMeta implements Built<ThemingOCSMeta, ThemingOCSMetaBui
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<ThemingOCSMeta> get serializer => _$themingOCSMetaSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsInterface {
+  ThemingOCSMeta get meta;
+  JsonObject get data;
+  ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs
     implements
+        ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsInterface,
         Built<ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs,
             ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder> {
   factory ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs([
@@ -638,14 +680,22 @@ abstract class ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ThemingOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs> get serializer =>
       _$themingUserThemeEnableThemeResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ThemingUserThemeEnableThemeResponse200ApplicationJsonInterface {
+  ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs get ocs;
+  ThemingUserThemeEnableThemeResponse200ApplicationJsonInterface rebuild(
+    final void Function(ThemingUserThemeEnableThemeResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ThemingUserThemeEnableThemeResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ThemingUserThemeEnableThemeResponse200ApplicationJson
     implements
+        ThemingUserThemeEnableThemeResponse200ApplicationJsonInterface,
         Built<ThemingUserThemeEnableThemeResponse200ApplicationJson,
             ThemingUserThemeEnableThemeResponse200ApplicationJsonBuilder> {
   factory ThemingUserThemeEnableThemeResponse200ApplicationJson([
@@ -664,13 +714,23 @@ abstract class ThemingUserThemeEnableThemeResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ThemingUserThemeEnableThemeResponse200ApplicationJson> get serializer =>
       _$themingUserThemeEnableThemeResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsInterface {
+  ThemingOCSMeta get meta;
+  JsonObject get data;
+  ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs
     implements
+        ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsInterface,
         Built<ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs,
             ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder> {
   factory ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs([
@@ -689,14 +749,22 @@ abstract class ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ThemingOCSMeta get meta;
-  JsonObject get data;
   static Serializer<ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs> get serializer =>
       _$themingUserThemeDisableThemeResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class ThemingUserThemeDisableThemeResponse200ApplicationJsonInterface {
+  ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs get ocs;
+  ThemingUserThemeDisableThemeResponse200ApplicationJsonInterface rebuild(
+    final void Function(ThemingUserThemeDisableThemeResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  ThemingUserThemeDisableThemeResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class ThemingUserThemeDisableThemeResponse200ApplicationJson
     implements
+        ThemingUserThemeDisableThemeResponse200ApplicationJsonInterface,
         Built<ThemingUserThemeDisableThemeResponse200ApplicationJson,
             ThemingUserThemeDisableThemeResponse200ApplicationJsonBuilder> {
   factory ThemingUserThemeDisableThemeResponse200ApplicationJson([
@@ -715,28 +783,12 @@ abstract class ThemingUserThemeDisableThemeResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs get ocs;
   static Serializer<ThemingUserThemeDisableThemeResponse200ApplicationJson> get serializer =>
       _$themingUserThemeDisableThemeResponse200ApplicationJsonSerializer;
 }
 
-abstract class ThemingPublicCapabilities_Theming
-    implements Built<ThemingPublicCapabilities_Theming, ThemingPublicCapabilities_ThemingBuilder> {
-  factory ThemingPublicCapabilities_Theming([final void Function(ThemingPublicCapabilities_ThemingBuilder)? b]) =
-      _$ThemingPublicCapabilities_Theming;
-
-  // coverage:ignore-start
-  const ThemingPublicCapabilities_Theming._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory ThemingPublicCapabilities_Theming.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class ThemingPublicCapabilities_ThemingInterface {
   String get name;
   String get url;
   String get slogan;
@@ -757,10 +809,43 @@ abstract class ThemingPublicCapabilities_Theming
   bool get backgroundDefault;
   String get logoheader;
   String get favicon;
+  ThemingPublicCapabilities_ThemingInterface rebuild(
+    final void Function(ThemingPublicCapabilities_ThemingInterfaceBuilder) updates,
+  );
+  ThemingPublicCapabilities_ThemingInterfaceBuilder toBuilder();
+}
+
+abstract class ThemingPublicCapabilities_Theming
+    implements
+        ThemingPublicCapabilities_ThemingInterface,
+        Built<ThemingPublicCapabilities_Theming, ThemingPublicCapabilities_ThemingBuilder> {
+  factory ThemingPublicCapabilities_Theming([final void Function(ThemingPublicCapabilities_ThemingBuilder)? b]) =
+      _$ThemingPublicCapabilities_Theming;
+
+  // coverage:ignore-start
+  const ThemingPublicCapabilities_Theming._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory ThemingPublicCapabilities_Theming.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<ThemingPublicCapabilities_Theming> get serializer => _$themingPublicCapabilitiesThemingSerializer;
 }
 
-abstract class ThemingPublicCapabilities implements Built<ThemingPublicCapabilities, ThemingPublicCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class ThemingPublicCapabilitiesInterface {
+  ThemingPublicCapabilities_Theming get theming;
+  ThemingPublicCapabilitiesInterface rebuild(final void Function(ThemingPublicCapabilitiesInterfaceBuilder) updates);
+  ThemingPublicCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class ThemingPublicCapabilities
+    implements ThemingPublicCapabilitiesInterface, Built<ThemingPublicCapabilities, ThemingPublicCapabilitiesBuilder> {
   factory ThemingPublicCapabilities([final void Function(ThemingPublicCapabilitiesBuilder)? b]) =
       _$ThemingPublicCapabilities;
 
@@ -776,7 +861,6 @@ abstract class ThemingPublicCapabilities implements Built<ThemingPublicCapabilit
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  ThemingPublicCapabilities_Theming get theming;
   static Serializer<ThemingPublicCapabilities> get serializer => _$themingPublicCapabilitiesSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/theming.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.g.dart
@@ -620,6 +620,19 @@ class _$ThemingPublicCapabilitiesSerializer implements StructuredSerializer<Them
   }
 }
 
+abstract mixin class ThemingThemingGetManifestResponse200ApplicationJson_IconsInterfaceBuilder {
+  void replace(ThemingThemingGetManifestResponse200ApplicationJson_IconsInterface other);
+  void update(void Function(ThemingThemingGetManifestResponse200ApplicationJson_IconsInterfaceBuilder) updates);
+  String? get src;
+  set src(String? src);
+
+  String? get type;
+  set type(String? type);
+
+  String? get sizes;
+  set sizes(String? sizes);
+}
+
 class _$ThemingThemingGetManifestResponse200ApplicationJson_Icons
     extends ThemingThemingGetManifestResponse200ApplicationJson_Icons {
   @override
@@ -682,20 +695,21 @@ class _$ThemingThemingGetManifestResponse200ApplicationJson_Icons
 class ThemingThemingGetManifestResponse200ApplicationJson_IconsBuilder
     implements
         Builder<ThemingThemingGetManifestResponse200ApplicationJson_Icons,
-            ThemingThemingGetManifestResponse200ApplicationJson_IconsBuilder> {
+            ThemingThemingGetManifestResponse200ApplicationJson_IconsBuilder>,
+        ThemingThemingGetManifestResponse200ApplicationJson_IconsInterfaceBuilder {
   _$ThemingThemingGetManifestResponse200ApplicationJson_Icons? _$v;
 
   String? _src;
   String? get src => _$this._src;
-  set src(String? src) => _$this._src = src;
+  set src(covariant String? src) => _$this._src = src;
 
   String? _type;
   String? get type => _$this._type;
-  set type(String? type) => _$this._type = type;
+  set type(covariant String? type) => _$this._type = type;
 
   String? _sizes;
   String? get sizes => _$this._sizes;
-  set sizes(String? sizes) => _$this._sizes = sizes;
+  set sizes(covariant String? sizes) => _$this._sizes = sizes;
 
   ThemingThemingGetManifestResponse200ApplicationJson_IconsBuilder();
 
@@ -711,7 +725,7 @@ class ThemingThemingGetManifestResponse200ApplicationJson_IconsBuilder
   }
 
   @override
-  void replace(ThemingThemingGetManifestResponse200ApplicationJson_Icons other) {
+  void replace(covariant ThemingThemingGetManifestResponse200ApplicationJson_Icons other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ThemingThemingGetManifestResponse200ApplicationJson_Icons;
   }
@@ -736,6 +750,34 @@ class ThemingThemingGetManifestResponse200ApplicationJson_IconsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ThemingThemingGetManifestResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ThemingThemingGetManifestResponse200ApplicationJsonInterface other);
+  void update(void Function(ThemingThemingGetManifestResponse200ApplicationJsonInterfaceBuilder) updates);
+  String? get name;
+  set name(String? name);
+
+  String? get shortName;
+  set shortName(String? shortName);
+
+  String? get startUrl;
+  set startUrl(String? startUrl);
+
+  String? get themeColor;
+  set themeColor(String? themeColor);
+
+  String? get backgroundColor;
+  set backgroundColor(String? backgroundColor);
+
+  String? get description;
+  set description(String? description);
+
+  ListBuilder<ThemingThemingGetManifestResponse200ApplicationJson_Icons> get icons;
+  set icons(ListBuilder<ThemingThemingGetManifestResponse200ApplicationJson_Icons>? icons);
+
+  String? get display;
+  set display(String? display);
 }
 
 class _$ThemingThemingGetManifestResponse200ApplicationJson
@@ -841,41 +883,43 @@ class _$ThemingThemingGetManifestResponse200ApplicationJson
 class ThemingThemingGetManifestResponse200ApplicationJsonBuilder
     implements
         Builder<ThemingThemingGetManifestResponse200ApplicationJson,
-            ThemingThemingGetManifestResponse200ApplicationJsonBuilder> {
+            ThemingThemingGetManifestResponse200ApplicationJsonBuilder>,
+        ThemingThemingGetManifestResponse200ApplicationJsonInterfaceBuilder {
   _$ThemingThemingGetManifestResponse200ApplicationJson? _$v;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   String? _shortName;
   String? get shortName => _$this._shortName;
-  set shortName(String? shortName) => _$this._shortName = shortName;
+  set shortName(covariant String? shortName) => _$this._shortName = shortName;
 
   String? _startUrl;
   String? get startUrl => _$this._startUrl;
-  set startUrl(String? startUrl) => _$this._startUrl = startUrl;
+  set startUrl(covariant String? startUrl) => _$this._startUrl = startUrl;
 
   String? _themeColor;
   String? get themeColor => _$this._themeColor;
-  set themeColor(String? themeColor) => _$this._themeColor = themeColor;
+  set themeColor(covariant String? themeColor) => _$this._themeColor = themeColor;
 
   String? _backgroundColor;
   String? get backgroundColor => _$this._backgroundColor;
-  set backgroundColor(String? backgroundColor) => _$this._backgroundColor = backgroundColor;
+  set backgroundColor(covariant String? backgroundColor) => _$this._backgroundColor = backgroundColor;
 
   String? _description;
   String? get description => _$this._description;
-  set description(String? description) => _$this._description = description;
+  set description(covariant String? description) => _$this._description = description;
 
   ListBuilder<ThemingThemingGetManifestResponse200ApplicationJson_Icons>? _icons;
   ListBuilder<ThemingThemingGetManifestResponse200ApplicationJson_Icons> get icons =>
       _$this._icons ??= ListBuilder<ThemingThemingGetManifestResponse200ApplicationJson_Icons>();
-  set icons(ListBuilder<ThemingThemingGetManifestResponse200ApplicationJson_Icons>? icons) => _$this._icons = icons;
+  set icons(covariant ListBuilder<ThemingThemingGetManifestResponse200ApplicationJson_Icons>? icons) =>
+      _$this._icons = icons;
 
   String? _display;
   String? get display => _$this._display;
-  set display(String? display) => _$this._display = display;
+  set display(covariant String? display) => _$this._display = display;
 
   ThemingThemingGetManifestResponse200ApplicationJsonBuilder();
 
@@ -896,7 +940,7 @@ class ThemingThemingGetManifestResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ThemingThemingGetManifestResponse200ApplicationJson other) {
+  void replace(covariant ThemingThemingGetManifestResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ThemingThemingGetManifestResponse200ApplicationJson;
   }
@@ -943,6 +987,19 @@ class ThemingThemingGetManifestResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ThemingBackgroundInterfaceBuilder {
+  void replace(ThemingBackgroundInterface other);
+  void update(void Function(ThemingBackgroundInterfaceBuilder) updates);
+  String? get backgroundImage;
+  set backgroundImage(String? backgroundImage);
+
+  String? get backgroundColor;
+  set backgroundColor(String? backgroundColor);
+
+  int? get version;
+  set version(int? version);
 }
 
 class _$ThemingBackground extends ThemingBackground {
@@ -996,20 +1053,21 @@ class _$ThemingBackground extends ThemingBackground {
   }
 }
 
-class ThemingBackgroundBuilder implements Builder<ThemingBackground, ThemingBackgroundBuilder> {
+class ThemingBackgroundBuilder
+    implements Builder<ThemingBackground, ThemingBackgroundBuilder>, ThemingBackgroundInterfaceBuilder {
   _$ThemingBackground? _$v;
 
   String? _backgroundImage;
   String? get backgroundImage => _$this._backgroundImage;
-  set backgroundImage(String? backgroundImage) => _$this._backgroundImage = backgroundImage;
+  set backgroundImage(covariant String? backgroundImage) => _$this._backgroundImage = backgroundImage;
 
   String? _backgroundColor;
   String? get backgroundColor => _$this._backgroundColor;
-  set backgroundColor(String? backgroundColor) => _$this._backgroundColor = backgroundColor;
+  set backgroundColor(covariant String? backgroundColor) => _$this._backgroundColor = backgroundColor;
 
   int? _version;
   int? get version => _$this._version;
-  set version(int? version) => _$this._version = version;
+  set version(covariant int? version) => _$this._version = version;
 
   ThemingBackgroundBuilder();
 
@@ -1025,7 +1083,7 @@ class ThemingBackgroundBuilder implements Builder<ThemingBackground, ThemingBack
   }
 
   @override
-  void replace(ThemingBackground other) {
+  void replace(covariant ThemingBackground other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ThemingBackground;
   }
@@ -1048,6 +1106,25 @@ class ThemingBackgroundBuilder implements Builder<ThemingBackground, ThemingBack
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ThemingOCSMetaInterfaceBuilder {
+  void replace(ThemingOCSMetaInterface other);
+  void update(void Function(ThemingOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
 }
 
 class _$ThemingOCSMeta extends ThemingOCSMeta {
@@ -1112,28 +1189,28 @@ class _$ThemingOCSMeta extends ThemingOCSMeta {
   }
 }
 
-class ThemingOCSMetaBuilder implements Builder<ThemingOCSMeta, ThemingOCSMetaBuilder> {
+class ThemingOCSMetaBuilder implements Builder<ThemingOCSMeta, ThemingOCSMetaBuilder>, ThemingOCSMetaInterfaceBuilder {
   _$ThemingOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   ThemingOCSMetaBuilder();
 
@@ -1151,7 +1228,7 @@ class ThemingOCSMetaBuilder implements Builder<ThemingOCSMeta, ThemingOCSMetaBui
   }
 
   @override
-  void replace(ThemingOCSMeta other) {
+  void replace(covariant ThemingOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ThemingOCSMeta;
   }
@@ -1175,6 +1252,16 @@ class ThemingOCSMetaBuilder implements Builder<ThemingOCSMeta, ThemingOCSMetaBui
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ThemingOCSMetaBuilder get meta;
+  set meta(ThemingOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs
@@ -1231,16 +1318,17 @@ class _$ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs
 class ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs,
-            ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder> {
+            ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder>,
+        ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs? _$v;
 
   ThemingOCSMetaBuilder? _meta;
   ThemingOCSMetaBuilder get meta => _$this._meta ??= ThemingOCSMetaBuilder();
-  set meta(ThemingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ThemingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder();
 
@@ -1255,7 +1343,7 @@ class ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ThemingUserThemeEnableThemeResponse200ApplicationJson_Ocs;
   }
@@ -1290,6 +1378,13 @@ class ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ThemingUserThemeEnableThemeResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ThemingUserThemeEnableThemeResponse200ApplicationJsonInterface other);
+  void update(void Function(ThemingUserThemeEnableThemeResponse200ApplicationJsonInterfaceBuilder) updates);
+  ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ThemingUserThemeEnableThemeResponse200ApplicationJson
@@ -1338,13 +1433,14 @@ class _$ThemingUserThemeEnableThemeResponse200ApplicationJson
 class ThemingUserThemeEnableThemeResponse200ApplicationJsonBuilder
     implements
         Builder<ThemingUserThemeEnableThemeResponse200ApplicationJson,
-            ThemingUserThemeEnableThemeResponse200ApplicationJsonBuilder> {
+            ThemingUserThemeEnableThemeResponse200ApplicationJsonBuilder>,
+        ThemingUserThemeEnableThemeResponse200ApplicationJsonInterfaceBuilder {
   _$ThemingUserThemeEnableThemeResponse200ApplicationJson? _$v;
 
   ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder? _ocs;
   ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder();
-  set ocs(ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ThemingUserThemeEnableThemeResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ThemingUserThemeEnableThemeResponse200ApplicationJsonBuilder();
 
@@ -1358,7 +1454,7 @@ class ThemingUserThemeEnableThemeResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ThemingUserThemeEnableThemeResponse200ApplicationJson other) {
+  void replace(covariant ThemingUserThemeEnableThemeResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ThemingUserThemeEnableThemeResponse200ApplicationJson;
   }
@@ -1389,6 +1485,16 @@ class ThemingUserThemeEnableThemeResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  ThemingOCSMetaBuilder get meta;
+  set meta(ThemingOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs
@@ -1445,16 +1551,17 @@ class _$ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs
 class ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder
     implements
         Builder<ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs,
-            ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder> {
+            ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder>,
+        ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsInterfaceBuilder {
   _$ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs? _$v;
 
   ThemingOCSMetaBuilder? _meta;
   ThemingOCSMetaBuilder get meta => _$this._meta ??= ThemingOCSMetaBuilder();
-  set meta(ThemingOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant ThemingOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder();
 
@@ -1469,7 +1576,7 @@ class ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs other) {
+  void replace(covariant ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ThemingUserThemeDisableThemeResponse200ApplicationJson_Ocs;
   }
@@ -1504,6 +1611,13 @@ class ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ThemingUserThemeDisableThemeResponse200ApplicationJsonInterfaceBuilder {
+  void replace(ThemingUserThemeDisableThemeResponse200ApplicationJsonInterface other);
+  void update(void Function(ThemingUserThemeDisableThemeResponse200ApplicationJsonInterfaceBuilder) updates);
+  ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$ThemingUserThemeDisableThemeResponse200ApplicationJson
@@ -1552,13 +1666,14 @@ class _$ThemingUserThemeDisableThemeResponse200ApplicationJson
 class ThemingUserThemeDisableThemeResponse200ApplicationJsonBuilder
     implements
         Builder<ThemingUserThemeDisableThemeResponse200ApplicationJson,
-            ThemingUserThemeDisableThemeResponse200ApplicationJsonBuilder> {
+            ThemingUserThemeDisableThemeResponse200ApplicationJsonBuilder>,
+        ThemingUserThemeDisableThemeResponse200ApplicationJsonInterfaceBuilder {
   _$ThemingUserThemeDisableThemeResponse200ApplicationJson? _$v;
 
   ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder? _ocs;
   ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder();
-  set ocs(ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant ThemingUserThemeDisableThemeResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   ThemingUserThemeDisableThemeResponse200ApplicationJsonBuilder();
 
@@ -1572,7 +1687,7 @@ class ThemingUserThemeDisableThemeResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(ThemingUserThemeDisableThemeResponse200ApplicationJson other) {
+  void replace(covariant ThemingUserThemeDisableThemeResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ThemingUserThemeDisableThemeResponse200ApplicationJson;
   }
@@ -1603,6 +1718,52 @@ class ThemingUserThemeDisableThemeResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class ThemingPublicCapabilities_ThemingInterfaceBuilder {
+  void replace(ThemingPublicCapabilities_ThemingInterface other);
+  void update(void Function(ThemingPublicCapabilities_ThemingInterfaceBuilder) updates);
+  String? get name;
+  set name(String? name);
+
+  String? get url;
+  set url(String? url);
+
+  String? get slogan;
+  set slogan(String? slogan);
+
+  String? get color;
+  set color(String? color);
+
+  String? get colorText;
+  set colorText(String? colorText);
+
+  String? get colorElement;
+  set colorElement(String? colorElement);
+
+  String? get colorElementBright;
+  set colorElementBright(String? colorElementBright);
+
+  String? get colorElementDark;
+  set colorElementDark(String? colorElementDark);
+
+  String? get logo;
+  set logo(String? logo);
+
+  String? get background;
+  set background(String? background);
+
+  bool? get backgroundPlain;
+  set backgroundPlain(bool? backgroundPlain);
+
+  bool? get backgroundDefault;
+  set backgroundDefault(bool? backgroundDefault);
+
+  String? get logoheader;
+  set logoheader(String? logoheader);
+
+  String? get favicon;
+  set favicon(String? favicon);
 }
 
 class _$ThemingPublicCapabilities_Theming extends ThemingPublicCapabilities_Theming {
@@ -1741,64 +1902,66 @@ class _$ThemingPublicCapabilities_Theming extends ThemingPublicCapabilities_Them
 }
 
 class ThemingPublicCapabilities_ThemingBuilder
-    implements Builder<ThemingPublicCapabilities_Theming, ThemingPublicCapabilities_ThemingBuilder> {
+    implements
+        Builder<ThemingPublicCapabilities_Theming, ThemingPublicCapabilities_ThemingBuilder>,
+        ThemingPublicCapabilities_ThemingInterfaceBuilder {
   _$ThemingPublicCapabilities_Theming? _$v;
 
   String? _name;
   String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
+  set name(covariant String? name) => _$this._name = name;
 
   String? _url;
   String? get url => _$this._url;
-  set url(String? url) => _$this._url = url;
+  set url(covariant String? url) => _$this._url = url;
 
   String? _slogan;
   String? get slogan => _$this._slogan;
-  set slogan(String? slogan) => _$this._slogan = slogan;
+  set slogan(covariant String? slogan) => _$this._slogan = slogan;
 
   String? _color;
   String? get color => _$this._color;
-  set color(String? color) => _$this._color = color;
+  set color(covariant String? color) => _$this._color = color;
 
   String? _colorText;
   String? get colorText => _$this._colorText;
-  set colorText(String? colorText) => _$this._colorText = colorText;
+  set colorText(covariant String? colorText) => _$this._colorText = colorText;
 
   String? _colorElement;
   String? get colorElement => _$this._colorElement;
-  set colorElement(String? colorElement) => _$this._colorElement = colorElement;
+  set colorElement(covariant String? colorElement) => _$this._colorElement = colorElement;
 
   String? _colorElementBright;
   String? get colorElementBright => _$this._colorElementBright;
-  set colorElementBright(String? colorElementBright) => _$this._colorElementBright = colorElementBright;
+  set colorElementBright(covariant String? colorElementBright) => _$this._colorElementBright = colorElementBright;
 
   String? _colorElementDark;
   String? get colorElementDark => _$this._colorElementDark;
-  set colorElementDark(String? colorElementDark) => _$this._colorElementDark = colorElementDark;
+  set colorElementDark(covariant String? colorElementDark) => _$this._colorElementDark = colorElementDark;
 
   String? _logo;
   String? get logo => _$this._logo;
-  set logo(String? logo) => _$this._logo = logo;
+  set logo(covariant String? logo) => _$this._logo = logo;
 
   String? _background;
   String? get background => _$this._background;
-  set background(String? background) => _$this._background = background;
+  set background(covariant String? background) => _$this._background = background;
 
   bool? _backgroundPlain;
   bool? get backgroundPlain => _$this._backgroundPlain;
-  set backgroundPlain(bool? backgroundPlain) => _$this._backgroundPlain = backgroundPlain;
+  set backgroundPlain(covariant bool? backgroundPlain) => _$this._backgroundPlain = backgroundPlain;
 
   bool? _backgroundDefault;
   bool? get backgroundDefault => _$this._backgroundDefault;
-  set backgroundDefault(bool? backgroundDefault) => _$this._backgroundDefault = backgroundDefault;
+  set backgroundDefault(covariant bool? backgroundDefault) => _$this._backgroundDefault = backgroundDefault;
 
   String? _logoheader;
   String? get logoheader => _$this._logoheader;
-  set logoheader(String? logoheader) => _$this._logoheader = logoheader;
+  set logoheader(covariant String? logoheader) => _$this._logoheader = logoheader;
 
   String? _favicon;
   String? get favicon => _$this._favicon;
-  set favicon(String? favicon) => _$this._favicon = favicon;
+  set favicon(covariant String? favicon) => _$this._favicon = favicon;
 
   ThemingPublicCapabilities_ThemingBuilder();
 
@@ -1825,7 +1988,7 @@ class ThemingPublicCapabilities_ThemingBuilder
   }
 
   @override
-  void replace(ThemingPublicCapabilities_Theming other) {
+  void replace(covariant ThemingPublicCapabilities_Theming other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ThemingPublicCapabilities_Theming;
   }
@@ -1868,6 +2031,13 @@ class ThemingPublicCapabilities_ThemingBuilder
   }
 }
 
+abstract mixin class ThemingPublicCapabilitiesInterfaceBuilder {
+  void replace(ThemingPublicCapabilitiesInterface other);
+  void update(void Function(ThemingPublicCapabilitiesInterfaceBuilder) updates);
+  ThemingPublicCapabilities_ThemingBuilder get theming;
+  set theming(ThemingPublicCapabilities_ThemingBuilder? theming);
+}
+
 class _$ThemingPublicCapabilities extends ThemingPublicCapabilities {
   @override
   final ThemingPublicCapabilities_Theming theming;
@@ -1906,13 +2076,16 @@ class _$ThemingPublicCapabilities extends ThemingPublicCapabilities {
   }
 }
 
-class ThemingPublicCapabilitiesBuilder implements Builder<ThemingPublicCapabilities, ThemingPublicCapabilitiesBuilder> {
+class ThemingPublicCapabilitiesBuilder
+    implements
+        Builder<ThemingPublicCapabilities, ThemingPublicCapabilitiesBuilder>,
+        ThemingPublicCapabilitiesInterfaceBuilder {
   _$ThemingPublicCapabilities? _$v;
 
   ThemingPublicCapabilities_ThemingBuilder? _theming;
   ThemingPublicCapabilities_ThemingBuilder get theming =>
       _$this._theming ??= ThemingPublicCapabilities_ThemingBuilder();
-  set theming(ThemingPublicCapabilities_ThemingBuilder? theming) => _$this._theming = theming;
+  set theming(covariant ThemingPublicCapabilities_ThemingBuilder? theming) => _$this._theming = theming;
 
   ThemingPublicCapabilitiesBuilder();
 
@@ -1926,7 +2099,7 @@ class ThemingPublicCapabilitiesBuilder implements Builder<ThemingPublicCapabilit
   }
 
   @override
-  void replace(ThemingPublicCapabilities other) {
+  void replace(covariant ThemingPublicCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ThemingPublicCapabilities;
   }

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
@@ -138,7 +138,19 @@ class UpdatenotificationApiGetAppListApiVersion extends EnumClass {
       _$updatenotificationApiGetAppListApiVersionSerializer;
 }
 
-abstract class UpdatenotificationOCSMeta implements Built<UpdatenotificationOCSMeta, UpdatenotificationOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class UpdatenotificationOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  UpdatenotificationOCSMetaInterface rebuild(final void Function(UpdatenotificationOCSMetaInterfaceBuilder) updates);
+  UpdatenotificationOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class UpdatenotificationOCSMeta
+    implements UpdatenotificationOCSMetaInterface, Built<UpdatenotificationOCSMeta, UpdatenotificationOCSMetaBuilder> {
   factory UpdatenotificationOCSMeta([final void Function(UpdatenotificationOCSMetaBuilder)? b]) =
       _$UpdatenotificationOCSMeta;
 
@@ -154,15 +166,19 @@ abstract class UpdatenotificationOCSMeta implements Built<UpdatenotificationOCSM
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<UpdatenotificationOCSMeta> get serializer => _$updatenotificationOCSMetaSerializer;
 }
 
-abstract class UpdatenotificationApp implements Built<UpdatenotificationApp, UpdatenotificationAppBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class UpdatenotificationAppInterface {
+  String get appId;
+  String get appName;
+  UpdatenotificationAppInterface rebuild(final void Function(UpdatenotificationAppInterfaceBuilder) updates);
+  UpdatenotificationAppInterfaceBuilder toBuilder();
+}
+
+abstract class UpdatenotificationApp
+    implements UpdatenotificationAppInterface, Built<UpdatenotificationApp, UpdatenotificationAppBuilder> {
   factory UpdatenotificationApp([final void Function(UpdatenotificationAppBuilder)? b]) = _$UpdatenotificationApp;
 
   // coverage:ignore-start
@@ -177,13 +193,22 @@ abstract class UpdatenotificationApp implements Built<UpdatenotificationApp, Upd
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get appId;
-  String get appName;
   static Serializer<UpdatenotificationApp> get serializer => _$updatenotificationAppSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataInterface {
+  BuiltList<UpdatenotificationApp> get missing;
+  BuiltList<UpdatenotificationApp> get available;
+  UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
 }
 
 abstract class UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data
     implements
+        UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataInterface,
         Built<UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data,
             UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder> {
   factory UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data([
@@ -204,14 +229,23 @@ abstract class UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Dat
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<UpdatenotificationApp> get missing;
-  BuiltList<UpdatenotificationApp> get available;
   static Serializer<UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$updatenotificationApiGetAppListResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsInterface {
+  UpdatenotificationOCSMeta get meta;
+  UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data get data;
+  UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs
     implements
+        UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsInterface,
         Built<UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs,
             UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder> {
   factory UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs([
@@ -230,14 +264,22 @@ abstract class UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UpdatenotificationOCSMeta get meta;
-  UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs> get serializer =>
       _$updatenotificationApiGetAppListResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UpdatenotificationApiGetAppListResponse200ApplicationJsonInterface {
+  UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs get ocs;
+  UpdatenotificationApiGetAppListResponse200ApplicationJsonInterface rebuild(
+    final void Function(UpdatenotificationApiGetAppListResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UpdatenotificationApiGetAppListResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UpdatenotificationApiGetAppListResponse200ApplicationJson
     implements
+        UpdatenotificationApiGetAppListResponse200ApplicationJsonInterface,
         Built<UpdatenotificationApiGetAppListResponse200ApplicationJson,
             UpdatenotificationApiGetAppListResponse200ApplicationJsonBuilder> {
   factory UpdatenotificationApiGetAppListResponse200ApplicationJson([
@@ -256,7 +298,6 @@ abstract class UpdatenotificationApiGetAppListResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UpdatenotificationApiGetAppListResponse200ApplicationJson> get serializer =>
       _$updatenotificationApiGetAppListResponse200ApplicationJsonSerializer;
 }

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.g.dart
@@ -320,6 +320,25 @@ class _$UpdatenotificationApiGetAppListResponse200ApplicationJsonSerializer
   }
 }
 
+abstract mixin class UpdatenotificationOCSMetaInterfaceBuilder {
+  void replace(UpdatenotificationOCSMetaInterface other);
+  void update(void Function(UpdatenotificationOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
+}
+
 class _$UpdatenotificationOCSMeta extends UpdatenotificationOCSMeta {
   @override
   final String status;
@@ -384,28 +403,31 @@ class _$UpdatenotificationOCSMeta extends UpdatenotificationOCSMeta {
   }
 }
 
-class UpdatenotificationOCSMetaBuilder implements Builder<UpdatenotificationOCSMeta, UpdatenotificationOCSMetaBuilder> {
+class UpdatenotificationOCSMetaBuilder
+    implements
+        Builder<UpdatenotificationOCSMeta, UpdatenotificationOCSMetaBuilder>,
+        UpdatenotificationOCSMetaInterfaceBuilder {
   _$UpdatenotificationOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   UpdatenotificationOCSMetaBuilder();
 
@@ -423,7 +445,7 @@ class UpdatenotificationOCSMetaBuilder implements Builder<UpdatenotificationOCSM
   }
 
   @override
-  void replace(UpdatenotificationOCSMeta other) {
+  void replace(covariant UpdatenotificationOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UpdatenotificationOCSMeta;
   }
@@ -447,6 +469,16 @@ class UpdatenotificationOCSMetaBuilder implements Builder<UpdatenotificationOCSM
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UpdatenotificationAppInterfaceBuilder {
+  void replace(UpdatenotificationAppInterface other);
+  void update(void Function(UpdatenotificationAppInterfaceBuilder) updates);
+  String? get appId;
+  set appId(String? appId);
+
+  String? get appName;
+  set appName(String? appName);
 }
 
 class _$UpdatenotificationApp extends UpdatenotificationApp {
@@ -494,16 +526,17 @@ class _$UpdatenotificationApp extends UpdatenotificationApp {
   }
 }
 
-class UpdatenotificationAppBuilder implements Builder<UpdatenotificationApp, UpdatenotificationAppBuilder> {
+class UpdatenotificationAppBuilder
+    implements Builder<UpdatenotificationApp, UpdatenotificationAppBuilder>, UpdatenotificationAppInterfaceBuilder {
   _$UpdatenotificationApp? _$v;
 
   String? _appId;
   String? get appId => _$this._appId;
-  set appId(String? appId) => _$this._appId = appId;
+  set appId(covariant String? appId) => _$this._appId = appId;
 
   String? _appName;
   String? get appName => _$this._appName;
-  set appName(String? appName) => _$this._appName = appName;
+  set appName(covariant String? appName) => _$this._appName = appName;
 
   UpdatenotificationAppBuilder();
 
@@ -518,7 +551,7 @@ class UpdatenotificationAppBuilder implements Builder<UpdatenotificationApp, Upd
   }
 
   @override
-  void replace(UpdatenotificationApp other) {
+  void replace(covariant UpdatenotificationApp other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UpdatenotificationApp;
   }
@@ -539,6 +572,17 @@ class UpdatenotificationAppBuilder implements Builder<UpdatenotificationApp, Upd
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  ListBuilder<UpdatenotificationApp> get missing;
+  set missing(ListBuilder<UpdatenotificationApp>? missing);
+
+  ListBuilder<UpdatenotificationApp> get available;
+  set available(ListBuilder<UpdatenotificationApp>? available);
 }
 
 class _$UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data
@@ -599,16 +643,17 @@ class _$UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data
 class UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data,
-            UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder> {
+            UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder>,
+        UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data? _$v;
 
   ListBuilder<UpdatenotificationApp>? _missing;
   ListBuilder<UpdatenotificationApp> get missing => _$this._missing ??= ListBuilder<UpdatenotificationApp>();
-  set missing(ListBuilder<UpdatenotificationApp>? missing) => _$this._missing = missing;
+  set missing(covariant ListBuilder<UpdatenotificationApp>? missing) => _$this._missing = missing;
 
   ListBuilder<UpdatenotificationApp>? _available;
   ListBuilder<UpdatenotificationApp> get available => _$this._available ??= ListBuilder<UpdatenotificationApp>();
-  set available(ListBuilder<UpdatenotificationApp>? available) => _$this._available = available;
+  set available(covariant ListBuilder<UpdatenotificationApp>? available) => _$this._available = available;
 
   UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -623,7 +668,7 @@ class UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder
   }
 
   @override
-  void replace(UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_Data;
   }
@@ -658,6 +703,16 @@ class UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UpdatenotificationOCSMetaBuilder get meta;
+  set meta(UpdatenotificationOCSMetaBuilder? meta);
+
+  UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs
@@ -717,17 +772,19 @@ class _$UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs
 class UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs,
-            UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder> {
+            UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder>,
+        UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs? _$v;
 
   UpdatenotificationOCSMetaBuilder? _meta;
   UpdatenotificationOCSMetaBuilder get meta => _$this._meta ??= UpdatenotificationOCSMetaBuilder();
-  set meta(UpdatenotificationOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UpdatenotificationOCSMetaBuilder? meta) => _$this._meta = meta;
 
   UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder? _data;
   UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder();
 
@@ -742,7 +799,7 @@ class UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UpdatenotificationApiGetAppListResponse200ApplicationJson_Ocs;
   }
@@ -776,6 +833,13 @@ class UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UpdatenotificationApiGetAppListResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UpdatenotificationApiGetAppListResponse200ApplicationJsonInterface other);
+  void update(void Function(UpdatenotificationApiGetAppListResponse200ApplicationJsonInterfaceBuilder) updates);
+  UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UpdatenotificationApiGetAppListResponse200ApplicationJson
@@ -824,13 +888,14 @@ class _$UpdatenotificationApiGetAppListResponse200ApplicationJson
 class UpdatenotificationApiGetAppListResponse200ApplicationJsonBuilder
     implements
         Builder<UpdatenotificationApiGetAppListResponse200ApplicationJson,
-            UpdatenotificationApiGetAppListResponse200ApplicationJsonBuilder> {
+            UpdatenotificationApiGetAppListResponse200ApplicationJsonBuilder>,
+        UpdatenotificationApiGetAppListResponse200ApplicationJsonInterfaceBuilder {
   _$UpdatenotificationApiGetAppListResponse200ApplicationJson? _$v;
 
   UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder? _ocs;
   UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder();
-  set ocs(UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UpdatenotificationApiGetAppListResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   UpdatenotificationApiGetAppListResponse200ApplicationJsonBuilder();
 
@@ -844,7 +909,7 @@ class UpdatenotificationApiGetAppListResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UpdatenotificationApiGetAppListResponse200ApplicationJson other) {
+  void replace(covariant UpdatenotificationApiGetAppListResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UpdatenotificationApiGetAppListResponse200ApplicationJson;
   }

--- a/packages/nextcloud/lib/src/api/uppush.openapi.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.dart
@@ -418,8 +418,19 @@ class UppushClient extends DynamiteClient {
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushCheckResponse200ApplicationJsonInterface {
+  bool get success;
+  UppushCheckResponse200ApplicationJsonInterface rebuild(
+    final void Function(UppushCheckResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushCheckResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushCheckResponse200ApplicationJson
-    implements Built<UppushCheckResponse200ApplicationJson, UppushCheckResponse200ApplicationJsonBuilder> {
+    implements
+        UppushCheckResponse200ApplicationJsonInterface,
+        Built<UppushCheckResponse200ApplicationJson, UppushCheckResponse200ApplicationJsonBuilder> {
   factory UppushCheckResponse200ApplicationJson([
     final void Function(UppushCheckResponse200ApplicationJsonBuilder)? b,
   ]) = _$UppushCheckResponse200ApplicationJson;
@@ -436,13 +447,22 @@ abstract class UppushCheckResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
   static Serializer<UppushCheckResponse200ApplicationJson> get serializer =>
       _$uppushCheckResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushSetKeepaliveResponse200ApplicationJsonInterface {
+  bool get success;
+  UppushSetKeepaliveResponse200ApplicationJsonInterface rebuild(
+    final void Function(UppushSetKeepaliveResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushSetKeepaliveResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushSetKeepaliveResponse200ApplicationJson
     implements
+        UppushSetKeepaliveResponse200ApplicationJsonInterface,
         Built<UppushSetKeepaliveResponse200ApplicationJson, UppushSetKeepaliveResponse200ApplicationJsonBuilder> {
   factory UppushSetKeepaliveResponse200ApplicationJson([
     final void Function(UppushSetKeepaliveResponse200ApplicationJsonBuilder)? b,
@@ -460,13 +480,23 @@ abstract class UppushSetKeepaliveResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
   static Serializer<UppushSetKeepaliveResponse200ApplicationJson> get serializer =>
       _$uppushSetKeepaliveResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushCreateDeviceResponse200ApplicationJsonInterface {
+  bool get success;
+  String get deviceId;
+  UppushCreateDeviceResponse200ApplicationJsonInterface rebuild(
+    final void Function(UppushCreateDeviceResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushCreateDeviceResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushCreateDeviceResponse200ApplicationJson
     implements
+        UppushCreateDeviceResponse200ApplicationJsonInterface,
         Built<UppushCreateDeviceResponse200ApplicationJson, UppushCreateDeviceResponse200ApplicationJsonBuilder> {
   factory UppushCreateDeviceResponse200ApplicationJson([
     final void Function(UppushCreateDeviceResponse200ApplicationJsonBuilder)? b,
@@ -484,14 +514,23 @@ abstract class UppushCreateDeviceResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
-  String get deviceId;
   static Serializer<UppushCreateDeviceResponse200ApplicationJson> get serializer =>
       _$uppushCreateDeviceResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushSyncDeviceResponse401ApplicationJsonInterface {
+  bool get success;
+  UppushSyncDeviceResponse401ApplicationJsonInterface rebuild(
+    final void Function(UppushSyncDeviceResponse401ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushSyncDeviceResponse401ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushSyncDeviceResponse401ApplicationJson
-    implements Built<UppushSyncDeviceResponse401ApplicationJson, UppushSyncDeviceResponse401ApplicationJsonBuilder> {
+    implements
+        UppushSyncDeviceResponse401ApplicationJsonInterface,
+        Built<UppushSyncDeviceResponse401ApplicationJson, UppushSyncDeviceResponse401ApplicationJsonBuilder> {
   factory UppushSyncDeviceResponse401ApplicationJson([
     final void Function(UppushSyncDeviceResponse401ApplicationJsonBuilder)? b,
   ]) = _$UppushSyncDeviceResponse401ApplicationJson;
@@ -508,13 +547,22 @@ abstract class UppushSyncDeviceResponse401ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
   static Serializer<UppushSyncDeviceResponse401ApplicationJson> get serializer =>
       _$uppushSyncDeviceResponse401ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushDeleteDeviceResponse200ApplicationJsonInterface {
+  bool get success;
+  UppushDeleteDeviceResponse200ApplicationJsonInterface rebuild(
+    final void Function(UppushDeleteDeviceResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushDeleteDeviceResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushDeleteDeviceResponse200ApplicationJson
     implements
+        UppushDeleteDeviceResponse200ApplicationJsonInterface,
         Built<UppushDeleteDeviceResponse200ApplicationJson, UppushDeleteDeviceResponse200ApplicationJsonBuilder> {
   factory UppushDeleteDeviceResponse200ApplicationJson([
     final void Function(UppushDeleteDeviceResponse200ApplicationJsonBuilder)? b,
@@ -532,13 +580,24 @@ abstract class UppushDeleteDeviceResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
   static Serializer<UppushDeleteDeviceResponse200ApplicationJson> get serializer =>
       _$uppushDeleteDeviceResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushCreateAppResponse200ApplicationJsonInterface {
+  bool get success;
+  String get token;
+  UppushCreateAppResponse200ApplicationJsonInterface rebuild(
+    final void Function(UppushCreateAppResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushCreateAppResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushCreateAppResponse200ApplicationJson
-    implements Built<UppushCreateAppResponse200ApplicationJson, UppushCreateAppResponse200ApplicationJsonBuilder> {
+    implements
+        UppushCreateAppResponse200ApplicationJsonInterface,
+        Built<UppushCreateAppResponse200ApplicationJson, UppushCreateAppResponse200ApplicationJsonBuilder> {
   factory UppushCreateAppResponse200ApplicationJson([
     final void Function(UppushCreateAppResponse200ApplicationJsonBuilder)? b,
   ]) = _$UppushCreateAppResponse200ApplicationJson;
@@ -555,14 +614,23 @@ abstract class UppushCreateAppResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
-  String get token;
   static Serializer<UppushCreateAppResponse200ApplicationJson> get serializer =>
       _$uppushCreateAppResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushDeleteAppResponse200ApplicationJsonInterface {
+  bool get success;
+  UppushDeleteAppResponse200ApplicationJsonInterface rebuild(
+    final void Function(UppushDeleteAppResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushDeleteAppResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushDeleteAppResponse200ApplicationJson
-    implements Built<UppushDeleteAppResponse200ApplicationJson, UppushDeleteAppResponse200ApplicationJsonBuilder> {
+    implements
+        UppushDeleteAppResponse200ApplicationJsonInterface,
+        Built<UppushDeleteAppResponse200ApplicationJson, UppushDeleteAppResponse200ApplicationJsonBuilder> {
   factory UppushDeleteAppResponse200ApplicationJson([
     final void Function(UppushDeleteAppResponse200ApplicationJsonBuilder)? b,
   ]) = _$UppushDeleteAppResponse200ApplicationJson;
@@ -579,13 +647,22 @@ abstract class UppushDeleteAppResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
   static Serializer<UppushDeleteAppResponse200ApplicationJson> get serializer =>
       _$uppushDeleteAppResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushInterface {
+  int get version;
+  UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushInterface rebuild(
+    final void Function(UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushInterfaceBuilder) updates,
+  );
+  UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushInterfaceBuilder toBuilder();
+}
+
 abstract class UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush
     implements
+        UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushInterface,
         Built<UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush,
             UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder> {
   factory UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush([
@@ -604,13 +681,22 @@ abstract class UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  int get version;
   static Serializer<UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush> get serializer =>
       _$uppushUnifiedpushDiscoveryResponse200ApplicationJsonUnifiedpushSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushUnifiedpushDiscoveryResponse200ApplicationJsonInterface {
+  UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush get unifiedpush;
+  UppushUnifiedpushDiscoveryResponse200ApplicationJsonInterface rebuild(
+    final void Function(UppushUnifiedpushDiscoveryResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushUnifiedpushDiscoveryResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushUnifiedpushDiscoveryResponse200ApplicationJson
     implements
+        UppushUnifiedpushDiscoveryResponse200ApplicationJsonInterface,
         Built<UppushUnifiedpushDiscoveryResponse200ApplicationJson,
             UppushUnifiedpushDiscoveryResponse200ApplicationJsonBuilder> {
   factory UppushUnifiedpushDiscoveryResponse200ApplicationJson([
@@ -629,13 +715,23 @@ abstract class UppushUnifiedpushDiscoveryResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush get unifiedpush;
   static Serializer<UppushUnifiedpushDiscoveryResponse200ApplicationJson> get serializer =>
       _$uppushUnifiedpushDiscoveryResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushPushResponse201ApplicationJsonInterface {
+  bool get success;
+  UppushPushResponse201ApplicationJsonInterface rebuild(
+    final void Function(UppushPushResponse201ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushPushResponse201ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushPushResponse201ApplicationJson
-    implements Built<UppushPushResponse201ApplicationJson, UppushPushResponse201ApplicationJsonBuilder> {
+    implements
+        UppushPushResponse201ApplicationJsonInterface,
+        Built<UppushPushResponse201ApplicationJson, UppushPushResponse201ApplicationJsonBuilder> {
   factory UppushPushResponse201ApplicationJson([final void Function(UppushPushResponse201ApplicationJsonBuilder)? b]) =
       _$UppushPushResponse201ApplicationJson;
 
@@ -651,13 +747,22 @@ abstract class UppushPushResponse201ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
   static Serializer<UppushPushResponse201ApplicationJson> get serializer =>
       _$uppushPushResponse201ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushInterface {
+  String get gateway;
+  UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushInterface rebuild(
+    final void Function(UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushInterfaceBuilder) updates,
+  );
+  UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushInterfaceBuilder toBuilder();
+}
+
 abstract class UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush
     implements
+        UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushInterface,
         Built<UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush,
             UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder> {
   factory UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush([
@@ -678,13 +783,22 @@ abstract class UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpus
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get gateway;
   static Serializer<UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush> get serializer =>
       _$uppushGatewayMatrixDiscoveryResponse200ApplicationJsonUnifiedpushSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushGatewayMatrixDiscoveryResponse200ApplicationJsonInterface {
+  UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush get unifiedpush;
+  UppushGatewayMatrixDiscoveryResponse200ApplicationJsonInterface rebuild(
+    final void Function(UppushGatewayMatrixDiscoveryResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushGatewayMatrixDiscoveryResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushGatewayMatrixDiscoveryResponse200ApplicationJson
     implements
+        UppushGatewayMatrixDiscoveryResponse200ApplicationJsonInterface,
         Built<UppushGatewayMatrixDiscoveryResponse200ApplicationJson,
             UppushGatewayMatrixDiscoveryResponse200ApplicationJsonBuilder> {
   factory UppushGatewayMatrixDiscoveryResponse200ApplicationJson([
@@ -703,13 +817,22 @@ abstract class UppushGatewayMatrixDiscoveryResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush get unifiedpush;
   static Serializer<UppushGatewayMatrixDiscoveryResponse200ApplicationJson> get serializer =>
       _$uppushGatewayMatrixDiscoveryResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UppushGatewayMatrixResponse200ApplicationJsonInterface {
+  BuiltList<String> get rejected;
+  UppushGatewayMatrixResponse200ApplicationJsonInterface rebuild(
+    final void Function(UppushGatewayMatrixResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UppushGatewayMatrixResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UppushGatewayMatrixResponse200ApplicationJson
     implements
+        UppushGatewayMatrixResponse200ApplicationJsonInterface,
         Built<UppushGatewayMatrixResponse200ApplicationJson, UppushGatewayMatrixResponse200ApplicationJsonBuilder> {
   factory UppushGatewayMatrixResponse200ApplicationJson([
     final void Function(UppushGatewayMatrixResponse200ApplicationJsonBuilder)? b,
@@ -727,7 +850,6 @@ abstract class UppushGatewayMatrixResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  BuiltList<String> get rejected;
   static Serializer<UppushGatewayMatrixResponse200ApplicationJson> get serializer =>
       _$uppushGatewayMatrixResponse200ApplicationJsonSerializer;
 }

--- a/packages/nextcloud/lib/src/api/uppush.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.g.dart
@@ -600,6 +600,13 @@ class _$UppushGatewayMatrixResponse200ApplicationJsonSerializer
   }
 }
 
+abstract mixin class UppushCheckResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UppushCheckResponse200ApplicationJsonInterface other);
+  void update(void Function(UppushCheckResponse200ApplicationJsonInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
+}
+
 class _$UppushCheckResponse200ApplicationJson extends UppushCheckResponse200ApplicationJson {
   @override
   final bool success;
@@ -641,12 +648,14 @@ class _$UppushCheckResponse200ApplicationJson extends UppushCheckResponse200Appl
 }
 
 class UppushCheckResponse200ApplicationJsonBuilder
-    implements Builder<UppushCheckResponse200ApplicationJson, UppushCheckResponse200ApplicationJsonBuilder> {
+    implements
+        Builder<UppushCheckResponse200ApplicationJson, UppushCheckResponse200ApplicationJsonBuilder>,
+        UppushCheckResponse200ApplicationJsonInterfaceBuilder {
   _$UppushCheckResponse200ApplicationJson? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   UppushCheckResponse200ApplicationJsonBuilder();
 
@@ -660,7 +669,7 @@ class UppushCheckResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushCheckResponse200ApplicationJson other) {
+  void replace(covariant UppushCheckResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushCheckResponse200ApplicationJson;
   }
@@ -681,6 +690,13 @@ class UppushCheckResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushSetKeepaliveResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UppushSetKeepaliveResponse200ApplicationJsonInterface other);
+  void update(void Function(UppushSetKeepaliveResponse200ApplicationJsonInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
 }
 
 class _$UppushSetKeepaliveResponse200ApplicationJson extends UppushSetKeepaliveResponse200ApplicationJson {
@@ -727,12 +743,13 @@ class _$UppushSetKeepaliveResponse200ApplicationJson extends UppushSetKeepaliveR
 
 class UppushSetKeepaliveResponse200ApplicationJsonBuilder
     implements
-        Builder<UppushSetKeepaliveResponse200ApplicationJson, UppushSetKeepaliveResponse200ApplicationJsonBuilder> {
+        Builder<UppushSetKeepaliveResponse200ApplicationJson, UppushSetKeepaliveResponse200ApplicationJsonBuilder>,
+        UppushSetKeepaliveResponse200ApplicationJsonInterfaceBuilder {
   _$UppushSetKeepaliveResponse200ApplicationJson? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   UppushSetKeepaliveResponse200ApplicationJsonBuilder();
 
@@ -746,7 +763,7 @@ class UppushSetKeepaliveResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushSetKeepaliveResponse200ApplicationJson other) {
+  void replace(covariant UppushSetKeepaliveResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushSetKeepaliveResponse200ApplicationJson;
   }
@@ -767,6 +784,16 @@ class UppushSetKeepaliveResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushCreateDeviceResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UppushCreateDeviceResponse200ApplicationJsonInterface other);
+  void update(void Function(UppushCreateDeviceResponse200ApplicationJsonInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
+
+  String? get deviceId;
+  set deviceId(String? deviceId);
 }
 
 class _$UppushCreateDeviceResponse200ApplicationJson extends UppushCreateDeviceResponse200ApplicationJson {
@@ -821,16 +848,17 @@ class _$UppushCreateDeviceResponse200ApplicationJson extends UppushCreateDeviceR
 
 class UppushCreateDeviceResponse200ApplicationJsonBuilder
     implements
-        Builder<UppushCreateDeviceResponse200ApplicationJson, UppushCreateDeviceResponse200ApplicationJsonBuilder> {
+        Builder<UppushCreateDeviceResponse200ApplicationJson, UppushCreateDeviceResponse200ApplicationJsonBuilder>,
+        UppushCreateDeviceResponse200ApplicationJsonInterfaceBuilder {
   _$UppushCreateDeviceResponse200ApplicationJson? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   String? _deviceId;
   String? get deviceId => _$this._deviceId;
-  set deviceId(String? deviceId) => _$this._deviceId = deviceId;
+  set deviceId(covariant String? deviceId) => _$this._deviceId = deviceId;
 
   UppushCreateDeviceResponse200ApplicationJsonBuilder();
 
@@ -845,7 +873,7 @@ class UppushCreateDeviceResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushCreateDeviceResponse200ApplicationJson other) {
+  void replace(covariant UppushCreateDeviceResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushCreateDeviceResponse200ApplicationJson;
   }
@@ -868,6 +896,13 @@ class UppushCreateDeviceResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushSyncDeviceResponse401ApplicationJsonInterfaceBuilder {
+  void replace(UppushSyncDeviceResponse401ApplicationJsonInterface other);
+  void update(void Function(UppushSyncDeviceResponse401ApplicationJsonInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
 }
 
 class _$UppushSyncDeviceResponse401ApplicationJson extends UppushSyncDeviceResponse401ApplicationJson {
@@ -913,12 +948,14 @@ class _$UppushSyncDeviceResponse401ApplicationJson extends UppushSyncDeviceRespo
 }
 
 class UppushSyncDeviceResponse401ApplicationJsonBuilder
-    implements Builder<UppushSyncDeviceResponse401ApplicationJson, UppushSyncDeviceResponse401ApplicationJsonBuilder> {
+    implements
+        Builder<UppushSyncDeviceResponse401ApplicationJson, UppushSyncDeviceResponse401ApplicationJsonBuilder>,
+        UppushSyncDeviceResponse401ApplicationJsonInterfaceBuilder {
   _$UppushSyncDeviceResponse401ApplicationJson? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   UppushSyncDeviceResponse401ApplicationJsonBuilder();
 
@@ -932,7 +969,7 @@ class UppushSyncDeviceResponse401ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushSyncDeviceResponse401ApplicationJson other) {
+  void replace(covariant UppushSyncDeviceResponse401ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushSyncDeviceResponse401ApplicationJson;
   }
@@ -953,6 +990,13 @@ class UppushSyncDeviceResponse401ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushDeleteDeviceResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UppushDeleteDeviceResponse200ApplicationJsonInterface other);
+  void update(void Function(UppushDeleteDeviceResponse200ApplicationJsonInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
 }
 
 class _$UppushDeleteDeviceResponse200ApplicationJson extends UppushDeleteDeviceResponse200ApplicationJson {
@@ -999,12 +1043,13 @@ class _$UppushDeleteDeviceResponse200ApplicationJson extends UppushDeleteDeviceR
 
 class UppushDeleteDeviceResponse200ApplicationJsonBuilder
     implements
-        Builder<UppushDeleteDeviceResponse200ApplicationJson, UppushDeleteDeviceResponse200ApplicationJsonBuilder> {
+        Builder<UppushDeleteDeviceResponse200ApplicationJson, UppushDeleteDeviceResponse200ApplicationJsonBuilder>,
+        UppushDeleteDeviceResponse200ApplicationJsonInterfaceBuilder {
   _$UppushDeleteDeviceResponse200ApplicationJson? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   UppushDeleteDeviceResponse200ApplicationJsonBuilder();
 
@@ -1018,7 +1063,7 @@ class UppushDeleteDeviceResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushDeleteDeviceResponse200ApplicationJson other) {
+  void replace(covariant UppushDeleteDeviceResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushDeleteDeviceResponse200ApplicationJson;
   }
@@ -1039,6 +1084,16 @@ class UppushDeleteDeviceResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushCreateAppResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UppushCreateAppResponse200ApplicationJsonInterface other);
+  void update(void Function(UppushCreateAppResponse200ApplicationJsonInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
+
+  String? get token;
+  set token(String? token);
 }
 
 class _$UppushCreateAppResponse200ApplicationJson extends UppushCreateAppResponse200ApplicationJson {
@@ -1090,16 +1145,18 @@ class _$UppushCreateAppResponse200ApplicationJson extends UppushCreateAppRespons
 }
 
 class UppushCreateAppResponse200ApplicationJsonBuilder
-    implements Builder<UppushCreateAppResponse200ApplicationJson, UppushCreateAppResponse200ApplicationJsonBuilder> {
+    implements
+        Builder<UppushCreateAppResponse200ApplicationJson, UppushCreateAppResponse200ApplicationJsonBuilder>,
+        UppushCreateAppResponse200ApplicationJsonInterfaceBuilder {
   _$UppushCreateAppResponse200ApplicationJson? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   String? _token;
   String? get token => _$this._token;
-  set token(String? token) => _$this._token = token;
+  set token(covariant String? token) => _$this._token = token;
 
   UppushCreateAppResponse200ApplicationJsonBuilder();
 
@@ -1114,7 +1171,7 @@ class UppushCreateAppResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushCreateAppResponse200ApplicationJson other) {
+  void replace(covariant UppushCreateAppResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushCreateAppResponse200ApplicationJson;
   }
@@ -1136,6 +1193,13 @@ class UppushCreateAppResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushDeleteAppResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UppushDeleteAppResponse200ApplicationJsonInterface other);
+  void update(void Function(UppushDeleteAppResponse200ApplicationJsonInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
 }
 
 class _$UppushDeleteAppResponse200ApplicationJson extends UppushDeleteAppResponse200ApplicationJson {
@@ -1181,12 +1245,14 @@ class _$UppushDeleteAppResponse200ApplicationJson extends UppushDeleteAppRespons
 }
 
 class UppushDeleteAppResponse200ApplicationJsonBuilder
-    implements Builder<UppushDeleteAppResponse200ApplicationJson, UppushDeleteAppResponse200ApplicationJsonBuilder> {
+    implements
+        Builder<UppushDeleteAppResponse200ApplicationJson, UppushDeleteAppResponse200ApplicationJsonBuilder>,
+        UppushDeleteAppResponse200ApplicationJsonInterfaceBuilder {
   _$UppushDeleteAppResponse200ApplicationJson? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   UppushDeleteAppResponse200ApplicationJsonBuilder();
 
@@ -1200,7 +1266,7 @@ class UppushDeleteAppResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushDeleteAppResponse200ApplicationJson other) {
+  void replace(covariant UppushDeleteAppResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushDeleteAppResponse200ApplicationJson;
   }
@@ -1221,6 +1287,13 @@ class UppushDeleteAppResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushInterfaceBuilder {
+  void replace(UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushInterface other);
+  void update(void Function(UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushInterfaceBuilder) updates);
+  int? get version;
+  set version(int? version);
 }
 
 class _$UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush
@@ -1271,12 +1344,13 @@ class _$UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush
 class UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder
     implements
         Builder<UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush,
-            UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder> {
+            UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder>,
+        UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushInterfaceBuilder {
   _$UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush? _$v;
 
   int? _version;
   int? get version => _$this._version;
-  set version(int? version) => _$this._version = version;
+  set version(covariant int? version) => _$this._version = version;
 
   UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder();
 
@@ -1290,7 +1364,7 @@ class UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder
   }
 
   @override
-  void replace(UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush other) {
+  void replace(covariant UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushUnifiedpushDiscoveryResponse200ApplicationJson_Unifiedpush;
   }
@@ -1311,6 +1385,13 @@ class UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushUnifiedpushDiscoveryResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UppushUnifiedpushDiscoveryResponse200ApplicationJsonInterface other);
+  void update(void Function(UppushUnifiedpushDiscoveryResponse200ApplicationJsonInterfaceBuilder) updates);
+  UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder get unifiedpush;
+  set unifiedpush(UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder? unifiedpush);
 }
 
 class _$UppushUnifiedpushDiscoveryResponse200ApplicationJson
@@ -1361,13 +1442,14 @@ class _$UppushUnifiedpushDiscoveryResponse200ApplicationJson
 class UppushUnifiedpushDiscoveryResponse200ApplicationJsonBuilder
     implements
         Builder<UppushUnifiedpushDiscoveryResponse200ApplicationJson,
-            UppushUnifiedpushDiscoveryResponse200ApplicationJsonBuilder> {
+            UppushUnifiedpushDiscoveryResponse200ApplicationJsonBuilder>,
+        UppushUnifiedpushDiscoveryResponse200ApplicationJsonInterfaceBuilder {
   _$UppushUnifiedpushDiscoveryResponse200ApplicationJson? _$v;
 
   UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder? _unifiedpush;
   UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder get unifiedpush =>
       _$this._unifiedpush ??= UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder();
-  set unifiedpush(UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder? unifiedpush) =>
+  set unifiedpush(covariant UppushUnifiedpushDiscoveryResponse200ApplicationJson_UnifiedpushBuilder? unifiedpush) =>
       _$this._unifiedpush = unifiedpush;
 
   UppushUnifiedpushDiscoveryResponse200ApplicationJsonBuilder();
@@ -1382,7 +1464,7 @@ class UppushUnifiedpushDiscoveryResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushUnifiedpushDiscoveryResponse200ApplicationJson other) {
+  void replace(covariant UppushUnifiedpushDiscoveryResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushUnifiedpushDiscoveryResponse200ApplicationJson;
   }
@@ -1413,6 +1495,13 @@ class UppushUnifiedpushDiscoveryResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushPushResponse201ApplicationJsonInterfaceBuilder {
+  void replace(UppushPushResponse201ApplicationJsonInterface other);
+  void update(void Function(UppushPushResponse201ApplicationJsonInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
 }
 
 class _$UppushPushResponse201ApplicationJson extends UppushPushResponse201ApplicationJson {
@@ -1456,12 +1545,14 @@ class _$UppushPushResponse201ApplicationJson extends UppushPushResponse201Applic
 }
 
 class UppushPushResponse201ApplicationJsonBuilder
-    implements Builder<UppushPushResponse201ApplicationJson, UppushPushResponse201ApplicationJsonBuilder> {
+    implements
+        Builder<UppushPushResponse201ApplicationJson, UppushPushResponse201ApplicationJsonBuilder>,
+        UppushPushResponse201ApplicationJsonInterfaceBuilder {
   _$UppushPushResponse201ApplicationJson? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   UppushPushResponse201ApplicationJsonBuilder();
 
@@ -1475,7 +1566,7 @@ class UppushPushResponse201ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushPushResponse201ApplicationJson other) {
+  void replace(covariant UppushPushResponse201ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushPushResponse201ApplicationJson;
   }
@@ -1496,6 +1587,14 @@ class UppushPushResponse201ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushInterfaceBuilder {
+  void replace(UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushInterface other);
+  void update(
+      void Function(UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushInterfaceBuilder) updates);
+  String? get gateway;
+  set gateway(String? gateway);
 }
 
 class _$UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush
@@ -1546,12 +1645,13 @@ class _$UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush
 class UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder
     implements
         Builder<UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush,
-            UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder> {
+            UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder>,
+        UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushInterfaceBuilder {
   _$UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush? _$v;
 
   String? _gateway;
   String? get gateway => _$this._gateway;
-  set gateway(String? gateway) => _$this._gateway = gateway;
+  set gateway(covariant String? gateway) => _$this._gateway = gateway;
 
   UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder();
 
@@ -1565,7 +1665,7 @@ class UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder
   }
 
   @override
-  void replace(UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush other) {
+  void replace(covariant UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushGatewayMatrixDiscoveryResponse200ApplicationJson_Unifiedpush;
   }
@@ -1586,6 +1686,13 @@ class UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushGatewayMatrixDiscoveryResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UppushGatewayMatrixDiscoveryResponse200ApplicationJsonInterface other);
+  void update(void Function(UppushGatewayMatrixDiscoveryResponse200ApplicationJsonInterfaceBuilder) updates);
+  UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder get unifiedpush;
+  set unifiedpush(UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder? unifiedpush);
 }
 
 class _$UppushGatewayMatrixDiscoveryResponse200ApplicationJson
@@ -1636,13 +1743,14 @@ class _$UppushGatewayMatrixDiscoveryResponse200ApplicationJson
 class UppushGatewayMatrixDiscoveryResponse200ApplicationJsonBuilder
     implements
         Builder<UppushGatewayMatrixDiscoveryResponse200ApplicationJson,
-            UppushGatewayMatrixDiscoveryResponse200ApplicationJsonBuilder> {
+            UppushGatewayMatrixDiscoveryResponse200ApplicationJsonBuilder>,
+        UppushGatewayMatrixDiscoveryResponse200ApplicationJsonInterfaceBuilder {
   _$UppushGatewayMatrixDiscoveryResponse200ApplicationJson? _$v;
 
   UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder? _unifiedpush;
   UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder get unifiedpush =>
       _$this._unifiedpush ??= UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder();
-  set unifiedpush(UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder? unifiedpush) =>
+  set unifiedpush(covariant UppushGatewayMatrixDiscoveryResponse200ApplicationJson_UnifiedpushBuilder? unifiedpush) =>
       _$this._unifiedpush = unifiedpush;
 
   UppushGatewayMatrixDiscoveryResponse200ApplicationJsonBuilder();
@@ -1657,7 +1765,7 @@ class UppushGatewayMatrixDiscoveryResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushGatewayMatrixDiscoveryResponse200ApplicationJson other) {
+  void replace(covariant UppushGatewayMatrixDiscoveryResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushGatewayMatrixDiscoveryResponse200ApplicationJson;
   }
@@ -1688,6 +1796,13 @@ class UppushGatewayMatrixDiscoveryResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UppushGatewayMatrixResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UppushGatewayMatrixResponse200ApplicationJsonInterface other);
+  void update(void Function(UppushGatewayMatrixResponse200ApplicationJsonInterfaceBuilder) updates);
+  ListBuilder<String> get rejected;
+  set rejected(ListBuilder<String>? rejected);
 }
 
 class _$UppushGatewayMatrixResponse200ApplicationJson extends UppushGatewayMatrixResponse200ApplicationJson {
@@ -1734,12 +1849,13 @@ class _$UppushGatewayMatrixResponse200ApplicationJson extends UppushGatewayMatri
 
 class UppushGatewayMatrixResponse200ApplicationJsonBuilder
     implements
-        Builder<UppushGatewayMatrixResponse200ApplicationJson, UppushGatewayMatrixResponse200ApplicationJsonBuilder> {
+        Builder<UppushGatewayMatrixResponse200ApplicationJson, UppushGatewayMatrixResponse200ApplicationJsonBuilder>,
+        UppushGatewayMatrixResponse200ApplicationJsonInterfaceBuilder {
   _$UppushGatewayMatrixResponse200ApplicationJson? _$v;
 
   ListBuilder<String>? _rejected;
   ListBuilder<String> get rejected => _$this._rejected ??= ListBuilder<String>();
-  set rejected(ListBuilder<String>? rejected) => _$this._rejected = rejected;
+  set rejected(covariant ListBuilder<String>? rejected) => _$this._rejected = rejected;
 
   UppushGatewayMatrixResponse200ApplicationJsonBuilder();
 
@@ -1753,7 +1869,7 @@ class UppushGatewayMatrixResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UppushGatewayMatrixResponse200ApplicationJson other) {
+  void replace(covariant UppushGatewayMatrixResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UppushGatewayMatrixResponse200ApplicationJson;
   }

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -524,7 +524,19 @@ class UserStatusUserStatusClient {
   }
 }
 
-abstract class UserStatusOCSMeta implements Built<UserStatusOCSMeta, UserStatusOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  UserStatusOCSMetaInterface rebuild(final void Function(UserStatusOCSMetaInterfaceBuilder) updates);
+  UserStatusOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class UserStatusOCSMeta
+    implements UserStatusOCSMetaInterface, Built<UserStatusOCSMeta, UserStatusOCSMetaBuilder> {
   factory UserStatusOCSMeta([final void Function(UserStatusOCSMetaBuilder)? b]) = _$UserStatusOCSMeta;
 
   // coverage:ignore-start
@@ -539,15 +551,21 @@ abstract class UserStatusOCSMeta implements Built<UserStatusOCSMeta, UserStatusO
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<UserStatusOCSMeta> get serializer => _$userStatusOCSMetaSerializer;
 }
 
-abstract class UserStatusPublic implements Built<UserStatusPublic, UserStatusPublicBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusPublicInterface {
+  String get userId;
+  String? get message;
+  String? get icon;
+  int? get clearAt;
+  String get status;
+  UserStatusPublicInterface rebuild(final void Function(UserStatusPublicInterfaceBuilder) updates);
+  UserStatusPublicInterfaceBuilder toBuilder();
+}
+
+abstract class UserStatusPublic implements UserStatusPublicInterface, Built<UserStatusPublic, UserStatusPublicBuilder> {
   factory UserStatusPublic([final void Function(UserStatusPublicBuilder)? b]) = _$UserStatusPublic;
 
   // coverage:ignore-start
@@ -562,36 +580,23 @@ abstract class UserStatusPublic implements Built<UserStatusPublic, UserStatusPub
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get userId;
-  String? get message;
-  String? get icon;
-  int? get clearAt;
-  String get status;
   static Serializer<UserStatusPublic> get serializer => _$userStatusPublicSerializer;
 }
 
-abstract class UserStatusPrivate1 implements Built<UserStatusPrivate1, UserStatusPrivate1Builder> {
-  factory UserStatusPrivate1([final void Function(UserStatusPrivate1Builder)? b]) = _$UserStatusPrivate1;
-
-  // coverage:ignore-start
-  const UserStatusPrivate1._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory UserStatusPrivate1.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusPrivate_1Interface {
   String? get messageId;
   bool get messageIsPredefined;
   bool get statusIsUserDefined;
-  static Serializer<UserStatusPrivate1> get serializer => _$userStatusPrivate1Serializer;
+  UserStatusPrivate_1Interface rebuild(final void Function(UserStatusPrivate_1InterfaceBuilder) updates);
+  UserStatusPrivate_1InterfaceBuilder toBuilder();
 }
 
-abstract class UserStatusPrivate implements Built<UserStatusPrivate, UserStatusPrivateBuilder> {
+abstract class UserStatusPrivate
+    implements
+        UserStatusPublicInterface,
+        UserStatusPrivate_1Interface,
+        Built<UserStatusPrivate, UserStatusPrivateBuilder> {
   factory UserStatusPrivate([final void Function(UserStatusPrivateBuilder)? b]) = _$UserStatusPrivate;
 
   // coverage:ignore-start
@@ -606,47 +611,22 @@ abstract class UserStatusPrivate implements Built<UserStatusPrivate, UserStatusP
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  JsonObject get data;
-  UserStatusPublic get public;
-  UserStatusPrivate1 get private1;
-  @BuiltValueSerializer(custom: true)
-  static Serializer<UserStatusPrivate> get serializer => _$UserStatusPrivateSerializer();
+  static Serializer<UserStatusPrivate> get serializer => _$userStatusPrivateSerializer;
 }
 
-class _$UserStatusPrivateSerializer implements PrimitiveSerializer<UserStatusPrivate> {
-  @override
-  final Iterable<Type> types = const [UserStatusPrivate, _$UserStatusPrivate];
-
-  @override
-  final String wireName = 'UserStatusPrivate';
-
-  @override
-  Object serialize(
-    final Serializers serializers,
-    final UserStatusPrivate object, {
-    final FullType specifiedType = FullType.unspecified,
-  }) =>
-      object.data.value;
-
-  @override
-  UserStatusPrivate deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = UserStatusPrivateBuilder()..data = JsonObject(data);
-    result.public.replace(
-      _jsonSerializers.deserialize(data, specifiedType: const FullType(UserStatusPublic))! as UserStatusPublic,
-    );
-    result.private1.replace(
-      _jsonSerializers.deserialize(data, specifiedType: const FullType(UserStatusPrivate1))! as UserStatusPrivate1,
-    );
-    return result.build();
-  }
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsInterface {
+  UserStatusOCSMeta get meta;
+  UserStatusPrivate get data;
+  UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs
     implements
+        UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsInterface,
         Built<UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs,
             UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder> {
   factory UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs([
@@ -665,14 +645,22 @@ abstract class UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusOCSMeta get meta;
-  UserStatusPrivate get data;
   static Serializer<UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs> get serializer =>
       _$userStatusHeartbeatHeartbeatResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusHeartbeatHeartbeatResponse200ApplicationJsonInterface {
+  UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs get ocs;
+  UserStatusHeartbeatHeartbeatResponse200ApplicationJsonInterface rebuild(
+    final void Function(UserStatusHeartbeatHeartbeatResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UserStatusHeartbeatHeartbeatResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusHeartbeatHeartbeatResponse200ApplicationJson
     implements
+        UserStatusHeartbeatHeartbeatResponse200ApplicationJsonInterface,
         Built<UserStatusHeartbeatHeartbeatResponse200ApplicationJson,
             UserStatusHeartbeatHeartbeatResponse200ApplicationJsonBuilder> {
   factory UserStatusHeartbeatHeartbeatResponse200ApplicationJson([
@@ -691,7 +679,6 @@ abstract class UserStatusHeartbeatHeartbeatResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UserStatusHeartbeatHeartbeatResponse200ApplicationJson> get serializer =>
       _$userStatusHeartbeatHeartbeatResponse200ApplicationJsonSerializer;
 }
@@ -786,7 +773,16 @@ class _$UserStatusClearAt_TimeSerializer implements PrimitiveSerializer<UserStat
   }
 }
 
-abstract class UserStatusClearAt implements Built<UserStatusClearAt, UserStatusClearAtBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusClearAtInterface {
+  UserStatusClearAt_Type get type;
+  UserStatusClearAt_Time get time;
+  UserStatusClearAtInterface rebuild(final void Function(UserStatusClearAtInterfaceBuilder) updates);
+  UserStatusClearAtInterfaceBuilder toBuilder();
+}
+
+abstract class UserStatusClearAt
+    implements UserStatusClearAtInterface, Built<UserStatusClearAt, UserStatusClearAtBuilder> {
   factory UserStatusClearAt([final void Function(UserStatusClearAtBuilder)? b]) = _$UserStatusClearAt;
 
   // coverage:ignore-start
@@ -801,12 +797,22 @@ abstract class UserStatusClearAt implements Built<UserStatusClearAt, UserStatusC
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusClearAt_Type get type;
-  UserStatusClearAt_Time get time;
   static Serializer<UserStatusClearAt> get serializer => _$userStatusClearAtSerializer;
 }
 
-abstract class UserStatusPredefined implements Built<UserStatusPredefined, UserStatusPredefinedBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusPredefinedInterface {
+  String get id;
+  String get icon;
+  String get message;
+  UserStatusClearAt? get clearAt;
+  bool? get visible;
+  UserStatusPredefinedInterface rebuild(final void Function(UserStatusPredefinedInterfaceBuilder) updates);
+  UserStatusPredefinedInterfaceBuilder toBuilder();
+}
+
+abstract class UserStatusPredefined
+    implements UserStatusPredefinedInterface, Built<UserStatusPredefined, UserStatusPredefinedBuilder> {
   factory UserStatusPredefined([final void Function(UserStatusPredefinedBuilder)? b]) = _$UserStatusPredefined;
 
   // coverage:ignore-start
@@ -821,16 +827,22 @@ abstract class UserStatusPredefined implements Built<UserStatusPredefined, UserS
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get id;
-  String get icon;
-  String get message;
-  UserStatusClearAt? get clearAt;
-  bool? get visible;
   static Serializer<UserStatusPredefined> get serializer => _$userStatusPredefinedSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsInterface {
+  UserStatusOCSMeta get meta;
+  BuiltList<UserStatusPredefined> get data;
+  UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs
     implements
+        UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsInterface,
         Built<UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs,
             UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder> {
   factory UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs([
@@ -849,14 +861,22 @@ abstract class UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusOCSMeta get meta;
-  BuiltList<UserStatusPredefined> get data;
   static Serializer<UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs> get serializer =>
       _$userStatusPredefinedStatusFindAllResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusPredefinedStatusFindAllResponse200ApplicationJsonInterface {
+  UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs get ocs;
+  UserStatusPredefinedStatusFindAllResponse200ApplicationJsonInterface rebuild(
+    final void Function(UserStatusPredefinedStatusFindAllResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UserStatusPredefinedStatusFindAllResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusPredefinedStatusFindAllResponse200ApplicationJson
     implements
+        UserStatusPredefinedStatusFindAllResponse200ApplicationJsonInterface,
         Built<UserStatusPredefinedStatusFindAllResponse200ApplicationJson,
             UserStatusPredefinedStatusFindAllResponse200ApplicationJsonBuilder> {
   factory UserStatusPredefinedStatusFindAllResponse200ApplicationJson([
@@ -875,13 +895,23 @@ abstract class UserStatusPredefinedStatusFindAllResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UserStatusPredefinedStatusFindAllResponse200ApplicationJson> get serializer =>
       _$userStatusPredefinedStatusFindAllResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusStatusesFindAllResponse200ApplicationJson_OcsInterface {
+  UserStatusOCSMeta get meta;
+  BuiltList<UserStatusPublic> get data;
+  UserStatusStatusesFindAllResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UserStatusStatusesFindAllResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UserStatusStatusesFindAllResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusStatusesFindAllResponse200ApplicationJson_Ocs
     implements
+        UserStatusStatusesFindAllResponse200ApplicationJson_OcsInterface,
         Built<UserStatusStatusesFindAllResponse200ApplicationJson_Ocs,
             UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder> {
   factory UserStatusStatusesFindAllResponse200ApplicationJson_Ocs([
@@ -900,14 +930,22 @@ abstract class UserStatusStatusesFindAllResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusOCSMeta get meta;
-  BuiltList<UserStatusPublic> get data;
   static Serializer<UserStatusStatusesFindAllResponse200ApplicationJson_Ocs> get serializer =>
       _$userStatusStatusesFindAllResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusStatusesFindAllResponse200ApplicationJsonInterface {
+  UserStatusStatusesFindAllResponse200ApplicationJson_Ocs get ocs;
+  UserStatusStatusesFindAllResponse200ApplicationJsonInterface rebuild(
+    final void Function(UserStatusStatusesFindAllResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UserStatusStatusesFindAllResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusStatusesFindAllResponse200ApplicationJson
     implements
+        UserStatusStatusesFindAllResponse200ApplicationJsonInterface,
         Built<UserStatusStatusesFindAllResponse200ApplicationJson,
             UserStatusStatusesFindAllResponse200ApplicationJsonBuilder> {
   factory UserStatusStatusesFindAllResponse200ApplicationJson([
@@ -926,13 +964,23 @@ abstract class UserStatusStatusesFindAllResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusStatusesFindAllResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UserStatusStatusesFindAllResponse200ApplicationJson> get serializer =>
       _$userStatusStatusesFindAllResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusStatusesFindResponse200ApplicationJson_OcsInterface {
+  UserStatusOCSMeta get meta;
+  UserStatusPublic get data;
+  UserStatusStatusesFindResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UserStatusStatusesFindResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UserStatusStatusesFindResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusStatusesFindResponse200ApplicationJson_Ocs
     implements
+        UserStatusStatusesFindResponse200ApplicationJson_OcsInterface,
         Built<UserStatusStatusesFindResponse200ApplicationJson_Ocs,
             UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder> {
   factory UserStatusStatusesFindResponse200ApplicationJson_Ocs([
@@ -951,14 +999,22 @@ abstract class UserStatusStatusesFindResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusOCSMeta get meta;
-  UserStatusPublic get data;
   static Serializer<UserStatusStatusesFindResponse200ApplicationJson_Ocs> get serializer =>
       _$userStatusStatusesFindResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusStatusesFindResponse200ApplicationJsonInterface {
+  UserStatusStatusesFindResponse200ApplicationJson_Ocs get ocs;
+  UserStatusStatusesFindResponse200ApplicationJsonInterface rebuild(
+    final void Function(UserStatusStatusesFindResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UserStatusStatusesFindResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusStatusesFindResponse200ApplicationJson
     implements
+        UserStatusStatusesFindResponse200ApplicationJsonInterface,
         Built<UserStatusStatusesFindResponse200ApplicationJson,
             UserStatusStatusesFindResponse200ApplicationJsonBuilder> {
   factory UserStatusStatusesFindResponse200ApplicationJson([
@@ -977,13 +1033,23 @@ abstract class UserStatusStatusesFindResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusStatusesFindResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UserStatusStatusesFindResponse200ApplicationJson> get serializer =>
       _$userStatusStatusesFindResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsInterface {
+  UserStatusOCSMeta get meta;
+  UserStatusPrivate get data;
+  UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs
     implements
+        UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsInterface,
         Built<UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs,
             UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder> {
   factory UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs([
@@ -1002,14 +1068,22 @@ abstract class UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusOCSMeta get meta;
-  UserStatusPrivate get data;
   static Serializer<UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs> get serializer =>
       _$userStatusUserStatusGetStatusResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusGetStatusResponse200ApplicationJsonInterface {
+  UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs get ocs;
+  UserStatusUserStatusGetStatusResponse200ApplicationJsonInterface rebuild(
+    final void Function(UserStatusUserStatusGetStatusResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusGetStatusResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusGetStatusResponse200ApplicationJson
     implements
+        UserStatusUserStatusGetStatusResponse200ApplicationJsonInterface,
         Built<UserStatusUserStatusGetStatusResponse200ApplicationJson,
             UserStatusUserStatusGetStatusResponse200ApplicationJsonBuilder> {
   factory UserStatusUserStatusGetStatusResponse200ApplicationJson([
@@ -1028,13 +1102,23 @@ abstract class UserStatusUserStatusGetStatusResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UserStatusUserStatusGetStatusResponse200ApplicationJson> get serializer =>
       _$userStatusUserStatusGetStatusResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsInterface {
+  UserStatusOCSMeta get meta;
+  UserStatusPrivate get data;
+  UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs
     implements
+        UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsInterface,
         Built<UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs,
             UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder> {
   factory UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs([
@@ -1053,14 +1137,22 @@ abstract class UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusOCSMeta get meta;
-  UserStatusPrivate get data;
   static Serializer<UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs> get serializer =>
       _$userStatusUserStatusSetStatusResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusSetStatusResponse200ApplicationJsonInterface {
+  UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs get ocs;
+  UserStatusUserStatusSetStatusResponse200ApplicationJsonInterface rebuild(
+    final void Function(UserStatusUserStatusSetStatusResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusSetStatusResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusSetStatusResponse200ApplicationJson
     implements
+        UserStatusUserStatusSetStatusResponse200ApplicationJsonInterface,
         Built<UserStatusUserStatusSetStatusResponse200ApplicationJson,
             UserStatusUserStatusSetStatusResponse200ApplicationJsonBuilder> {
   factory UserStatusUserStatusSetStatusResponse200ApplicationJson([
@@ -1079,13 +1171,23 @@ abstract class UserStatusUserStatusSetStatusResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UserStatusUserStatusSetStatusResponse200ApplicationJson> get serializer =>
       _$userStatusUserStatusSetStatusResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsInterface {
+  UserStatusOCSMeta get meta;
+  UserStatusPrivate get data;
+  UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs
     implements
+        UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsInterface,
         Built<UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs,
             UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder> {
   factory UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs([
@@ -1106,14 +1208,22 @@ abstract class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusOCSMeta get meta;
-  UserStatusPrivate get data;
   static Serializer<UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs> get serializer =>
       _$userStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonInterface {
+  UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs get ocs;
+  UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonInterface rebuild(
+    final void Function(UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson
     implements
+        UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonInterface,
         Built<UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson,
             UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonBuilder> {
   factory UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson([
@@ -1134,13 +1244,23 @@ abstract class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJso
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson> get serializer =>
       _$userStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsInterface {
+  UserStatusOCSMeta get meta;
+  UserStatusPrivate get data;
+  UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs
     implements
+        UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsInterface,
         Built<UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs,
             UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder> {
   factory UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs([
@@ -1161,14 +1281,22 @@ abstract class UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Oc
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusOCSMeta get meta;
-  UserStatusPrivate get data;
   static Serializer<UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs> get serializer =>
       _$userStatusUserStatusSetCustomMessageResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonInterface {
+  UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs get ocs;
+  UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonInterface rebuild(
+    final void Function(UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusSetCustomMessageResponse200ApplicationJson
     implements
+        UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonInterface,
         Built<UserStatusUserStatusSetCustomMessageResponse200ApplicationJson,
             UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonBuilder> {
   factory UserStatusUserStatusSetCustomMessageResponse200ApplicationJson([
@@ -1187,13 +1315,23 @@ abstract class UserStatusUserStatusSetCustomMessageResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UserStatusUserStatusSetCustomMessageResponse200ApplicationJson> get serializer =>
       _$userStatusUserStatusSetCustomMessageResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsInterface {
+  UserStatusOCSMeta get meta;
+  JsonObject get data;
+  UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs
     implements
+        UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsInterface,
         Built<UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs,
             UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder> {
   factory UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs([
@@ -1212,14 +1350,22 @@ abstract class UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusOCSMeta get meta;
-  JsonObject get data;
   static Serializer<UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs> get serializer =>
       _$userStatusUserStatusClearMessageResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusClearMessageResponse200ApplicationJsonInterface {
+  UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs get ocs;
+  UserStatusUserStatusClearMessageResponse200ApplicationJsonInterface rebuild(
+    final void Function(UserStatusUserStatusClearMessageResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusClearMessageResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusClearMessageResponse200ApplicationJson
     implements
+        UserStatusUserStatusClearMessageResponse200ApplicationJsonInterface,
         Built<UserStatusUserStatusClearMessageResponse200ApplicationJson,
             UserStatusUserStatusClearMessageResponse200ApplicationJsonBuilder> {
   factory UserStatusUserStatusClearMessageResponse200ApplicationJson([
@@ -1238,7 +1384,6 @@ abstract class UserStatusUserStatusClearMessageResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UserStatusUserStatusClearMessageResponse200ApplicationJson> get serializer =>
       _$userStatusUserStatusClearMessageResponse200ApplicationJsonSerializer;
 }
@@ -1316,8 +1461,19 @@ class _$UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_DataSeria
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsInterface {
+  UserStatusOCSMeta get meta;
+  UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_Data get data;
+  UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs
     implements
+        UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsInterface,
         Built<UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs,
             UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder> {
   factory UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs([
@@ -1336,14 +1492,22 @@ abstract class UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusOCSMeta get meta;
-  UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs> get serializer =>
       _$userStatusUserStatusRevertStatusResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusUserStatusRevertStatusResponse200ApplicationJsonInterface {
+  UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs get ocs;
+  UserStatusUserStatusRevertStatusResponse200ApplicationJsonInterface rebuild(
+    final void Function(UserStatusUserStatusRevertStatusResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  UserStatusUserStatusRevertStatusResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusUserStatusRevertStatusResponse200ApplicationJson
     implements
+        UserStatusUserStatusRevertStatusResponse200ApplicationJsonInterface,
         Built<UserStatusUserStatusRevertStatusResponse200ApplicationJson,
             UserStatusUserStatusRevertStatusResponse200ApplicationJsonBuilder> {
   factory UserStatusUserStatusRevertStatusResponse200ApplicationJson([
@@ -1362,13 +1526,26 @@ abstract class UserStatusUserStatusRevertStatusResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs get ocs;
   static Serializer<UserStatusUserStatusRevertStatusResponse200ApplicationJson> get serializer =>
       _$userStatusUserStatusRevertStatusResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusCapabilities_UserStatusInterface {
+  bool get enabled;
+  bool get restore;
+  @BuiltValueField(wireName: 'supports_emoji')
+  bool get supportsEmoji;
+  UserStatusCapabilities_UserStatusInterface rebuild(
+    final void Function(UserStatusCapabilities_UserStatusInterfaceBuilder) updates,
+  );
+  UserStatusCapabilities_UserStatusInterfaceBuilder toBuilder();
+}
+
 abstract class UserStatusCapabilities_UserStatus
-    implements Built<UserStatusCapabilities_UserStatus, UserStatusCapabilities_UserStatusBuilder> {
+    implements
+        UserStatusCapabilities_UserStatusInterface,
+        Built<UserStatusCapabilities_UserStatus, UserStatusCapabilities_UserStatusBuilder> {
   factory UserStatusCapabilities_UserStatus([final void Function(UserStatusCapabilities_UserStatusBuilder)? b]) =
       _$UserStatusCapabilities_UserStatus;
 
@@ -1384,14 +1561,19 @@ abstract class UserStatusCapabilities_UserStatus
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
-  bool get restore;
-  @BuiltValueField(wireName: 'supports_emoji')
-  bool get supportsEmoji;
   static Serializer<UserStatusCapabilities_UserStatus> get serializer => _$userStatusCapabilitiesUserStatusSerializer;
 }
 
-abstract class UserStatusCapabilities implements Built<UserStatusCapabilities, UserStatusCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class UserStatusCapabilitiesInterface {
+  @BuiltValueField(wireName: 'user_status')
+  UserStatusCapabilities_UserStatus get userStatus;
+  UserStatusCapabilitiesInterface rebuild(final void Function(UserStatusCapabilitiesInterfaceBuilder) updates);
+  UserStatusCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class UserStatusCapabilities
+    implements UserStatusCapabilitiesInterface, Built<UserStatusCapabilities, UserStatusCapabilitiesBuilder> {
   factory UserStatusCapabilities([final void Function(UserStatusCapabilitiesBuilder)? b]) = _$UserStatusCapabilities;
 
   // coverage:ignore-start
@@ -1406,8 +1588,6 @@ abstract class UserStatusCapabilities implements Built<UserStatusCapabilities, U
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'user_status')
-  UserStatusCapabilities_UserStatus get userStatus;
   static Serializer<UserStatusCapabilities> get serializer => _$userStatusCapabilitiesSerializer;
 }
 
@@ -1429,8 +1609,6 @@ final Serializers _serializers = (Serializers().toBuilder()
       ..add(UserStatusPrivate.serializer)
       ..addBuilderFactory(const FullType(UserStatusPublic), UserStatusPublic.new)
       ..add(UserStatusPublic.serializer)
-      ..addBuilderFactory(const FullType(UserStatusPrivate1), UserStatusPrivate1.new)
-      ..add(UserStatusPrivate1.serializer)
       ..addBuilderFactory(
         const FullType(UserStatusPredefinedStatusFindAllResponse200ApplicationJson),
         UserStatusPredefinedStatusFindAllResponse200ApplicationJson.new,

--- a/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
@@ -48,7 +48,7 @@ final BuiltSet<UserStatusClearAtTimeType> _$userStatusClearAtTimeTypeValues =
 
 Serializer<UserStatusOCSMeta> _$userStatusOCSMetaSerializer = _$UserStatusOCSMetaSerializer();
 Serializer<UserStatusPublic> _$userStatusPublicSerializer = _$UserStatusPublicSerializer();
-Serializer<UserStatusPrivate1> _$userStatusPrivate1Serializer = _$UserStatusPrivate1Serializer();
+Serializer<UserStatusPrivate> _$userStatusPrivateSerializer = _$UserStatusPrivateSerializer();
 Serializer<UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs>
     _$userStatusHeartbeatHeartbeatResponse200ApplicationJsonOcsSerializer =
     _$UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsSerializer();
@@ -257,22 +257,44 @@ class _$UserStatusPublicSerializer implements StructuredSerializer<UserStatusPub
   }
 }
 
-class _$UserStatusPrivate1Serializer implements StructuredSerializer<UserStatusPrivate1> {
+class _$UserStatusPrivateSerializer implements StructuredSerializer<UserStatusPrivate> {
   @override
-  final Iterable<Type> types = const [UserStatusPrivate1, _$UserStatusPrivate1];
+  final Iterable<Type> types = const [UserStatusPrivate, _$UserStatusPrivate];
   @override
-  final String wireName = 'UserStatusPrivate1';
+  final String wireName = 'UserStatusPrivate';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, UserStatusPrivate1 object,
+  Iterable<Object?> serialize(Serializers serializers, UserStatusPrivate object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'userId',
+      serializers.serialize(object.userId, specifiedType: const FullType(String)),
+      'status',
+      serializers.serialize(object.status, specifiedType: const FullType(String)),
       'messageIsPredefined',
       serializers.serialize(object.messageIsPredefined, specifiedType: const FullType(bool)),
       'statusIsUserDefined',
       serializers.serialize(object.statusIsUserDefined, specifiedType: const FullType(bool)),
     ];
     Object? value;
+    value = object.message;
+    if (value != null) {
+      result
+        ..add('message')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.icon;
+    if (value != null) {
+      result
+        ..add('icon')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.clearAt;
+    if (value != null) {
+      result
+        ..add('clearAt')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
     value = object.messageId;
     if (value != null) {
       result
@@ -283,9 +305,9 @@ class _$UserStatusPrivate1Serializer implements StructuredSerializer<UserStatusP
   }
 
   @override
-  UserStatusPrivate1 deserialize(Serializers serializers, Iterable<Object?> serialized,
+  UserStatusPrivate deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = UserStatusPrivate1Builder();
+    final result = UserStatusPrivateBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -293,6 +315,21 @@ class _$UserStatusPrivate1Serializer implements StructuredSerializer<UserStatusP
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'userId':
+          result.userId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'message':
+          result.message = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'icon':
+          result.icon = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'clearAt':
+          result.clearAt = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'status':
+          result.status = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'messageId':
           result.messageId = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
@@ -1522,6 +1559,25 @@ class _$UserStatusCapabilitiesSerializer implements StructuredSerializer<UserSta
   }
 }
 
+abstract mixin class UserStatusOCSMetaInterfaceBuilder {
+  void replace(UserStatusOCSMetaInterface other);
+  void update(void Function(UserStatusOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
+}
+
 class _$UserStatusOCSMeta extends UserStatusOCSMeta {
   @override
   final String status;
@@ -1585,28 +1641,29 @@ class _$UserStatusOCSMeta extends UserStatusOCSMeta {
   }
 }
 
-class UserStatusOCSMetaBuilder implements Builder<UserStatusOCSMeta, UserStatusOCSMetaBuilder> {
+class UserStatusOCSMetaBuilder
+    implements Builder<UserStatusOCSMeta, UserStatusOCSMetaBuilder>, UserStatusOCSMetaInterfaceBuilder {
   _$UserStatusOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   UserStatusOCSMetaBuilder();
 
@@ -1624,7 +1681,7 @@ class UserStatusOCSMetaBuilder implements Builder<UserStatusOCSMeta, UserStatusO
   }
 
   @override
-  void replace(UserStatusOCSMeta other) {
+  void replace(covariant UserStatusOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusOCSMeta;
   }
@@ -1648,6 +1705,25 @@ class UserStatusOCSMetaBuilder implements Builder<UserStatusOCSMeta, UserStatusO
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusPublicInterfaceBuilder {
+  void replace(UserStatusPublicInterface other);
+  void update(void Function(UserStatusPublicInterfaceBuilder) updates);
+  String? get userId;
+  set userId(String? userId);
+
+  String? get message;
+  set message(String? message);
+
+  String? get icon;
+  set icon(String? icon);
+
+  int? get clearAt;
+  set clearAt(int? clearAt);
+
+  String? get status;
+  set status(String? status);
 }
 
 class _$UserStatusPublic extends UserStatusPublic {
@@ -1712,28 +1788,29 @@ class _$UserStatusPublic extends UserStatusPublic {
   }
 }
 
-class UserStatusPublicBuilder implements Builder<UserStatusPublic, UserStatusPublicBuilder> {
+class UserStatusPublicBuilder
+    implements Builder<UserStatusPublic, UserStatusPublicBuilder>, UserStatusPublicInterfaceBuilder {
   _$UserStatusPublic? _$v;
 
   String? _userId;
   String? get userId => _$this._userId;
-  set userId(String? userId) => _$this._userId = userId;
+  set userId(covariant String? userId) => _$this._userId = userId;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _icon;
   String? get icon => _$this._icon;
-  set icon(String? icon) => _$this._icon = icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
 
   int? _clearAt;
   int? get clearAt => _$this._clearAt;
-  set clearAt(int? clearAt) => _$this._clearAt = clearAt;
+  set clearAt(covariant int? clearAt) => _$this._clearAt = clearAt;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   UserStatusPublicBuilder();
 
@@ -1751,7 +1828,7 @@ class UserStatusPublicBuilder implements Builder<UserStatusPublic, UserStatusPub
   }
 
   @override
-  void replace(UserStatusPublic other) {
+  void replace(covariant UserStatusPublic other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusPublic;
   }
@@ -1777,7 +1854,30 @@ class UserStatusPublicBuilder implements Builder<UserStatusPublic, UserStatusPub
   }
 }
 
-class _$UserStatusPrivate1 extends UserStatusPrivate1 {
+abstract mixin class UserStatusPrivate_1InterfaceBuilder {
+  void replace(UserStatusPrivate_1Interface other);
+  void update(void Function(UserStatusPrivate_1InterfaceBuilder) updates);
+  String? get messageId;
+  set messageId(String? messageId);
+
+  bool? get messageIsPredefined;
+  set messageIsPredefined(bool? messageIsPredefined);
+
+  bool? get statusIsUserDefined;
+  set statusIsUserDefined(bool? statusIsUserDefined);
+}
+
+class _$UserStatusPrivate extends UserStatusPrivate {
+  @override
+  final String userId;
+  @override
+  final String? message;
+  @override
+  final String? icon;
+  @override
+  final int? clearAt;
+  @override
+  final String status;
   @override
   final String? messageId;
   @override
@@ -1785,121 +1885,23 @@ class _$UserStatusPrivate1 extends UserStatusPrivate1 {
   @override
   final bool statusIsUserDefined;
 
-  factory _$UserStatusPrivate1([void Function(UserStatusPrivate1Builder)? updates]) =>
-      (UserStatusPrivate1Builder()..update(updates))._build();
-
-  _$UserStatusPrivate1._({this.messageId, required this.messageIsPredefined, required this.statusIsUserDefined})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(messageIsPredefined, r'UserStatusPrivate1', 'messageIsPredefined');
-    BuiltValueNullFieldError.checkNotNull(statusIsUserDefined, r'UserStatusPrivate1', 'statusIsUserDefined');
-  }
-
-  @override
-  UserStatusPrivate1 rebuild(void Function(UserStatusPrivate1Builder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  UserStatusPrivate1Builder toBuilder() => UserStatusPrivate1Builder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is UserStatusPrivate1 &&
-        messageId == other.messageId &&
-        messageIsPredefined == other.messageIsPredefined &&
-        statusIsUserDefined == other.statusIsUserDefined;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, messageId.hashCode);
-    _$hash = $jc(_$hash, messageIsPredefined.hashCode);
-    _$hash = $jc(_$hash, statusIsUserDefined.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'UserStatusPrivate1')
-          ..add('messageId', messageId)
-          ..add('messageIsPredefined', messageIsPredefined)
-          ..add('statusIsUserDefined', statusIsUserDefined))
-        .toString();
-  }
-}
-
-class UserStatusPrivate1Builder implements Builder<UserStatusPrivate1, UserStatusPrivate1Builder> {
-  _$UserStatusPrivate1? _$v;
-
-  String? _messageId;
-  String? get messageId => _$this._messageId;
-  set messageId(String? messageId) => _$this._messageId = messageId;
-
-  bool? _messageIsPredefined;
-  bool? get messageIsPredefined => _$this._messageIsPredefined;
-  set messageIsPredefined(bool? messageIsPredefined) => _$this._messageIsPredefined = messageIsPredefined;
-
-  bool? _statusIsUserDefined;
-  bool? get statusIsUserDefined => _$this._statusIsUserDefined;
-  set statusIsUserDefined(bool? statusIsUserDefined) => _$this._statusIsUserDefined = statusIsUserDefined;
-
-  UserStatusPrivate1Builder();
-
-  UserStatusPrivate1Builder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _messageId = $v.messageId;
-      _messageIsPredefined = $v.messageIsPredefined;
-      _statusIsUserDefined = $v.statusIsUserDefined;
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(UserStatusPrivate1 other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$UserStatusPrivate1;
-  }
-
-  @override
-  void update(void Function(UserStatusPrivate1Builder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  UserStatusPrivate1 build() => _build();
-
-  _$UserStatusPrivate1 _build() {
-    final _$result = _$v ??
-        _$UserStatusPrivate1._(
-            messageId: messageId,
-            messageIsPredefined: BuiltValueNullFieldError.checkNotNull(
-                messageIsPredefined, r'UserStatusPrivate1', 'messageIsPredefined'),
-            statusIsUserDefined: BuiltValueNullFieldError.checkNotNull(
-                statusIsUserDefined, r'UserStatusPrivate1', 'statusIsUserDefined'));
-    replace(_$result);
-    return _$result;
-  }
-}
-
-class _$UserStatusPrivate extends UserStatusPrivate {
-  @override
-  final JsonObject data;
-  @override
-  final UserStatusPublic public;
-  @override
-  final UserStatusPrivate1 private1;
-
   factory _$UserStatusPrivate([void Function(UserStatusPrivateBuilder)? updates]) =>
       (UserStatusPrivateBuilder()..update(updates))._build();
 
-  _$UserStatusPrivate._({required this.data, required this.public, required this.private1}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(data, r'UserStatusPrivate', 'data');
-    BuiltValueNullFieldError.checkNotNull(public, r'UserStatusPrivate', 'public');
-    BuiltValueNullFieldError.checkNotNull(private1, r'UserStatusPrivate', 'private1');
+  _$UserStatusPrivate._(
+      {required this.userId,
+      this.message,
+      this.icon,
+      this.clearAt,
+      required this.status,
+      this.messageId,
+      required this.messageIsPredefined,
+      required this.statusIsUserDefined})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(userId, r'UserStatusPrivate', 'userId');
+    BuiltValueNullFieldError.checkNotNull(status, r'UserStatusPrivate', 'status');
+    BuiltValueNullFieldError.checkNotNull(messageIsPredefined, r'UserStatusPrivate', 'messageIsPredefined');
+    BuiltValueNullFieldError.checkNotNull(statusIsUserDefined, r'UserStatusPrivate', 'statusIsUserDefined');
   }
 
   @override
@@ -1911,15 +1913,28 @@ class _$UserStatusPrivate extends UserStatusPrivate {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is UserStatusPrivate && data == other.data && public == other.public && private1 == other.private1;
+    return other is UserStatusPrivate &&
+        userId == other.userId &&
+        message == other.message &&
+        icon == other.icon &&
+        clearAt == other.clearAt &&
+        status == other.status &&
+        messageId == other.messageId &&
+        messageIsPredefined == other.messageIsPredefined &&
+        statusIsUserDefined == other.statusIsUserDefined;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, data.hashCode);
-    _$hash = $jc(_$hash, public.hashCode);
-    _$hash = $jc(_$hash, private1.hashCode);
+    _$hash = $jc(_$hash, userId.hashCode);
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jc(_$hash, icon.hashCode);
+    _$hash = $jc(_$hash, clearAt.hashCode);
+    _$hash = $jc(_$hash, status.hashCode);
+    _$hash = $jc(_$hash, messageId.hashCode);
+    _$hash = $jc(_$hash, messageIsPredefined.hashCode);
+    _$hash = $jc(_$hash, statusIsUserDefined.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -1927,43 +1942,78 @@ class _$UserStatusPrivate extends UserStatusPrivate {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'UserStatusPrivate')
-          ..add('data', data)
-          ..add('public', public)
-          ..add('private1', private1))
+          ..add('userId', userId)
+          ..add('message', message)
+          ..add('icon', icon)
+          ..add('clearAt', clearAt)
+          ..add('status', status)
+          ..add('messageId', messageId)
+          ..add('messageIsPredefined', messageIsPredefined)
+          ..add('statusIsUserDefined', statusIsUserDefined))
         .toString();
   }
 }
 
-class UserStatusPrivateBuilder implements Builder<UserStatusPrivate, UserStatusPrivateBuilder> {
+class UserStatusPrivateBuilder
+    implements
+        Builder<UserStatusPrivate, UserStatusPrivateBuilder>,
+        UserStatusPublicInterfaceBuilder,
+        UserStatusPrivate_1InterfaceBuilder {
   _$UserStatusPrivate? _$v;
 
-  JsonObject? _data;
-  JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  String? _userId;
+  String? get userId => _$this._userId;
+  set userId(covariant String? userId) => _$this._userId = userId;
 
-  UserStatusPublicBuilder? _public;
-  UserStatusPublicBuilder get public => _$this._public ??= UserStatusPublicBuilder();
-  set public(UserStatusPublicBuilder? public) => _$this._public = public;
+  String? _message;
+  String? get message => _$this._message;
+  set message(covariant String? message) => _$this._message = message;
 
-  UserStatusPrivate1Builder? _private1;
-  UserStatusPrivate1Builder get private1 => _$this._private1 ??= UserStatusPrivate1Builder();
-  set private1(UserStatusPrivate1Builder? private1) => _$this._private1 = private1;
+  String? _icon;
+  String? get icon => _$this._icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
+
+  int? _clearAt;
+  int? get clearAt => _$this._clearAt;
+  set clearAt(covariant int? clearAt) => _$this._clearAt = clearAt;
+
+  String? _status;
+  String? get status => _$this._status;
+  set status(covariant String? status) => _$this._status = status;
+
+  String? _messageId;
+  String? get messageId => _$this._messageId;
+  set messageId(covariant String? messageId) => _$this._messageId = messageId;
+
+  bool? _messageIsPredefined;
+  bool? get messageIsPredefined => _$this._messageIsPredefined;
+  set messageIsPredefined(covariant bool? messageIsPredefined) => _$this._messageIsPredefined = messageIsPredefined;
+
+  bool? _statusIsUserDefined;
+  bool? get statusIsUserDefined => _$this._statusIsUserDefined;
+  set statusIsUserDefined(covariant bool? statusIsUserDefined) => _$this._statusIsUserDefined = statusIsUserDefined;
 
   UserStatusPrivateBuilder();
 
   UserStatusPrivateBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _data = $v.data;
-      _public = $v.public.toBuilder();
-      _private1 = $v.private1.toBuilder();
+      _userId = $v.userId;
+      _message = $v.message;
+      _icon = $v.icon;
+      _clearAt = $v.clearAt;
+      _status = $v.status;
+      _messageId = $v.messageId;
+      _messageIsPredefined = $v.messageIsPredefined;
+      _statusIsUserDefined = $v.statusIsUserDefined;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(UserStatusPrivate other) {
+// ignore: override_on_non_overriding_method
+  void replace(covariant UserStatusPrivate other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusPrivate;
   }
@@ -1977,28 +2027,31 @@ class UserStatusPrivateBuilder implements Builder<UserStatusPrivate, UserStatusP
   UserStatusPrivate build() => _build();
 
   _$UserStatusPrivate _build() {
-    _$UserStatusPrivate _$result;
-    try {
-      _$result = _$v ??
-          _$UserStatusPrivate._(
-              data: BuiltValueNullFieldError.checkNotNull(data, r'UserStatusPrivate', 'data'),
-              public: public.build(),
-              private1: private1.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'public';
-        public.build();
-        _$failedField = 'private1';
-        private1.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'UserStatusPrivate', _$failedField, e.toString());
-      }
-      rethrow;
-    }
+    final _$result = _$v ??
+        _$UserStatusPrivate._(
+            userId: BuiltValueNullFieldError.checkNotNull(userId, r'UserStatusPrivate', 'userId'),
+            message: message,
+            icon: icon,
+            clearAt: clearAt,
+            status: BuiltValueNullFieldError.checkNotNull(status, r'UserStatusPrivate', 'status'),
+            messageId: messageId,
+            messageIsPredefined:
+                BuiltValueNullFieldError.checkNotNull(messageIsPredefined, r'UserStatusPrivate', 'messageIsPredefined'),
+            statusIsUserDefined: BuiltValueNullFieldError.checkNotNull(
+                statusIsUserDefined, r'UserStatusPrivate', 'statusIsUserDefined'));
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UserStatusOCSMetaBuilder get meta;
+  set meta(UserStatusOCSMetaBuilder? meta);
+
+  UserStatusPrivateBuilder get data;
+  set data(UserStatusPrivateBuilder? data);
 }
 
 class _$UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs
@@ -2055,16 +2108,17 @@ class _$UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs
 class UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs,
-            UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder> {
+            UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder>,
+        UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs? _$v;
 
   UserStatusOCSMetaBuilder? _meta;
   UserStatusOCSMetaBuilder get meta => _$this._meta ??= UserStatusOCSMetaBuilder();
-  set meta(UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   UserStatusPrivateBuilder? _data;
   UserStatusPrivateBuilder get data => _$this._data ??= UserStatusPrivateBuilder();
-  set data(UserStatusPrivateBuilder? data) => _$this._data = data;
+  set data(covariant UserStatusPrivateBuilder? data) => _$this._data = data;
 
   UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder();
 
@@ -2079,7 +2133,7 @@ class UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusHeartbeatHeartbeatResponse200ApplicationJson_Ocs;
   }
@@ -2113,6 +2167,13 @@ class UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusHeartbeatHeartbeatResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UserStatusHeartbeatHeartbeatResponse200ApplicationJsonInterface other);
+  void update(void Function(UserStatusHeartbeatHeartbeatResponse200ApplicationJsonInterfaceBuilder) updates);
+  UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UserStatusHeartbeatHeartbeatResponse200ApplicationJson
@@ -2161,13 +2222,14 @@ class _$UserStatusHeartbeatHeartbeatResponse200ApplicationJson
 class UserStatusHeartbeatHeartbeatResponse200ApplicationJsonBuilder
     implements
         Builder<UserStatusHeartbeatHeartbeatResponse200ApplicationJson,
-            UserStatusHeartbeatHeartbeatResponse200ApplicationJsonBuilder> {
+            UserStatusHeartbeatHeartbeatResponse200ApplicationJsonBuilder>,
+        UserStatusHeartbeatHeartbeatResponse200ApplicationJsonInterfaceBuilder {
   _$UserStatusHeartbeatHeartbeatResponse200ApplicationJson? _$v;
 
   UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder? _ocs;
   UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder();
-  set ocs(UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UserStatusHeartbeatHeartbeatResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   UserStatusHeartbeatHeartbeatResponse200ApplicationJsonBuilder();
 
@@ -2181,7 +2243,7 @@ class UserStatusHeartbeatHeartbeatResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UserStatusHeartbeatHeartbeatResponse200ApplicationJson other) {
+  void replace(covariant UserStatusHeartbeatHeartbeatResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusHeartbeatHeartbeatResponse200ApplicationJson;
   }
@@ -2318,6 +2380,16 @@ class UserStatusClearAt_TimeBuilder implements Builder<UserStatusClearAt_Time, U
   }
 }
 
+abstract mixin class UserStatusClearAtInterfaceBuilder {
+  void replace(UserStatusClearAtInterface other);
+  void update(void Function(UserStatusClearAtInterfaceBuilder) updates);
+  UserStatusClearAt_Type? get type;
+  set type(UserStatusClearAt_Type? type);
+
+  UserStatusClearAt_TimeBuilder get time;
+  set time(UserStatusClearAt_TimeBuilder? time);
+}
+
 class _$UserStatusClearAt extends UserStatusClearAt {
   @override
   final UserStatusClearAt_Type type;
@@ -2362,16 +2434,17 @@ class _$UserStatusClearAt extends UserStatusClearAt {
   }
 }
 
-class UserStatusClearAtBuilder implements Builder<UserStatusClearAt, UserStatusClearAtBuilder> {
+class UserStatusClearAtBuilder
+    implements Builder<UserStatusClearAt, UserStatusClearAtBuilder>, UserStatusClearAtInterfaceBuilder {
   _$UserStatusClearAt? _$v;
 
   UserStatusClearAt_Type? _type;
   UserStatusClearAt_Type? get type => _$this._type;
-  set type(UserStatusClearAt_Type? type) => _$this._type = type;
+  set type(covariant UserStatusClearAt_Type? type) => _$this._type = type;
 
   UserStatusClearAt_TimeBuilder? _time;
   UserStatusClearAt_TimeBuilder get time => _$this._time ??= UserStatusClearAt_TimeBuilder();
-  set time(UserStatusClearAt_TimeBuilder? time) => _$this._time = time;
+  set time(covariant UserStatusClearAt_TimeBuilder? time) => _$this._time = time;
 
   UserStatusClearAtBuilder();
 
@@ -2386,7 +2459,7 @@ class UserStatusClearAtBuilder implements Builder<UserStatusClearAt, UserStatusC
   }
 
   @override
-  void replace(UserStatusClearAt other) {
+  void replace(covariant UserStatusClearAt other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusClearAt;
   }
@@ -2418,6 +2491,25 @@ class UserStatusClearAtBuilder implements Builder<UserStatusClearAt, UserStatusC
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusPredefinedInterfaceBuilder {
+  void replace(UserStatusPredefinedInterface other);
+  void update(void Function(UserStatusPredefinedInterfaceBuilder) updates);
+  String? get id;
+  set id(String? id);
+
+  String? get icon;
+  set icon(String? icon);
+
+  String? get message;
+  set message(String? message);
+
+  UserStatusClearAtBuilder get clearAt;
+  set clearAt(UserStatusClearAtBuilder? clearAt);
+
+  bool? get visible;
+  set visible(bool? visible);
 }
 
 class _$UserStatusPredefined extends UserStatusPredefined {
@@ -2484,28 +2576,29 @@ class _$UserStatusPredefined extends UserStatusPredefined {
   }
 }
 
-class UserStatusPredefinedBuilder implements Builder<UserStatusPredefined, UserStatusPredefinedBuilder> {
+class UserStatusPredefinedBuilder
+    implements Builder<UserStatusPredefined, UserStatusPredefinedBuilder>, UserStatusPredefinedInterfaceBuilder {
   _$UserStatusPredefined? _$v;
 
   String? _id;
   String? get id => _$this._id;
-  set id(String? id) => _$this._id = id;
+  set id(covariant String? id) => _$this._id = id;
 
   String? _icon;
   String? get icon => _$this._icon;
-  set icon(String? icon) => _$this._icon = icon;
+  set icon(covariant String? icon) => _$this._icon = icon;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   UserStatusClearAtBuilder? _clearAt;
   UserStatusClearAtBuilder get clearAt => _$this._clearAt ??= UserStatusClearAtBuilder();
-  set clearAt(UserStatusClearAtBuilder? clearAt) => _$this._clearAt = clearAt;
+  set clearAt(covariant UserStatusClearAtBuilder? clearAt) => _$this._clearAt = clearAt;
 
   bool? _visible;
   bool? get visible => _$this._visible;
-  set visible(bool? visible) => _$this._visible = visible;
+  set visible(covariant bool? visible) => _$this._visible = visible;
 
   UserStatusPredefinedBuilder();
 
@@ -2523,7 +2616,7 @@ class UserStatusPredefinedBuilder implements Builder<UserStatusPredefined, UserS
   }
 
   @override
-  void replace(UserStatusPredefined other) {
+  void replace(covariant UserStatusPredefined other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusPredefined;
   }
@@ -2559,6 +2652,16 @@ class UserStatusPredefinedBuilder implements Builder<UserStatusPredefined, UserS
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UserStatusOCSMetaBuilder get meta;
+  set meta(UserStatusOCSMetaBuilder? meta);
+
+  ListBuilder<UserStatusPredefined> get data;
+  set data(ListBuilder<UserStatusPredefined>? data);
 }
 
 class _$UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs
@@ -2618,16 +2721,17 @@ class _$UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs
 class UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs,
-            UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder> {
+            UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder>,
+        UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs? _$v;
 
   UserStatusOCSMetaBuilder? _meta;
   UserStatusOCSMetaBuilder get meta => _$this._meta ??= UserStatusOCSMetaBuilder();
-  set meta(UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<UserStatusPredefined>? _data;
   ListBuilder<UserStatusPredefined> get data => _$this._data ??= ListBuilder<UserStatusPredefined>();
-  set data(ListBuilder<UserStatusPredefined>? data) => _$this._data = data;
+  set data(covariant ListBuilder<UserStatusPredefined>? data) => _$this._data = data;
 
   UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder();
 
@@ -2642,7 +2746,7 @@ class UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusPredefinedStatusFindAllResponse200ApplicationJson_Ocs;
   }
@@ -2676,6 +2780,13 @@ class UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusPredefinedStatusFindAllResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UserStatusPredefinedStatusFindAllResponse200ApplicationJsonInterface other);
+  void update(void Function(UserStatusPredefinedStatusFindAllResponse200ApplicationJsonInterfaceBuilder) updates);
+  UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UserStatusPredefinedStatusFindAllResponse200ApplicationJson
@@ -2725,13 +2836,14 @@ class _$UserStatusPredefinedStatusFindAllResponse200ApplicationJson
 class UserStatusPredefinedStatusFindAllResponse200ApplicationJsonBuilder
     implements
         Builder<UserStatusPredefinedStatusFindAllResponse200ApplicationJson,
-            UserStatusPredefinedStatusFindAllResponse200ApplicationJsonBuilder> {
+            UserStatusPredefinedStatusFindAllResponse200ApplicationJsonBuilder>,
+        UserStatusPredefinedStatusFindAllResponse200ApplicationJsonInterfaceBuilder {
   _$UserStatusPredefinedStatusFindAllResponse200ApplicationJson? _$v;
 
   UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder? _ocs;
   UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder();
-  set ocs(UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UserStatusPredefinedStatusFindAllResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   UserStatusPredefinedStatusFindAllResponse200ApplicationJsonBuilder();
 
@@ -2745,7 +2857,7 @@ class UserStatusPredefinedStatusFindAllResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UserStatusPredefinedStatusFindAllResponse200ApplicationJson other) {
+  void replace(covariant UserStatusPredefinedStatusFindAllResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusPredefinedStatusFindAllResponse200ApplicationJson;
   }
@@ -2776,6 +2888,16 @@ class UserStatusPredefinedStatusFindAllResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusStatusesFindAllResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UserStatusStatusesFindAllResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(UserStatusStatusesFindAllResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UserStatusOCSMetaBuilder get meta;
+  set meta(UserStatusOCSMetaBuilder? meta);
+
+  ListBuilder<UserStatusPublic> get data;
+  set data(ListBuilder<UserStatusPublic>? data);
 }
 
 class _$UserStatusStatusesFindAllResponse200ApplicationJson_Ocs
@@ -2830,16 +2952,17 @@ class _$UserStatusStatusesFindAllResponse200ApplicationJson_Ocs
 class UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UserStatusStatusesFindAllResponse200ApplicationJson_Ocs,
-            UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder> {
+            UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder>,
+        UserStatusStatusesFindAllResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UserStatusStatusesFindAllResponse200ApplicationJson_Ocs? _$v;
 
   UserStatusOCSMetaBuilder? _meta;
   UserStatusOCSMetaBuilder get meta => _$this._meta ??= UserStatusOCSMetaBuilder();
-  set meta(UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<UserStatusPublic>? _data;
   ListBuilder<UserStatusPublic> get data => _$this._data ??= ListBuilder<UserStatusPublic>();
-  set data(ListBuilder<UserStatusPublic>? data) => _$this._data = data;
+  set data(covariant ListBuilder<UserStatusPublic>? data) => _$this._data = data;
 
   UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder();
 
@@ -2854,7 +2977,7 @@ class UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(UserStatusStatusesFindAllResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UserStatusStatusesFindAllResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusStatusesFindAllResponse200ApplicationJson_Ocs;
   }
@@ -2888,6 +3011,13 @@ class UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusStatusesFindAllResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UserStatusStatusesFindAllResponse200ApplicationJsonInterface other);
+  void update(void Function(UserStatusStatusesFindAllResponse200ApplicationJsonInterfaceBuilder) updates);
+  UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UserStatusStatusesFindAllResponse200ApplicationJson
@@ -2936,13 +3066,14 @@ class _$UserStatusStatusesFindAllResponse200ApplicationJson
 class UserStatusStatusesFindAllResponse200ApplicationJsonBuilder
     implements
         Builder<UserStatusStatusesFindAllResponse200ApplicationJson,
-            UserStatusStatusesFindAllResponse200ApplicationJsonBuilder> {
+            UserStatusStatusesFindAllResponse200ApplicationJsonBuilder>,
+        UserStatusStatusesFindAllResponse200ApplicationJsonInterfaceBuilder {
   _$UserStatusStatusesFindAllResponse200ApplicationJson? _$v;
 
   UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder? _ocs;
   UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder();
-  set ocs(UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UserStatusStatusesFindAllResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   UserStatusStatusesFindAllResponse200ApplicationJsonBuilder();
 
@@ -2956,7 +3087,7 @@ class UserStatusStatusesFindAllResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UserStatusStatusesFindAllResponse200ApplicationJson other) {
+  void replace(covariant UserStatusStatusesFindAllResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusStatusesFindAllResponse200ApplicationJson;
   }
@@ -2987,6 +3118,16 @@ class UserStatusStatusesFindAllResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusStatusesFindResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UserStatusStatusesFindResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(UserStatusStatusesFindResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UserStatusOCSMetaBuilder get meta;
+  set meta(UserStatusOCSMetaBuilder? meta);
+
+  UserStatusPublicBuilder get data;
+  set data(UserStatusPublicBuilder? data);
 }
 
 class _$UserStatusStatusesFindResponse200ApplicationJson_Ocs
@@ -3041,16 +3182,17 @@ class _$UserStatusStatusesFindResponse200ApplicationJson_Ocs
 class UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UserStatusStatusesFindResponse200ApplicationJson_Ocs,
-            UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder> {
+            UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder>,
+        UserStatusStatusesFindResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UserStatusStatusesFindResponse200ApplicationJson_Ocs? _$v;
 
   UserStatusOCSMetaBuilder? _meta;
   UserStatusOCSMetaBuilder get meta => _$this._meta ??= UserStatusOCSMetaBuilder();
-  set meta(UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   UserStatusPublicBuilder? _data;
   UserStatusPublicBuilder get data => _$this._data ??= UserStatusPublicBuilder();
-  set data(UserStatusPublicBuilder? data) => _$this._data = data;
+  set data(covariant UserStatusPublicBuilder? data) => _$this._data = data;
 
   UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder();
 
@@ -3065,7 +3207,7 @@ class UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(UserStatusStatusesFindResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UserStatusStatusesFindResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusStatusesFindResponse200ApplicationJson_Ocs;
   }
@@ -3099,6 +3241,13 @@ class UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusStatusesFindResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UserStatusStatusesFindResponse200ApplicationJsonInterface other);
+  void update(void Function(UserStatusStatusesFindResponse200ApplicationJsonInterfaceBuilder) updates);
+  UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UserStatusStatusesFindResponse200ApplicationJson extends UserStatusStatusesFindResponse200ApplicationJson {
@@ -3146,13 +3295,14 @@ class _$UserStatusStatusesFindResponse200ApplicationJson extends UserStatusStatu
 class UserStatusStatusesFindResponse200ApplicationJsonBuilder
     implements
         Builder<UserStatusStatusesFindResponse200ApplicationJson,
-            UserStatusStatusesFindResponse200ApplicationJsonBuilder> {
+            UserStatusStatusesFindResponse200ApplicationJsonBuilder>,
+        UserStatusStatusesFindResponse200ApplicationJsonInterfaceBuilder {
   _$UserStatusStatusesFindResponse200ApplicationJson? _$v;
 
   UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder? _ocs;
   UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder();
-  set ocs(UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UserStatusStatusesFindResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   UserStatusStatusesFindResponse200ApplicationJsonBuilder();
 
@@ -3166,7 +3316,7 @@ class UserStatusStatusesFindResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UserStatusStatusesFindResponse200ApplicationJson other) {
+  void replace(covariant UserStatusStatusesFindResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusStatusesFindResponse200ApplicationJson;
   }
@@ -3197,6 +3347,16 @@ class UserStatusStatusesFindResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UserStatusOCSMetaBuilder get meta;
+  set meta(UserStatusOCSMetaBuilder? meta);
+
+  UserStatusPrivateBuilder get data;
+  set data(UserStatusPrivateBuilder? data);
 }
 
 class _$UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs
@@ -3254,16 +3414,17 @@ class _$UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs
 class UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs,
-            UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder> {
+            UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder>,
+        UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs? _$v;
 
   UserStatusOCSMetaBuilder? _meta;
   UserStatusOCSMetaBuilder get meta => _$this._meta ??= UserStatusOCSMetaBuilder();
-  set meta(UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   UserStatusPrivateBuilder? _data;
   UserStatusPrivateBuilder get data => _$this._data ??= UserStatusPrivateBuilder();
-  set data(UserStatusPrivateBuilder? data) => _$this._data = data;
+  set data(covariant UserStatusPrivateBuilder? data) => _$this._data = data;
 
   UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder();
 
@@ -3278,7 +3439,7 @@ class UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusGetStatusResponse200ApplicationJson_Ocs;
   }
@@ -3312,6 +3473,13 @@ class UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusGetStatusResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UserStatusUserStatusGetStatusResponse200ApplicationJsonInterface other);
+  void update(void Function(UserStatusUserStatusGetStatusResponse200ApplicationJsonInterfaceBuilder) updates);
+  UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UserStatusUserStatusGetStatusResponse200ApplicationJson
@@ -3360,13 +3528,14 @@ class _$UserStatusUserStatusGetStatusResponse200ApplicationJson
 class UserStatusUserStatusGetStatusResponse200ApplicationJsonBuilder
     implements
         Builder<UserStatusUserStatusGetStatusResponse200ApplicationJson,
-            UserStatusUserStatusGetStatusResponse200ApplicationJsonBuilder> {
+            UserStatusUserStatusGetStatusResponse200ApplicationJsonBuilder>,
+        UserStatusUserStatusGetStatusResponse200ApplicationJsonInterfaceBuilder {
   _$UserStatusUserStatusGetStatusResponse200ApplicationJson? _$v;
 
   UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder? _ocs;
   UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder();
-  set ocs(UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UserStatusUserStatusGetStatusResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   UserStatusUserStatusGetStatusResponse200ApplicationJsonBuilder();
 
@@ -3380,7 +3549,7 @@ class UserStatusUserStatusGetStatusResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusGetStatusResponse200ApplicationJson other) {
+  void replace(covariant UserStatusUserStatusGetStatusResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusGetStatusResponse200ApplicationJson;
   }
@@ -3411,6 +3580,16 @@ class UserStatusUserStatusGetStatusResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UserStatusOCSMetaBuilder get meta;
+  set meta(UserStatusOCSMetaBuilder? meta);
+
+  UserStatusPrivateBuilder get data;
+  set data(UserStatusPrivateBuilder? data);
 }
 
 class _$UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs
@@ -3468,16 +3647,17 @@ class _$UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs
 class UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs,
-            UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder> {
+            UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder>,
+        UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs? _$v;
 
   UserStatusOCSMetaBuilder? _meta;
   UserStatusOCSMetaBuilder get meta => _$this._meta ??= UserStatusOCSMetaBuilder();
-  set meta(UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   UserStatusPrivateBuilder? _data;
   UserStatusPrivateBuilder get data => _$this._data ??= UserStatusPrivateBuilder();
-  set data(UserStatusPrivateBuilder? data) => _$this._data = data;
+  set data(covariant UserStatusPrivateBuilder? data) => _$this._data = data;
 
   UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder();
 
@@ -3492,7 +3672,7 @@ class UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusSetStatusResponse200ApplicationJson_Ocs;
   }
@@ -3526,6 +3706,13 @@ class UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusSetStatusResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UserStatusUserStatusSetStatusResponse200ApplicationJsonInterface other);
+  void update(void Function(UserStatusUserStatusSetStatusResponse200ApplicationJsonInterfaceBuilder) updates);
+  UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UserStatusUserStatusSetStatusResponse200ApplicationJson
@@ -3574,13 +3761,14 @@ class _$UserStatusUserStatusSetStatusResponse200ApplicationJson
 class UserStatusUserStatusSetStatusResponse200ApplicationJsonBuilder
     implements
         Builder<UserStatusUserStatusSetStatusResponse200ApplicationJson,
-            UserStatusUserStatusSetStatusResponse200ApplicationJsonBuilder> {
+            UserStatusUserStatusSetStatusResponse200ApplicationJsonBuilder>,
+        UserStatusUserStatusSetStatusResponse200ApplicationJsonInterfaceBuilder {
   _$UserStatusUserStatusSetStatusResponse200ApplicationJson? _$v;
 
   UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder? _ocs;
   UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder();
-  set ocs(UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UserStatusUserStatusSetStatusResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   UserStatusUserStatusSetStatusResponse200ApplicationJsonBuilder();
 
@@ -3594,7 +3782,7 @@ class UserStatusUserStatusSetStatusResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusSetStatusResponse200ApplicationJson other) {
+  void replace(covariant UserStatusUserStatusSetStatusResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusSetStatusResponse200ApplicationJson;
   }
@@ -3625,6 +3813,17 @@ class UserStatusUserStatusSetStatusResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UserStatusOCSMetaBuilder get meta;
+  set meta(UserStatusOCSMetaBuilder? meta);
+
+  UserStatusPrivateBuilder get data;
+  set data(UserStatusPrivateBuilder? data);
 }
 
 class _$UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs
@@ -3684,16 +3883,17 @@ class _$UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs
 class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs,
-            UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder> {
+            UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder>,
+        UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs? _$v;
 
   UserStatusOCSMetaBuilder? _meta;
   UserStatusOCSMetaBuilder get meta => _$this._meta ??= UserStatusOCSMetaBuilder();
-  set meta(UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   UserStatusPrivateBuilder? _data;
   UserStatusPrivateBuilder get data => _$this._data ??= UserStatusPrivateBuilder();
-  set data(UserStatusPrivateBuilder? data) => _$this._data = data;
+  set data(covariant UserStatusPrivateBuilder? data) => _$this._data = data;
 
   UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder();
 
@@ -3708,7 +3908,7 @@ class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuil
   }
 
   @override
-  void replace(UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_Ocs;
   }
@@ -3743,6 +3943,14 @@ class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonInterfaceBuilder) updates);
+  UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson
@@ -3793,13 +4001,15 @@ class _$UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson
 class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonBuilder
     implements
         Builder<UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson,
-            UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonBuilder> {
+            UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonBuilder>,
+        UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonInterfaceBuilder {
   _$UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson? _$v;
 
   UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder? _ocs;
   UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder();
-  set ocs(UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonBuilder();
 
@@ -3813,7 +4023,7 @@ class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson other) {
+  void replace(covariant UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJson;
   }
@@ -3844,6 +4054,17 @@ class UserStatusUserStatusSetPredefinedMessageResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UserStatusOCSMetaBuilder get meta;
+  set meta(UserStatusOCSMetaBuilder? meta);
+
+  UserStatusPrivateBuilder get data;
+  set data(UserStatusPrivateBuilder? data);
 }
 
 class _$UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs
@@ -3903,16 +4124,17 @@ class _$UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs
 class UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs,
-            UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder> {
+            UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder>,
+        UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs? _$v;
 
   UserStatusOCSMetaBuilder? _meta;
   UserStatusOCSMetaBuilder get meta => _$this._meta ??= UserStatusOCSMetaBuilder();
-  set meta(UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   UserStatusPrivateBuilder? _data;
   UserStatusPrivateBuilder get data => _$this._data ??= UserStatusPrivateBuilder();
-  set data(UserStatusPrivateBuilder? data) => _$this._data = data;
+  set data(covariant UserStatusPrivateBuilder? data) => _$this._data = data;
 
   UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder();
 
@@ -3927,7 +4149,7 @@ class UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_Ocs;
   }
@@ -3962,6 +4184,13 @@ class UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonInterface other);
+  void update(void Function(UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonInterfaceBuilder) updates);
+  UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UserStatusUserStatusSetCustomMessageResponse200ApplicationJson
@@ -4012,13 +4241,15 @@ class _$UserStatusUserStatusSetCustomMessageResponse200ApplicationJson
 class UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonBuilder
     implements
         Builder<UserStatusUserStatusSetCustomMessageResponse200ApplicationJson,
-            UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonBuilder> {
+            UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonBuilder>,
+        UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonInterfaceBuilder {
   _$UserStatusUserStatusSetCustomMessageResponse200ApplicationJson? _$v;
 
   UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder? _ocs;
   UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder();
-  set ocs(UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UserStatusUserStatusSetCustomMessageResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonBuilder();
 
@@ -4032,7 +4263,7 @@ class UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusSetCustomMessageResponse200ApplicationJson other) {
+  void replace(covariant UserStatusUserStatusSetCustomMessageResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusSetCustomMessageResponse200ApplicationJson;
   }
@@ -4063,6 +4294,16 @@ class UserStatusUserStatusSetCustomMessageResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UserStatusOCSMetaBuilder get meta;
+  set meta(UserStatusOCSMetaBuilder? meta);
+
+  JsonObject? get data;
+  set data(JsonObject? data);
 }
 
 class _$UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs
@@ -4122,16 +4363,17 @@ class _$UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs
 class UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs,
-            UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder> {
+            UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder>,
+        UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs? _$v;
 
   UserStatusOCSMetaBuilder? _meta;
   UserStatusOCSMetaBuilder get meta => _$this._meta ??= UserStatusOCSMetaBuilder();
-  set meta(UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   JsonObject? _data;
   JsonObject? get data => _$this._data;
-  set data(JsonObject? data) => _$this._data = data;
+  set data(covariant JsonObject? data) => _$this._data = data;
 
   UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder();
 
@@ -4146,7 +4388,7 @@ class UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusClearMessageResponse200ApplicationJson_Ocs;
   }
@@ -4181,6 +4423,13 @@ class UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusClearMessageResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UserStatusUserStatusClearMessageResponse200ApplicationJsonInterface other);
+  void update(void Function(UserStatusUserStatusClearMessageResponse200ApplicationJsonInterfaceBuilder) updates);
+  UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UserStatusUserStatusClearMessageResponse200ApplicationJson
@@ -4229,13 +4478,14 @@ class _$UserStatusUserStatusClearMessageResponse200ApplicationJson
 class UserStatusUserStatusClearMessageResponse200ApplicationJsonBuilder
     implements
         Builder<UserStatusUserStatusClearMessageResponse200ApplicationJson,
-            UserStatusUserStatusClearMessageResponse200ApplicationJsonBuilder> {
+            UserStatusUserStatusClearMessageResponse200ApplicationJsonBuilder>,
+        UserStatusUserStatusClearMessageResponse200ApplicationJsonInterfaceBuilder {
   _$UserStatusUserStatusClearMessageResponse200ApplicationJson? _$v;
 
   UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder? _ocs;
   UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder();
-  set ocs(UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UserStatusUserStatusClearMessageResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   UserStatusUserStatusClearMessageResponse200ApplicationJsonBuilder();
 
@@ -4249,7 +4499,7 @@ class UserStatusUserStatusClearMessageResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusClearMessageResponse200ApplicationJson other) {
+  void replace(covariant UserStatusUserStatusClearMessageResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusClearMessageResponse200ApplicationJson;
   }
@@ -4410,6 +4660,16 @@ class UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_DataBuilder
   }
 }
 
+abstract mixin class UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  UserStatusOCSMetaBuilder get meta;
+  set meta(UserStatusOCSMetaBuilder? meta);
+
+  UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_DataBuilder? data);
+}
+
 class _$UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs
     extends UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs {
   @override
@@ -4467,17 +4727,19 @@ class _$UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs
 class UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder
     implements
         Builder<UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs,
-            UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder> {
+            UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder>,
+        UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsInterfaceBuilder {
   _$UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs? _$v;
 
   UserStatusOCSMetaBuilder? _meta;
   UserStatusOCSMetaBuilder get meta => _$this._meta ??= UserStatusOCSMetaBuilder();
-  set meta(UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant UserStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_DataBuilder? _data;
   UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder();
 
@@ -4492,7 +4754,7 @@ class UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs other) {
+  void replace(covariant UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusRevertStatusResponse200ApplicationJson_Ocs;
   }
@@ -4526,6 +4788,13 @@ class UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusUserStatusRevertStatusResponse200ApplicationJsonInterfaceBuilder {
+  void replace(UserStatusUserStatusRevertStatusResponse200ApplicationJsonInterface other);
+  void update(void Function(UserStatusUserStatusRevertStatusResponse200ApplicationJsonInterfaceBuilder) updates);
+  UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$UserStatusUserStatusRevertStatusResponse200ApplicationJson
@@ -4574,13 +4843,14 @@ class _$UserStatusUserStatusRevertStatusResponse200ApplicationJson
 class UserStatusUserStatusRevertStatusResponse200ApplicationJsonBuilder
     implements
         Builder<UserStatusUserStatusRevertStatusResponse200ApplicationJson,
-            UserStatusUserStatusRevertStatusResponse200ApplicationJsonBuilder> {
+            UserStatusUserStatusRevertStatusResponse200ApplicationJsonBuilder>,
+        UserStatusUserStatusRevertStatusResponse200ApplicationJsonInterfaceBuilder {
   _$UserStatusUserStatusRevertStatusResponse200ApplicationJson? _$v;
 
   UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder? _ocs;
   UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder();
-  set ocs(UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant UserStatusUserStatusRevertStatusResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   UserStatusUserStatusRevertStatusResponse200ApplicationJsonBuilder();
 
@@ -4594,7 +4864,7 @@ class UserStatusUserStatusRevertStatusResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(UserStatusUserStatusRevertStatusResponse200ApplicationJson other) {
+  void replace(covariant UserStatusUserStatusRevertStatusResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusUserStatusRevertStatusResponse200ApplicationJson;
   }
@@ -4625,6 +4895,19 @@ class UserStatusUserStatusRevertStatusResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusCapabilities_UserStatusInterfaceBuilder {
+  void replace(UserStatusCapabilities_UserStatusInterface other);
+  void update(void Function(UserStatusCapabilities_UserStatusInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  bool? get restore;
+  set restore(bool? restore);
+
+  bool? get supportsEmoji;
+  set supportsEmoji(bool? supportsEmoji);
 }
 
 class _$UserStatusCapabilities_UserStatus extends UserStatusCapabilities_UserStatus {
@@ -4682,20 +4965,22 @@ class _$UserStatusCapabilities_UserStatus extends UserStatusCapabilities_UserSta
 }
 
 class UserStatusCapabilities_UserStatusBuilder
-    implements Builder<UserStatusCapabilities_UserStatus, UserStatusCapabilities_UserStatusBuilder> {
+    implements
+        Builder<UserStatusCapabilities_UserStatus, UserStatusCapabilities_UserStatusBuilder>,
+        UserStatusCapabilities_UserStatusInterfaceBuilder {
   _$UserStatusCapabilities_UserStatus? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   bool? _restore;
   bool? get restore => _$this._restore;
-  set restore(bool? restore) => _$this._restore = restore;
+  set restore(covariant bool? restore) => _$this._restore = restore;
 
   bool? _supportsEmoji;
   bool? get supportsEmoji => _$this._supportsEmoji;
-  set supportsEmoji(bool? supportsEmoji) => _$this._supportsEmoji = supportsEmoji;
+  set supportsEmoji(covariant bool? supportsEmoji) => _$this._supportsEmoji = supportsEmoji;
 
   UserStatusCapabilities_UserStatusBuilder();
 
@@ -4711,7 +4996,7 @@ class UserStatusCapabilities_UserStatusBuilder
   }
 
   @override
-  void replace(UserStatusCapabilities_UserStatus other) {
+  void replace(covariant UserStatusCapabilities_UserStatus other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusCapabilities_UserStatus;
   }
@@ -4734,6 +5019,13 @@ class UserStatusCapabilities_UserStatusBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class UserStatusCapabilitiesInterfaceBuilder {
+  void replace(UserStatusCapabilitiesInterface other);
+  void update(void Function(UserStatusCapabilitiesInterfaceBuilder) updates);
+  UserStatusCapabilities_UserStatusBuilder get userStatus;
+  set userStatus(UserStatusCapabilities_UserStatusBuilder? userStatus);
 }
 
 class _$UserStatusCapabilities extends UserStatusCapabilities {
@@ -4774,13 +5066,14 @@ class _$UserStatusCapabilities extends UserStatusCapabilities {
   }
 }
 
-class UserStatusCapabilitiesBuilder implements Builder<UserStatusCapabilities, UserStatusCapabilitiesBuilder> {
+class UserStatusCapabilitiesBuilder
+    implements Builder<UserStatusCapabilities, UserStatusCapabilitiesBuilder>, UserStatusCapabilitiesInterfaceBuilder {
   _$UserStatusCapabilities? _$v;
 
   UserStatusCapabilities_UserStatusBuilder? _userStatus;
   UserStatusCapabilities_UserStatusBuilder get userStatus =>
       _$this._userStatus ??= UserStatusCapabilities_UserStatusBuilder();
-  set userStatus(UserStatusCapabilities_UserStatusBuilder? userStatus) => _$this._userStatus = userStatus;
+  set userStatus(covariant UserStatusCapabilities_UserStatusBuilder? userStatus) => _$this._userStatus = userStatus;
 
   UserStatusCapabilitiesBuilder();
 
@@ -4794,7 +5087,7 @@ class UserStatusCapabilitiesBuilder implements Builder<UserStatusCapabilities, U
   }
 
   @override
-  void replace(UserStatusCapabilities other) {
+  void replace(covariant UserStatusCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$UserStatusCapabilities;
   }

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -367,7 +367,19 @@ class WeatherStatusWeatherStatusClient {
   }
 }
 
-abstract class WeatherStatusOCSMeta implements Built<WeatherStatusOCSMeta, WeatherStatusOCSMetaBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusOCSMetaInterface {
+  String get status;
+  int get statuscode;
+  String? get message;
+  String? get totalitems;
+  String? get itemsperpage;
+  WeatherStatusOCSMetaInterface rebuild(final void Function(WeatherStatusOCSMetaInterfaceBuilder) updates);
+  WeatherStatusOCSMetaInterfaceBuilder toBuilder();
+}
+
+abstract class WeatherStatusOCSMeta
+    implements WeatherStatusOCSMetaInterface, Built<WeatherStatusOCSMeta, WeatherStatusOCSMetaBuilder> {
   factory WeatherStatusOCSMeta([final void Function(WeatherStatusOCSMetaBuilder)? b]) = _$WeatherStatusOCSMeta;
 
   // coverage:ignore-start
@@ -382,16 +394,21 @@ abstract class WeatherStatusOCSMeta implements Built<WeatherStatusOCSMeta, Weath
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get status;
-  int get statuscode;
-  String? get message;
-  String? get totalitems;
-  String? get itemsperpage;
   static Serializer<WeatherStatusOCSMeta> get serializer => _$weatherStatusOCSMetaSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataInterface {
+  bool get success;
+  WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
 }
 
 abstract class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data
     implements
+        WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataInterface,
         Built<WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data,
             WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder> {
   factory WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data([
@@ -412,13 +429,23 @@ abstract class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_D
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
   static Serializer<WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$weatherStatusWeatherStatusSetModeResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsInterface {
+  WeatherStatusOCSMeta get meta;
+  WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data get data;
+  WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs
     implements
+        WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsInterface,
         Built<WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs,
             WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder> {
   factory WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs([
@@ -437,14 +464,22 @@ abstract class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusOCSMeta get meta;
-  WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs> get serializer =>
       _$weatherStatusWeatherStatusSetModeResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonInterface {
+  WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs get ocs;
+  WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson
     implements
+        WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonInterface,
         Built<WeatherStatusWeatherStatusSetModeResponse200ApplicationJson,
             WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonBuilder> {
   factory WeatherStatusWeatherStatusSetModeResponse200ApplicationJson([
@@ -463,13 +498,26 @@ abstract class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs get ocs;
   static Serializer<WeatherStatusWeatherStatusSetModeResponse200ApplicationJson> get serializer =>
       _$weatherStatusWeatherStatusSetModeResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataInterface {
+  bool get success;
+  num? get lat;
+  num? get lon;
+  String? get address;
+  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataInterfaceBuilder)
+        updates,
+  );
+  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data
     implements
+        WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataInterface,
         Built<WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data,
             WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder> {
   factory WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data([
@@ -490,16 +538,24 @@ abstract class WeatherStatusWeatherStatusUsePersonalAddressResponse200Applicatio
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
-  num? get lat;
-  num? get lon;
-  String? get address;
   static Serializer<WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$weatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsInterface {
+  WeatherStatusOCSMeta get meta;
+  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data get data;
+  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsInterfaceBuilder)
+        updates,
+  );
+  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs
     implements
+        WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsInterface,
         Built<WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs,
             WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder> {
   factory WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs([
@@ -520,14 +576,22 @@ abstract class WeatherStatusWeatherStatusUsePersonalAddressResponse200Applicatio
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusOCSMeta get meta;
-  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs> get serializer =>
       _$weatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonInterface {
+  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs get ocs;
+  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson
     implements
+        WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonInterface,
         Built<WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson,
             WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonBuilder> {
   factory WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson([
@@ -548,13 +612,26 @@ abstract class WeatherStatusWeatherStatusUsePersonalAddressResponse200Applicatio
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs get ocs;
   static Serializer<WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson> get serializer =>
       _$weatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataInterface {
+  num get lat;
+  num get lon;
+  String get address;
+  int get mode;
+  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataInterfaceBuilder)
+        updates,
+  );
+  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data
     implements
+        WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataInterface,
         Built<WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data,
             WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder> {
   factory WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data([
@@ -575,16 +652,23 @@ abstract class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  num get lat;
-  num get lon;
-  String get address;
-  int get mode;
   static Serializer<WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$weatherStatusWeatherStatusGetLocationResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsInterface {
+  WeatherStatusOCSMeta get meta;
+  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data get data;
+  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs
     implements
+        WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsInterface,
         Built<WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs,
             WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder> {
   factory WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs([
@@ -605,14 +689,22 @@ abstract class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusOCSMeta get meta;
-  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs> get serializer =>
       _$weatherStatusWeatherStatusGetLocationResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonInterface {
+  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs get ocs;
+  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson
     implements
+        WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonInterface,
         Built<WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson,
             WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonBuilder> {
   factory WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson([
@@ -631,13 +723,26 @@ abstract class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs get ocs;
   static Serializer<WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson> get serializer =>
       _$weatherStatusWeatherStatusGetLocationResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataInterface {
+  bool get success;
+  num? get lat;
+  num? get lon;
+  String? get address;
+  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataInterfaceBuilder)
+        updates,
+  );
+  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data
     implements
+        WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataInterface,
         Built<WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data,
             WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder> {
   factory WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data([
@@ -658,16 +763,23 @@ abstract class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
-  num? get lat;
-  num? get lon;
-  String? get address;
   static Serializer<WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$weatherStatusWeatherStatusSetLocationResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsInterface {
+  WeatherStatusOCSMeta get meta;
+  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data get data;
+  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs
     implements
+        WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsInterface,
         Built<WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs,
             WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder> {
   factory WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs([
@@ -688,14 +800,22 @@ abstract class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusOCSMeta get meta;
-  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs> get serializer =>
       _$weatherStatusWeatherStatusSetLocationResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonInterface {
+  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs get ocs;
+  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson
     implements
+        WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonInterface,
         Built<WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson,
             WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonBuilder> {
   factory WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson([
@@ -714,29 +834,12 @@ abstract class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs get ocs;
   static Serializer<WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson> get serializer =>
       _$weatherStatusWeatherStatusSetLocationResponse200ApplicationJsonSerializer;
 }
 
-abstract class WeatherStatusForecast_Data_Instant_Details
-    implements Built<WeatherStatusForecast_Data_Instant_Details, WeatherStatusForecast_Data_Instant_DetailsBuilder> {
-  factory WeatherStatusForecast_Data_Instant_Details([
-    final void Function(WeatherStatusForecast_Data_Instant_DetailsBuilder)? b,
-  ]) = _$WeatherStatusForecast_Data_Instant_Details;
-
-  // coverage:ignore-start
-  const WeatherStatusForecast_Data_Instant_Details._();
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  factory WeatherStatusForecast_Data_Instant_Details.fromJson(final Map<String, dynamic> json) =>
-      _jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_Instant_DetailsInterface {
   @BuiltValueField(wireName: 'air_pressure_at_sea_level')
   num get airPressureAtSeaLevel;
   @BuiltValueField(wireName: 'air_temperature')
@@ -763,12 +866,49 @@ abstract class WeatherStatusForecast_Data_Instant_Details
   num get windSpeed;
   @BuiltValueField(wireName: 'wind_speed_of_gust')
   num get windSpeedOfGust;
+  WeatherStatusForecast_Data_Instant_DetailsInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_Instant_DetailsInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_Instant_DetailsInterfaceBuilder toBuilder();
+}
+
+abstract class WeatherStatusForecast_Data_Instant_Details
+    implements
+        WeatherStatusForecast_Data_Instant_DetailsInterface,
+        Built<WeatherStatusForecast_Data_Instant_Details, WeatherStatusForecast_Data_Instant_DetailsBuilder> {
+  factory WeatherStatusForecast_Data_Instant_Details([
+    final void Function(WeatherStatusForecast_Data_Instant_DetailsBuilder)? b,
+  ]) = _$WeatherStatusForecast_Data_Instant_Details;
+
+  // coverage:ignore-start
+  const WeatherStatusForecast_Data_Instant_Details._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory WeatherStatusForecast_Data_Instant_Details.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
   static Serializer<WeatherStatusForecast_Data_Instant_Details> get serializer =>
       _$weatherStatusForecastDataInstantDetailsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_InstantInterface {
+  WeatherStatusForecast_Data_Instant_Details get details;
+  WeatherStatusForecast_Data_InstantInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_InstantInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_InstantInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusForecast_Data_Instant
-    implements Built<WeatherStatusForecast_Data_Instant, WeatherStatusForecast_Data_InstantBuilder> {
+    implements
+        WeatherStatusForecast_Data_InstantInterface,
+        Built<WeatherStatusForecast_Data_Instant, WeatherStatusForecast_Data_InstantBuilder> {
   factory WeatherStatusForecast_Data_Instant([final void Function(WeatherStatusForecast_Data_InstantBuilder)? b]) =
       _$WeatherStatusForecast_Data_Instant;
 
@@ -784,12 +924,22 @@ abstract class WeatherStatusForecast_Data_Instant
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusForecast_Data_Instant_Details get details;
   static Serializer<WeatherStatusForecast_Data_Instant> get serializer => _$weatherStatusForecastDataInstantSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_Next12Hours_SummaryInterface {
+  @BuiltValueField(wireName: 'symbol_code')
+  String get symbolCode;
+  WeatherStatusForecast_Data_Next12Hours_SummaryInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_Next12Hours_SummaryInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_Next12Hours_SummaryInterfaceBuilder toBuilder();
 }
 
 abstract class WeatherStatusForecast_Data_Next12Hours_Summary
     implements
+        WeatherStatusForecast_Data_Next12Hours_SummaryInterface,
         Built<WeatherStatusForecast_Data_Next12Hours_Summary, WeatherStatusForecast_Data_Next12Hours_SummaryBuilder> {
   factory WeatherStatusForecast_Data_Next12Hours_Summary([
     final void Function(WeatherStatusForecast_Data_Next12Hours_SummaryBuilder)? b,
@@ -807,14 +957,23 @@ abstract class WeatherStatusForecast_Data_Next12Hours_Summary
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'symbol_code')
-  String get symbolCode;
   static Serializer<WeatherStatusForecast_Data_Next12Hours_Summary> get serializer =>
       _$weatherStatusForecastDataNext12HoursSummarySerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_Next12Hours_DetailsInterface {
+  @BuiltValueField(wireName: 'probability_of_precipitation')
+  num get probabilityOfPrecipitation;
+  WeatherStatusForecast_Data_Next12Hours_DetailsInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_Next12Hours_DetailsInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_Next12Hours_DetailsInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusForecast_Data_Next12Hours_Details
     implements
+        WeatherStatusForecast_Data_Next12Hours_DetailsInterface,
         Built<WeatherStatusForecast_Data_Next12Hours_Details, WeatherStatusForecast_Data_Next12Hours_DetailsBuilder> {
   factory WeatherStatusForecast_Data_Next12Hours_Details([
     final void Function(WeatherStatusForecast_Data_Next12Hours_DetailsBuilder)? b,
@@ -832,14 +991,24 @@ abstract class WeatherStatusForecast_Data_Next12Hours_Details
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'probability_of_precipitation')
-  num get probabilityOfPrecipitation;
   static Serializer<WeatherStatusForecast_Data_Next12Hours_Details> get serializer =>
       _$weatherStatusForecastDataNext12HoursDetailsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_Next12HoursInterface {
+  WeatherStatusForecast_Data_Next12Hours_Summary get summary;
+  WeatherStatusForecast_Data_Next12Hours_Details get details;
+  WeatherStatusForecast_Data_Next12HoursInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_Next12HoursInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_Next12HoursInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusForecast_Data_Next12Hours
-    implements Built<WeatherStatusForecast_Data_Next12Hours, WeatherStatusForecast_Data_Next12HoursBuilder> {
+    implements
+        WeatherStatusForecast_Data_Next12HoursInterface,
+        Built<WeatherStatusForecast_Data_Next12Hours, WeatherStatusForecast_Data_Next12HoursBuilder> {
   factory WeatherStatusForecast_Data_Next12Hours([
     final void Function(WeatherStatusForecast_Data_Next12HoursBuilder)? b,
   ]) = _$WeatherStatusForecast_Data_Next12Hours;
@@ -856,14 +1025,23 @@ abstract class WeatherStatusForecast_Data_Next12Hours
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusForecast_Data_Next12Hours_Summary get summary;
-  WeatherStatusForecast_Data_Next12Hours_Details get details;
   static Serializer<WeatherStatusForecast_Data_Next12Hours> get serializer =>
       _$weatherStatusForecastDataNext12HoursSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_Next1Hours_SummaryInterface {
+  @BuiltValueField(wireName: 'symbol_code')
+  String get symbolCode;
+  WeatherStatusForecast_Data_Next1Hours_SummaryInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_Next1Hours_SummaryInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_Next1Hours_SummaryInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusForecast_Data_Next1Hours_Summary
     implements
+        WeatherStatusForecast_Data_Next1Hours_SummaryInterface,
         Built<WeatherStatusForecast_Data_Next1Hours_Summary, WeatherStatusForecast_Data_Next1Hours_SummaryBuilder> {
   factory WeatherStatusForecast_Data_Next1Hours_Summary([
     final void Function(WeatherStatusForecast_Data_Next1Hours_SummaryBuilder)? b,
@@ -881,14 +1059,31 @@ abstract class WeatherStatusForecast_Data_Next1Hours_Summary
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'symbol_code')
-  String get symbolCode;
   static Serializer<WeatherStatusForecast_Data_Next1Hours_Summary> get serializer =>
       _$weatherStatusForecastDataNext1HoursSummarySerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_Next1Hours_DetailsInterface {
+  @BuiltValueField(wireName: 'precipitation_amount')
+  num get precipitationAmount;
+  @BuiltValueField(wireName: 'precipitation_amount_max')
+  num get precipitationAmountMax;
+  @BuiltValueField(wireName: 'precipitation_amount_min')
+  num get precipitationAmountMin;
+  @BuiltValueField(wireName: 'probability_of_precipitation')
+  num get probabilityOfPrecipitation;
+  @BuiltValueField(wireName: 'probability_of_thunder')
+  num get probabilityOfThunder;
+  WeatherStatusForecast_Data_Next1Hours_DetailsInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_Next1Hours_DetailsInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_Next1Hours_DetailsInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusForecast_Data_Next1Hours_Details
     implements
+        WeatherStatusForecast_Data_Next1Hours_DetailsInterface,
         Built<WeatherStatusForecast_Data_Next1Hours_Details, WeatherStatusForecast_Data_Next1Hours_DetailsBuilder> {
   factory WeatherStatusForecast_Data_Next1Hours_Details([
     final void Function(WeatherStatusForecast_Data_Next1Hours_DetailsBuilder)? b,
@@ -906,22 +1101,24 @@ abstract class WeatherStatusForecast_Data_Next1Hours_Details
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'precipitation_amount')
-  num get precipitationAmount;
-  @BuiltValueField(wireName: 'precipitation_amount_max')
-  num get precipitationAmountMax;
-  @BuiltValueField(wireName: 'precipitation_amount_min')
-  num get precipitationAmountMin;
-  @BuiltValueField(wireName: 'probability_of_precipitation')
-  num get probabilityOfPrecipitation;
-  @BuiltValueField(wireName: 'probability_of_thunder')
-  num get probabilityOfThunder;
   static Serializer<WeatherStatusForecast_Data_Next1Hours_Details> get serializer =>
       _$weatherStatusForecastDataNext1HoursDetailsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_Next1HoursInterface {
+  WeatherStatusForecast_Data_Next1Hours_Summary get summary;
+  WeatherStatusForecast_Data_Next1Hours_Details get details;
+  WeatherStatusForecast_Data_Next1HoursInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_Next1HoursInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_Next1HoursInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusForecast_Data_Next1Hours
-    implements Built<WeatherStatusForecast_Data_Next1Hours, WeatherStatusForecast_Data_Next1HoursBuilder> {
+    implements
+        WeatherStatusForecast_Data_Next1HoursInterface,
+        Built<WeatherStatusForecast_Data_Next1Hours, WeatherStatusForecast_Data_Next1HoursBuilder> {
   factory WeatherStatusForecast_Data_Next1Hours([
     final void Function(WeatherStatusForecast_Data_Next1HoursBuilder)? b,
   ]) = _$WeatherStatusForecast_Data_Next1Hours;
@@ -938,14 +1135,23 @@ abstract class WeatherStatusForecast_Data_Next1Hours
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusForecast_Data_Next1Hours_Summary get summary;
-  WeatherStatusForecast_Data_Next1Hours_Details get details;
   static Serializer<WeatherStatusForecast_Data_Next1Hours> get serializer =>
       _$weatherStatusForecastDataNext1HoursSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_Next6Hours_SummaryInterface {
+  @BuiltValueField(wireName: 'symbol_code')
+  String get symbolCode;
+  WeatherStatusForecast_Data_Next6Hours_SummaryInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_Next6Hours_SummaryInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_Next6Hours_SummaryInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusForecast_Data_Next6Hours_Summary
     implements
+        WeatherStatusForecast_Data_Next6Hours_SummaryInterface,
         Built<WeatherStatusForecast_Data_Next6Hours_Summary, WeatherStatusForecast_Data_Next6Hours_SummaryBuilder> {
   factory WeatherStatusForecast_Data_Next6Hours_Summary([
     final void Function(WeatherStatusForecast_Data_Next6Hours_SummaryBuilder)? b,
@@ -963,14 +1169,33 @@ abstract class WeatherStatusForecast_Data_Next6Hours_Summary
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'symbol_code')
-  String get symbolCode;
   static Serializer<WeatherStatusForecast_Data_Next6Hours_Summary> get serializer =>
       _$weatherStatusForecastDataNext6HoursSummarySerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_Next6Hours_DetailsInterface {
+  @BuiltValueField(wireName: 'air_temperature_max')
+  num get airTemperatureMax;
+  @BuiltValueField(wireName: 'air_temperature_min')
+  num get airTemperatureMin;
+  @BuiltValueField(wireName: 'precipitation_amount')
+  num get precipitationAmount;
+  @BuiltValueField(wireName: 'precipitation_amount_max')
+  num get precipitationAmountMax;
+  @BuiltValueField(wireName: 'precipitation_amount_min')
+  num get precipitationAmountMin;
+  @BuiltValueField(wireName: 'probability_of_precipitation')
+  num get probabilityOfPrecipitation;
+  WeatherStatusForecast_Data_Next6Hours_DetailsInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_Next6Hours_DetailsInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_Next6Hours_DetailsInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusForecast_Data_Next6Hours_Details
     implements
+        WeatherStatusForecast_Data_Next6Hours_DetailsInterface,
         Built<WeatherStatusForecast_Data_Next6Hours_Details, WeatherStatusForecast_Data_Next6Hours_DetailsBuilder> {
   factory WeatherStatusForecast_Data_Next6Hours_Details([
     final void Function(WeatherStatusForecast_Data_Next6Hours_DetailsBuilder)? b,
@@ -988,24 +1213,24 @@ abstract class WeatherStatusForecast_Data_Next6Hours_Details
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'air_temperature_max')
-  num get airTemperatureMax;
-  @BuiltValueField(wireName: 'air_temperature_min')
-  num get airTemperatureMin;
-  @BuiltValueField(wireName: 'precipitation_amount')
-  num get precipitationAmount;
-  @BuiltValueField(wireName: 'precipitation_amount_max')
-  num get precipitationAmountMax;
-  @BuiltValueField(wireName: 'precipitation_amount_min')
-  num get precipitationAmountMin;
-  @BuiltValueField(wireName: 'probability_of_precipitation')
-  num get probabilityOfPrecipitation;
   static Serializer<WeatherStatusForecast_Data_Next6Hours_Details> get serializer =>
       _$weatherStatusForecastDataNext6HoursDetailsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_Data_Next6HoursInterface {
+  WeatherStatusForecast_Data_Next6Hours_Summary get summary;
+  WeatherStatusForecast_Data_Next6Hours_Details get details;
+  WeatherStatusForecast_Data_Next6HoursInterface rebuild(
+    final void Function(WeatherStatusForecast_Data_Next6HoursInterfaceBuilder) updates,
+  );
+  WeatherStatusForecast_Data_Next6HoursInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusForecast_Data_Next6Hours
-    implements Built<WeatherStatusForecast_Data_Next6Hours, WeatherStatusForecast_Data_Next6HoursBuilder> {
+    implements
+        WeatherStatusForecast_Data_Next6HoursInterface,
+        Built<WeatherStatusForecast_Data_Next6Hours, WeatherStatusForecast_Data_Next6HoursBuilder> {
   factory WeatherStatusForecast_Data_Next6Hours([
     final void Function(WeatherStatusForecast_Data_Next6HoursBuilder)? b,
   ]) = _$WeatherStatusForecast_Data_Next6Hours;
@@ -1022,14 +1247,27 @@ abstract class WeatherStatusForecast_Data_Next6Hours
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusForecast_Data_Next6Hours_Summary get summary;
-  WeatherStatusForecast_Data_Next6Hours_Details get details;
   static Serializer<WeatherStatusForecast_Data_Next6Hours> get serializer =>
       _$weatherStatusForecastDataNext6HoursSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecast_DataInterface {
+  WeatherStatusForecast_Data_Instant get instant;
+  @BuiltValueField(wireName: 'next_12_hours')
+  WeatherStatusForecast_Data_Next12Hours get next12Hours;
+  @BuiltValueField(wireName: 'next_1_hours')
+  WeatherStatusForecast_Data_Next1Hours get next1Hours;
+  @BuiltValueField(wireName: 'next_6_hours')
+  WeatherStatusForecast_Data_Next6Hours get next6Hours;
+  WeatherStatusForecast_DataInterface rebuild(final void Function(WeatherStatusForecast_DataInterfaceBuilder) updates);
+  WeatherStatusForecast_DataInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusForecast_Data
-    implements Built<WeatherStatusForecast_Data, WeatherStatusForecast_DataBuilder> {
+    implements
+        WeatherStatusForecast_DataInterface,
+        Built<WeatherStatusForecast_Data, WeatherStatusForecast_DataBuilder> {
   factory WeatherStatusForecast_Data([final void Function(WeatherStatusForecast_DataBuilder)? b]) =
       _$WeatherStatusForecast_Data;
 
@@ -1045,17 +1283,19 @@ abstract class WeatherStatusForecast_Data
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusForecast_Data_Instant get instant;
-  @BuiltValueField(wireName: 'next_12_hours')
-  WeatherStatusForecast_Data_Next12Hours get next12Hours;
-  @BuiltValueField(wireName: 'next_1_hours')
-  WeatherStatusForecast_Data_Next1Hours get next1Hours;
-  @BuiltValueField(wireName: 'next_6_hours')
-  WeatherStatusForecast_Data_Next6Hours get next6Hours;
   static Serializer<WeatherStatusForecast_Data> get serializer => _$weatherStatusForecastDataSerializer;
 }
 
-abstract class WeatherStatusForecast implements Built<WeatherStatusForecast, WeatherStatusForecastBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusForecastInterface {
+  String get time;
+  WeatherStatusForecast_Data get data;
+  WeatherStatusForecastInterface rebuild(final void Function(WeatherStatusForecastInterfaceBuilder) updates);
+  WeatherStatusForecastInterfaceBuilder toBuilder();
+}
+
+abstract class WeatherStatusForecast
+    implements WeatherStatusForecastInterface, Built<WeatherStatusForecast, WeatherStatusForecastBuilder> {
   factory WeatherStatusForecast([final void Function(WeatherStatusForecastBuilder)? b]) = _$WeatherStatusForecast;
 
   // coverage:ignore-start
@@ -1070,13 +1310,22 @@ abstract class WeatherStatusForecast implements Built<WeatherStatusForecast, Wea
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  String get time;
-  WeatherStatusForecast_Data get data;
   static Serializer<WeatherStatusForecast> get serializer => _$weatherStatusForecastSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsInterface {
+  WeatherStatusOCSMeta get meta;
+  BuiltList<WeatherStatusForecast> get data;
+  WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
 }
 
 abstract class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs
     implements
+        WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsInterface,
         Built<WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs,
             WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder> {
   factory WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs([
@@ -1097,14 +1346,22 @@ abstract class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_O
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusOCSMeta get meta;
-  BuiltList<WeatherStatusForecast> get data;
   static Serializer<WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs> get serializer =>
       _$weatherStatusWeatherStatusGetForecastResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonInterface {
+  WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs get ocs;
+  WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson
     implements
+        WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonInterface,
         Built<WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson,
             WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonBuilder> {
   factory WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson([
@@ -1123,13 +1380,23 @@ abstract class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs get ocs;
   static Serializer<WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson> get serializer =>
       _$weatherStatusWeatherStatusGetForecastResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsInterface {
+  WeatherStatusOCSMeta get meta;
+  BuiltList<String> get data;
+  WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs
     implements
+        WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsInterface,
         Built<WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs,
             WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder> {
   factory WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs([
@@ -1150,14 +1417,22 @@ abstract class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusOCSMeta get meta;
-  BuiltList<String> get data;
   static Serializer<WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs> get serializer =>
       _$weatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonInterface {
+  WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs get ocs;
+  WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson
     implements
+        WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonInterface,
         Built<WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson,
             WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonBuilder> {
   factory WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson([
@@ -1176,13 +1451,23 @@ abstract class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson> get serializer =>
       _$weatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataInterface {
+  bool get success;
+  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataInterfaceBuilder)
+        updates,
+  );
+  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data
     implements
+        WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataInterface,
         Built<WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data,
             WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder> {
   factory WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data([
@@ -1203,13 +1488,23 @@ abstract class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get success;
   static Serializer<WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data> get serializer =>
       _$weatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonOcsDataSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsInterface {
+  WeatherStatusOCSMeta get meta;
+  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data get data;
+  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs
     implements
+        WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsInterface,
         Built<WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs,
             WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder> {
   factory WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs([
@@ -1230,14 +1525,22 @@ abstract class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusOCSMeta get meta;
-  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data get data;
   static Serializer<WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs> get serializer =>
       _$weatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonOcsSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonInterface {
+  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs get ocs;
+  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonInterface rebuild(
+    final void Function(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonInterfaceBuilder) updates,
+  );
+  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson
     implements
+        WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonInterface,
         Built<WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson,
             WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonBuilder> {
   factory WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson([
@@ -1256,13 +1559,23 @@ abstract class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs get ocs;
   static Serializer<WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson> get serializer =>
       _$weatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusCapabilities_WeatherStatusInterface {
+  bool get enabled;
+  WeatherStatusCapabilities_WeatherStatusInterface rebuild(
+    final void Function(WeatherStatusCapabilities_WeatherStatusInterfaceBuilder) updates,
+  );
+  WeatherStatusCapabilities_WeatherStatusInterfaceBuilder toBuilder();
+}
+
 abstract class WeatherStatusCapabilities_WeatherStatus
-    implements Built<WeatherStatusCapabilities_WeatherStatus, WeatherStatusCapabilities_WeatherStatusBuilder> {
+    implements
+        WeatherStatusCapabilities_WeatherStatusInterface,
+        Built<WeatherStatusCapabilities_WeatherStatus, WeatherStatusCapabilities_WeatherStatusBuilder> {
   factory WeatherStatusCapabilities_WeatherStatus([
     final void Function(WeatherStatusCapabilities_WeatherStatusBuilder)? b,
   ]) = _$WeatherStatusCapabilities_WeatherStatus;
@@ -1279,12 +1592,20 @@ abstract class WeatherStatusCapabilities_WeatherStatus
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  bool get enabled;
   static Serializer<WeatherStatusCapabilities_WeatherStatus> get serializer =>
       _$weatherStatusCapabilitiesWeatherStatusSerializer;
 }
 
-abstract class WeatherStatusCapabilities implements Built<WeatherStatusCapabilities, WeatherStatusCapabilitiesBuilder> {
+@BuiltValue(instantiable: false)
+abstract interface class WeatherStatusCapabilitiesInterface {
+  @BuiltValueField(wireName: 'weather_status')
+  WeatherStatusCapabilities_WeatherStatus get weatherStatus;
+  WeatherStatusCapabilitiesInterface rebuild(final void Function(WeatherStatusCapabilitiesInterfaceBuilder) updates);
+  WeatherStatusCapabilitiesInterfaceBuilder toBuilder();
+}
+
+abstract class WeatherStatusCapabilities
+    implements WeatherStatusCapabilitiesInterface, Built<WeatherStatusCapabilities, WeatherStatusCapabilitiesBuilder> {
   factory WeatherStatusCapabilities([final void Function(WeatherStatusCapabilitiesBuilder)? b]) =
       _$WeatherStatusCapabilities;
 
@@ -1300,8 +1621,6 @@ abstract class WeatherStatusCapabilities implements Built<WeatherStatusCapabilit
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
-  @BuiltValueField(wireName: 'weather_status')
-  WeatherStatusCapabilities_WeatherStatus get weatherStatus;
   static Serializer<WeatherStatusCapabilities> get serializer => _$weatherStatusCapabilitiesSerializer;
 }
 

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.g.dart
@@ -1934,6 +1934,25 @@ class _$WeatherStatusCapabilitiesSerializer implements StructuredSerializer<Weat
   }
 }
 
+abstract mixin class WeatherStatusOCSMetaInterfaceBuilder {
+  void replace(WeatherStatusOCSMetaInterface other);
+  void update(void Function(WeatherStatusOCSMetaInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+
+  int? get statuscode;
+  set statuscode(int? statuscode);
+
+  String? get message;
+  set message(String? message);
+
+  String? get totalitems;
+  set totalitems(String? totalitems);
+
+  String? get itemsperpage;
+  set itemsperpage(String? itemsperpage);
+}
+
 class _$WeatherStatusOCSMeta extends WeatherStatusOCSMeta {
   @override
   final String status;
@@ -1998,28 +2017,29 @@ class _$WeatherStatusOCSMeta extends WeatherStatusOCSMeta {
   }
 }
 
-class WeatherStatusOCSMetaBuilder implements Builder<WeatherStatusOCSMeta, WeatherStatusOCSMetaBuilder> {
+class WeatherStatusOCSMetaBuilder
+    implements Builder<WeatherStatusOCSMeta, WeatherStatusOCSMetaBuilder>, WeatherStatusOCSMetaInterfaceBuilder {
   _$WeatherStatusOCSMeta? _$v;
 
   String? _status;
   String? get status => _$this._status;
-  set status(String? status) => _$this._status = status;
+  set status(covariant String? status) => _$this._status = status;
 
   int? _statuscode;
   int? get statuscode => _$this._statuscode;
-  set statuscode(int? statuscode) => _$this._statuscode = statuscode;
+  set statuscode(covariant int? statuscode) => _$this._statuscode = statuscode;
 
   String? _message;
   String? get message => _$this._message;
-  set message(String? message) => _$this._message = message;
+  set message(covariant String? message) => _$this._message = message;
 
   String? _totalitems;
   String? get totalitems => _$this._totalitems;
-  set totalitems(String? totalitems) => _$this._totalitems = totalitems;
+  set totalitems(covariant String? totalitems) => _$this._totalitems = totalitems;
 
   String? _itemsperpage;
   String? get itemsperpage => _$this._itemsperpage;
-  set itemsperpage(String? itemsperpage) => _$this._itemsperpage = itemsperpage;
+  set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
   WeatherStatusOCSMetaBuilder();
 
@@ -2037,7 +2057,7 @@ class WeatherStatusOCSMetaBuilder implements Builder<WeatherStatusOCSMeta, Weath
   }
 
   @override
-  void replace(WeatherStatusOCSMeta other) {
+  void replace(covariant WeatherStatusOCSMeta other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusOCSMeta;
   }
@@ -2061,6 +2081,14 @@ class WeatherStatusOCSMetaBuilder implements Builder<WeatherStatusOCSMeta, Weath
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
 }
 
 class _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data
@@ -2111,12 +2139,13 @@ class _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data
 class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data,
-            WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder> {
+            WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder>,
+        WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -2130,7 +2159,7 @@ class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilde
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_Data;
   }
@@ -2151,6 +2180,16 @@ class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsInterface other);
+  void update(void Function(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  WeatherStatusOCSMetaBuilder get meta;
+  set meta(WeatherStatusOCSMetaBuilder? meta);
+
+  WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs
@@ -2210,17 +2249,19 @@ class _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs
 class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder
     implements
         Builder<WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs,
-            WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder> {
+            WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder>,
+        WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsInterfaceBuilder {
   _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs? _$v;
 
   WeatherStatusOCSMetaBuilder? _meta;
   WeatherStatusOCSMetaBuilder get meta => _$this._meta ??= WeatherStatusOCSMetaBuilder();
-  set meta(WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder? _data;
   WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
+  set data(covariant WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+      _$this._data = data;
 
   WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder();
 
@@ -2235,7 +2276,7 @@ class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs other) {
+  void replace(covariant WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_Ocs;
   }
@@ -2269,6 +2310,13 @@ class WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonInterface other);
+  void update(void Function(WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonInterfaceBuilder) updates);
+  WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson
@@ -2318,13 +2366,14 @@ class _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson
 class WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonBuilder
     implements
         Builder<WeatherStatusWeatherStatusSetModeResponse200ApplicationJson,
-            WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonBuilder> {
+            WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonBuilder>,
+        WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonInterfaceBuilder {
   _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson? _$v;
 
   WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder? _ocs;
   WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder();
-  set ocs(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant WeatherStatusWeatherStatusSetModeResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
   WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonBuilder();
 
@@ -2338,7 +2387,7 @@ class WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusSetModeResponse200ApplicationJson other) {
+  void replace(covariant WeatherStatusWeatherStatusSetModeResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusSetModeResponse200ApplicationJson;
   }
@@ -2369,6 +2418,24 @@ class WeatherStatusWeatherStatusSetModeResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataInterfaceBuilder)
+          updates);
+  bool? get success;
+  set success(bool? success);
+
+  num? get lat;
+  set lat(num? lat);
+
+  num? get lon;
+  set lon(num? lon);
+
+  String? get address;
+  set address(String? address);
 }
 
 class _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data
@@ -2441,24 +2508,25 @@ class _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_O
 class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data,
-            WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder> {
+            WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder>,
+        WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   num? _lat;
   num? get lat => _$this._lat;
-  set lat(num? lat) => _$this._lat = lat;
+  set lat(covariant num? lat) => _$this._lat = lat;
 
   num? _lon;
   num? get lon => _$this._lon;
-  set lon(num? lon) => _$this._lon = lon;
+  set lon(covariant num? lon) => _$this._lon = lon;
 
   String? _address;
   String? get address => _$this._address;
-  set address(String? address) => _$this._address = address;
+  set address(covariant String? address) => _$this._address = address;
 
   WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -2475,7 +2543,7 @@ class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_Data;
   }
@@ -2500,6 +2568,18 @@ class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsInterfaceBuilder)
+          updates);
+  WeatherStatusOCSMetaBuilder get meta;
+  set meta(WeatherStatusOCSMetaBuilder? meta);
+
+  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs
@@ -2561,17 +2641,18 @@ class _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_O
 class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder
     implements
         Builder<WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs,
-            WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder> {
+            WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder>,
+        WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsInterfaceBuilder {
   _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs? _$v;
 
   WeatherStatusOCSMetaBuilder? _meta;
   WeatherStatusOCSMetaBuilder get meta => _$this._meta ??= WeatherStatusOCSMetaBuilder();
-  set meta(WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder? _data;
   WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+  set data(covariant WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
   WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder();
@@ -2587,7 +2668,7 @@ class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs other) {
+  void replace(covariant WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs;
   }
@@ -2623,6 +2704,14 @@ class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_Ocs
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonInterfaceBuilder) updates);
+  WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson
@@ -2673,13 +2762,15 @@ class _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson
 class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonBuilder
     implements
         Builder<WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson,
-            WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonBuilder> {
+            WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonBuilder>,
+        WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonInterfaceBuilder {
   _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson? _$v;
 
   WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder? _ocs;
   WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder();
-  set ocs(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonBuilder();
 
@@ -2693,7 +2784,7 @@ class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonBuil
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson other) {
+  void replace(covariant WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJson;
   }
@@ -2724,6 +2815,23 @@ class WeatherStatusWeatherStatusUsePersonalAddressResponse200ApplicationJsonBuil
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  num? get lat;
+  set lat(num? lat);
+
+  num? get lon;
+  set lon(num? lon);
+
+  String? get address;
+  set address(String? address);
+
+  int? get mode;
+  set mode(int? mode);
 }
 
 class _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data
@@ -2798,24 +2906,25 @@ class _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data
 class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data,
-            WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder> {
+            WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder>,
+        WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data? _$v;
 
   num? _lat;
   num? get lat => _$this._lat;
-  set lat(num? lat) => _$this._lat = lat;
+  set lat(covariant num? lat) => _$this._lat = lat;
 
   num? _lon;
   num? get lon => _$this._lon;
-  set lon(num? lon) => _$this._lon = lon;
+  set lon(covariant num? lon) => _$this._lon = lon;
 
   String? _address;
   String? get address => _$this._address;
-  set address(String? address) => _$this._address = address;
+  set address(covariant String? address) => _$this._address = address;
 
   int? _mode;
   int? get mode => _$this._mode;
-  set mode(int? mode) => _$this._mode = mode;
+  set mode(covariant int? mode) => _$this._mode = mode;
 
   WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -2832,7 +2941,7 @@ class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBu
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_Data;
   }
@@ -2859,6 +2968,17 @@ class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBu
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  WeatherStatusOCSMetaBuilder get meta;
+  set meta(WeatherStatusOCSMetaBuilder? meta);
+
+  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs
@@ -2918,17 +3038,18 @@ class _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs
 class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder
     implements
         Builder<WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs,
-            WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder> {
+            WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder>,
+        WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsInterfaceBuilder {
   _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs? _$v;
 
   WeatherStatusOCSMetaBuilder? _meta;
   WeatherStatusOCSMetaBuilder get meta => _$this._meta ??= WeatherStatusOCSMetaBuilder();
-  set meta(WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder? _data;
   WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+  set data(covariant WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
   WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder();
@@ -2944,7 +3065,7 @@ class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs other) {
+  void replace(covariant WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_Ocs;
   }
@@ -2979,6 +3100,13 @@ class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonInterface other);
+  void update(void Function(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonInterfaceBuilder) updates);
+  WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson
@@ -3029,13 +3157,15 @@ class _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson
 class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonBuilder
     implements
         Builder<WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson,
-            WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonBuilder> {
+            WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonBuilder>,
+        WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonInterfaceBuilder {
   _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson? _$v;
 
   WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder? _ocs;
   WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder();
-  set ocs(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonBuilder();
 
@@ -3049,7 +3179,7 @@ class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson other) {
+  void replace(covariant WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusGetLocationResponse200ApplicationJson;
   }
@@ -3080,6 +3210,23 @@ class WeatherStatusWeatherStatusGetLocationResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
+
+  num? get lat;
+  set lat(num? lat);
+
+  num? get lon;
+  set lon(num? lon);
+
+  String? get address;
+  set address(String? address);
 }
 
 class _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data
@@ -3148,24 +3295,25 @@ class _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data
 class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data,
-            WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder> {
+            WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder>,
+        WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   num? _lat;
   num? get lat => _$this._lat;
-  set lat(num? lat) => _$this._lat = lat;
+  set lat(covariant num? lat) => _$this._lat = lat;
 
   num? _lon;
   num? get lon => _$this._lon;
-  set lon(num? lon) => _$this._lon = lon;
+  set lon(covariant num? lon) => _$this._lon = lon;
 
   String? _address;
   String? get address => _$this._address;
-  set address(String? address) => _$this._address = address;
+  set address(covariant String? address) => _$this._address = address;
 
   WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -3182,7 +3330,7 @@ class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBu
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_Data;
   }
@@ -3206,6 +3354,17 @@ class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBu
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  WeatherStatusOCSMetaBuilder get meta;
+  set meta(WeatherStatusOCSMetaBuilder? meta);
+
+  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs
@@ -3265,17 +3424,18 @@ class _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs
 class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder
     implements
         Builder<WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs,
-            WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder> {
+            WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder>,
+        WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsInterfaceBuilder {
   _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs? _$v;
 
   WeatherStatusOCSMetaBuilder? _meta;
   WeatherStatusOCSMetaBuilder get meta => _$this._meta ??= WeatherStatusOCSMetaBuilder();
-  set meta(WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder? _data;
   WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+  set data(covariant WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
   WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder();
@@ -3291,7 +3451,7 @@ class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs other) {
+  void replace(covariant WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_Ocs;
   }
@@ -3326,6 +3486,13 @@ class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonInterface other);
+  void update(void Function(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonInterfaceBuilder) updates);
+  WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson
@@ -3376,13 +3543,15 @@ class _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson
 class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonBuilder
     implements
         Builder<WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson,
-            WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonBuilder> {
+            WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonBuilder>,
+        WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonInterfaceBuilder {
   _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson? _$v;
 
   WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder? _ocs;
   WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder();
-  set ocs(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonBuilder();
 
@@ -3396,7 +3565,7 @@ class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson other) {
+  void replace(covariant WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusSetLocationResponse200ApplicationJson;
   }
@@ -3427,6 +3596,49 @@ class WeatherStatusWeatherStatusSetLocationResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_Data_Instant_DetailsInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_Instant_DetailsInterface other);
+  void update(void Function(WeatherStatusForecast_Data_Instant_DetailsInterfaceBuilder) updates);
+  num? get airPressureAtSeaLevel;
+  set airPressureAtSeaLevel(num? airPressureAtSeaLevel);
+
+  num? get airTemperature;
+  set airTemperature(num? airTemperature);
+
+  num? get cloudAreaFraction;
+  set cloudAreaFraction(num? cloudAreaFraction);
+
+  num? get cloudAreaFractionHigh;
+  set cloudAreaFractionHigh(num? cloudAreaFractionHigh);
+
+  num? get cloudAreaFractionLow;
+  set cloudAreaFractionLow(num? cloudAreaFractionLow);
+
+  num? get cloudAreaFractionMedium;
+  set cloudAreaFractionMedium(num? cloudAreaFractionMedium);
+
+  num? get dewPointTemperature;
+  set dewPointTemperature(num? dewPointTemperature);
+
+  num? get fogAreaFraction;
+  set fogAreaFraction(num? fogAreaFraction);
+
+  num? get relativeHumidity;
+  set relativeHumidity(num? relativeHumidity);
+
+  num? get ultravioletIndexClearSky;
+  set ultravioletIndexClearSky(num? ultravioletIndexClearSky);
+
+  num? get windFromDirection;
+  set windFromDirection(num? windFromDirection);
+
+  num? get windSpeed;
+  set windSpeed(num? windSpeed);
+
+  num? get windSpeedOfGust;
+  set windSpeedOfGust(num? windSpeedOfGust);
 }
 
 class _$WeatherStatusForecast_Data_Instant_Details extends WeatherStatusForecast_Data_Instant_Details {
@@ -3572,62 +3784,66 @@ class _$WeatherStatusForecast_Data_Instant_Details extends WeatherStatusForecast
 }
 
 class WeatherStatusForecast_Data_Instant_DetailsBuilder
-    implements Builder<WeatherStatusForecast_Data_Instant_Details, WeatherStatusForecast_Data_Instant_DetailsBuilder> {
+    implements
+        Builder<WeatherStatusForecast_Data_Instant_Details, WeatherStatusForecast_Data_Instant_DetailsBuilder>,
+        WeatherStatusForecast_Data_Instant_DetailsInterfaceBuilder {
   _$WeatherStatusForecast_Data_Instant_Details? _$v;
 
   num? _airPressureAtSeaLevel;
   num? get airPressureAtSeaLevel => _$this._airPressureAtSeaLevel;
-  set airPressureAtSeaLevel(num? airPressureAtSeaLevel) => _$this._airPressureAtSeaLevel = airPressureAtSeaLevel;
+  set airPressureAtSeaLevel(covariant num? airPressureAtSeaLevel) =>
+      _$this._airPressureAtSeaLevel = airPressureAtSeaLevel;
 
   num? _airTemperature;
   num? get airTemperature => _$this._airTemperature;
-  set airTemperature(num? airTemperature) => _$this._airTemperature = airTemperature;
+  set airTemperature(covariant num? airTemperature) => _$this._airTemperature = airTemperature;
 
   num? _cloudAreaFraction;
   num? get cloudAreaFraction => _$this._cloudAreaFraction;
-  set cloudAreaFraction(num? cloudAreaFraction) => _$this._cloudAreaFraction = cloudAreaFraction;
+  set cloudAreaFraction(covariant num? cloudAreaFraction) => _$this._cloudAreaFraction = cloudAreaFraction;
 
   num? _cloudAreaFractionHigh;
   num? get cloudAreaFractionHigh => _$this._cloudAreaFractionHigh;
-  set cloudAreaFractionHigh(num? cloudAreaFractionHigh) => _$this._cloudAreaFractionHigh = cloudAreaFractionHigh;
+  set cloudAreaFractionHigh(covariant num? cloudAreaFractionHigh) =>
+      _$this._cloudAreaFractionHigh = cloudAreaFractionHigh;
 
   num? _cloudAreaFractionLow;
   num? get cloudAreaFractionLow => _$this._cloudAreaFractionLow;
-  set cloudAreaFractionLow(num? cloudAreaFractionLow) => _$this._cloudAreaFractionLow = cloudAreaFractionLow;
+  set cloudAreaFractionLow(covariant num? cloudAreaFractionLow) => _$this._cloudAreaFractionLow = cloudAreaFractionLow;
 
   num? _cloudAreaFractionMedium;
   num? get cloudAreaFractionMedium => _$this._cloudAreaFractionMedium;
-  set cloudAreaFractionMedium(num? cloudAreaFractionMedium) =>
+  set cloudAreaFractionMedium(covariant num? cloudAreaFractionMedium) =>
       _$this._cloudAreaFractionMedium = cloudAreaFractionMedium;
 
   num? _dewPointTemperature;
   num? get dewPointTemperature => _$this._dewPointTemperature;
-  set dewPointTemperature(num? dewPointTemperature) => _$this._dewPointTemperature = dewPointTemperature;
+  set dewPointTemperature(covariant num? dewPointTemperature) => _$this._dewPointTemperature = dewPointTemperature;
 
   num? _fogAreaFraction;
   num? get fogAreaFraction => _$this._fogAreaFraction;
-  set fogAreaFraction(num? fogAreaFraction) => _$this._fogAreaFraction = fogAreaFraction;
+  set fogAreaFraction(covariant num? fogAreaFraction) => _$this._fogAreaFraction = fogAreaFraction;
 
   num? _relativeHumidity;
   num? get relativeHumidity => _$this._relativeHumidity;
-  set relativeHumidity(num? relativeHumidity) => _$this._relativeHumidity = relativeHumidity;
+  set relativeHumidity(covariant num? relativeHumidity) => _$this._relativeHumidity = relativeHumidity;
 
   num? _ultravioletIndexClearSky;
   num? get ultravioletIndexClearSky => _$this._ultravioletIndexClearSky;
-  set ultravioletIndexClearSky(num? ultravioletIndexClearSky) =>
+  set ultravioletIndexClearSky(covariant num? ultravioletIndexClearSky) =>
       _$this._ultravioletIndexClearSky = ultravioletIndexClearSky;
 
   num? _windFromDirection;
   num? get windFromDirection => _$this._windFromDirection;
-  set windFromDirection(num? windFromDirection) => _$this._windFromDirection = windFromDirection;
+  set windFromDirection(covariant num? windFromDirection) => _$this._windFromDirection = windFromDirection;
 
   num? _windSpeed;
   num? get windSpeed => _$this._windSpeed;
-  set windSpeed(num? windSpeed) => _$this._windSpeed = windSpeed;
+  set windSpeed(covariant num? windSpeed) => _$this._windSpeed = windSpeed;
 
   num? _windSpeedOfGust;
   num? get windSpeedOfGust => _$this._windSpeedOfGust;
-  set windSpeedOfGust(num? windSpeedOfGust) => _$this._windSpeedOfGust = windSpeedOfGust;
+  set windSpeedOfGust(covariant num? windSpeedOfGust) => _$this._windSpeedOfGust = windSpeedOfGust;
 
   WeatherStatusForecast_Data_Instant_DetailsBuilder();
 
@@ -3653,7 +3869,7 @@ class WeatherStatusForecast_Data_Instant_DetailsBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Instant_Details other) {
+  void replace(covariant WeatherStatusForecast_Data_Instant_Details other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Instant_Details;
   }
@@ -3695,6 +3911,13 @@ class WeatherStatusForecast_Data_Instant_DetailsBuilder
   }
 }
 
+abstract mixin class WeatherStatusForecast_Data_InstantInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_InstantInterface other);
+  void update(void Function(WeatherStatusForecast_Data_InstantInterfaceBuilder) updates);
+  WeatherStatusForecast_Data_Instant_DetailsBuilder get details;
+  set details(WeatherStatusForecast_Data_Instant_DetailsBuilder? details);
+}
+
 class _$WeatherStatusForecast_Data_Instant extends WeatherStatusForecast_Data_Instant {
   @override
   final WeatherStatusForecast_Data_Instant_Details details;
@@ -3734,13 +3957,15 @@ class _$WeatherStatusForecast_Data_Instant extends WeatherStatusForecast_Data_In
 }
 
 class WeatherStatusForecast_Data_InstantBuilder
-    implements Builder<WeatherStatusForecast_Data_Instant, WeatherStatusForecast_Data_InstantBuilder> {
+    implements
+        Builder<WeatherStatusForecast_Data_Instant, WeatherStatusForecast_Data_InstantBuilder>,
+        WeatherStatusForecast_Data_InstantInterfaceBuilder {
   _$WeatherStatusForecast_Data_Instant? _$v;
 
   WeatherStatusForecast_Data_Instant_DetailsBuilder? _details;
   WeatherStatusForecast_Data_Instant_DetailsBuilder get details =>
       _$this._details ??= WeatherStatusForecast_Data_Instant_DetailsBuilder();
-  set details(WeatherStatusForecast_Data_Instant_DetailsBuilder? details) => _$this._details = details;
+  set details(covariant WeatherStatusForecast_Data_Instant_DetailsBuilder? details) => _$this._details = details;
 
   WeatherStatusForecast_Data_InstantBuilder();
 
@@ -3754,7 +3979,7 @@ class WeatherStatusForecast_Data_InstantBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Instant other) {
+  void replace(covariant WeatherStatusForecast_Data_Instant other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Instant;
   }
@@ -3784,6 +4009,13 @@ class WeatherStatusForecast_Data_InstantBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_Data_Next12Hours_SummaryInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_Next12Hours_SummaryInterface other);
+  void update(void Function(WeatherStatusForecast_Data_Next12Hours_SummaryInterfaceBuilder) updates);
+  String? get symbolCode;
+  set symbolCode(String? symbolCode);
 }
 
 class _$WeatherStatusForecast_Data_Next12Hours_Summary extends WeatherStatusForecast_Data_Next12Hours_Summary {
@@ -3831,12 +4063,13 @@ class _$WeatherStatusForecast_Data_Next12Hours_Summary extends WeatherStatusFore
 
 class WeatherStatusForecast_Data_Next12Hours_SummaryBuilder
     implements
-        Builder<WeatherStatusForecast_Data_Next12Hours_Summary, WeatherStatusForecast_Data_Next12Hours_SummaryBuilder> {
+        Builder<WeatherStatusForecast_Data_Next12Hours_Summary, WeatherStatusForecast_Data_Next12Hours_SummaryBuilder>,
+        WeatherStatusForecast_Data_Next12Hours_SummaryInterfaceBuilder {
   _$WeatherStatusForecast_Data_Next12Hours_Summary? _$v;
 
   String? _symbolCode;
   String? get symbolCode => _$this._symbolCode;
-  set symbolCode(String? symbolCode) => _$this._symbolCode = symbolCode;
+  set symbolCode(covariant String? symbolCode) => _$this._symbolCode = symbolCode;
 
   WeatherStatusForecast_Data_Next12Hours_SummaryBuilder();
 
@@ -3850,7 +4083,7 @@ class WeatherStatusForecast_Data_Next12Hours_SummaryBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Next12Hours_Summary other) {
+  void replace(covariant WeatherStatusForecast_Data_Next12Hours_Summary other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Next12Hours_Summary;
   }
@@ -3871,6 +4104,13 @@ class WeatherStatusForecast_Data_Next12Hours_SummaryBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_Data_Next12Hours_DetailsInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_Next12Hours_DetailsInterface other);
+  void update(void Function(WeatherStatusForecast_Data_Next12Hours_DetailsInterfaceBuilder) updates);
+  num? get probabilityOfPrecipitation;
+  set probabilityOfPrecipitation(num? probabilityOfPrecipitation);
 }
 
 class _$WeatherStatusForecast_Data_Next12Hours_Details extends WeatherStatusForecast_Data_Next12Hours_Details {
@@ -3920,12 +4160,13 @@ class _$WeatherStatusForecast_Data_Next12Hours_Details extends WeatherStatusFore
 
 class WeatherStatusForecast_Data_Next12Hours_DetailsBuilder
     implements
-        Builder<WeatherStatusForecast_Data_Next12Hours_Details, WeatherStatusForecast_Data_Next12Hours_DetailsBuilder> {
+        Builder<WeatherStatusForecast_Data_Next12Hours_Details, WeatherStatusForecast_Data_Next12Hours_DetailsBuilder>,
+        WeatherStatusForecast_Data_Next12Hours_DetailsInterfaceBuilder {
   _$WeatherStatusForecast_Data_Next12Hours_Details? _$v;
 
   num? _probabilityOfPrecipitation;
   num? get probabilityOfPrecipitation => _$this._probabilityOfPrecipitation;
-  set probabilityOfPrecipitation(num? probabilityOfPrecipitation) =>
+  set probabilityOfPrecipitation(covariant num? probabilityOfPrecipitation) =>
       _$this._probabilityOfPrecipitation = probabilityOfPrecipitation;
 
   WeatherStatusForecast_Data_Next12Hours_DetailsBuilder();
@@ -3940,7 +4181,7 @@ class WeatherStatusForecast_Data_Next12Hours_DetailsBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Next12Hours_Details other) {
+  void replace(covariant WeatherStatusForecast_Data_Next12Hours_Details other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Next12Hours_Details;
   }
@@ -3961,6 +4202,16 @@ class WeatherStatusForecast_Data_Next12Hours_DetailsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_Data_Next12HoursInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_Next12HoursInterface other);
+  void update(void Function(WeatherStatusForecast_Data_Next12HoursInterfaceBuilder) updates);
+  WeatherStatusForecast_Data_Next12Hours_SummaryBuilder get summary;
+  set summary(WeatherStatusForecast_Data_Next12Hours_SummaryBuilder? summary);
+
+  WeatherStatusForecast_Data_Next12Hours_DetailsBuilder get details;
+  set details(WeatherStatusForecast_Data_Next12Hours_DetailsBuilder? details);
 }
 
 class _$WeatherStatusForecast_Data_Next12Hours extends WeatherStatusForecast_Data_Next12Hours {
@@ -4012,18 +4263,20 @@ class _$WeatherStatusForecast_Data_Next12Hours extends WeatherStatusForecast_Dat
 }
 
 class WeatherStatusForecast_Data_Next12HoursBuilder
-    implements Builder<WeatherStatusForecast_Data_Next12Hours, WeatherStatusForecast_Data_Next12HoursBuilder> {
+    implements
+        Builder<WeatherStatusForecast_Data_Next12Hours, WeatherStatusForecast_Data_Next12HoursBuilder>,
+        WeatherStatusForecast_Data_Next12HoursInterfaceBuilder {
   _$WeatherStatusForecast_Data_Next12Hours? _$v;
 
   WeatherStatusForecast_Data_Next12Hours_SummaryBuilder? _summary;
   WeatherStatusForecast_Data_Next12Hours_SummaryBuilder get summary =>
       _$this._summary ??= WeatherStatusForecast_Data_Next12Hours_SummaryBuilder();
-  set summary(WeatherStatusForecast_Data_Next12Hours_SummaryBuilder? summary) => _$this._summary = summary;
+  set summary(covariant WeatherStatusForecast_Data_Next12Hours_SummaryBuilder? summary) => _$this._summary = summary;
 
   WeatherStatusForecast_Data_Next12Hours_DetailsBuilder? _details;
   WeatherStatusForecast_Data_Next12Hours_DetailsBuilder get details =>
       _$this._details ??= WeatherStatusForecast_Data_Next12Hours_DetailsBuilder();
-  set details(WeatherStatusForecast_Data_Next12Hours_DetailsBuilder? details) => _$this._details = details;
+  set details(covariant WeatherStatusForecast_Data_Next12Hours_DetailsBuilder? details) => _$this._details = details;
 
   WeatherStatusForecast_Data_Next12HoursBuilder();
 
@@ -4038,7 +4291,7 @@ class WeatherStatusForecast_Data_Next12HoursBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Next12Hours other) {
+  void replace(covariant WeatherStatusForecast_Data_Next12Hours other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Next12Hours;
   }
@@ -4070,6 +4323,13 @@ class WeatherStatusForecast_Data_Next12HoursBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_Data_Next1Hours_SummaryInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_Next1Hours_SummaryInterface other);
+  void update(void Function(WeatherStatusForecast_Data_Next1Hours_SummaryInterfaceBuilder) updates);
+  String? get symbolCode;
+  set symbolCode(String? symbolCode);
 }
 
 class _$WeatherStatusForecast_Data_Next1Hours_Summary extends WeatherStatusForecast_Data_Next1Hours_Summary {
@@ -4117,12 +4377,13 @@ class _$WeatherStatusForecast_Data_Next1Hours_Summary extends WeatherStatusForec
 
 class WeatherStatusForecast_Data_Next1Hours_SummaryBuilder
     implements
-        Builder<WeatherStatusForecast_Data_Next1Hours_Summary, WeatherStatusForecast_Data_Next1Hours_SummaryBuilder> {
+        Builder<WeatherStatusForecast_Data_Next1Hours_Summary, WeatherStatusForecast_Data_Next1Hours_SummaryBuilder>,
+        WeatherStatusForecast_Data_Next1Hours_SummaryInterfaceBuilder {
   _$WeatherStatusForecast_Data_Next1Hours_Summary? _$v;
 
   String? _symbolCode;
   String? get symbolCode => _$this._symbolCode;
-  set symbolCode(String? symbolCode) => _$this._symbolCode = symbolCode;
+  set symbolCode(covariant String? symbolCode) => _$this._symbolCode = symbolCode;
 
   WeatherStatusForecast_Data_Next1Hours_SummaryBuilder();
 
@@ -4136,7 +4397,7 @@ class WeatherStatusForecast_Data_Next1Hours_SummaryBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Next1Hours_Summary other) {
+  void replace(covariant WeatherStatusForecast_Data_Next1Hours_Summary other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Next1Hours_Summary;
   }
@@ -4157,6 +4418,25 @@ class WeatherStatusForecast_Data_Next1Hours_SummaryBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_Data_Next1Hours_DetailsInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_Next1Hours_DetailsInterface other);
+  void update(void Function(WeatherStatusForecast_Data_Next1Hours_DetailsInterfaceBuilder) updates);
+  num? get precipitationAmount;
+  set precipitationAmount(num? precipitationAmount);
+
+  num? get precipitationAmountMax;
+  set precipitationAmountMax(num? precipitationAmountMax);
+
+  num? get precipitationAmountMin;
+  set precipitationAmountMin(num? precipitationAmountMin);
+
+  num? get probabilityOfPrecipitation;
+  set probabilityOfPrecipitation(num? probabilityOfPrecipitation);
+
+  num? get probabilityOfThunder;
+  set probabilityOfThunder(num? probabilityOfThunder);
 }
 
 class _$WeatherStatusForecast_Data_Next1Hours_Details extends WeatherStatusForecast_Data_Next1Hours_Details {
@@ -4240,29 +4520,32 @@ class _$WeatherStatusForecast_Data_Next1Hours_Details extends WeatherStatusForec
 
 class WeatherStatusForecast_Data_Next1Hours_DetailsBuilder
     implements
-        Builder<WeatherStatusForecast_Data_Next1Hours_Details, WeatherStatusForecast_Data_Next1Hours_DetailsBuilder> {
+        Builder<WeatherStatusForecast_Data_Next1Hours_Details, WeatherStatusForecast_Data_Next1Hours_DetailsBuilder>,
+        WeatherStatusForecast_Data_Next1Hours_DetailsInterfaceBuilder {
   _$WeatherStatusForecast_Data_Next1Hours_Details? _$v;
 
   num? _precipitationAmount;
   num? get precipitationAmount => _$this._precipitationAmount;
-  set precipitationAmount(num? precipitationAmount) => _$this._precipitationAmount = precipitationAmount;
+  set precipitationAmount(covariant num? precipitationAmount) => _$this._precipitationAmount = precipitationAmount;
 
   num? _precipitationAmountMax;
   num? get precipitationAmountMax => _$this._precipitationAmountMax;
-  set precipitationAmountMax(num? precipitationAmountMax) => _$this._precipitationAmountMax = precipitationAmountMax;
+  set precipitationAmountMax(covariant num? precipitationAmountMax) =>
+      _$this._precipitationAmountMax = precipitationAmountMax;
 
   num? _precipitationAmountMin;
   num? get precipitationAmountMin => _$this._precipitationAmountMin;
-  set precipitationAmountMin(num? precipitationAmountMin) => _$this._precipitationAmountMin = precipitationAmountMin;
+  set precipitationAmountMin(covariant num? precipitationAmountMin) =>
+      _$this._precipitationAmountMin = precipitationAmountMin;
 
   num? _probabilityOfPrecipitation;
   num? get probabilityOfPrecipitation => _$this._probabilityOfPrecipitation;
-  set probabilityOfPrecipitation(num? probabilityOfPrecipitation) =>
+  set probabilityOfPrecipitation(covariant num? probabilityOfPrecipitation) =>
       _$this._probabilityOfPrecipitation = probabilityOfPrecipitation;
 
   num? _probabilityOfThunder;
   num? get probabilityOfThunder => _$this._probabilityOfThunder;
-  set probabilityOfThunder(num? probabilityOfThunder) => _$this._probabilityOfThunder = probabilityOfThunder;
+  set probabilityOfThunder(covariant num? probabilityOfThunder) => _$this._probabilityOfThunder = probabilityOfThunder;
 
   WeatherStatusForecast_Data_Next1Hours_DetailsBuilder();
 
@@ -4280,7 +4563,7 @@ class WeatherStatusForecast_Data_Next1Hours_DetailsBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Next1Hours_Details other) {
+  void replace(covariant WeatherStatusForecast_Data_Next1Hours_Details other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Next1Hours_Details;
   }
@@ -4309,6 +4592,16 @@ class WeatherStatusForecast_Data_Next1Hours_DetailsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_Data_Next1HoursInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_Next1HoursInterface other);
+  void update(void Function(WeatherStatusForecast_Data_Next1HoursInterfaceBuilder) updates);
+  WeatherStatusForecast_Data_Next1Hours_SummaryBuilder get summary;
+  set summary(WeatherStatusForecast_Data_Next1Hours_SummaryBuilder? summary);
+
+  WeatherStatusForecast_Data_Next1Hours_DetailsBuilder get details;
+  set details(WeatherStatusForecast_Data_Next1Hours_DetailsBuilder? details);
 }
 
 class _$WeatherStatusForecast_Data_Next1Hours extends WeatherStatusForecast_Data_Next1Hours {
@@ -4359,18 +4652,20 @@ class _$WeatherStatusForecast_Data_Next1Hours extends WeatherStatusForecast_Data
 }
 
 class WeatherStatusForecast_Data_Next1HoursBuilder
-    implements Builder<WeatherStatusForecast_Data_Next1Hours, WeatherStatusForecast_Data_Next1HoursBuilder> {
+    implements
+        Builder<WeatherStatusForecast_Data_Next1Hours, WeatherStatusForecast_Data_Next1HoursBuilder>,
+        WeatherStatusForecast_Data_Next1HoursInterfaceBuilder {
   _$WeatherStatusForecast_Data_Next1Hours? _$v;
 
   WeatherStatusForecast_Data_Next1Hours_SummaryBuilder? _summary;
   WeatherStatusForecast_Data_Next1Hours_SummaryBuilder get summary =>
       _$this._summary ??= WeatherStatusForecast_Data_Next1Hours_SummaryBuilder();
-  set summary(WeatherStatusForecast_Data_Next1Hours_SummaryBuilder? summary) => _$this._summary = summary;
+  set summary(covariant WeatherStatusForecast_Data_Next1Hours_SummaryBuilder? summary) => _$this._summary = summary;
 
   WeatherStatusForecast_Data_Next1Hours_DetailsBuilder? _details;
   WeatherStatusForecast_Data_Next1Hours_DetailsBuilder get details =>
       _$this._details ??= WeatherStatusForecast_Data_Next1Hours_DetailsBuilder();
-  set details(WeatherStatusForecast_Data_Next1Hours_DetailsBuilder? details) => _$this._details = details;
+  set details(covariant WeatherStatusForecast_Data_Next1Hours_DetailsBuilder? details) => _$this._details = details;
 
   WeatherStatusForecast_Data_Next1HoursBuilder();
 
@@ -4385,7 +4680,7 @@ class WeatherStatusForecast_Data_Next1HoursBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Next1Hours other) {
+  void replace(covariant WeatherStatusForecast_Data_Next1Hours other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Next1Hours;
   }
@@ -4417,6 +4712,13 @@ class WeatherStatusForecast_Data_Next1HoursBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_Data_Next6Hours_SummaryInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_Next6Hours_SummaryInterface other);
+  void update(void Function(WeatherStatusForecast_Data_Next6Hours_SummaryInterfaceBuilder) updates);
+  String? get symbolCode;
+  set symbolCode(String? symbolCode);
 }
 
 class _$WeatherStatusForecast_Data_Next6Hours_Summary extends WeatherStatusForecast_Data_Next6Hours_Summary {
@@ -4464,12 +4766,13 @@ class _$WeatherStatusForecast_Data_Next6Hours_Summary extends WeatherStatusForec
 
 class WeatherStatusForecast_Data_Next6Hours_SummaryBuilder
     implements
-        Builder<WeatherStatusForecast_Data_Next6Hours_Summary, WeatherStatusForecast_Data_Next6Hours_SummaryBuilder> {
+        Builder<WeatherStatusForecast_Data_Next6Hours_Summary, WeatherStatusForecast_Data_Next6Hours_SummaryBuilder>,
+        WeatherStatusForecast_Data_Next6Hours_SummaryInterfaceBuilder {
   _$WeatherStatusForecast_Data_Next6Hours_Summary? _$v;
 
   String? _symbolCode;
   String? get symbolCode => _$this._symbolCode;
-  set symbolCode(String? symbolCode) => _$this._symbolCode = symbolCode;
+  set symbolCode(covariant String? symbolCode) => _$this._symbolCode = symbolCode;
 
   WeatherStatusForecast_Data_Next6Hours_SummaryBuilder();
 
@@ -4483,7 +4786,7 @@ class WeatherStatusForecast_Data_Next6Hours_SummaryBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Next6Hours_Summary other) {
+  void replace(covariant WeatherStatusForecast_Data_Next6Hours_Summary other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Next6Hours_Summary;
   }
@@ -4504,6 +4807,28 @@ class WeatherStatusForecast_Data_Next6Hours_SummaryBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_Data_Next6Hours_DetailsInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_Next6Hours_DetailsInterface other);
+  void update(void Function(WeatherStatusForecast_Data_Next6Hours_DetailsInterfaceBuilder) updates);
+  num? get airTemperatureMax;
+  set airTemperatureMax(num? airTemperatureMax);
+
+  num? get airTemperatureMin;
+  set airTemperatureMin(num? airTemperatureMin);
+
+  num? get precipitationAmount;
+  set precipitationAmount(num? precipitationAmount);
+
+  num? get precipitationAmountMax;
+  set precipitationAmountMax(num? precipitationAmountMax);
+
+  num? get precipitationAmountMin;
+  set precipitationAmountMin(num? precipitationAmountMin);
+
+  num? get probabilityOfPrecipitation;
+  set probabilityOfPrecipitation(num? probabilityOfPrecipitation);
 }
 
 class _$WeatherStatusForecast_Data_Next6Hours_Details extends WeatherStatusForecast_Data_Next6Hours_Details {
@@ -4595,32 +4920,35 @@ class _$WeatherStatusForecast_Data_Next6Hours_Details extends WeatherStatusForec
 
 class WeatherStatusForecast_Data_Next6Hours_DetailsBuilder
     implements
-        Builder<WeatherStatusForecast_Data_Next6Hours_Details, WeatherStatusForecast_Data_Next6Hours_DetailsBuilder> {
+        Builder<WeatherStatusForecast_Data_Next6Hours_Details, WeatherStatusForecast_Data_Next6Hours_DetailsBuilder>,
+        WeatherStatusForecast_Data_Next6Hours_DetailsInterfaceBuilder {
   _$WeatherStatusForecast_Data_Next6Hours_Details? _$v;
 
   num? _airTemperatureMax;
   num? get airTemperatureMax => _$this._airTemperatureMax;
-  set airTemperatureMax(num? airTemperatureMax) => _$this._airTemperatureMax = airTemperatureMax;
+  set airTemperatureMax(covariant num? airTemperatureMax) => _$this._airTemperatureMax = airTemperatureMax;
 
   num? _airTemperatureMin;
   num? get airTemperatureMin => _$this._airTemperatureMin;
-  set airTemperatureMin(num? airTemperatureMin) => _$this._airTemperatureMin = airTemperatureMin;
+  set airTemperatureMin(covariant num? airTemperatureMin) => _$this._airTemperatureMin = airTemperatureMin;
 
   num? _precipitationAmount;
   num? get precipitationAmount => _$this._precipitationAmount;
-  set precipitationAmount(num? precipitationAmount) => _$this._precipitationAmount = precipitationAmount;
+  set precipitationAmount(covariant num? precipitationAmount) => _$this._precipitationAmount = precipitationAmount;
 
   num? _precipitationAmountMax;
   num? get precipitationAmountMax => _$this._precipitationAmountMax;
-  set precipitationAmountMax(num? precipitationAmountMax) => _$this._precipitationAmountMax = precipitationAmountMax;
+  set precipitationAmountMax(covariant num? precipitationAmountMax) =>
+      _$this._precipitationAmountMax = precipitationAmountMax;
 
   num? _precipitationAmountMin;
   num? get precipitationAmountMin => _$this._precipitationAmountMin;
-  set precipitationAmountMin(num? precipitationAmountMin) => _$this._precipitationAmountMin = precipitationAmountMin;
+  set precipitationAmountMin(covariant num? precipitationAmountMin) =>
+      _$this._precipitationAmountMin = precipitationAmountMin;
 
   num? _probabilityOfPrecipitation;
   num? get probabilityOfPrecipitation => _$this._probabilityOfPrecipitation;
-  set probabilityOfPrecipitation(num? probabilityOfPrecipitation) =>
+  set probabilityOfPrecipitation(covariant num? probabilityOfPrecipitation) =>
       _$this._probabilityOfPrecipitation = probabilityOfPrecipitation;
 
   WeatherStatusForecast_Data_Next6Hours_DetailsBuilder();
@@ -4640,7 +4968,7 @@ class WeatherStatusForecast_Data_Next6Hours_DetailsBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Next6Hours_Details other) {
+  void replace(covariant WeatherStatusForecast_Data_Next6Hours_Details other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Next6Hours_Details;
   }
@@ -4671,6 +4999,16 @@ class WeatherStatusForecast_Data_Next6Hours_DetailsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_Data_Next6HoursInterfaceBuilder {
+  void replace(WeatherStatusForecast_Data_Next6HoursInterface other);
+  void update(void Function(WeatherStatusForecast_Data_Next6HoursInterfaceBuilder) updates);
+  WeatherStatusForecast_Data_Next6Hours_SummaryBuilder get summary;
+  set summary(WeatherStatusForecast_Data_Next6Hours_SummaryBuilder? summary);
+
+  WeatherStatusForecast_Data_Next6Hours_DetailsBuilder get details;
+  set details(WeatherStatusForecast_Data_Next6Hours_DetailsBuilder? details);
 }
 
 class _$WeatherStatusForecast_Data_Next6Hours extends WeatherStatusForecast_Data_Next6Hours {
@@ -4721,18 +5059,20 @@ class _$WeatherStatusForecast_Data_Next6Hours extends WeatherStatusForecast_Data
 }
 
 class WeatherStatusForecast_Data_Next6HoursBuilder
-    implements Builder<WeatherStatusForecast_Data_Next6Hours, WeatherStatusForecast_Data_Next6HoursBuilder> {
+    implements
+        Builder<WeatherStatusForecast_Data_Next6Hours, WeatherStatusForecast_Data_Next6HoursBuilder>,
+        WeatherStatusForecast_Data_Next6HoursInterfaceBuilder {
   _$WeatherStatusForecast_Data_Next6Hours? _$v;
 
   WeatherStatusForecast_Data_Next6Hours_SummaryBuilder? _summary;
   WeatherStatusForecast_Data_Next6Hours_SummaryBuilder get summary =>
       _$this._summary ??= WeatherStatusForecast_Data_Next6Hours_SummaryBuilder();
-  set summary(WeatherStatusForecast_Data_Next6Hours_SummaryBuilder? summary) => _$this._summary = summary;
+  set summary(covariant WeatherStatusForecast_Data_Next6Hours_SummaryBuilder? summary) => _$this._summary = summary;
 
   WeatherStatusForecast_Data_Next6Hours_DetailsBuilder? _details;
   WeatherStatusForecast_Data_Next6Hours_DetailsBuilder get details =>
       _$this._details ??= WeatherStatusForecast_Data_Next6Hours_DetailsBuilder();
-  set details(WeatherStatusForecast_Data_Next6Hours_DetailsBuilder? details) => _$this._details = details;
+  set details(covariant WeatherStatusForecast_Data_Next6Hours_DetailsBuilder? details) => _$this._details = details;
 
   WeatherStatusForecast_Data_Next6HoursBuilder();
 
@@ -4747,7 +5087,7 @@ class WeatherStatusForecast_Data_Next6HoursBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data_Next6Hours other) {
+  void replace(covariant WeatherStatusForecast_Data_Next6Hours other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data_Next6Hours;
   }
@@ -4779,6 +5119,22 @@ class WeatherStatusForecast_Data_Next6HoursBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecast_DataInterfaceBuilder {
+  void replace(WeatherStatusForecast_DataInterface other);
+  void update(void Function(WeatherStatusForecast_DataInterfaceBuilder) updates);
+  WeatherStatusForecast_Data_InstantBuilder get instant;
+  set instant(WeatherStatusForecast_Data_InstantBuilder? instant);
+
+  WeatherStatusForecast_Data_Next12HoursBuilder get next12Hours;
+  set next12Hours(WeatherStatusForecast_Data_Next12HoursBuilder? next12Hours);
+
+  WeatherStatusForecast_Data_Next1HoursBuilder get next1Hours;
+  set next1Hours(WeatherStatusForecast_Data_Next1HoursBuilder? next1Hours);
+
+  WeatherStatusForecast_Data_Next6HoursBuilder get next6Hours;
+  set next6Hours(WeatherStatusForecast_Data_Next6HoursBuilder? next6Hours);
 }
 
 class _$WeatherStatusForecast_Data extends WeatherStatusForecast_Data {
@@ -4843,28 +5199,31 @@ class _$WeatherStatusForecast_Data extends WeatherStatusForecast_Data {
 }
 
 class WeatherStatusForecast_DataBuilder
-    implements Builder<WeatherStatusForecast_Data, WeatherStatusForecast_DataBuilder> {
+    implements
+        Builder<WeatherStatusForecast_Data, WeatherStatusForecast_DataBuilder>,
+        WeatherStatusForecast_DataInterfaceBuilder {
   _$WeatherStatusForecast_Data? _$v;
 
   WeatherStatusForecast_Data_InstantBuilder? _instant;
   WeatherStatusForecast_Data_InstantBuilder get instant =>
       _$this._instant ??= WeatherStatusForecast_Data_InstantBuilder();
-  set instant(WeatherStatusForecast_Data_InstantBuilder? instant) => _$this._instant = instant;
+  set instant(covariant WeatherStatusForecast_Data_InstantBuilder? instant) => _$this._instant = instant;
 
   WeatherStatusForecast_Data_Next12HoursBuilder? _next12Hours;
   WeatherStatusForecast_Data_Next12HoursBuilder get next12Hours =>
       _$this._next12Hours ??= WeatherStatusForecast_Data_Next12HoursBuilder();
-  set next12Hours(WeatherStatusForecast_Data_Next12HoursBuilder? next12Hours) => _$this._next12Hours = next12Hours;
+  set next12Hours(covariant WeatherStatusForecast_Data_Next12HoursBuilder? next12Hours) =>
+      _$this._next12Hours = next12Hours;
 
   WeatherStatusForecast_Data_Next1HoursBuilder? _next1Hours;
   WeatherStatusForecast_Data_Next1HoursBuilder get next1Hours =>
       _$this._next1Hours ??= WeatherStatusForecast_Data_Next1HoursBuilder();
-  set next1Hours(WeatherStatusForecast_Data_Next1HoursBuilder? next1Hours) => _$this._next1Hours = next1Hours;
+  set next1Hours(covariant WeatherStatusForecast_Data_Next1HoursBuilder? next1Hours) => _$this._next1Hours = next1Hours;
 
   WeatherStatusForecast_Data_Next6HoursBuilder? _next6Hours;
   WeatherStatusForecast_Data_Next6HoursBuilder get next6Hours =>
       _$this._next6Hours ??= WeatherStatusForecast_Data_Next6HoursBuilder();
-  set next6Hours(WeatherStatusForecast_Data_Next6HoursBuilder? next6Hours) => _$this._next6Hours = next6Hours;
+  set next6Hours(covariant WeatherStatusForecast_Data_Next6HoursBuilder? next6Hours) => _$this._next6Hours = next6Hours;
 
   WeatherStatusForecast_DataBuilder();
 
@@ -4881,7 +5240,7 @@ class WeatherStatusForecast_DataBuilder
   }
 
   @override
-  void replace(WeatherStatusForecast_Data other) {
+  void replace(covariant WeatherStatusForecast_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast_Data;
   }
@@ -4922,6 +5281,16 @@ class WeatherStatusForecast_DataBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusForecastInterfaceBuilder {
+  void replace(WeatherStatusForecastInterface other);
+  void update(void Function(WeatherStatusForecastInterfaceBuilder) updates);
+  String? get time;
+  set time(String? time);
+
+  WeatherStatusForecast_DataBuilder get data;
+  set data(WeatherStatusForecast_DataBuilder? data);
 }
 
 class _$WeatherStatusForecast extends WeatherStatusForecast {
@@ -4969,16 +5338,17 @@ class _$WeatherStatusForecast extends WeatherStatusForecast {
   }
 }
 
-class WeatherStatusForecastBuilder implements Builder<WeatherStatusForecast, WeatherStatusForecastBuilder> {
+class WeatherStatusForecastBuilder
+    implements Builder<WeatherStatusForecast, WeatherStatusForecastBuilder>, WeatherStatusForecastInterfaceBuilder {
   _$WeatherStatusForecast? _$v;
 
   String? _time;
   String? get time => _$this._time;
-  set time(String? time) => _$this._time = time;
+  set time(covariant String? time) => _$this._time = time;
 
   WeatherStatusForecast_DataBuilder? _data;
   WeatherStatusForecast_DataBuilder get data => _$this._data ??= WeatherStatusForecast_DataBuilder();
-  set data(WeatherStatusForecast_DataBuilder? data) => _$this._data = data;
+  set data(covariant WeatherStatusForecast_DataBuilder? data) => _$this._data = data;
 
   WeatherStatusForecastBuilder();
 
@@ -4993,7 +5363,7 @@ class WeatherStatusForecastBuilder implements Builder<WeatherStatusForecast, Wea
   }
 
   @override
-  void replace(WeatherStatusForecast other) {
+  void replace(covariant WeatherStatusForecast other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusForecast;
   }
@@ -5025,6 +5395,17 @@ class WeatherStatusForecastBuilder implements Builder<WeatherStatusForecast, Wea
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  WeatherStatusOCSMetaBuilder get meta;
+  set meta(WeatherStatusOCSMetaBuilder? meta);
+
+  ListBuilder<WeatherStatusForecast> get data;
+  set data(ListBuilder<WeatherStatusForecast>? data);
 }
 
 class _$WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs
@@ -5084,16 +5465,17 @@ class _$WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs
 class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder
     implements
         Builder<WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs,
-            WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder> {
+            WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder>,
+        WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsInterfaceBuilder {
   _$WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs? _$v;
 
   WeatherStatusOCSMetaBuilder? _meta;
   WeatherStatusOCSMetaBuilder get meta => _$this._meta ??= WeatherStatusOCSMetaBuilder();
-  set meta(WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<WeatherStatusForecast>? _data;
   ListBuilder<WeatherStatusForecast> get data => _$this._data ??= ListBuilder<WeatherStatusForecast>();
-  set data(ListBuilder<WeatherStatusForecast>? data) => _$this._data = data;
+  set data(covariant ListBuilder<WeatherStatusForecast>? data) => _$this._data = data;
 
   WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder();
 
@@ -5108,7 +5490,7 @@ class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs other) {
+  void replace(covariant WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_Ocs;
   }
@@ -5143,6 +5525,13 @@ class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonInterface other);
+  void update(void Function(WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonInterfaceBuilder) updates);
+  WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson
@@ -5193,13 +5582,15 @@ class _$WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson
 class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonBuilder
     implements
         Builder<WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson,
-            WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonBuilder> {
+            WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonBuilder>,
+        WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonInterfaceBuilder {
   _$WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson? _$v;
 
   WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder? _ocs;
   WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder();
-  set ocs(WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonBuilder();
 
@@ -5213,7 +5604,7 @@ class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson other) {
+  void replace(covariant WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusGetForecastResponse200ApplicationJson;
   }
@@ -5244,6 +5635,17 @@ class WeatherStatusWeatherStatusGetForecastResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  WeatherStatusOCSMetaBuilder get meta;
+  set meta(WeatherStatusOCSMetaBuilder? meta);
+
+  ListBuilder<String> get data;
+  set data(ListBuilder<String>? data);
 }
 
 class _$WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs
@@ -5303,16 +5705,17 @@ class _$WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs
 class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs,
-            WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder> {
+            WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder>,
+        WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs? _$v;
 
   WeatherStatusOCSMetaBuilder? _meta;
   WeatherStatusOCSMetaBuilder get meta => _$this._meta ??= WeatherStatusOCSMetaBuilder();
-  set meta(WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   ListBuilder<String>? _data;
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
-  set data(ListBuilder<String>? data) => _$this._data = data;
+  set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
   WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder();
 
@@ -5327,7 +5730,7 @@ class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilde
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_Ocs;
   }
@@ -5362,6 +5765,13 @@ class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonInterface other);
+  void update(void Function(WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonInterfaceBuilder) updates);
+  WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson
@@ -5412,13 +5822,15 @@ class _$WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson
 class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonBuilder
     implements
         Builder<WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson,
-            WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonBuilder> {
+            WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonBuilder>,
+        WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonInterfaceBuilder {
   _$WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson? _$v;
 
   WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder? _ocs;
   WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder();
-  set ocs(WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonBuilder();
 
@@ -5432,7 +5844,7 @@ class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson other) {
+  void replace(covariant WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJson;
   }
@@ -5463,6 +5875,14 @@ class WeatherStatusWeatherStatusGetFavoritesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataInterfaceBuilder) updates);
+  bool? get success;
+  set success(bool? success);
 }
 
 class _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data
@@ -5514,12 +5934,13 @@ class _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Dat
 class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder
     implements
         Builder<WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data,
-            WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder> {
+            WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder>,
+        WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataInterfaceBuilder {
   _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data? _$v;
 
   bool? _success;
   bool? get success => _$this._success;
-  set success(bool? success) => _$this._success = success;
+  set success(covariant bool? success) => _$this._success = success;
 
   WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder();
 
@@ -5533,7 +5954,7 @@ class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataB
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data other) {
+  void replace(covariant WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_Data;
   }
@@ -5555,6 +5976,17 @@ class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataB
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsInterface other);
+  void update(
+      void Function(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsInterfaceBuilder) updates);
+  WeatherStatusOCSMetaBuilder get meta;
+  set meta(WeatherStatusOCSMetaBuilder? meta);
+
+  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder get data;
+  set data(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder? data);
 }
 
 class _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs
@@ -5614,17 +6046,18 @@ class _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs
 class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder
     implements
         Builder<WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs,
-            WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder> {
+            WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder>,
+        WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsInterfaceBuilder {
   _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs? _$v;
 
   WeatherStatusOCSMetaBuilder? _meta;
   WeatherStatusOCSMetaBuilder get meta => _$this._meta ??= WeatherStatusOCSMetaBuilder();
-  set meta(WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
+  set meta(covariant WeatherStatusOCSMetaBuilder? meta) => _$this._meta = meta;
 
   WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder? _data;
   WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder get data =>
       _$this._data ??= WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder();
-  set data(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder? data) =>
+  set data(covariant WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
   WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder();
@@ -5640,7 +6073,7 @@ class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilde
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs other) {
+  void replace(covariant WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_Ocs;
   }
@@ -5675,6 +6108,13 @@ class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilde
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonInterfaceBuilder {
+  void replace(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonInterface other);
+  void update(void Function(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonInterfaceBuilder) updates);
+  WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder get ocs;
+  set ocs(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder? ocs);
 }
 
 class _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson
@@ -5725,13 +6165,15 @@ class _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson
 class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonBuilder
     implements
         Builder<WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson,
-            WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonBuilder> {
+            WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonBuilder>,
+        WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonInterfaceBuilder {
   _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson? _$v;
 
   WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder? _ocs;
   WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder get ocs =>
       _$this._ocs ??= WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder();
-  set ocs(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
+  set ocs(covariant WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson_OcsBuilder? ocs) =>
+      _$this._ocs = ocs;
 
   WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonBuilder();
 
@@ -5745,7 +6187,7 @@ class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonBuilder
   }
 
   @override
-  void replace(WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson other) {
+  void replace(covariant WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJson;
   }
@@ -5776,6 +6218,13 @@ class WeatherStatusWeatherStatusSetFavoritesResponse200ApplicationJsonBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusCapabilities_WeatherStatusInterfaceBuilder {
+  void replace(WeatherStatusCapabilities_WeatherStatusInterface other);
+  void update(void Function(WeatherStatusCapabilities_WeatherStatusInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
 }
 
 class _$WeatherStatusCapabilities_WeatherStatus extends WeatherStatusCapabilities_WeatherStatus {
@@ -5821,12 +6270,14 @@ class _$WeatherStatusCapabilities_WeatherStatus extends WeatherStatusCapabilitie
 }
 
 class WeatherStatusCapabilities_WeatherStatusBuilder
-    implements Builder<WeatherStatusCapabilities_WeatherStatus, WeatherStatusCapabilities_WeatherStatusBuilder> {
+    implements
+        Builder<WeatherStatusCapabilities_WeatherStatus, WeatherStatusCapabilities_WeatherStatusBuilder>,
+        WeatherStatusCapabilities_WeatherStatusInterfaceBuilder {
   _$WeatherStatusCapabilities_WeatherStatus? _$v;
 
   bool? _enabled;
   bool? get enabled => _$this._enabled;
-  set enabled(bool? enabled) => _$this._enabled = enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
   WeatherStatusCapabilities_WeatherStatusBuilder();
 
@@ -5840,7 +6291,7 @@ class WeatherStatusCapabilities_WeatherStatusBuilder
   }
 
   @override
-  void replace(WeatherStatusCapabilities_WeatherStatus other) {
+  void replace(covariant WeatherStatusCapabilities_WeatherStatus other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusCapabilities_WeatherStatus;
   }
@@ -5861,6 +6312,13 @@ class WeatherStatusCapabilities_WeatherStatusBuilder
     replace(_$result);
     return _$result;
   }
+}
+
+abstract mixin class WeatherStatusCapabilitiesInterfaceBuilder {
+  void replace(WeatherStatusCapabilitiesInterface other);
+  void update(void Function(WeatherStatusCapabilitiesInterfaceBuilder) updates);
+  WeatherStatusCapabilities_WeatherStatusBuilder get weatherStatus;
+  set weatherStatus(WeatherStatusCapabilities_WeatherStatusBuilder? weatherStatus);
 }
 
 class _$WeatherStatusCapabilities extends WeatherStatusCapabilities {
@@ -5901,13 +6359,16 @@ class _$WeatherStatusCapabilities extends WeatherStatusCapabilities {
   }
 }
 
-class WeatherStatusCapabilitiesBuilder implements Builder<WeatherStatusCapabilities, WeatherStatusCapabilitiesBuilder> {
+class WeatherStatusCapabilitiesBuilder
+    implements
+        Builder<WeatherStatusCapabilities, WeatherStatusCapabilitiesBuilder>,
+        WeatherStatusCapabilitiesInterfaceBuilder {
   _$WeatherStatusCapabilities? _$v;
 
   WeatherStatusCapabilities_WeatherStatusBuilder? _weatherStatus;
   WeatherStatusCapabilities_WeatherStatusBuilder get weatherStatus =>
       _$this._weatherStatus ??= WeatherStatusCapabilities_WeatherStatusBuilder();
-  set weatherStatus(WeatherStatusCapabilities_WeatherStatusBuilder? weatherStatus) =>
+  set weatherStatus(covariant WeatherStatusCapabilities_WeatherStatusBuilder? weatherStatus) =>
       _$this._weatherStatus = weatherStatus;
 
   WeatherStatusCapabilitiesBuilder();
@@ -5922,7 +6383,7 @@ class WeatherStatusCapabilitiesBuilder implements Builder<WeatherStatusCapabilit
   }
 
   @override
-  void replace(WeatherStatusCapabilities other) {
+  void replace(covariant WeatherStatusCapabilities other) {
     ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$WeatherStatusCapabilities;
   }

--- a/packages/nextcloud/test/user_status_test.dart
+++ b/packages/nextcloud/test/user_status_test.dart
@@ -52,14 +52,14 @@ void main() {
       test('Set status', () async {
         final response = await client.userStatus.userStatus.setStatus(statusType: 'online');
 
-        expect(response.ocs.data.public.userId, 'user1');
-        expect(response.ocs.data.public.message, null);
-        expect(response.ocs.data.private1.messageId, null);
-        expect(response.ocs.data.private1.messageIsPredefined, false);
-        expect(response.ocs.data.public.icon, null);
-        expect(response.ocs.data.public.clearAt, null);
-        expect(response.ocs.data.public.status, 'online');
-        expect(response.ocs.data.private1.statusIsUserDefined, true);
+        expect(response.ocs.data.userId, 'user1');
+        expect(response.ocs.data.message, null);
+        expect(response.ocs.data.messageId, null);
+        expect(response.ocs.data.messageIsPredefined, false);
+        expect(response.ocs.data.icon, null);
+        expect(response.ocs.data.clearAt, null);
+        expect(response.ocs.data.status, 'online');
+        expect(response.ocs.data.statusIsUserDefined, true);
       });
 
       test('Get status', () async {
@@ -68,14 +68,14 @@ void main() {
         await client.userStatus.userStatus.setStatus(statusType: 'online');
 
         final response = await client.userStatus.userStatus.getStatus();
-        expect(response.ocs.data.public.userId, 'user1');
-        expect(response.ocs.data.public.message, null);
-        expect(response.ocs.data.private1.messageId, null);
-        expect(response.ocs.data.private1.messageIsPredefined, false);
-        expect(response.ocs.data.public.icon, null);
-        expect(response.ocs.data.public.clearAt, null);
-        expect(response.ocs.data.public.status, 'online');
-        expect(response.ocs.data.private1.statusIsUserDefined, true);
+        expect(response.ocs.data.userId, 'user1');
+        expect(response.ocs.data.message, null);
+        expect(response.ocs.data.messageId, null);
+        expect(response.ocs.data.messageIsPredefined, false);
+        expect(response.ocs.data.icon, null);
+        expect(response.ocs.data.clearAt, null);
+        expect(response.ocs.data.status, 'online');
+        expect(response.ocs.data.statusIsUserDefined, true);
       });
 
       test('Find all statuses', () async {
@@ -111,14 +111,14 @@ void main() {
           messageId: 'meeting',
           clearAt: clearAt,
         );
-        expect(response.ocs.data.public.userId, 'user1');
-        expect(response.ocs.data.public.message, null);
-        expect(response.ocs.data.private1.messageId, 'meeting');
-        expect(response.ocs.data.private1.messageIsPredefined, true);
-        expect(response.ocs.data.public.icon, null);
-        expect(response.ocs.data.public.clearAt, clearAt);
-        expect(response.ocs.data.public.status, 'offline');
-        expect(response.ocs.data.private1.statusIsUserDefined, false);
+        expect(response.ocs.data.userId, 'user1');
+        expect(response.ocs.data.message, null);
+        expect(response.ocs.data.messageId, 'meeting');
+        expect(response.ocs.data.messageIsPredefined, true);
+        expect(response.ocs.data.icon, null);
+        expect(response.ocs.data.clearAt, clearAt);
+        expect(response.ocs.data.status, 'offline');
+        expect(response.ocs.data.statusIsUserDefined, false);
       });
 
       test('Set custom message', () async {
@@ -128,14 +128,14 @@ void main() {
           message: 'bla',
           clearAt: clearAt,
         );
-        expect(response.ocs.data.public.userId, 'user1');
-        expect(response.ocs.data.public.message, 'bla');
-        expect(response.ocs.data.private1.messageId, null);
-        expect(response.ocs.data.private1.messageIsPredefined, false);
-        expect(response.ocs.data.public.icon, '😀');
-        expect(response.ocs.data.public.clearAt, clearAt);
-        expect(response.ocs.data.public.status, 'offline');
-        expect(response.ocs.data.private1.statusIsUserDefined, false);
+        expect(response.ocs.data.userId, 'user1');
+        expect(response.ocs.data.message, 'bla');
+        expect(response.ocs.data.messageId, null);
+        expect(response.ocs.data.messageIsPredefined, false);
+        expect(response.ocs.data.icon, '😀');
+        expect(response.ocs.data.clearAt, clearAt);
+        expect(response.ocs.data.status, 'offline');
+        expect(response.ocs.data.statusIsUserDefined, false);
       });
 
       test('Clear message', () async {
@@ -148,26 +148,26 @@ void main() {
         await client.userStatus.userStatus.clearMessage();
 
         final response = await client.userStatus.userStatus.getStatus();
-        expect(response.ocs.data.public.userId, 'user1');
-        expect(response.ocs.data.public.message, null);
-        expect(response.ocs.data.private1.messageId, null);
-        expect(response.ocs.data.private1.messageIsPredefined, false);
-        expect(response.ocs.data.public.icon, null);
-        expect(response.ocs.data.public.clearAt, null);
-        expect(response.ocs.data.public.status, 'offline');
-        expect(response.ocs.data.private1.statusIsUserDefined, false);
+        expect(response.ocs.data.userId, 'user1');
+        expect(response.ocs.data.message, null);
+        expect(response.ocs.data.messageId, null);
+        expect(response.ocs.data.messageIsPredefined, false);
+        expect(response.ocs.data.icon, null);
+        expect(response.ocs.data.clearAt, null);
+        expect(response.ocs.data.status, 'offline');
+        expect(response.ocs.data.statusIsUserDefined, false);
       });
 
       test('Heartbeat', () async {
         final response = await client.userStatus.heartbeat.heartbeat(status: 'online');
-        expect(response.ocs.data.public.userId, 'user1');
-        expect(response.ocs.data.public.message, null);
-        expect(response.ocs.data.private1.messageId, null);
-        expect(response.ocs.data.private1.messageIsPredefined, false);
-        expect(response.ocs.data.public.icon, null);
-        expect(response.ocs.data.public.clearAt, null);
-        expect(response.ocs.data.public.status, 'online');
-        expect(response.ocs.data.private1.statusIsUserDefined, false);
+        expect(response.ocs.data.userId, 'user1');
+        expect(response.ocs.data.message, null);
+        expect(response.ocs.data.messageId, null);
+        expect(response.ocs.data.messageIsPredefined, false);
+        expect(response.ocs.data.icon, null);
+        expect(response.ocs.data.clearAt, null);
+        expect(response.ocs.data.status, 'online');
+        expect(response.ocs.data.statusIsUserDefined, false);
       });
     },
     retry: retryCount,


### PR DESCRIPTION
finally implements #420 

How it works:
1. We generate an interface class for every `TypeResultObject` as they are the only thing allowed in allOfs.
2. we simply use that interface in the normal class and the allOf class.

Yes this means that we generate interface classes that might only be used in one built_value one. We could traverse all schemes of the spec and find the interfaces we need but I consider this outside the scope of this PR and with more important stuff to work on something that I don't plan to change any time soon.