### PR TITLE
fix(dynamite_runtime): Skip empty query parameters

### DIFF
--- a/packages/dynamite/dynamite_runtime/lib/src/dynamite_client.dart
+++ b/packages/dynamite/dynamite_runtime/lib/src/dynamite_client.dart
@@ -412,12 +412,13 @@ class DynamiteClient {
     final Uint8List? body,
     final Set<int>? validStatuses,
   ) async {
+    final queryParameters = {
+      ...baseURL.queryParametersAll,
+      ...path.queryParametersAll,
+    };
     final uri = baseURL.replace(
       path: '${baseURL.path}${path.path}',
-      queryParameters: {
-        ...baseURL.queryParametersAll,
-        ...path.queryParametersAll,
-      },
+      queryParameters: queryParameters.isNotEmpty ? queryParameters : null,
     );
 
     final request = await httpClient.openUrl(method, uri);


### PR DESCRIPTION
Previously a trailing `?` was added to the URL when no query parameters were specified.