### PR TITLE
fix(neon): Fix server icon explicit null color

### DIFF
--- a/packages/neon/neon/lib/src/widgets/server_icon.dart
+++ b/packages/neon/neon/lib/src/widgets/server_icon.dart
@@ -8,7 +8,7 @@ class NeonServerIcon extends StatelessWidget {
   /// Creates a new server icon
   const NeonServerIcon({
     required this.icon,
-    this.color,
+    this.colorFilter,
     this.size,
     super.key,
   });
@@ -16,13 +16,7 @@ class NeonServerIcon extends StatelessWidget {
   /// Name of the server icon to draw.
   final String icon;
 
-  /// The color to use when drawing the icon.
-  ///
-  /// Defaults to the nearest [IconTheme]'s [IconThemeData.color].
-  ///
-  /// The color (whether specified explicitly here or obtained from the
-  /// [IconTheme]) will be further adjusted by the nearest [IconTheme]'s
-  /// [IconThemeData.opacity].
+  /// The color filter to use when drawing the icon.
   ///
   /// {@tool snippet}
   /// Typically, a Material Design color will be used, as follows:
@@ -30,11 +24,11 @@ class NeonServerIcon extends StatelessWidget {
   /// ```dart
   /// NeonServerIcon(
   ///   icon: 'icon-add',
-  ///   color: Colors.blue.shade400,
+  ///   colorFilter: ColorFilter.mode(Colors.blue.shade400, BlendMode.srcIn),
   /// )
   /// ```
   /// {@end-tool}
-  final Color? color;
+  final ColorFilter? colorFilter;
 
   /// The size of the icon in logical pixels.
   ///
@@ -53,12 +47,11 @@ class NeonServerIcon extends StatelessWidget {
     final iconTheme = Theme.of(context).iconTheme;
 
     final size = this.size ?? iconTheme.size;
-    final color = this.color ?? iconTheme.color;
 
     return VectorGraphic(
       width: size,
       height: size,
-      colorFilter: color != null ? ColorFilter.mode(color, BlendMode.srcIn) : null,
+      colorFilter: colorFilter,
       loader: AssetBytesLoader(
         'assets/icons/server/${icon.replaceFirst(RegExp('^icon-'), '').replaceFirst(RegExp(r'-(dark|white)$'), '')}.svg.vec',
         packageName: 'neon',

--- a/packages/neon/neon/lib/src/widgets/unified_search_results.dart
+++ b/packages/neon/neon/lib/src/widgets/unified_search_results.dart
@@ -137,7 +137,7 @@ class NeonUnifiedSearchResults extends StatelessWidget {
 
     if (entry.icon.startsWith('icon-')) {
       return NeonServerIcon(
-        color: Theme.of(context).colorScheme.primary,
+        colorFilter: ColorFilter.mode(Theme.of(context).colorScheme.primary, BlendMode.srcIn),
         icon: entry.icon,
       );
     }


### PR DESCRIPTION
For the user status indicator we want to use null as the color because the icon should be rendered with the color the icon actually has in the SVG. Switching to providing the color filter option makes this possible in an explicit way. The other option would be to not use the icon theme color, but that would be weird. This way it's even more flexible since you can pass different color filters now.