### PR TITLE
make oneOf and anyOf throw at build time rather then on deserialization

### DIFF
--- a/packages/dynamite/dynamite/lib/src/builder/ofs_builder.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/ofs_builder.dart
@@ -101,29 +101,63 @@ TypeResult resolveOfs(
       fields[result.name] = toFieldName(dartName, result.name);
     }
 
-    state.output.addAll([
-      buildInterface(
-        identifier,
-        methods: BuiltList.from(
-          results.map(
-            (final result) => Method(
-              (final b) {
-                final s = schema.ofs![results.indexOf(result)];
-                b
-                  ..name = fields[result.name]
-                  ..returns = refer(result.nullableName)
-                  ..type = MethodType.getter
-                  ..docs.addAll(s.formattedDescription);
-              },
-            ),
+    final interface = buildInterface(
+      identifier,
+      methods: BuiltList.from(
+        results.map(
+          (final result) => Method(
+            (final b) {
+              final s = schema.ofs![results.indexOf(result)];
+              b
+                ..name = fields[result.name]
+                ..returns = refer(result.nullableName)
+                ..type = MethodType.getter
+                ..docs.addAll(s.formattedDescription);
+            },
           ),
         ),
       ),
-      buildBuiltClass(
-        identifier,
-        customSerializer: true,
-        methods: BuiltList.build(
-          (final b) => b.add(
+    );
+
+    final hook = Method((final b) {
+      b
+        ..name = '_validate'
+        ..returns = refer('void')
+        ..annotations.add(
+          refer('BuiltValueHook').call([], {'finalizeBuilder': literalTrue}),
+        )
+        ..static = true
+        ..requiredParameters.add(
+          Parameter(
+            (final b) => b
+              ..name = 'b'
+              ..type = refer('${identifier}Builder'),
+          ),
+        );
+
+      final buffer = StringBuffer()
+        ..writeln('// When this is rebuild from another builder')
+        ..writeln('if (b._data == null) { return;}')
+        ..writeln()
+        ..writeln('final match = ')
+        ..writeln('[${fields.values.map((final e) => 'b._$e').join(',')}]')
+        ..writeln(schema.oneOf != null ? '.singleWhereOrNull' : '.firstWhereOrNull')
+        ..writeln('((final x) => x != null);')
+        ..writeln('if (match == null) {')
+        ..writeln(
+          'throw StateError("Need ${schema.oneOf != null ? 'exactly' : 'at least'} one of ${fields.values.map((final e) => "'$e'").join(', ')} for \${b._data}");',
+        )
+        ..writeln('}');
+
+      b.body = Code(buffer.toString());
+    });
+
+    final $class = buildBuiltClass(
+      identifier,
+      customSerializer: true,
+      methods: BuiltList.build(
+        (final b) => b
+          ..add(
             Method(
               (final b) {
                 b
@@ -132,149 +166,150 @@ TypeResult resolveOfs(
                   ..type = MethodType.getter;
               },
             ),
+          )
+          ..add(hook),
+      ),
+    );
+
+    final serializer = Class(
+      (final b) => b
+        ..name = '_\$${identifier}Serializer'
+        ..implements.add(refer('PrimitiveSerializer<$identifier>'))
+        ..fields.addAll([
+          Field(
+            (final b) => b
+              ..name = 'types'
+              ..modifier = FieldModifier.final$
+              ..type = refer('Iterable<Type>')
+              ..annotations.add(refer('override'))
+              ..assignment = Code('const [$identifier, _\$$identifier]'),
           ),
-        ),
-      ),
-      Class(
-        (final b) => b
-          ..name = '_\$${identifier}Serializer'
-          ..implements.add(refer('PrimitiveSerializer<$identifier>'))
-          ..fields.addAll([
-            Field(
-              (final b) => b
-                ..name = 'types'
-                ..modifier = FieldModifier.final$
-                ..type = refer('Iterable<Type>')
-                ..annotations.add(refer('override'))
-                ..assignment = Code('const [$identifier, _\$$identifier]'),
-            ),
-            Field(
-              (final b) => b
-                ..name = 'wireName'
-                ..modifier = FieldModifier.final$
-                ..type = refer('String')
-                ..annotations.add(refer('override'))
-                ..assignment = Code("r'$identifier'"),
-            ),
-          ])
-          ..methods.addAll([
-            Method((final b) {
-              b
-                ..name = 'serialize'
-                ..returns = refer('Object')
-                ..annotations.add(refer('override'))
-                ..requiredParameters.addAll([
-                  Parameter(
-                    (final b) => b
-                      ..name = 'serializers'
-                      ..type = refer('Serializers'),
-                  ),
-                  Parameter(
-                    (final b) => b
-                      ..name = 'object'
-                      ..type = refer(identifier),
-                  ),
-                ])
-                ..optionalParameters.add(
-                  Parameter(
-                    (final b) => b
-                      ..name = 'specifiedType'
-                      ..type = refer('FullType')
-                      ..named = true
-                      ..defaultTo = const Code('FullType.unspecified'),
-                  ),
-                )
-                ..body = const Code('return object.data.value;');
-            }),
-            Method((final b) {
-              b
-                ..name = 'deserialize'
-                ..returns = refer(identifier)
-                ..annotations.add(refer('override'))
-                ..requiredParameters.addAll([
-                  Parameter(
-                    (final b) => b
-                      ..name = 'serializers'
-                      ..type = refer('Serializers'),
-                  ),
-                  Parameter(
-                    (final b) => b
-                      ..name = 'data'
-                      ..type = refer('Object'),
-                  ),
-                ])
-                ..optionalParameters.add(
-                  Parameter(
-                    (final b) => b
-                      ..name = 'specifiedType'
-                      ..type = refer('FullType')
-                      ..named = true
-                      ..defaultTo = const Code('FullType.unspecified'),
-                  ),
-                )
-                ..body = Code(
-                  <String>[
-                    'final result = new ${identifier}Builder()',
-                    '..data = JsonObject(data);',
+          Field(
+            (final b) => b
+              ..name = 'wireName'
+              ..modifier = FieldModifier.final$
+              ..type = refer('String')
+              ..annotations.add(refer('override'))
+              ..assignment = Code("r'$identifier'"),
+          ),
+        ])
+        ..methods.addAll([
+          Method((final b) {
+            b
+              ..name = 'serialize'
+              ..returns = refer('Object')
+              ..annotations.add(refer('override'))
+              ..requiredParameters.addAll([
+                Parameter(
+                  (final b) => b
+                    ..name = 'serializers'
+                    ..type = refer('Serializers'),
+                ),
+                Parameter(
+                  (final b) => b
+                    ..name = 'object'
+                    ..type = refer(identifier),
+                ),
+              ])
+              ..optionalParameters.add(
+                Parameter(
+                  (final b) => b
+                    ..name = 'specifiedType'
+                    ..type = refer('FullType')
+                    ..named = true
+                    ..defaultTo = const Code('FullType.unspecified'),
+                ),
+              )
+              ..body = const Code('return object.data.value;');
+          }),
+          Method((final b) {
+            b
+              ..name = 'deserialize'
+              ..returns = refer(identifier)
+              ..annotations.add(refer('override'))
+              ..requiredParameters.addAll([
+                Parameter(
+                  (final b) => b
+                    ..name = 'serializers'
+                    ..type = refer('Serializers'),
+                ),
+                Parameter(
+                  (final b) => b
+                    ..name = 'data'
+                    ..type = refer('Object'),
+                ),
+              ])
+              ..optionalParameters.add(
+                Parameter(
+                  (final b) => b
+                    ..name = 'specifiedType'
+                    ..type = refer('FullType')
+                    ..named = true
+                    ..defaultTo = const Code('FullType.unspecified'),
+                ),
+              )
+              ..body = Code(
+                <String>[
+                  'final result = ${identifier}Builder()',
+                  '..data = JsonObject(data);',
+                  if (schema.discriminator != null) ...[
+                    'if (data is! Iterable) {',
+                    r"throw StateError('Expected an Iterable but got ${data.runtimeType}');",
+                    '}',
+                    '',
+                    'String? discriminator;',
+                    '',
+                    'final iterator = data.iterator;',
+                    'while (iterator.moveNext()) {',
+                    'final key = iterator.current! as String;',
+                    'iterator.moveNext();',
+                    'final Object? value = iterator.current;',
+                    "if (key == '${schema.discriminator!.propertyName}') {",
+                    'discriminator = value! as String;',
+                    'break;',
+                    '}',
+                    '}',
+                  ],
+                  for (final result in results) ...[
                     if (schema.discriminator != null) ...[
-                      'if (data is! Iterable) {',
-                      r"throw StateError('Expected an Iterable but got ${data.runtimeType}');",
-                      '}',
-                      '',
-                      'String? discriminator;',
-                      '',
-                      'final iterator = data.iterator;',
-                      'while (iterator.moveNext()) {',
-                      'final key = iterator.current! as String;',
-                      'iterator.moveNext();',
-                      'final Object? value = iterator.current;',
-                      "if (key == '${schema.discriminator!.propertyName}') {",
-                      'discriminator = value! as String;',
-                      'break;',
-                      '}',
-                      '}',
-                    ],
-                    for (final result in results) ...[
-                      if (schema.discriminator != null) ...[
-                        "if (discriminator == '${result.name}'",
-                        if (schema.discriminator!.mapping != null && schema.discriminator!.mapping!.isNotEmpty) ...[
-                          for (final key in schema.discriminator!.mapping!.entries
-                              .where(
-                                (final entry) => entry.value.endsWith('/${result.name}'),
-                              )
-                              .map((final entry) => entry.key)) ...[
-                            " ||  discriminator == '$key'",
-                          ],
-                          ') {',
+                      "if (discriminator == '${result.name}'",
+                      if (schema.discriminator!.mapping != null && schema.discriminator!.mapping!.isNotEmpty) ...[
+                        for (final key in schema.discriminator!.mapping!.entries
+                            .where(
+                              (final entry) => entry.value.endsWith('/${result.name}'),
+                            )
+                            .map((final entry) => entry.key)) ...[
+                          " ||  discriminator == '$key'",
                         ],
+                        ') {',
                       ],
-                      'try {',
-                      if (result is TypeResultBase || result is TypeResultEnum) ...[
-                        'result._${fields[result.name]!} = ${result.deserialize('data')};',
-                      ] else ...[
-                        'result._${fields[result.name]!} = ${result.deserialize('data')}.toBuilder();',
-                      ],
-                      '} catch (_) {',
-                      if (schema.discriminator != null) ...[
-                        'rethrow;',
-                      ],
+                    ],
+                    'try {',
+                    'final value = ${result.deserialize('data')};',
+                    if (result is TypeResultBase || result is TypeResultEnum)
+                      'result.${fields[result.name]!} = value;'
+                    else
+                      'result.${fields[result.name]!}.replace(value);',
+                    '} catch (_) {',
+                    if (schema.discriminator != null) ...[
+                      'rethrow;',
+                    ],
+                    '}',
+                    if (schema.discriminator != null) ...[
                       '}',
-                      if (schema.discriminator != null) ...[
-                        '}',
-                      ],
                     ],
-                    if (schema.oneOf != null) ...[
-                      "assert([${fields.values.map((final e) => 'result._$e').join(',')}].where((final x) => x != null).length >= 1, 'Need oneOf for \${result._data}');",
-                    ],
-                    if (schema.anyOf != null) ...[
-                      "assert([${fields.values.map((final e) => 'result._$e').join(',')}].where((final x) => x != null).length >= 1, 'Need anyOf for \${result._data}');",
-                    ],
-                    'return result.build();',
-                  ].join(),
-                );
-            }),
-          ]),
-      ),
+                  ],
+                  'return result.build();',
+                ].join(),
+              );
+          }),
+        ]),
+    );
+
+    state.output.addAll([
+      interface,
+      $class,
+      serializer,
     ]);
   }
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
@@ -7,6 +7,7 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart';
+import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 
@@ -33,7 +34,7 @@ class Client extends DynamiteClient {
 
 @BuiltValue(instantiable: false)
 abstract interface class BaseInterface {
-  String? get attribute;
+  String get attribute;
 }
 
 abstract class Base implements BaseInterface, Built<Base, BaseBuilder> {
@@ -57,7 +58,7 @@ abstract class Base implements BaseInterface, Built<Base, BaseBuilder> {
 @BuiltValue(instantiable: false)
 abstract interface class BaseAllOf_1Interface {
   @BuiltValueField(wireName: 'attribute-allOf')
-  String? get attributeAllOf;
+  String get attributeAllOf;
 }
 
 @BuiltValue(instantiable: false)
@@ -84,7 +85,7 @@ abstract class BaseAllOf implements BaseAllOfInterface, Built<BaseAllOf, BaseAll
 @BuiltValue(instantiable: false)
 abstract interface class BaseOneOf1Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
-  String? get attributeOneOf;
+  String get attributeOneOf;
 }
 
 abstract class BaseOneOf1 implements BaseOneOf1Interface, Built<BaseOneOf1, BaseOneOf1Builder> {
@@ -130,6 +131,18 @@ abstract class BaseOneOf implements BaseOneOfInterface, Built<BaseOneOf, BaseOne
   static Serializer<BaseOneOf> get serializer => _$BaseOneOfSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final BaseOneOfBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._base, b._baseOneOf1].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of 'base', 'baseOneOf1' for ${b._data}");
+    }
+  }
 }
 
 class _$BaseOneOfSerializer implements PrimitiveSerializer<BaseOneOf> {
@@ -155,16 +168,13 @@ class _$BaseOneOfSerializer implements PrimitiveSerializer<BaseOneOf> {
   }) {
     final result = BaseOneOfBuilder()..data = JsonObject(data);
     try {
-      result._base = (_jsonSerializers.deserialize(data, specifiedType: const FullType(Base))! as Base).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(Base))! as Base;
+      result.base.replace(value);
     } catch (_) {}
     try {
-      result._baseOneOf1 =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(BaseOneOf1))! as BaseOneOf1).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(BaseOneOf1))! as BaseOneOf1;
+      result.baseOneOf1.replace(value);
     } catch (_) {}
-    assert(
-      [result._base, result._baseOneOf1].where((final x) => x != null).isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }
@@ -172,7 +182,7 @@ class _$BaseOneOfSerializer implements PrimitiveSerializer<BaseOneOf> {
 @BuiltValue(instantiable: false)
 abstract interface class BaseAnyOf1Interface {
   @BuiltValueField(wireName: 'attribute-anyOf')
-  String? get attributeAnyOf;
+  String get attributeAnyOf;
 }
 
 abstract class BaseAnyOf1 implements BaseAnyOf1Interface, Built<BaseAnyOf1, BaseAnyOf1Builder> {
@@ -218,6 +228,18 @@ abstract class BaseAnyOf implements BaseAnyOfInterface, Built<BaseAnyOf, BaseAny
   static Serializer<BaseAnyOf> get serializer => _$BaseAnyOfSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final BaseAnyOfBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._base, b._baseAnyOf1].firstWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need at least one of 'base', 'baseAnyOf1' for ${b._data}");
+    }
+  }
 }
 
 class _$BaseAnyOfSerializer implements PrimitiveSerializer<BaseAnyOf> {
@@ -243,16 +265,13 @@ class _$BaseAnyOfSerializer implements PrimitiveSerializer<BaseAnyOf> {
   }) {
     final result = BaseAnyOfBuilder()..data = JsonObject(data);
     try {
-      result._base = (_jsonSerializers.deserialize(data, specifiedType: const FullType(Base))! as Base).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(Base))! as Base;
+      result.base.replace(value);
     } catch (_) {}
     try {
-      result._baseAnyOf1 =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(BaseAnyOf1))! as BaseAnyOf1).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(BaseAnyOf1))! as BaseAnyOf1;
+      result.baseAnyOf1.replace(value);
     } catch (_) {}
-    assert(
-      [result._base, result._baseAnyOf1].where((final x) => x != null).isNotEmpty,
-      'Need anyOf for ${result._data}',
-    );
     return result.build();
   }
 }
@@ -260,7 +279,7 @@ class _$BaseAnyOfSerializer implements PrimitiveSerializer<BaseAnyOf> {
 @BuiltValue(instantiable: false)
 abstract interface class BaseNestedAllOf_3Interface {
   @BuiltValueField(wireName: 'attribute-nested-allOf')
-  String? get attributeNestedAllOf;
+  String get attributeNestedAllOf;
 }
 
 @BuiltValue(instantiable: false)
@@ -289,7 +308,7 @@ abstract class BaseNestedAllOf implements BaseNestedAllOfInterface, Built<BaseNe
 @BuiltValue(instantiable: false)
 abstract interface class BaseNestedOneOf3Interface {
   @BuiltValueField(wireName: 'attribute-nested-oneOf')
-  String? get attributeNestedOneOf;
+  String get attributeNestedOneOf;
 }
 
 abstract class BaseNestedOneOf3 implements BaseNestedOneOf3Interface, Built<BaseNestedOneOf3, BaseNestedOneOf3Builder> {
@@ -339,6 +358,19 @@ abstract class BaseNestedOneOf implements BaseNestedOneOfInterface, Built<BaseNe
   static Serializer<BaseNestedOneOf> get serializer => _$BaseNestedOneOfSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final BaseNestedOneOfBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match =
+        [b._baseAllOf, b._baseOneOf, b._baseAnyOf, b._baseNestedOneOf3].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of 'baseAllOf', 'baseOneOf', 'baseAnyOf', 'baseNestedOneOf3' for ${b._data}");
+    }
+  }
 }
 
 class _$BaseNestedOneOfSerializer implements PrimitiveSerializer<BaseNestedOneOf> {
@@ -364,28 +396,22 @@ class _$BaseNestedOneOfSerializer implements PrimitiveSerializer<BaseNestedOneOf
   }) {
     final result = BaseNestedOneOfBuilder()..data = JsonObject(data);
     try {
-      result._baseAllOf =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(BaseAllOf))! as BaseAllOf).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(BaseAllOf))! as BaseAllOf;
+      result.baseAllOf.replace(value);
     } catch (_) {}
     try {
-      result._baseOneOf =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(BaseOneOf))! as BaseOneOf).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(BaseOneOf))! as BaseOneOf;
+      result.baseOneOf.replace(value);
     } catch (_) {}
     try {
-      result._baseAnyOf =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(BaseAnyOf))! as BaseAnyOf).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(BaseAnyOf))! as BaseAnyOf;
+      result.baseAnyOf.replace(value);
     } catch (_) {}
     try {
-      result._baseNestedOneOf3 =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(BaseNestedOneOf3))! as BaseNestedOneOf3)
-              .toBuilder();
+      final value =
+          _jsonSerializers.deserialize(data, specifiedType: const FullType(BaseNestedOneOf3))! as BaseNestedOneOf3;
+      result.baseNestedOneOf3.replace(value);
     } catch (_) {}
-    assert(
-      [result._baseAllOf, result._baseOneOf, result._baseAnyOf, result._baseNestedOneOf3]
-          .where((final x) => x != null)
-          .isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }
@@ -393,7 +419,7 @@ class _$BaseNestedOneOfSerializer implements PrimitiveSerializer<BaseNestedOneOf
 @BuiltValue(instantiable: false)
 abstract interface class BaseNestedAnyOf3Interface {
   @BuiltValueField(wireName: 'attribute-nested-anyOf')
-  String? get attributeNestedAnyOf;
+  String get attributeNestedAnyOf;
 }
 
 abstract class BaseNestedAnyOf3 implements BaseNestedAnyOf3Interface, Built<BaseNestedAnyOf3, BaseNestedAnyOf3Builder> {
@@ -443,6 +469,19 @@ abstract class BaseNestedAnyOf implements BaseNestedAnyOfInterface, Built<BaseNe
   static Serializer<BaseNestedAnyOf> get serializer => _$BaseNestedAnyOfSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final BaseNestedAnyOfBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match =
+        [b._baseAllOf, b._baseOneOf, b._baseAnyOf, b._baseNestedAnyOf3].firstWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need at least one of 'baseAllOf', 'baseOneOf', 'baseAnyOf', 'baseNestedAnyOf3' for ${b._data}");
+    }
+  }
 }
 
 class _$BaseNestedAnyOfSerializer implements PrimitiveSerializer<BaseNestedAnyOf> {
@@ -468,28 +507,22 @@ class _$BaseNestedAnyOfSerializer implements PrimitiveSerializer<BaseNestedAnyOf
   }) {
     final result = BaseNestedAnyOfBuilder()..data = JsonObject(data);
     try {
-      result._baseAllOf =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(BaseAllOf))! as BaseAllOf).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(BaseAllOf))! as BaseAllOf;
+      result.baseAllOf.replace(value);
     } catch (_) {}
     try {
-      result._baseOneOf =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(BaseOneOf))! as BaseOneOf).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(BaseOneOf))! as BaseOneOf;
+      result.baseOneOf.replace(value);
     } catch (_) {}
     try {
-      result._baseAnyOf =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(BaseAnyOf))! as BaseAnyOf).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(BaseAnyOf))! as BaseAnyOf;
+      result.baseAnyOf.replace(value);
     } catch (_) {}
     try {
-      result._baseNestedAnyOf3 =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(BaseNestedAnyOf3))! as BaseNestedAnyOf3)
-              .toBuilder();
+      final value =
+          _jsonSerializers.deserialize(data, specifiedType: const FullType(BaseNestedAnyOf3))! as BaseNestedAnyOf3;
+      result.baseNestedAnyOf3.replace(value);
     } catch (_) {}
-    assert(
-      [result._baseAllOf, result._baseOneOf, result._baseAnyOf, result._baseNestedAnyOf3]
-          .where((final x) => x != null)
-          .isNotEmpty,
-      'Need anyOf for ${result._data}',
-    );
     return result.build();
   }
 }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.g.dart
@@ -22,14 +22,11 @@ class _$BaseSerializer implements StructuredSerializer<Base> {
 
   @override
   Iterable<Object?> serialize(Serializers serializers, Base object, {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.attribute;
-    if (value != null) {
-      result
-        ..add('attribute')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
+    final result = <Object?>[
+      'attribute',
+      serializers.serialize(object.attribute, specifiedType: const FullType(String)),
+    ];
+
     return result;
   }
 
@@ -45,7 +42,7 @@ class _$BaseSerializer implements StructuredSerializer<Base> {
       final Object? value = iterator.current;
       switch (key) {
         case 'attribute':
-          result.attribute = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          result.attribute = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -63,20 +60,13 @@ class _$BaseAllOfSerializer implements StructuredSerializer<BaseAllOf> {
   @override
   Iterable<Object?> serialize(Serializers serializers, BaseAllOf object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.attribute;
-    if (value != null) {
-      result
-        ..add('attribute')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    value = object.attributeAllOf;
-    if (value != null) {
-      result
-        ..add('attribute-allOf')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
+    final result = <Object?>[
+      'attribute',
+      serializers.serialize(object.attribute, specifiedType: const FullType(String)),
+      'attribute-allOf',
+      serializers.serialize(object.attributeAllOf, specifiedType: const FullType(String)),
+    ];
+
     return result;
   }
 
@@ -92,10 +82,10 @@ class _$BaseAllOfSerializer implements StructuredSerializer<BaseAllOf> {
       final Object? value = iterator.current;
       switch (key) {
         case 'attribute':
-          result.attribute = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          result.attribute = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'attribute-allOf':
-          result.attributeAllOf = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          result.attributeAllOf = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -113,14 +103,11 @@ class _$BaseOneOf1Serializer implements StructuredSerializer<BaseOneOf1> {
   @override
   Iterable<Object?> serialize(Serializers serializers, BaseOneOf1 object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.attributeOneOf;
-    if (value != null) {
-      result
-        ..add('attribute-oneOf')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
+    final result = <Object?>[
+      'attribute-oneOf',
+      serializers.serialize(object.attributeOneOf, specifiedType: const FullType(String)),
+    ];
+
     return result;
   }
 
@@ -136,7 +123,7 @@ class _$BaseOneOf1Serializer implements StructuredSerializer<BaseOneOf1> {
       final Object? value = iterator.current;
       switch (key) {
         case 'attribute-oneOf':
-          result.attributeOneOf = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          result.attributeOneOf = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -154,14 +141,11 @@ class _$BaseAnyOf1Serializer implements StructuredSerializer<BaseAnyOf1> {
   @override
   Iterable<Object?> serialize(Serializers serializers, BaseAnyOf1 object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.attributeAnyOf;
-    if (value != null) {
-      result
-        ..add('attribute-anyOf')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
+    final result = <Object?>[
+      'attribute-anyOf',
+      serializers.serialize(object.attributeAnyOf, specifiedType: const FullType(String)),
+    ];
+
     return result;
   }
 
@@ -177,7 +161,7 @@ class _$BaseAnyOf1Serializer implements StructuredSerializer<BaseAnyOf1> {
       final Object? value = iterator.current;
       switch (key) {
         case 'attribute-anyOf':
-          result.attributeAnyOf = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          result.attributeAnyOf = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -195,20 +179,15 @@ class _$BaseNestedAllOfSerializer implements StructuredSerializer<BaseNestedAllO
   @override
   Iterable<Object?> serialize(Serializers serializers, BaseNestedAllOf object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
+    final result = <Object?>[
+      'attribute',
+      serializers.serialize(object.attribute, specifiedType: const FullType(String)),
+      'attribute-allOf',
+      serializers.serialize(object.attributeAllOf, specifiedType: const FullType(String)),
+      'attribute-nested-allOf',
+      serializers.serialize(object.attributeNestedAllOf, specifiedType: const FullType(String)),
+    ];
     Object? value;
-    value = object.attribute;
-    if (value != null) {
-      result
-        ..add('attribute')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    value = object.attributeAllOf;
-    if (value != null) {
-      result
-        ..add('attribute-allOf')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
     value = object.base;
     if (value != null) {
       result
@@ -227,12 +206,6 @@ class _$BaseNestedAllOfSerializer implements StructuredSerializer<BaseNestedAllO
         ..add('baseAnyOf1')
         ..add(serializers.serialize(value, specifiedType: const FullType(BaseAnyOf1)));
     }
-    value = object.attributeNestedAllOf;
-    if (value != null) {
-      result
-        ..add('attribute-nested-allOf')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
     return result;
   }
 
@@ -248,10 +221,10 @@ class _$BaseNestedAllOfSerializer implements StructuredSerializer<BaseNestedAllO
       final Object? value = iterator.current;
       switch (key) {
         case 'attribute':
-          result.attribute = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          result.attribute = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'attribute-allOf':
-          result.attributeAllOf = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          result.attributeAllOf = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'base':
           result.base.replace(serializers.deserialize(value, specifiedType: const FullType(Base))! as Base);
@@ -266,7 +239,7 @@ class _$BaseNestedAllOfSerializer implements StructuredSerializer<BaseNestedAllO
           break;
         case 'attribute-nested-allOf':
           result.attributeNestedAllOf =
-              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+              serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -284,14 +257,11 @@ class _$BaseNestedOneOf3Serializer implements StructuredSerializer<BaseNestedOne
   @override
   Iterable<Object?> serialize(Serializers serializers, BaseNestedOneOf3 object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.attributeNestedOneOf;
-    if (value != null) {
-      result
-        ..add('attribute-nested-oneOf')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
+    final result = <Object?>[
+      'attribute-nested-oneOf',
+      serializers.serialize(object.attributeNestedOneOf, specifiedType: const FullType(String)),
+    ];
+
     return result;
   }
 
@@ -308,7 +278,7 @@ class _$BaseNestedOneOf3Serializer implements StructuredSerializer<BaseNestedOne
       switch (key) {
         case 'attribute-nested-oneOf':
           result.attributeNestedOneOf =
-              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+              serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -326,14 +296,11 @@ class _$BaseNestedAnyOf3Serializer implements StructuredSerializer<BaseNestedAny
   @override
   Iterable<Object?> serialize(Serializers serializers, BaseNestedAnyOf3 object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.attributeNestedAnyOf;
-    if (value != null) {
-      result
-        ..add('attribute-nested-anyOf')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
+    final result = <Object?>[
+      'attribute-nested-anyOf',
+      serializers.serialize(object.attributeNestedAnyOf, specifiedType: const FullType(String)),
+    ];
+
     return result;
   }
 
@@ -350,7 +317,7 @@ class _$BaseNestedAnyOf3Serializer implements StructuredSerializer<BaseNestedAny
       switch (key) {
         case 'attribute-nested-anyOf':
           result.attributeNestedAnyOf =
-              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+              serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -368,11 +335,13 @@ abstract mixin class BaseInterfaceBuilder {
 
 class _$Base extends Base {
   @override
-  final String? attribute;
+  final String attribute;
 
   factory _$Base([void Function(BaseBuilder)? updates]) => (BaseBuilder()..update(updates))._build();
 
-  _$Base._({this.attribute}) : super._();
+  _$Base._({required this.attribute}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(attribute, r'Base', 'attribute');
+  }
 
   @override
   Base rebuild(void Function(BaseBuilder) updates) => (toBuilder()..update(updates)).build();
@@ -433,7 +402,7 @@ class BaseBuilder implements Builder<Base, BaseBuilder>, BaseInterfaceBuilder {
   Base build() => _build();
 
   _$Base _build() {
-    final _$result = _$v ?? _$Base._(attribute: attribute);
+    final _$result = _$v ?? _$Base._(attribute: BuiltValueNullFieldError.checkNotNull(attribute, r'Base', 'attribute'));
     replace(_$result);
     return _$result;
   }
@@ -458,13 +427,16 @@ abstract mixin class BaseAllOfInterfaceBuilder implements BaseInterfaceBuilder, 
 
 class _$BaseAllOf extends BaseAllOf {
   @override
-  final String? attribute;
+  final String attribute;
   @override
-  final String? attributeAllOf;
+  final String attributeAllOf;
 
   factory _$BaseAllOf([void Function(BaseAllOfBuilder)? updates]) => (BaseAllOfBuilder()..update(updates))._build();
 
-  _$BaseAllOf._({this.attribute, this.attributeAllOf}) : super._();
+  _$BaseAllOf._({required this.attribute, required this.attributeAllOf}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(attribute, r'BaseAllOf', 'attribute');
+    BuiltValueNullFieldError.checkNotNull(attributeAllOf, r'BaseAllOf', 'attributeAllOf');
+  }
 
   @override
   BaseAllOf rebuild(void Function(BaseAllOfBuilder) updates) => (toBuilder()..update(updates)).build();
@@ -534,7 +506,10 @@ class BaseAllOfBuilder implements Builder<BaseAllOf, BaseAllOfBuilder>, BaseAllO
   BaseAllOf build() => _build();
 
   _$BaseAllOf _build() {
-    final _$result = _$v ?? _$BaseAllOf._(attribute: attribute, attributeAllOf: attributeAllOf);
+    final _$result = _$v ??
+        _$BaseAllOf._(
+            attribute: BuiltValueNullFieldError.checkNotNull(attribute, r'BaseAllOf', 'attribute'),
+            attributeAllOf: BuiltValueNullFieldError.checkNotNull(attributeAllOf, r'BaseAllOf', 'attributeAllOf'));
     replace(_$result);
     return _$result;
   }
@@ -549,11 +524,13 @@ abstract mixin class BaseOneOf1InterfaceBuilder {
 
 class _$BaseOneOf1 extends BaseOneOf1 {
   @override
-  final String? attributeOneOf;
+  final String attributeOneOf;
 
   factory _$BaseOneOf1([void Function(BaseOneOf1Builder)? updates]) => (BaseOneOf1Builder()..update(updates))._build();
 
-  _$BaseOneOf1._({this.attributeOneOf}) : super._();
+  _$BaseOneOf1._({required this.attributeOneOf}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(attributeOneOf, r'BaseOneOf1', 'attributeOneOf');
+  }
 
   @override
   BaseOneOf1 rebuild(void Function(BaseOneOf1Builder) updates) => (toBuilder()..update(updates)).build();
@@ -614,7 +591,9 @@ class BaseOneOf1Builder implements Builder<BaseOneOf1, BaseOneOf1Builder>, BaseO
   BaseOneOf1 build() => _build();
 
   _$BaseOneOf1 _build() {
-    final _$result = _$v ?? _$BaseOneOf1._(attributeOneOf: attributeOneOf);
+    final _$result = _$v ??
+        _$BaseOneOf1._(
+            attributeOneOf: BuiltValueNullFieldError.checkNotNull(attributeOneOf, r'BaseOneOf1', 'attributeOneOf'));
     replace(_$result);
     return _$result;
   }
@@ -719,6 +698,7 @@ class BaseOneOfBuilder implements Builder<BaseOneOf, BaseOneOfBuilder>, BaseOneO
   BaseOneOf build() => _build();
 
   _$BaseOneOf _build() {
+    BaseOneOf._validate(this);
     _$BaseOneOf _$result;
     try {
       _$result = _$v ??
@@ -752,11 +732,13 @@ abstract mixin class BaseAnyOf1InterfaceBuilder {
 
 class _$BaseAnyOf1 extends BaseAnyOf1 {
   @override
-  final String? attributeAnyOf;
+  final String attributeAnyOf;
 
   factory _$BaseAnyOf1([void Function(BaseAnyOf1Builder)? updates]) => (BaseAnyOf1Builder()..update(updates))._build();
 
-  _$BaseAnyOf1._({this.attributeAnyOf}) : super._();
+  _$BaseAnyOf1._({required this.attributeAnyOf}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(attributeAnyOf, r'BaseAnyOf1', 'attributeAnyOf');
+  }
 
   @override
   BaseAnyOf1 rebuild(void Function(BaseAnyOf1Builder) updates) => (toBuilder()..update(updates)).build();
@@ -817,7 +799,9 @@ class BaseAnyOf1Builder implements Builder<BaseAnyOf1, BaseAnyOf1Builder>, BaseA
   BaseAnyOf1 build() => _build();
 
   _$BaseAnyOf1 _build() {
-    final _$result = _$v ?? _$BaseAnyOf1._(attributeAnyOf: attributeAnyOf);
+    final _$result = _$v ??
+        _$BaseAnyOf1._(
+            attributeAnyOf: BuiltValueNullFieldError.checkNotNull(attributeAnyOf, r'BaseAnyOf1', 'attributeAnyOf'));
     replace(_$result);
     return _$result;
   }
@@ -922,6 +906,7 @@ class BaseAnyOfBuilder implements Builder<BaseAnyOf, BaseAnyOfBuilder>, BaseAnyO
   BaseAnyOf build() => _build();
 
   _$BaseAnyOf _build() {
+    BaseAnyOf._validate(this);
     _$BaseAnyOf _$result;
     try {
       _$result = _$v ??
@@ -982,9 +967,9 @@ abstract mixin class BaseNestedAllOfInterfaceBuilder
 
 class _$BaseNestedAllOf extends BaseNestedAllOf {
   @override
-  final String? attribute;
+  final String attribute;
   @override
-  final String? attributeAllOf;
+  final String attributeAllOf;
   @override
   final Base? base;
   @override
@@ -992,14 +977,23 @@ class _$BaseNestedAllOf extends BaseNestedAllOf {
   @override
   final BaseAnyOf1? baseAnyOf1;
   @override
-  final String? attributeNestedAllOf;
+  final String attributeNestedAllOf;
 
   factory _$BaseNestedAllOf([void Function(BaseNestedAllOfBuilder)? updates]) =>
       (BaseNestedAllOfBuilder()..update(updates))._build();
 
   _$BaseNestedAllOf._(
-      {this.attribute, this.attributeAllOf, this.base, this.baseOneOf1, this.baseAnyOf1, this.attributeNestedAllOf})
-      : super._();
+      {required this.attribute,
+      required this.attributeAllOf,
+      this.base,
+      this.baseOneOf1,
+      this.baseAnyOf1,
+      required this.attributeNestedAllOf})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(attribute, r'BaseNestedAllOf', 'attribute');
+    BuiltValueNullFieldError.checkNotNull(attributeAllOf, r'BaseNestedAllOf', 'attributeAllOf');
+    BuiltValueNullFieldError.checkNotNull(attributeNestedAllOf, r'BaseNestedAllOf', 'attributeNestedAllOf');
+  }
 
   @override
   BaseNestedAllOf rebuild(void Function(BaseNestedAllOfBuilder) updates) => (toBuilder()..update(updates)).build();
@@ -1109,12 +1103,14 @@ class BaseNestedAllOfBuilder
     try {
       _$result = _$v ??
           _$BaseNestedAllOf._(
-              attribute: attribute,
-              attributeAllOf: attributeAllOf,
+              attribute: BuiltValueNullFieldError.checkNotNull(attribute, r'BaseNestedAllOf', 'attribute'),
+              attributeAllOf:
+                  BuiltValueNullFieldError.checkNotNull(attributeAllOf, r'BaseNestedAllOf', 'attributeAllOf'),
               base: _base?.build(),
               baseOneOf1: _baseOneOf1?.build(),
               baseAnyOf1: _baseAnyOf1?.build(),
-              attributeNestedAllOf: attributeNestedAllOf);
+              attributeNestedAllOf: BuiltValueNullFieldError.checkNotNull(
+                  attributeNestedAllOf, r'BaseNestedAllOf', 'attributeNestedAllOf'));
     } catch (_) {
       late String _$failedField;
       try {
@@ -1143,12 +1139,14 @@ abstract mixin class BaseNestedOneOf3InterfaceBuilder {
 
 class _$BaseNestedOneOf3 extends BaseNestedOneOf3 {
   @override
-  final String? attributeNestedOneOf;
+  final String attributeNestedOneOf;
 
   factory _$BaseNestedOneOf3([void Function(BaseNestedOneOf3Builder)? updates]) =>
       (BaseNestedOneOf3Builder()..update(updates))._build();
 
-  _$BaseNestedOneOf3._({this.attributeNestedOneOf}) : super._();
+  _$BaseNestedOneOf3._({required this.attributeNestedOneOf}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(attributeNestedOneOf, r'BaseNestedOneOf3', 'attributeNestedOneOf');
+  }
 
   @override
   BaseNestedOneOf3 rebuild(void Function(BaseNestedOneOf3Builder) updates) => (toBuilder()..update(updates)).build();
@@ -1212,7 +1210,10 @@ class BaseNestedOneOf3Builder
   BaseNestedOneOf3 build() => _build();
 
   _$BaseNestedOneOf3 _build() {
-    final _$result = _$v ?? _$BaseNestedOneOf3._(attributeNestedOneOf: attributeNestedOneOf);
+    final _$result = _$v ??
+        _$BaseNestedOneOf3._(
+            attributeNestedOneOf: BuiltValueNullFieldError.checkNotNull(
+                attributeNestedOneOf, r'BaseNestedOneOf3', 'attributeNestedOneOf'));
     replace(_$result);
     return _$result;
   }
@@ -1350,6 +1351,7 @@ class BaseNestedOneOfBuilder
   BaseNestedOneOf build() => _build();
 
   _$BaseNestedOneOf _build() {
+    BaseNestedOneOf._validate(this);
     _$BaseNestedOneOf _$result;
     try {
       _$result = _$v ??
@@ -1389,12 +1391,14 @@ abstract mixin class BaseNestedAnyOf3InterfaceBuilder {
 
 class _$BaseNestedAnyOf3 extends BaseNestedAnyOf3 {
   @override
-  final String? attributeNestedAnyOf;
+  final String attributeNestedAnyOf;
 
   factory _$BaseNestedAnyOf3([void Function(BaseNestedAnyOf3Builder)? updates]) =>
       (BaseNestedAnyOf3Builder()..update(updates))._build();
 
-  _$BaseNestedAnyOf3._({this.attributeNestedAnyOf}) : super._();
+  _$BaseNestedAnyOf3._({required this.attributeNestedAnyOf}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(attributeNestedAnyOf, r'BaseNestedAnyOf3', 'attributeNestedAnyOf');
+  }
 
   @override
   BaseNestedAnyOf3 rebuild(void Function(BaseNestedAnyOf3Builder) updates) => (toBuilder()..update(updates)).build();
@@ -1458,7 +1462,10 @@ class BaseNestedAnyOf3Builder
   BaseNestedAnyOf3 build() => _build();
 
   _$BaseNestedAnyOf3 _build() {
-    final _$result = _$v ?? _$BaseNestedAnyOf3._(attributeNestedAnyOf: attributeNestedAnyOf);
+    final _$result = _$v ??
+        _$BaseNestedAnyOf3._(
+            attributeNestedAnyOf: BuiltValueNullFieldError.checkNotNull(
+                attributeNestedAnyOf, r'BaseNestedAnyOf3', 'attributeNestedAnyOf'));
     replace(_$result);
     return _$result;
   }
@@ -1596,6 +1603,7 @@ class BaseNestedAnyOfBuilder
   BaseNestedAnyOf build() => _build();
 
   _$BaseNestedAnyOf _build() {
+    BaseNestedAnyOf._validate(this);
     _$BaseNestedAnyOf _$result;
     try {
       _$result = _$v ??

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.json
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.json
@@ -8,6 +8,9 @@
         "schemas": {
             "Base": {
                 "type": "object",
+                "required": [
+                    "attribute"
+                ],
                 "properties": {
                     "attribute": {
                         "type": "string"
@@ -21,6 +24,9 @@
                     },
                     {
                         "type": "object",
+                        "required": [
+                            "attribute-allOf"
+                        ],
                         "properties": {
                             "attribute-allOf": {
                                 "type": "string"
@@ -36,6 +42,9 @@
                     },
                     {
                         "type": "object",
+                        "required": [
+                            "attribute-oneOf"
+                        ],
                         "properties": {
                             "attribute-oneOf": {
                                 "type": "string"
@@ -51,6 +60,9 @@
                     },
                     {
                         "type": "object",
+                        "required": [
+                            "attribute-anyOf"
+                        ],
                         "properties": {
                             "attribute-anyOf": {
                                 "type": "string"
@@ -72,6 +84,9 @@
                     },
                     {
                         "type": "object",
+                        "required": [
+                            "attribute-nested-allOf"
+                        ],
                         "properties": {
                             "attribute-nested-allOf": {
                                 "type": "string"
@@ -93,6 +108,9 @@
                     },
                     {
                         "type": "object",
+                        "required": [
+                            "attribute-nested-oneOf"
+                        ],
                         "properties": {
                             "attribute-nested-oneOf": {
                                 "type": "string"
@@ -114,6 +132,9 @@
                     },
                     {
                         "type": "object",
+                        "required": [
+                            "attribute-nested-anyOf"
+                        ],
                         "properties": {
                             "attribute-nested-anyOf": {
                                 "type": "string"

--- a/packages/dynamite/dynamite_end_to_end_test/pubspec.yaml
+++ b/packages/dynamite/dynamite_end_to_end_test/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   built_collection: ^5.0.0
   built_value: ^8.0.0
+  collection: ^1.0.0
   dynamite_runtime:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/dynamite/dynamite_end_to_end_test/test/nested_ofs_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/nested_ofs_test.dart
@@ -1,4 +1,5 @@
 import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
 import 'package:dynamite_end_to_end_test/nested_ofs.openapi.dart';
 import 'package:test/test.dart';
 
@@ -37,48 +38,30 @@ void main() {
     final object = BaseNestedOneOf(
       (final b) => b
         ..data = JsonObject(['attribute-oneOf', 'baseOneOfAttributeOneOfValue'])
-        ..baseAllOf.update((final b) {})
         ..baseOneOf.update(
           (final b) => b
             ..data = JsonObject(['attribute-oneOf', 'baseOneOfAttributeOneOfValue'])
-            ..base.update((final b) {})
             ..baseOneOf1.attributeOneOf = 'baseOneOfAttributeOneOfValue',
-        )
-        ..baseAnyOf.update(
-          (final b) => b
-            ..data = JsonObject(['attribute-oneOf', 'baseOneOfAttributeOneOfValue'])
-            ..base.update((final b) {})
-            ..baseAnyOf1.update((final b) {}),
-        )
-        ..baseNestedOneOf3.update((final b) {}),
+        ),
     );
 
     final json = {
       'attribute-oneOf': 'baseOneOfAttributeOneOfValue',
     };
 
-    expect(object.toJson(), equals(json));
     expect(BaseNestedOneOf.fromJson(json), equals(object));
+    expect(object.toJson(), equals(json));
   });
 
   test('BaseNestedAnyOf', () {
     final object = BaseNestedAnyOf(
       (final b) => b
         ..data = JsonObject(['attribute-oneOf', 'baseOneOfAttributeOneOfValue'])
-        ..baseAllOf.update((final b) {})
         ..baseOneOf.update(
           (final b) => b
             ..data = JsonObject(['attribute-oneOf', 'baseOneOfAttributeOneOfValue'])
-            ..base.update((final b) {})
             ..baseOneOf1.attributeOneOf = 'baseOneOfAttributeOneOfValue',
-        )
-        ..baseAnyOf.update(
-          (final b) => b
-            ..data = JsonObject(['attribute-oneOf', 'baseOneOfAttributeOneOfValue'])
-            ..base.update((final b) {})
-            ..baseAnyOf1.update((final b) {}),
-        )
-        ..baseNestedAnyOf3.update((final b) {}),
+        ),
     );
 
     final json = {
@@ -87,5 +70,57 @@ void main() {
 
     expect(object.toJson(), equals(json));
     expect(BaseNestedAnyOf.fromJson(json), equals(object));
+  });
+
+  test('BaseOneOf', () {
+    final object = BaseOneOf(
+      (final b) => b
+        ..data = JsonObject(['attribute-oneOf', 'attributeOneOfValue'])
+        ..baseOneOf1.attributeOneOf = 'attributeOneOfValue',
+    );
+    var json = {'attribute-oneOf': 'attributeOneOfValue'};
+    expect(BaseOneOf.fromJson(json), equals(object));
+    expect(object.toJson(), equals(json));
+
+    final builder = BaseOneOfBuilder()
+      ..data = JsonObject(['attribute-oneOf', 'attributeOneOfValue'])
+      ..baseOneOf1.attributeOneOf = 'attributeOneOfValue'
+      ..base.attribute = 'baseAttributeValue';
+    json = {
+      'attribute-oneOf': 'attributeOneOfValue',
+      'attribute': 'baseAttributeValue',
+    };
+    expect(builder.build, throwsA(isA<StateError>()));
+    expect(() => BaseOneOf.fromJson(json), throwsA(isA<DeserializationError>()));
+
+    json = {};
+    expect(() => BaseOneOf.fromJson(json), throwsA(isA<DeserializationError>()));
+  });
+
+  test('BaseAnyOf', () {
+    var object = BaseAnyOf(
+      (final b) => b
+        ..data = JsonObject(['attribute-anyOf', 'attributeAnyOfValue'])
+        ..baseAnyOf1.attributeAnyOf = 'attributeAnyOfValue',
+    );
+    var json = {'attribute-anyOf': 'attributeAnyOfValue'};
+    expect(BaseAnyOf.fromJson(json), equals(object));
+    expect(object.toJson(), equals(json));
+
+    object = BaseAnyOf(
+      (final b) => b
+        ..data = JsonObject(['attribute-anyOf', 'attributeAnyOfValue', 'attribute', 'baseAttributeValue'])
+        ..baseAnyOf1.attributeAnyOf = 'attributeAnyOfValue'
+        ..base.attribute = 'baseAttributeValue',
+    );
+    json = {
+      'attribute-anyOf': 'attributeAnyOfValue',
+      'attribute': 'baseAttributeValue',
+    };
+    expect(BaseAnyOf.fromJson(json), equals(object));
+    expect(object.toJson(), equals(json));
+
+    json = {};
+    expect(() => BaseAnyOf.fromJson(json), throwsA(isA<DeserializationError>()));
   });
 }

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -4795,6 +4795,18 @@ abstract class AutocompleteResult_Status
   static Serializer<AutocompleteResult_Status> get serializer => _$AutocompleteResult_StatusSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final AutocompleteResult_StatusBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._autocompleteResultStatus0, b._string].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of 'autocompleteResultStatus0', 'string' for ${b._data}");
+    }
+  }
 }
 
 class _$AutocompleteResult_StatusSerializer implements PrimitiveSerializer<AutocompleteResult_Status> {
@@ -4820,19 +4832,14 @@ class _$AutocompleteResult_StatusSerializer implements PrimitiveSerializer<Autoc
   }) {
     final result = AutocompleteResult_StatusBuilder()..data = JsonObject(data);
     try {
-      result._autocompleteResultStatus0 = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(AutocompleteResult_Status0),
-      )! as AutocompleteResult_Status0)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(AutocompleteResult_Status0))!
+          as AutocompleteResult_Status0;
+      result.autocompleteResultStatus0.replace(value);
     } catch (_) {}
     try {
-      result._string = _jsonSerializers.deserialize(data, specifiedType: const FullType(String))! as String;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(String))! as String;
+      result.string = value;
     } catch (_) {}
-    assert(
-      [result._autocompleteResultStatus0, result._string].where((final x) => x != null).isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }
@@ -5823,6 +5830,18 @@ abstract class NavigationEntry_Order
   static Serializer<NavigationEntry_Order> get serializer => _$NavigationEntry_OrderSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final NavigationEntry_OrderBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$int, b._string].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$int', 'string' for ${b._data}");
+    }
+  }
 }
 
 class _$NavigationEntry_OrderSerializer implements PrimitiveSerializer<NavigationEntry_Order> {
@@ -5848,12 +5867,13 @@ class _$NavigationEntry_OrderSerializer implements PrimitiveSerializer<Navigatio
   }) {
     final result = NavigationEntry_OrderBuilder()..data = JsonObject(data);
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
     try {
-      result._string = _jsonSerializers.deserialize(data, specifiedType: const FullType(String))! as String;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(String))! as String;
+      result.string = value;
     } catch (_) {}
-    assert([result._$int, result._string].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }
@@ -7616,6 +7636,34 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities
       _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [
+      b._commentsCapabilities,
+      b._davCapabilities,
+      b._filesCapabilities,
+      b._filesSharingCapabilities,
+      b._filesTrashbinCapabilities,
+      b._filesVersionsCapabilities,
+      b._notesCapabilities,
+      b._notificationsCapabilities,
+      b._provisioningApiCapabilities,
+      b._sharebymailCapabilities,
+      b._themingPublicCapabilities,
+      b._userStatusCapabilities,
+      b._weatherStatusCapabilities,
+    ].firstWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError(
+        "Need at least one of 'commentsCapabilities', 'davCapabilities', 'filesCapabilities', 'filesSharingCapabilities', 'filesTrashbinCapabilities', 'filesVersionsCapabilities', 'notesCapabilities', 'notificationsCapabilities', 'provisioningApiCapabilities', 'sharebymailCapabilities', 'themingPublicCapabilities', 'userStatusCapabilities', 'weatherStatusCapabilities' for ${b._data}",
+      );
+    }
+  }
 }
 
 class _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesSerializer
@@ -7645,108 +7693,70 @@ class _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesSerialize
   }) {
     final result = OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesBuilder()..data = JsonObject(data);
     try {
-      result._commentsCapabilities = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(CommentsCapabilities),
-      )! as CommentsCapabilities)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(CommentsCapabilities))!
+          as CommentsCapabilities;
+      result.commentsCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._davCapabilities =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(DavCapabilities))! as DavCapabilities)
-              .toBuilder();
+      final value =
+          _jsonSerializers.deserialize(data, specifiedType: const FullType(DavCapabilities))! as DavCapabilities;
+      result.davCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._filesCapabilities =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(FilesCapabilities))! as FilesCapabilities)
-              .toBuilder();
+      final value =
+          _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesCapabilities))! as FilesCapabilities;
+      result.filesCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._filesSharingCapabilities = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesSharingCapabilities),
-      )! as FilesSharingCapabilities)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesSharingCapabilities))!
+          as FilesSharingCapabilities;
+      result.filesSharingCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._filesTrashbinCapabilities = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesTrashbinCapabilities),
-      )! as FilesTrashbinCapabilities)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesTrashbinCapabilities))!
+          as FilesTrashbinCapabilities;
+      result.filesTrashbinCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._filesVersionsCapabilities = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(FilesVersionsCapabilities),
-      )! as FilesVersionsCapabilities)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(FilesVersionsCapabilities))!
+          as FilesVersionsCapabilities;
+      result.filesVersionsCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._notesCapabilities =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(NotesCapabilities))! as NotesCapabilities)
-              .toBuilder();
+      final value =
+          _jsonSerializers.deserialize(data, specifiedType: const FullType(NotesCapabilities))! as NotesCapabilities;
+      result.notesCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._notificationsCapabilities = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(NotificationsCapabilities),
-      )! as NotificationsCapabilities)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(NotificationsCapabilities))!
+          as NotificationsCapabilities;
+      result.notificationsCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._provisioningApiCapabilities = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(ProvisioningApiCapabilities),
-      )! as ProvisioningApiCapabilities)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(ProvisioningApiCapabilities))!
+          as ProvisioningApiCapabilities;
+      result.provisioningApiCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._sharebymailCapabilities = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(SharebymailCapabilities),
-      )! as SharebymailCapabilities)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(SharebymailCapabilities))!
+          as SharebymailCapabilities;
+      result.sharebymailCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._themingPublicCapabilities = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(ThemingPublicCapabilities),
-      )! as ThemingPublicCapabilities)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(ThemingPublicCapabilities))!
+          as ThemingPublicCapabilities;
+      result.themingPublicCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._userStatusCapabilities = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(UserStatusCapabilities),
-      )! as UserStatusCapabilities)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(UserStatusCapabilities))!
+          as UserStatusCapabilities;
+      result.userStatusCapabilities.replace(value);
     } catch (_) {}
     try {
-      result._weatherStatusCapabilities = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(WeatherStatusCapabilities),
-      )! as WeatherStatusCapabilities)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(WeatherStatusCapabilities))!
+          as WeatherStatusCapabilities;
+      result.weatherStatusCapabilities.replace(value);
     } catch (_) {}
-    assert(
-      [
-        result._commentsCapabilities,
-        result._davCapabilities,
-        result._filesCapabilities,
-        result._filesSharingCapabilities,
-        result._filesTrashbinCapabilities,
-        result._filesVersionsCapabilities,
-        result._notesCapabilities,
-        result._notificationsCapabilities,
-        result._provisioningApiCapabilities,
-        result._sharebymailCapabilities,
-        result._themingPublicCapabilities,
-        result._userStatusCapabilities,
-        result._weatherStatusCapabilities,
-      ].where((final x) => x != null).isNotEmpty,
-      'Need anyOf for ${result._data}',
-    );
     return result.build();
   }
 }
@@ -9271,6 +9281,18 @@ abstract class UnifiedSearchSearchCursor
   static Serializer<UnifiedSearchSearchCursor> get serializer => _$UnifiedSearchSearchCursorSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final UnifiedSearchSearchCursorBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$int, b._string].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$int', 'string' for ${b._data}");
+    }
+  }
 }
 
 class _$UnifiedSearchSearchCursorSerializer implements PrimitiveSerializer<UnifiedSearchSearchCursor> {
@@ -9296,12 +9318,13 @@ class _$UnifiedSearchSearchCursorSerializer implements PrimitiveSerializer<Unifi
   }) {
     final result = UnifiedSearchSearchCursorBuilder()..data = JsonObject(data);
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
     try {
-      result._string = _jsonSerializers.deserialize(data, specifiedType: const FullType(String))! as String;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(String))! as String;
+      result.string = value;
     } catch (_) {}
-    assert([result._$int, result._string].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }
@@ -9368,6 +9391,18 @@ abstract class UnifiedSearchResult_Cursor
   static Serializer<UnifiedSearchResult_Cursor> get serializer => _$UnifiedSearchResult_CursorSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final UnifiedSearchResult_CursorBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$int, b._string].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$int', 'string' for ${b._data}");
+    }
+  }
 }
 
 class _$UnifiedSearchResult_CursorSerializer implements PrimitiveSerializer<UnifiedSearchResult_Cursor> {
@@ -9393,12 +9428,13 @@ class _$UnifiedSearchResult_CursorSerializer implements PrimitiveSerializer<Unif
   }) {
     final result = UnifiedSearchResult_CursorBuilder()..data = JsonObject(data);
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
     try {
-      result._string = _jsonSerializers.deserialize(data, specifiedType: const FullType(String))! as String;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(String))! as String;
+      result.string = value;
     } catch (_) {}
-    assert([result._$int, result._string].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }

--- a/packages/nextcloud/lib/src/api/core.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.g.dart
@@ -9394,6 +9394,7 @@ class AutocompleteResult_StatusBuilder
   AutocompleteResult_Status build() => _build();
 
   _$AutocompleteResult_Status _build() {
+    AutocompleteResult_Status._validate(this);
     _$AutocompleteResult_Status _$result;
     try {
       _$result = _$v ??
@@ -13044,6 +13045,7 @@ class NavigationEntry_OrderBuilder
   NavigationEntry_Order build() => _build();
 
   _$NavigationEntry_Order _build() {
+    NavigationEntry_Order._validate(this);
     final _$result = _$v ??
         _$NavigationEntry_Order._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'NavigationEntry_Order', 'data'),
@@ -20172,6 +20174,7 @@ class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesBuilder
   OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities build() => _build();
 
   _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities _build() {
+    OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities._validate(this);
     _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities _$result;
     try {
       _$result = _$v ??
@@ -26001,6 +26004,7 @@ class UnifiedSearchSearchCursorBuilder
   UnifiedSearchSearchCursor build() => _build();
 
   _$UnifiedSearchSearchCursor _build() {
+    UnifiedSearchSearchCursor._validate(this);
     final _$result = _$v ??
         _$UnifiedSearchSearchCursor._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'UnifiedSearchSearchCursor', 'data'),
@@ -26319,6 +26323,7 @@ class UnifiedSearchResult_CursorBuilder
   UnifiedSearchResult_Cursor build() => _build();
 
   _$UnifiedSearchResult_Cursor _build() {
+    UnifiedSearchResult_Cursor._validate(this);
     final _$result = _$v ??
         _$UnifiedSearchResult_Cursor._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'UnifiedSearchResult_Cursor', 'data'),

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -2919,6 +2919,18 @@ abstract class ShareInfo_Size implements ShareInfo_SizeInterface, Built<ShareInf
   static Serializer<ShareInfo_Size> get serializer => _$ShareInfo_SizeSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final ShareInfo_SizeBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$int, b._$double].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$int', '$double' for ${b._data}");
+    }
+  }
 }
 
 class _$ShareInfo_SizeSerializer implements PrimitiveSerializer<ShareInfo_Size> {
@@ -2944,12 +2956,13 @@ class _$ShareInfo_SizeSerializer implements PrimitiveSerializer<ShareInfo_Size> 
   }) {
     final result = ShareInfo_SizeBuilder()..data = JsonObject(data);
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
     try {
-      result._$double = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      result.$double = value;
     } catch (_) {}
-    assert([result._$int, result._$double].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }
@@ -3012,6 +3025,18 @@ abstract class Share_ItemSize implements Share_ItemSizeInterface, Built<Share_It
   static Serializer<Share_ItemSize> get serializer => _$Share_ItemSizeSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final Share_ItemSizeBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$double, b._$int].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$double', '$int' for ${b._data}");
+    }
+  }
 }
 
 class _$Share_ItemSizeSerializer implements PrimitiveSerializer<Share_ItemSize> {
@@ -3037,12 +3062,13 @@ class _$Share_ItemSizeSerializer implements PrimitiveSerializer<Share_ItemSize> 
   }) {
     final result = Share_ItemSizeBuilder()..data = JsonObject(data);
     try {
-      result._$double = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      result.$double = value;
     } catch (_) {}
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
-    assert([result._$double, result._$int].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }
@@ -3697,6 +3723,18 @@ abstract class ShareesapiSearchShareType
   static Serializer<ShareesapiSearchShareType> get serializer => _$ShareesapiSearchShareTypeSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final ShareesapiSearchShareTypeBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$int, b._builtListInt].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$int', 'builtListInt' for ${b._data}");
+    }
+  }
 }
 
 class _$ShareesapiSearchShareTypeSerializer implements PrimitiveSerializer<ShareesapiSearchShareType> {
@@ -3722,19 +3760,14 @@ class _$ShareesapiSearchShareTypeSerializer implements PrimitiveSerializer<Share
   }) {
     final result = ShareesapiSearchShareTypeBuilder()..data = JsonObject(data);
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
     try {
-      result._builtListInt = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(BuiltList, [FullType(int)]),
-      )! as BuiltList<int>)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(BuiltList, [FullType(int)]))!
+          as BuiltList<int>;
+      result.builtListInt.replace(value);
     } catch (_) {}
-    assert(
-      [result._$int, result._builtListInt].where((final x) => x != null).isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }
@@ -4394,6 +4427,18 @@ abstract class ShareesapiFindRecommendedShareType
       _$ShareesapiFindRecommendedShareTypeSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final ShareesapiFindRecommendedShareTypeBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$int, b._builtListInt].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$int', 'builtListInt' for ${b._data}");
+    }
+  }
 }
 
 class _$ShareesapiFindRecommendedShareTypeSerializer
@@ -4420,19 +4465,14 @@ class _$ShareesapiFindRecommendedShareTypeSerializer
   }) {
     final result = ShareesapiFindRecommendedShareTypeBuilder()..data = JsonObject(data);
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
     try {
-      result._builtListInt = (_jsonSerializers.deserialize(
-        data,
-        specifiedType: const FullType(BuiltList, [FullType(int)]),
-      )! as BuiltList<int>)
-          .toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(BuiltList, [FullType(int)]))!
+          as BuiltList<int>;
+      result.builtListInt.replace(value);
     } catch (_) {}
-    assert(
-      [result._$int, result._builtListInt].where((final x) => x != null).isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
@@ -7453,6 +7453,7 @@ class ShareInfo_SizeBuilder implements Builder<ShareInfo_Size, ShareInfo_SizeBui
   ShareInfo_Size build() => _build();
 
   _$ShareInfo_Size _build() {
+    ShareInfo_Size._validate(this);
     final _$result = _$v ??
         _$ShareInfo_Size._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'ShareInfo_Size', 'data'), $int: $int, $double: $double);
@@ -7809,6 +7810,7 @@ class Share_ItemSizeBuilder implements Builder<Share_ItemSize, Share_ItemSizeBui
   Share_ItemSize build() => _build();
 
   _$Share_ItemSize _build() {
+    Share_ItemSize._validate(this);
     final _$result = _$v ??
         _$Share_ItemSize._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'Share_ItemSize', 'data'), $double: $double, $int: $int);
@@ -10573,6 +10575,7 @@ class ShareesapiSearchShareTypeBuilder
   ShareesapiSearchShareType build() => _build();
 
   _$ShareesapiSearchShareType _build() {
+    ShareesapiSearchShareType._validate(this);
     _$ShareesapiSearchShareType _$result;
     try {
       _$result = _$v ??
@@ -13812,6 +13815,7 @@ class ShareesapiFindRecommendedShareTypeBuilder
   ShareesapiFindRecommendedShareType build() => _build();
 
   _$ShareesapiFindRecommendedShareType _build() {
+    ShareesapiFindRecommendedShareType._validate(this);
     _$ShareesapiFindRecommendedShareType _$result;
     try {
       _$result = _$v ??

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -5340,6 +5340,18 @@ abstract class GroupDetails_Usercount
   static Serializer<GroupDetails_Usercount> get serializer => _$GroupDetails_UsercountSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final GroupDetails_UsercountBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$bool, b._$int].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$bool', '$int' for ${b._data}");
+    }
+  }
 }
 
 class _$GroupDetails_UsercountSerializer implements PrimitiveSerializer<GroupDetails_Usercount> {
@@ -5365,12 +5377,13 @@ class _$GroupDetails_UsercountSerializer implements PrimitiveSerializer<GroupDet
   }) {
     final result = GroupDetails_UsercountBuilder()..data = JsonObject(data);
     try {
-      result._$bool = _jsonSerializers.deserialize(data, specifiedType: const FullType(bool))! as bool;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(bool))! as bool;
+      result.$bool = value;
     } catch (_) {}
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
-    assert([result._$bool, result._$int].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }
@@ -5402,6 +5415,18 @@ abstract class GroupDetails_Disabled
   static Serializer<GroupDetails_Disabled> get serializer => _$GroupDetails_DisabledSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final GroupDetails_DisabledBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$bool, b._$int].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$bool', '$int' for ${b._data}");
+    }
+  }
 }
 
 class _$GroupDetails_DisabledSerializer implements PrimitiveSerializer<GroupDetails_Disabled> {
@@ -5427,12 +5452,13 @@ class _$GroupDetails_DisabledSerializer implements PrimitiveSerializer<GroupDeta
   }) {
     final result = GroupDetails_DisabledBuilder()..data = JsonObject(data);
     try {
-      result._$bool = _jsonSerializers.deserialize(data, specifiedType: const FullType(bool))! as bool;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(bool))! as bool;
+      result.$bool = value;
     } catch (_) {}
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
-    assert([result._$bool, result._$int].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }
@@ -5706,6 +5732,18 @@ abstract class UserDetailsQuota_Free
   static Serializer<UserDetailsQuota_Free> get serializer => _$UserDetailsQuota_FreeSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final UserDetailsQuota_FreeBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$double, b._$int].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$double', '$int' for ${b._data}");
+    }
+  }
 }
 
 class _$UserDetailsQuota_FreeSerializer implements PrimitiveSerializer<UserDetailsQuota_Free> {
@@ -5731,12 +5769,13 @@ class _$UserDetailsQuota_FreeSerializer implements PrimitiveSerializer<UserDetai
   }) {
     final result = UserDetailsQuota_FreeBuilder()..data = JsonObject(data);
     try {
-      result._$double = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      result.$double = value;
     } catch (_) {}
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
-    assert([result._$double, result._$int].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }
@@ -5769,6 +5808,18 @@ abstract class UserDetailsQuota_Quota
   static Serializer<UserDetailsQuota_Quota> get serializer => _$UserDetailsQuota_QuotaSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final UserDetailsQuota_QuotaBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$double, b._$int, b._string].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$double', '$int', 'string' for ${b._data}");
+    }
+  }
 }
 
 class _$UserDetailsQuota_QuotaSerializer implements PrimitiveSerializer<UserDetailsQuota_Quota> {
@@ -5794,18 +5845,17 @@ class _$UserDetailsQuota_QuotaSerializer implements PrimitiveSerializer<UserDeta
   }) {
     final result = UserDetailsQuota_QuotaBuilder()..data = JsonObject(data);
     try {
-      result._$double = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      result.$double = value;
     } catch (_) {}
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
     try {
-      result._string = _jsonSerializers.deserialize(data, specifiedType: const FullType(String))! as String;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(String))! as String;
+      result.string = value;
     } catch (_) {}
-    assert(
-      [result._$double, result._$int, result._string].where((final x) => x != null).isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }
@@ -5838,6 +5888,18 @@ abstract class UserDetailsQuota_Relative
   static Serializer<UserDetailsQuota_Relative> get serializer => _$UserDetailsQuota_RelativeSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final UserDetailsQuota_RelativeBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$double, b._$int].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$double', '$int' for ${b._data}");
+    }
+  }
 }
 
 class _$UserDetailsQuota_RelativeSerializer implements PrimitiveSerializer<UserDetailsQuota_Relative> {
@@ -5863,12 +5925,13 @@ class _$UserDetailsQuota_RelativeSerializer implements PrimitiveSerializer<UserD
   }) {
     final result = UserDetailsQuota_RelativeBuilder()..data = JsonObject(data);
     try {
-      result._$double = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      result.$double = value;
     } catch (_) {}
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
-    assert([result._$double, result._$int].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }
@@ -5900,6 +5963,18 @@ abstract class UserDetailsQuota_Total
   static Serializer<UserDetailsQuota_Total> get serializer => _$UserDetailsQuota_TotalSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final UserDetailsQuota_TotalBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$double, b._$int].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$double', '$int' for ${b._data}");
+    }
+  }
 }
 
 class _$UserDetailsQuota_TotalSerializer implements PrimitiveSerializer<UserDetailsQuota_Total> {
@@ -5925,12 +6000,13 @@ class _$UserDetailsQuota_TotalSerializer implements PrimitiveSerializer<UserDeta
   }) {
     final result = UserDetailsQuota_TotalBuilder()..data = JsonObject(data);
     try {
-      result._$double = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      result.$double = value;
     } catch (_) {}
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
-    assert([result._$double, result._$int].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }
@@ -5962,6 +6038,18 @@ abstract class UserDetailsQuota_Used
   static Serializer<UserDetailsQuota_Used> get serializer => _$UserDetailsQuota_UsedSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final UserDetailsQuota_UsedBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$double, b._$int].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$double', '$int' for ${b._data}");
+    }
+  }
 }
 
 class _$UserDetailsQuota_UsedSerializer implements PrimitiveSerializer<UserDetailsQuota_Used> {
@@ -5987,12 +6075,13 @@ class _$UserDetailsQuota_UsedSerializer implements PrimitiveSerializer<UserDetai
   }) {
     final result = UserDetailsQuota_UsedBuilder()..data = JsonObject(data);
     try {
-      result._$double = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(double))! as double;
+      result.$double = value;
     } catch (_) {}
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
-    assert([result._$double, result._$int].where((final x) => x != null).isNotEmpty, 'Need oneOf for ${result._data}');
     return result.build();
   }
 }
@@ -6159,6 +6248,21 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users
       _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._userDetails, b._groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1]
+        .singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError(
+        "Need exactly one of 'userDetails', 'groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1' for ${b._data}",
+      );
+    }
+  }
 }
 
 class _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer
@@ -6188,22 +6292,16 @@ class _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializ
   }) {
     final result = GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersBuilder()..data = JsonObject(data);
     try {
-      result._userDetails =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(UserDetails))! as UserDetails).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(UserDetails))! as UserDetails;
+      result.userDetails.replace(value);
     } catch (_) {}
     try {
-      result._groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1 = (_jsonSerializers.deserialize(
+      final value = _jsonSerializers.deserialize(
         data,
         specifiedType: const FullType(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1),
-      )! as GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1)
-          .toBuilder();
+      )! as GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1;
+      result.groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1.replace(value);
     } catch (_) {}
-    assert(
-      [result._userDetails, result._groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1]
-          .where((final x) => x != null)
-          .isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }
@@ -7074,6 +7172,21 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users
       _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._userDetails, b._usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1]
+        .singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError(
+        "Need exactly one of 'userDetails', 'usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1' for ${b._data}",
+      );
+    }
+  }
 }
 
 class _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer
@@ -7103,22 +7216,16 @@ class _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer
   }) {
     final result = UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersBuilder()..data = JsonObject(data);
     try {
-      result._userDetails =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(UserDetails))! as UserDetails).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(UserDetails))! as UserDetails;
+      result.userDetails.replace(value);
     } catch (_) {}
     try {
-      result._usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1 = (_jsonSerializers.deserialize(
+      final value = _jsonSerializers.deserialize(
         data,
         specifiedType: const FullType(UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1),
-      )! as UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1)
-          .toBuilder();
+      )! as UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1;
+      result.usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1.replace(value);
     } catch (_) {}
-    assert(
-      [result._userDetails, result._usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1]
-          .where((final x) => x != null)
-          .isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }
@@ -7284,6 +7391,21 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_User
       _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_UsersBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._userDetails, b._usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1]
+        .singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError(
+        "Need exactly one of 'userDetails', 'usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1' for ${b._data}",
+      );
+    }
+  }
 }
 
 class _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer
@@ -7313,22 +7435,16 @@ class _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerial
   }) {
     final result = UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_UsersBuilder()..data = JsonObject(data);
     try {
-      result._userDetails =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(UserDetails))! as UserDetails).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(UserDetails))! as UserDetails;
+      result.userDetails.replace(value);
     } catch (_) {}
     try {
-      result._usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1 = (_jsonSerializers.deserialize(
+      final value = _jsonSerializers.deserialize(
         data,
         specifiedType: const FullType(UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1),
-      )! as UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1)
-          .toBuilder();
+      )! as UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1;
+      result.usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1.replace(value);
     } catch (_) {}
-    assert(
-      [result._userDetails, result._usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1]
-          .where((final x) => x != null)
-          .isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
@@ -9943,6 +9943,7 @@ class GroupDetails_UsercountBuilder
   GroupDetails_Usercount build() => _build();
 
   _$GroupDetails_Usercount _build() {
+    GroupDetails_Usercount._validate(this);
     final _$result = _$v ??
         _$GroupDetails_Usercount._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'GroupDetails_Usercount', 'data'),
@@ -10055,6 +10056,7 @@ class GroupDetails_DisabledBuilder
   GroupDetails_Disabled build() => _build();
 
   _$GroupDetails_Disabled _build() {
+    GroupDetails_Disabled._validate(this);
     final _$result = _$v ??
         _$GroupDetails_Disabled._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'GroupDetails_Disabled', 'data'),
@@ -11122,6 +11124,7 @@ class UserDetailsQuota_FreeBuilder
   UserDetailsQuota_Free build() => _build();
 
   _$UserDetailsQuota_Free _build() {
+    UserDetailsQuota_Free._validate(this);
     final _$result = _$v ??
         _$UserDetailsQuota_Free._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'UserDetailsQuota_Free', 'data'),
@@ -11250,6 +11253,7 @@ class UserDetailsQuota_QuotaBuilder
   UserDetailsQuota_Quota build() => _build();
 
   _$UserDetailsQuota_Quota _build() {
+    UserDetailsQuota_Quota._validate(this);
     final _$result = _$v ??
         _$UserDetailsQuota_Quota._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'UserDetailsQuota_Quota', 'data'),
@@ -11365,6 +11369,7 @@ class UserDetailsQuota_RelativeBuilder
   UserDetailsQuota_Relative build() => _build();
 
   _$UserDetailsQuota_Relative _build() {
+    UserDetailsQuota_Relative._validate(this);
     final _$result = _$v ??
         _$UserDetailsQuota_Relative._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'UserDetailsQuota_Relative', 'data'),
@@ -11477,6 +11482,7 @@ class UserDetailsQuota_TotalBuilder
   UserDetailsQuota_Total build() => _build();
 
   _$UserDetailsQuota_Total _build() {
+    UserDetailsQuota_Total._validate(this);
     final _$result = _$v ??
         _$UserDetailsQuota_Total._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'UserDetailsQuota_Total', 'data'),
@@ -11589,6 +11595,7 @@ class UserDetailsQuota_UsedBuilder
   UserDetailsQuota_Used build() => _build();
 
   _$UserDetailsQuota_Used _build() {
+    UserDetailsQuota_Used._validate(this);
     final _$result = _$v ??
         _$UserDetailsQuota_Used._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'UserDetailsQuota_Used', 'data'),
@@ -12731,6 +12738,7 @@ class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersBuilder
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users build() => _build();
 
   _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users _build() {
+    GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users._validate(this);
     _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users _$result;
     try {
       _$result = _$v ??
@@ -15895,6 +15903,7 @@ class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersBuilder
   UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users build() => _build();
 
   _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users _build() {
+    UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users._validate(this);
     _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users _$result;
     try {
       _$result = _$v ??
@@ -16485,6 +16494,7 @@ class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_UsersBuilder
   UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users build() => _build();
 
   _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users _build() {
+    UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users._validate(this);
     _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users _$result;
     try {
       _$result = _$v ??

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -1194,6 +1194,18 @@ abstract class ClearAt_Time implements ClearAt_TimeInterface, Built<ClearAt_Time
   static Serializer<ClearAt_Time> get serializer => _$ClearAt_TimeSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final ClearAt_TimeBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._$int, b._clearAtTimeType].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of '$int', 'clearAtTimeType' for ${b._data}");
+    }
+  }
 }
 
 class _$ClearAt_TimeSerializer implements PrimitiveSerializer<ClearAt_Time> {
@@ -1219,16 +1231,14 @@ class _$ClearAt_TimeSerializer implements PrimitiveSerializer<ClearAt_Time> {
   }) {
     final result = ClearAt_TimeBuilder()..data = JsonObject(data);
     try {
-      result._$int = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(int))! as int;
+      result.$int = value;
     } catch (_) {}
     try {
-      result._clearAtTimeType =
+      final value =
           _jsonSerializers.deserialize(data, specifiedType: const FullType(ClearAtTimeType))! as ClearAtTimeType;
+      result.clearAtTimeType = value;
     } catch (_) {}
-    assert(
-      [result._$int, result._clearAtTimeType].where((final x) => x != null).isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }
@@ -1810,6 +1820,18 @@ abstract class UserStatusRevertStatusResponseApplicationJson_Ocs_Data
       _$UserStatusRevertStatusResponseApplicationJson_Ocs_DataSerializer();
 
   JsonObject get data;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(final UserStatusRevertStatusResponseApplicationJson_Ocs_DataBuilder b) {
+    // When this is rebuild from another builder
+    if (b._data == null) {
+      return;
+    }
+
+    final match = [b._private, b._jsonObject].singleWhereOrNull((final x) => x != null);
+    if (match == null) {
+      throw StateError("Need exactly one of 'private', 'jsonObject' for ${b._data}");
+    }
+  }
 }
 
 class _$UserStatusRevertStatusResponseApplicationJson_Ocs_DataSerializer
@@ -1839,16 +1861,13 @@ class _$UserStatusRevertStatusResponseApplicationJson_Ocs_DataSerializer
   }) {
     final result = UserStatusRevertStatusResponseApplicationJson_Ocs_DataBuilder()..data = JsonObject(data);
     try {
-      result._private =
-          (_jsonSerializers.deserialize(data, specifiedType: const FullType(Private))! as Private).toBuilder();
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(Private))! as Private;
+      result.private.replace(value);
     } catch (_) {}
     try {
-      result._jsonObject = _jsonSerializers.deserialize(data, specifiedType: const FullType(JsonObject))! as JsonObject;
+      final value = _jsonSerializers.deserialize(data, specifiedType: const FullType(JsonObject))! as JsonObject;
+      result.jsonObject = value;
     } catch (_) {}
-    assert(
-      [result._private, result._jsonObject].where((final x) => x != null).isNotEmpty,
-      'Need oneOf for ${result._data}',
-    );
     return result.build();
   }
 }

--- a/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
@@ -2308,6 +2308,7 @@ class ClearAt_TimeBuilder implements Builder<ClearAt_Time, ClearAt_TimeBuilder>,
   ClearAt_Time build() => _build();
 
   _$ClearAt_Time _build() {
+    ClearAt_Time._validate(this);
     final _$result = _$v ??
         _$ClearAt_Time._(
             data: BuiltValueNullFieldError.checkNotNull(data, r'ClearAt_Time', 'data'),
@@ -4498,6 +4499,7 @@ class UserStatusRevertStatusResponseApplicationJson_Ocs_DataBuilder
   UserStatusRevertStatusResponseApplicationJson_Ocs_Data build() => _build();
 
   _$UserStatusRevertStatusResponseApplicationJson_Ocs_Data _build() {
+    UserStatusRevertStatusResponseApplicationJson_Ocs_Data._validate(this);
     _$UserStatusRevertStatusResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ??


### PR DESCRIPTION
Also correctly requires oneOf to only have one matching member.
Depends on #999 thus also blocked on the spec being corrected