### PR TITLE
Revert "fix(deps): update dependency share_plus to v8"

### DIFF
--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -975,10 +975,10 @@ packages:
     dependency: transitive
     description:
       name: share_plus
-      sha256: f86c5acc512b20e074137075824fc29e29b2cf395dcbfcc371e96e3e6290cce1
+      sha256: "6cec740fa0943a826951223e76218df002804adb588235a8910dc3d6b0654e11"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "7.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:

--- a/packages/neon/neon_files/pubspec.yaml
+++ b/packages/neon/neon_files/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   path_provider: ^2.0.0
   queue: ^3.0.0
   rxdart: ^0.27.0
-  share_plus: ^8.0.0
+  share_plus: ^7.0.0
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/packages/neon/neon_news/pubspec.yaml
+++ b/packages/neon/neon_news/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
       url: https://github.com/nextcloud/neon
       path: packages/nextcloud
   rxdart: ^0.27.0
-  share_plus: ^8.0.0
+  share_plus: ^7.0.0
   url_launcher: ^6.0.0
   wakelock_plus: ^1.0.0
   webview_flutter: ^4.0.0


### PR DESCRIPTION
Reverts https://github.com/nextcloud/neon/pull/948. Seems like the version was retracted :woman_shrugging: