### PR TITLE
fix(neon_notifications): Fix serialization

### DIFF
--- a/packages/neon/neon_notifications/lib/blocs/notifications.dart
+++ b/packages/neon/neon_notifications/lib/blocs/notifications.dart
@@ -50,15 +50,16 @@ class NotificationsBloc extends InteractiveBloc
 
   @override
   Future refresh() async {
-    await RequestManager.instance.wrapNextcloud<
-        List<NotificationsNotification>,
-        NotificationsResponse<NotificationsEndpointListNotificationsResponseApplicationJson,
-            NotificationsEndpointEndpointListNotificationsHeaders>>(
+    await RequestManager.instance
+        .wrapNextcloud<List<NotificationsNotification>, NotificationsEndpointListNotificationsResponseApplicationJson>(
       _account.id,
       'notifications-notifications',
       notifications,
-      () async => _account.client.notifications.endpoint.listNotifications(),
-      (final response) => response.data.ocs.data.toList(),
+      () async {
+        final response = await _account.client.notifications.endpoint.listNotifications();
+        return response.data;
+      },
+      (final response) => response.ocs.data.toList(),
     );
   }
 


### PR DESCRIPTION
Got broken in https://github.com/nextcloud/neon/pull/710

We should probably add serializers for all the `*Response<*, *>` at some point.