### PR TITLE
Fix cspell CI

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -8,3 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
       - uses: streetsidesoftware/cspell-action@22e32eb3d70acf30e3fc09bd46edc1d30fb2d6db # v3
+        with:
+          incremental_files_only: false

--- a/cspell.json
+++ b/cspell.json
@@ -2,6 +2,7 @@
   "version": "0.2",
   "language": "en",
   "useGitignore": true,
+  "enableGlobDot": false,
   "words": [
     "OpenAPI"
   ],


### PR DESCRIPTION
The action enables dot matching by default, while it is disabled by default on cli.
The option to disable dot matching in the config file also wasn't documented at all...
Cspell should now also always run on all files, so we shouldn't trigger random spelling errors in unrelated PRs.