### PR TITLE
fix(ci): Fix stuck CI jobs

### DIFF
--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   untested-apis:
     name: Untested APIs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4


### PR DESCRIPTION
Just use the provided GH runners, self-hosted seems to be quite broken on some days...