### PR TITLE
build(app): Update compileSdkVersion to 34

### DIFF
--- a/packages/app/android/app/build.gradle
+++ b/packages/app/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {


### PR DESCRIPTION
Since https://github.com/nextcloud/neon/pull/908 unifiedpush_android has the compileSdkVersion set to 34 and we get a warning because we use a lower version.