### PR TITLE
perf(tool): avoid rebuilding the specs if nothing changed

### DIFF
--- a/tool/generate-nextcloud.sh
+++ b/tool/generate-nextcloud.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")/.."
 
 (
   cd packages/nextcloud
-  rm -rf .dart_tool/build
+  rm -rf .dart_tool/build/generated/dynamite
   fvm dart run nextcloud:generate_props
   fvm dart pub run build_runner build --delete-conflicting-outputs
   fvm dart run nextcloud:generate_exports


### PR DESCRIPTION
I quickly tested it with subsequent runs so only the `dart fix` part is really invoked but changing something in the dynamite package still correctly rebuilds the specs.

Please also test this on your side. As said I only quickly tested it for now