### PR TITLE
feat(tool,ci): Only run tests of changed packages and their dependents

### DIFF
--- a/.github/workflows/.gitattributes
+++ b/.github/workflows/.gitattributes
@@ -1,1 +1,0 @@
-dart.yml -diff

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        with:
+          fetch-depth: 0
       - name: Login to GHCR
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
         with:
@@ -44,4 +46,9 @@ jobs:
       - name: Lint code
         run: melos run analyze
       - name: Run tests
-        run: melos run test
+        run: |
+          mapfile -t packages < <(melos list --parsable --diff=${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }}..${{ github.event.pull_request.head.sha }} --include-dependents | xargs -r -n1 basename)
+          if [ -z "$packages" ]; then exit 0; fi
+          packages_glob="$(printf ",%s" "${packages[@]}")"
+          packages_glob="${packages_glob:1}"
+          melos exec --scope="$packages_glob" --concurrency=1 --fail-fast --dir-exists=test -- "flutter test --concurrency=$(nproc --all)"

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./tool/setup.sh
 
       - name: Check formatting
-        run: melos run format-check
+        run: melos run format:check
       - name: Lint code
         run: melos run analyze
       - name: Run tests

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-melos run format-check
+melos run format:check

--- a/melos.yaml
+++ b/melos.yaml
@@ -20,7 +20,7 @@ ide:
 
 scripts:
   format: dart format --fix --line-length 120 .
-  format-check: dart format --output=none --set-exit-if-changed --line-length 120 .
+  format:check: dart format --output=none --set-exit-if-changed --line-length 120 .
   analyze: dart analyze --fatal-infos .
   test: melos exec --concurrency=1 --fail-fast --dir-exists=test -- "flutter test --concurrency=$(nproc --all)"
   generate:neon:build_runner: melos exec --scope="neon*" --file-exists="build.yaml" -- dart run build_runner build --delete-conflicting-outputs && melos run format


### PR DESCRIPTION
Closes https://github.com/nextcloud/neon/issues/494

The script is a bit more complicated because melos does not care about the order of arguments.
First we need to find the changed packages and the dependents.
Then all tests of those packages need to run.
Putting both conditions into a single command does not work.