### PR TITLE
fix(neon_files): empty browser view

### DIFF
--- a/packages/neon/neon_files/lib/widgets/browser_view.dart
+++ b/packages/neon/neon_files/lib/widgets/browser_view.dart
@@ -123,6 +123,7 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
                               bloc: widget.filesBloc,
                               browserBloc: widget.bloc,
                               details: details,
+                              mode: widget.mode,
                             );
                           },
                           isLoading: filesSnapshot.isLoading,

--- a/packages/neon/neon_files/lib/widgets/file_list_tile.dart
+++ b/packages/neon/neon_files/lib/widgets/file_list_tile.dart
@@ -73,7 +73,7 @@ class FileListTile extends StatelessWidget {
           details: details,
           bloc: bloc,
         ),
-        trailing: !details.hasTask && mode != FilesBrowserMode.noActions
+        trailing: !details.hasTask && mode == FilesBrowserMode.browser
             ? FileActions(details: details)
             : const SizedBox.square(
                 dimension: largeIconSize,


### PR DESCRIPTION
How didn't we realize that the files view was broken :thinking: 
I think this was introduced with the NeonListView rework.