### PR TITLE
feat(neon): use logout icon instead of delete on account_settings page

### DIFF
--- a/packages/neon/neon/lib/src/pages/account_settings.dart
+++ b/packages/neon/neon/lib/src/pages/account_settings.dart
@@ -58,7 +58,7 @@ class AccountSettingsPage extends StatelessWidget {
             }
           },
           tooltip: AppLocalizations.of(context).accountOptionsRemove,
-          icon: Icon(MdiIcons.delete),
+          icon: const Icon(Icons.logout),
         ),
         IconButton(
           onPressed: () async {


### PR DESCRIPTION
![Screenshot_20230907_003629](https://github.com/nextcloud/neon/assets/25266387/c1a66693-8879-4c9e-91a4-be8241db687c)
