### PR TITLE
fix(neon_dashboard): Fix empty widget item icon urls

### DIFF
--- a/packages/neon/neon_dashboard/lib/src/widgets/widget_item.dart
+++ b/packages/neon/neon_dashboard/lib/src/widgets/widget_item.dart
@@ -25,10 +25,15 @@ class DashboardWidgetItem extends StatelessWidget {
       dimension: largeIconSize,
       child: NeonImageWrapper(
         borderRadius: roundIcon ? BorderRadius.circular(largeIconSize) : null,
-        child: NeonUrlImage(
-          url: item.iconUrl,
-          size: const Size.square(largeIconSize),
-        ),
+        child: item.iconUrl.isNotEmpty
+            ? NeonUrlImage(
+                url: item.iconUrl,
+                size: const Size.square(largeIconSize),
+              )
+            : Icon(
+                Icons.question_mark,
+                color: Theme.of(context).colorScheme.error,
+              ),
       ),
     );
     if (item.overlayIconUrl.isNotEmpty) {


### PR DESCRIPTION
Seems like icon URLs can be empty. The question mark is also how it is implemented in the web frontend.