### PR TITLE
refactor(neon,nextcloud): cleanup PushNotification decryption

### DIFF
--- a/packages/neon/neon/lib/src/blocs/push_notifications.dart
+++ b/packages/neon/neon/lib/src/blocs/push_notifications.dart
@@ -62,7 +62,7 @@ class PushNotificationsBloc extends Bloc implements PushNotificationsBlocEvents,
 
   Future<void> _setupUnifiedPush() async {
     // We just use a single RSA keypair for all accounts
-    final keypair = await PushUtils.loadRSAKeypair();
+    final keypair = PushUtils.loadRSAKeypair();
 
     await UnifiedPush.initialize(
       onNewEndpoint: (final endpoint, final instance) async {


### PR DESCRIPTION
extracted from #886

I really dislike this approach. I think we should just have a second method like `PushNotification.fromEncrypted` similar to the fromJson one. We could also do something similar with `DecryptedSubject`.

What do you think.