### PR TITLE
fix(neon_dashboard): Fix widgets reloading scrolling back up

### DIFF
--- a/packages/neon/neon/lib/src/widgets/list_view.dart
+++ b/packages/neon/neon/lib/src/widgets/list_view.dart
@@ -8,8 +8,8 @@ class NeonListView extends StatelessWidget {
     required this.error,
     required this.onRefresh,
     required final NullableIndexedWidgetBuilder itemBuilder,
+    required this.scrollKey,
     final int? itemCount,
-    this.scrollKey,
     this.topFixedChildren,
     this.topScrollingChildren,
     super.key,
@@ -23,7 +23,7 @@ class NeonListView extends StatelessWidget {
     required this.error,
     required this.onRefresh,
     required this.sliver,
-    this.scrollKey,
+    required this.scrollKey,
     this.topFixedChildren,
     this.topScrollingChildren,
     super.key,
@@ -32,7 +32,7 @@ class NeonListView extends StatelessWidget {
   final bool isLoading;
   final Object? error;
   final RefreshCallback onRefresh;
-  final String? scrollKey;
+  final String scrollKey;
   final List<Widget>? topFixedChildren;
   final List<Widget>? topScrollingChildren;
   final Widget sliver;
@@ -46,7 +46,7 @@ class NeonListView extends StatelessWidget {
       key: refreshIndicatorKey,
       onRefresh: onRefresh,
       child: CustomScrollView(
-        key: scrollKey != null ? PageStorageKey<String>(scrollKey!) : null,
+        key: PageStorageKey<String>(scrollKey),
         primary: true,
         slivers: [
           if (topFixedChildren != null)

--- a/packages/neon/neon/lib/src/widgets/unified_search_results.dart
+++ b/packages/neon/neon/lib/src/widgets/unified_search_results.dart
@@ -32,6 +32,7 @@ class NeonUnifiedSearchResults extends StatelessWidget {
         final values = results.data?.entries.toList();
 
         return NeonListView(
+          scrollKey: 'unified-search',
           isLoading: results.isLoading,
           error: results.error,
           onRefresh: bloc.refresh,

--- a/packages/neon/neon_dashboard/lib/src/pages/main.dart
+++ b/packages/neon/neon_dashboard/lib/src/pages/main.dart
@@ -38,6 +38,7 @@ class DashboardMainPage extends StatelessWidget {
 
         return Center(
           child: NeonListView.custom(
+            scrollKey: 'dashboard',
             isLoading: snapshot.isLoading,
             error: snapshot.error,
             onRefresh: bloc.refresh,

--- a/packages/neon/neon_dashboard/lib/src/widgets/widget.dart
+++ b/packages/neon/neon_dashboard/lib/src/widgets/widget.dart
@@ -36,6 +36,7 @@ class DashboardWidget extends StatelessWidget {
           borderRadius: const BorderRadius.all(Radius.circular(12)),
           child: ListView(
             padding: const EdgeInsets.all(8),
+            key: PageStorageKey<String>('dashboard-${widget.id}'),
             children: [
               ListTile(
                 title: Text(


### PR DESCRIPTION
When the dashboard was reloading everything was resetting the scroll so it was very ugly.
Also enforced to always set a scroll key for NeonListView (and only unified search was missing one).