### PR TITLE
fix(ci): Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -137,8 +137,8 @@ jobs:
 
       - name: Install dart
         uses: dart-lang/setup-dart@8a4b97ea2017cc079571daec46542f76189836b1 # v1
-      - name: Install melos
-        run: dart pub global activate melos
+      - name: Setup
+        run: ./tool/setup.sh
       - name: Build
         run: ./tool/build-app.sh linux/${{ matrix.architecture.docker }} --build-number="${{ needs.setup.outputs.build_number }}"
 


### PR DESCRIPTION
https://github.com/nextcloud/neon/pull/919 forgot that melos also requires the flutter sdk provided by fvm and so on. Full setup is required for everything to work.