### PR TITLE
fix(dynamite): do not add someOf.data to the interface

### DIFF
--- a/packages/dynamite/dynamite/lib/src/builder/ofs_builder.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/ofs_builder.dart
@@ -104,8 +104,26 @@ TypeResult resolveOfs(
     state.output.addAll([
       buildInterface(
         identifier,
-        methods: BuiltList.build((final b) {
-          b.add(
+        methods: BuiltList.from(
+          results.map(
+            (final result) => Method(
+              (final b) {
+                final s = schema.ofs![results.indexOf(result)];
+                b
+                  ..name = fields[result.name]
+                  ..returns = refer(result.nullableName)
+                  ..type = MethodType.getter
+                  ..docs.addAll(s.formattedDescription);
+              },
+            ),
+          ),
+        ),
+      ),
+      buildBuiltClass(
+        identifier,
+        customSerializer: true,
+        methods: BuiltList.build(
+          (final b) => b.add(
             Method(
               (final b) {
                 b
@@ -114,27 +132,8 @@ TypeResult resolveOfs(
                   ..type = MethodType.getter;
               },
             ),
-          );
-
-          for (final result in results) {
-            b.add(
-              Method(
-                (final b) {
-                  final s = schema.ofs![results.indexOf(result)];
-                  b
-                    ..name = fields[result.name]
-                    ..returns = refer(result.nullableName)
-                    ..type = MethodType.getter
-                    ..docs.addAll(s.formattedDescription);
-                },
-              ),
-            );
-          }
-        }),
-      ),
-      buildBuiltClass(
-        identifier,
-        customSerializer: true,
+          ),
+        ),
       ),
       Class(
         (final b) => b

--- a/packages/dynamite/dynamite/lib/src/helpers/built_value.dart
+++ b/packages/dynamite/dynamite/lib/src/helpers/built_value.dart
@@ -9,6 +9,7 @@ const interfaceSuffix = 'Interface';
 Spec buildBuiltClass(
   final String className, {
   final Iterable<String>? defaults,
+  final Iterable<Method>? methods,
   final bool customSerializer = false,
 }) =>
     Class(
@@ -31,6 +32,10 @@ Spec buildBuiltClass(
             toJsonMethod,
             buildSerializer(className, isCustom: customSerializer),
           ]);
+
+        if (methods != null) {
+          b.methods.addAll(methods);
+        }
 
         if (defaults != null && defaults.isNotEmpty) {
           b.methods.add(

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -4725,7 +4725,6 @@ abstract class AutocompleteResult_Status0
 
 @BuiltValue(instantiable: false)
 abstract interface class AutocompleteResult_StatusInterface {
-  JsonObject get data;
   AutocompleteResult_Status0? get autocompleteResultStatus0;
   String? get string;
 }
@@ -4750,6 +4749,8 @@ abstract class AutocompleteResult_Status
 
   @BuiltValueSerializer(custom: true)
   static Serializer<AutocompleteResult_Status> get serializer => _$AutocompleteResult_StatusSerializer();
+
+  JsonObject get data;
 }
 
 class _$AutocompleteResult_StatusSerializer implements PrimitiveSerializer<AutocompleteResult_Status> {
@@ -5753,7 +5754,6 @@ abstract class HoverCardGetUserResponseApplicationJson
 
 @BuiltValue(instantiable: false)
 abstract interface class NavigationEntry_OrderInterface {
-  JsonObject get data;
   int? get $int;
   String? get string;
 }
@@ -5777,6 +5777,8 @@ abstract class NavigationEntry_Order
 
   @BuiltValueSerializer(custom: true)
   static Serializer<NavigationEntry_Order> get serializer => _$NavigationEntry_OrderSerializer();
+
+  JsonObject get data;
 }
 
 class _$NavigationEntry_OrderSerializer implements PrimitiveSerializer<NavigationEntry_Order> {
@@ -7528,7 +7530,6 @@ abstract class WeatherStatusCapabilities
 
 @BuiltValue(instantiable: false)
 abstract interface class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesInterface {
-  JsonObject get data;
   CommentsCapabilities? get commentsCapabilities;
   DavCapabilities? get davCapabilities;
   FilesCapabilities? get filesCapabilities;
@@ -7569,6 +7570,8 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities
   @BuiltValueSerializer(custom: true)
   static Serializer<OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities> get serializer =>
       _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesSerializer();
+
+  JsonObject get data;
 }
 
 class _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesSerializer
@@ -9198,7 +9201,6 @@ abstract class UnifiedSearchGetProvidersResponseApplicationJson
 
 @BuiltValue(instantiable: false)
 abstract interface class UnifiedSearchSearchCursorInterface {
-  JsonObject get data;
   int? get $int;
   String? get string;
 }
@@ -9223,6 +9225,8 @@ abstract class UnifiedSearchSearchCursor
 
   @BuiltValueSerializer(custom: true)
   static Serializer<UnifiedSearchSearchCursor> get serializer => _$UnifiedSearchSearchCursorSerializer();
+
+  JsonObject get data;
 }
 
 class _$UnifiedSearchSearchCursorSerializer implements PrimitiveSerializer<UnifiedSearchSearchCursor> {
@@ -9292,7 +9296,6 @@ abstract class UnifiedSearchResultEntry
 
 @BuiltValue(instantiable: false)
 abstract interface class UnifiedSearchResult_CursorInterface {
-  JsonObject get data;
   int? get $int;
   String? get string;
 }
@@ -9319,6 +9322,8 @@ abstract class UnifiedSearchResult_Cursor
 
   @BuiltValueSerializer(custom: true)
   static Serializer<UnifiedSearchResult_Cursor> get serializer => _$UnifiedSearchResult_CursorSerializer();
+
+  JsonObject get data;
 }
 
 class _$UnifiedSearchResult_CursorSerializer implements PrimitiveSerializer<UnifiedSearchResult_Cursor> {

--- a/packages/nextcloud/lib/src/api/core.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.g.dart
@@ -9288,9 +9288,6 @@ class AutocompleteResult_Status0Builder
 abstract mixin class AutocompleteResult_StatusInterfaceBuilder {
   void replace(AutocompleteResult_StatusInterface other);
   void update(void Function(AutocompleteResult_StatusInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   AutocompleteResult_Status0Builder get autocompleteResultStatus0;
   set autocompleteResultStatus0(AutocompleteResult_Status0Builder? autocompleteResultStatus0);
 
@@ -12948,9 +12945,6 @@ class HoverCardGetUserResponseApplicationJsonBuilder
 abstract mixin class NavigationEntry_OrderInterfaceBuilder {
   void replace(NavigationEntry_OrderInterface other);
   void update(void Function(NavigationEntry_OrderInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   int? get $int;
   set $int(int? $int);
 
@@ -19888,9 +19882,6 @@ class WeatherStatusCapabilitiesBuilder
 abstract mixin class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesInterfaceBuilder {
   void replace(OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesInterface other);
   void update(void Function(OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   CommentsCapabilitiesBuilder get commentsCapabilities;
   set commentsCapabilities(CommentsCapabilitiesBuilder? commentsCapabilities);
 
@@ -25909,9 +25900,6 @@ class UnifiedSearchGetProvidersResponseApplicationJsonBuilder
 abstract mixin class UnifiedSearchSearchCursorInterfaceBuilder {
   void replace(UnifiedSearchSearchCursorInterface other);
   void update(void Function(UnifiedSearchSearchCursorInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   int? get $int;
   set $int(int? $int);
 
@@ -26230,9 +26218,6 @@ class UnifiedSearchResultEntryBuilder
 abstract mixin class UnifiedSearchResult_CursorInterfaceBuilder {
   void replace(UnifiedSearchResult_CursorInterface other);
   void update(void Function(UnifiedSearchResult_CursorInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   int? get $int;
   set $int(int? $int);
 

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -2873,7 +2873,6 @@ abstract class RemoteUnshareResponseApplicationJson
 
 @BuiltValue(instantiable: false)
 abstract interface class ShareInfo_SizeInterface {
-  JsonObject get data;
   int? get $int;
   num? get $num;
 }
@@ -2896,6 +2895,8 @@ abstract class ShareInfo_Size implements ShareInfo_SizeInterface, Built<ShareInf
 
   @BuiltValueSerializer(custom: true)
   static Serializer<ShareInfo_Size> get serializer => _$ShareInfo_SizeSerializer();
+
+  JsonObject get data;
 }
 
 class _$ShareInfo_SizeSerializer implements PrimitiveSerializer<ShareInfo_Size> {
@@ -2965,7 +2966,6 @@ abstract class ShareInfo implements ShareInfoInterface, Built<ShareInfo, ShareIn
 
 @BuiltValue(instantiable: false)
 abstract interface class Share_ItemSizeInterface {
-  JsonObject get data;
   num? get $num;
   int? get $int;
 }
@@ -2988,6 +2988,8 @@ abstract class Share_ItemSize implements Share_ItemSizeInterface, Built<Share_It
 
   @BuiltValueSerializer(custom: true)
   static Serializer<Share_ItemSize> get serializer => _$Share_ItemSizeSerializer();
+
+  JsonObject get data;
 }
 
 class _$Share_ItemSizeSerializer implements PrimitiveSerializer<Share_ItemSize> {
@@ -3647,7 +3649,6 @@ abstract class ShareapiAcceptShareResponseApplicationJson
 
 @BuiltValue(instantiable: false)
 abstract interface class ShareesapiSearchShareTypeInterface {
-  JsonObject get data;
   int? get $int;
   BuiltList<int>? get builtListInt;
 }
@@ -3672,6 +3673,8 @@ abstract class ShareesapiSearchShareType
 
   @BuiltValueSerializer(custom: true)
   static Serializer<ShareesapiSearchShareType> get serializer => _$ShareesapiSearchShareTypeSerializer();
+
+  JsonObject get data;
 }
 
 class _$ShareesapiSearchShareTypeSerializer implements PrimitiveSerializer<ShareesapiSearchShareType> {
@@ -4340,7 +4343,6 @@ abstract class ShareesapiSearchResponseApplicationJson
 
 @BuiltValue(instantiable: false)
 abstract interface class ShareesapiFindRecommendedShareTypeInterface {
-  JsonObject get data;
   int? get $int;
   BuiltList<int>? get builtListInt;
 }
@@ -4368,6 +4370,8 @@ abstract class ShareesapiFindRecommendedShareType
   @BuiltValueSerializer(custom: true)
   static Serializer<ShareesapiFindRecommendedShareType> get serializer =>
       _$ShareesapiFindRecommendedShareTypeSerializer();
+
+  JsonObject get data;
 }
 
 class _$ShareesapiFindRecommendedShareTypeSerializer

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
@@ -7356,9 +7356,6 @@ class RemoteUnshareResponseApplicationJsonBuilder
 abstract mixin class ShareInfo_SizeInterfaceBuilder {
   void replace(ShareInfo_SizeInterface other);
   void update(void Function(ShareInfo_SizeInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   int? get $int;
   set $int(int? $int);
 
@@ -7715,9 +7712,6 @@ class ShareInfoBuilder implements Builder<ShareInfo, ShareInfoBuilder>, ShareInf
 abstract mixin class Share_ItemSizeInterfaceBuilder {
   void replace(Share_ItemSizeInterface other);
   void update(void Function(Share_ItemSizeInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   num? get $num;
   set $num(num? $num);
 
@@ -10475,9 +10469,6 @@ class ShareapiAcceptShareResponseApplicationJsonBuilder
 abstract mixin class ShareesapiSearchShareTypeInterfaceBuilder {
   void replace(ShareesapiSearchShareTypeInterface other);
   void update(void Function(ShareesapiSearchShareTypeInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   int? get $int;
   set $int(int? $int);
 
@@ -13717,9 +13708,6 @@ class ShareesapiSearchResponseApplicationJsonBuilder
 abstract mixin class ShareesapiFindRecommendedShareTypeInterfaceBuilder {
   void replace(ShareesapiFindRecommendedShareTypeInterface other);
   void update(void Function(ShareesapiFindRecommendedShareTypeInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   int? get $int;
   set $int(int? $int);
 

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -5172,7 +5172,6 @@ abstract class GroupsAddGroupResponseApplicationJson
 
 @BuiltValue(instantiable: false)
 abstract interface class GroupDetails_UsercountInterface {
-  JsonObject get data;
   bool? get $bool;
   int? get $int;
 }
@@ -5196,6 +5195,8 @@ abstract class GroupDetails_Usercount
 
   @BuiltValueSerializer(custom: true)
   static Serializer<GroupDetails_Usercount> get serializer => _$GroupDetails_UsercountSerializer();
+
+  JsonObject get data;
 }
 
 class _$GroupDetails_UsercountSerializer implements PrimitiveSerializer<GroupDetails_Usercount> {
@@ -5233,7 +5234,6 @@ class _$GroupDetails_UsercountSerializer implements PrimitiveSerializer<GroupDet
 
 @BuiltValue(instantiable: false)
 abstract interface class GroupDetails_DisabledInterface {
-  JsonObject get data;
   bool? get $bool;
   int? get $int;
 }
@@ -5257,6 +5257,8 @@ abstract class GroupDetails_Disabled
 
   @BuiltValueSerializer(custom: true)
   static Serializer<GroupDetails_Disabled> get serializer => _$GroupDetails_DisabledSerializer();
+
+  JsonObject get data;
 }
 
 class _$GroupDetails_DisabledSerializer implements PrimitiveSerializer<GroupDetails_Disabled> {
@@ -5536,7 +5538,6 @@ abstract class UserDetails_BackendCapabilities
 
 @BuiltValue(instantiable: false)
 abstract interface class UserDetailsQuota_QuotaInterface {
-  JsonObject get data;
   num? get $num;
   int? get $int;
   String? get string;
@@ -5561,6 +5562,8 @@ abstract class UserDetailsQuota_Quota
 
   @BuiltValueSerializer(custom: true)
   static Serializer<UserDetailsQuota_Quota> get serializer => _$UserDetailsQuota_QuotaSerializer();
+
+  JsonObject get data;
 }
 
 class _$UserDetailsQuota_QuotaSerializer implements PrimitiveSerializer<UserDetailsQuota_Quota> {
@@ -5732,7 +5735,6 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1
 
 @BuiltValue(instantiable: false)
 abstract interface class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersInterface {
-  JsonObject get data;
   UserDetails? get userDetails;
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1?
       get groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1;
@@ -5763,6 +5765,8 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users
   @BuiltValueSerializer(custom: true)
   static Serializer<GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users> get serializer =>
       _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer();
+
+  JsonObject get data;
 }
 
 class _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer
@@ -6646,7 +6650,6 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1
 
 @BuiltValue(instantiable: false)
 abstract interface class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersInterface {
-  JsonObject get data;
   UserDetails? get userDetails;
   UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1?
       get usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1;
@@ -6677,6 +6680,8 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users
   @BuiltValueSerializer(custom: true)
   static Serializer<UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users> get serializer =>
       _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer();
+
+  JsonObject get data;
 }
 
 class _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersSerializer

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
@@ -9640,9 +9640,6 @@ class GroupsAddGroupResponseApplicationJsonBuilder
 abstract mixin class GroupDetails_UsercountInterfaceBuilder {
   void replace(GroupDetails_UsercountInterface other);
   void update(void Function(GroupDetails_UsercountInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   bool? get $bool;
   set $bool(bool? $bool);
 
@@ -9755,9 +9752,6 @@ class GroupDetails_UsercountBuilder
 abstract mixin class GroupDetails_DisabledInterfaceBuilder {
   void replace(GroupDetails_DisabledInterface other);
   void update(void Function(GroupDetails_DisabledInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   bool? get $bool;
   set $bool(bool? $bool);
 
@@ -10825,9 +10819,6 @@ class UserDetails_BackendCapabilitiesBuilder
 abstract mixin class UserDetailsQuota_QuotaInterfaceBuilder {
   void replace(UserDetailsQuota_QuotaInterface other);
   void update(void Function(UserDetailsQuota_QuotaInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   num? get $num;
   set $num(num? $num);
 
@@ -11946,9 +11937,6 @@ class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder
 abstract mixin class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersInterfaceBuilder {
   void replace(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersInterface other);
   void update(void Function(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_UsersInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   UserDetailsBuilder get userDetails;
   set userDetails(UserDetailsBuilder? userDetails);
 
@@ -15114,9 +15102,6 @@ class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder
 abstract mixin class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersInterfaceBuilder {
   void replace(UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersInterface other);
   void update(void Function(UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_UsersInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   UserDetailsBuilder get userDetails;
   set userDetails(UserDetailsBuilder? userDetails);
 

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -1161,7 +1161,6 @@ class ClearAtTimeType extends EnumClass {
 
 @BuiltValue(instantiable: false)
 abstract interface class ClearAt_TimeInterface {
-  JsonObject get data;
   int? get $int;
   ClearAtTimeType? get clearAtTimeType;
 }
@@ -1183,6 +1182,8 @@ abstract class ClearAt_Time implements ClearAt_TimeInterface, Built<ClearAt_Time
 
   @BuiltValueSerializer(custom: true)
   static Serializer<ClearAt_Time> get serializer => _$ClearAt_TimeSerializer();
+
+  JsonObject get data;
 }
 
 class _$ClearAt_TimeSerializer implements PrimitiveSerializer<ClearAt_Time> {
@@ -1768,7 +1769,6 @@ abstract class UserStatusClearMessageResponseApplicationJson
 
 @BuiltValue(instantiable: false)
 abstract interface class UserStatusRevertStatusResponseApplicationJson_Ocs_DataInterface {
-  JsonObject get data;
   Private? get private;
   JsonObject? get jsonObject;
 }
@@ -1798,6 +1798,8 @@ abstract class UserStatusRevertStatusResponseApplicationJson_Ocs_Data
   @BuiltValueSerializer(custom: true)
   static Serializer<UserStatusRevertStatusResponseApplicationJson_Ocs_Data> get serializer =>
       _$UserStatusRevertStatusResponseApplicationJson_Ocs_DataSerializer();
+
+  JsonObject get data;
 }
 
 class _$UserStatusRevertStatusResponseApplicationJson_Ocs_DataSerializer

--- a/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
@@ -2208,9 +2208,6 @@ class HeartbeatHeartbeatResponseApplicationJsonBuilder
 abstract mixin class ClearAt_TimeInterfaceBuilder {
   void replace(ClearAt_TimeInterface other);
   void update(void Function(ClearAt_TimeInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   int? get $int;
   set $int(int? $int);
 
@@ -4391,9 +4388,6 @@ class UserStatusClearMessageResponseApplicationJsonBuilder
 abstract mixin class UserStatusRevertStatusResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace(UserStatusRevertStatusResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function(UserStatusRevertStatusResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
-  JsonObject? get data;
-  set data(JsonObject? data);
-
   PrivateBuilder get private;
   set private(PrivateBuilder? private);
 


### PR DESCRIPTION
extracted from #1009

When having `allOf[ oneOf[ ... ], ... ]` the helper field `data` would have been added to the interface of the object using the allOf.

I already tested this on the spreed branch and I couldn't find any obvious errors.