### PR TITLE
fix(neon): Fix list view flicker when loading

### DIFF
--- a/packages/neon/neon/lib/src/widgets/list_view.dart
+++ b/packages/neon/neon/lib/src/widgets/list_view.dart
@@ -54,22 +54,21 @@ class NeonListView extends StatelessWidget {
               itemCount: topFixedChildren!.length,
               itemBuilder: (final context, final index) => topFixedChildren![index],
             ),
-          if (isLoading)
-            const SliverToBoxAdapter(
-              child: NeonLinearProgressIndicator(
-                margin: EdgeInsets.symmetric(
-                  horizontal: 10,
-                  vertical: 5,
-                ),
+          SliverToBoxAdapter(
+            child: NeonLinearProgressIndicator(
+              visible: isLoading,
+              margin: const EdgeInsets.symmetric(
+                horizontal: 10,
+                vertical: 5,
               ),
             ),
-          if (error != null)
-            SliverToBoxAdapter(
-              child: NeonError(
-                error,
-                onRetry: () async => refreshIndicatorKey.currentState!.show(),
-              ),
+          ),
+          SliverToBoxAdapter(
+            child: NeonError(
+              error,
+              onRetry: () async => refreshIndicatorKey.currentState!.show(),
             ),
+          ),
           if (topScrollingChildren != null)
             SliverList.builder(
               itemCount: topScrollingChildren!.length,


### PR DESCRIPTION
When hiding and showing these widgets the list view would resized. This lead to quite some flicker if the network request was fast and additionally if there were images in the rendered list.