### PR TITLE
feat(dynamite): support yaml specs

### DIFF
--- a/packages/dynamite/dynamite/pubspec.yaml
+++ b/packages/dynamite/dynamite/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
   build: ^2.4.1
   built_collection: ^5.1.1
   built_value: ^8.6.2
+  checked_yaml: ^2.0.3
   code_builder: ^4.6.0
   collection: ^1.17.2
   dart_style: ^2.3.2


### PR DESCRIPTION
This was surprisingly simple.

I tested it on the [petstore example](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml) and we might need to use it for the cookbook app.