### PR TITLE
feat(neon_lints): use published lint_maker package

### DIFF
--- a/packages/neon_lints/lib/src/base.yaml
+++ b/packages/neon_lints/lib/src/base.yaml
@@ -7,8 +7,7 @@ analyzer:
     flutter_style_todos: ignore
     todo: ignore
   exclude:
-    - "**.g.dart"
-    - "**.mocks.dart"
+    - '**.g.dart'
 linter:
   rules:
     always_declare_return_types: true
@@ -227,3 +226,4 @@ linter:
     use_to_and_as_if_applicable: true
     valid_regexps: true
     void_checks: true
+    avoid_as: false

--- a/packages/neon_lints/lint_maker.yaml
+++ b/packages/neon_lints/lint_maker.yaml
@@ -1,20 +1,5 @@
-dart:
-  commitHash: 0a567d0
+base:
   output: 'lib/src/base.yaml'
-  disabledRules:
-    - always_specify_types
-    - avoid_annotating_with_dynamic
-    - avoid_as
-    - avoid_catches_without_on_clauses
-    - avoid_final_parameters
-    - avoid_print
-    - diagnostic_describe_all_properties
-    - lines_longer_than_80_chars
-    - no_default_cases
-    - one_member_abstracts
-    - prefer_double_quotes
-    - prefer_relative_imports
-    - unnecessary_final
   preset:
     analyzer:
       language:
@@ -26,4 +11,18 @@ dart:
         todo: ignore
       exclude:
         - '**.g.dart'
-        - '**.mocks.dart'
+    linter:
+      rules:
+        always_specify_types: false
+        avoid_annotating_with_dynamic: false
+        avoid_as: false
+        avoid_catches_without_on_clauses: false
+        avoid_final_parameters: false
+        avoid_print: false
+        diagnostic_describe_all_properties: false
+        lines_longer_than_80_chars: false
+        no_default_cases: false
+        one_member_abstracts: false
+        prefer_double_quotes: false
+        prefer_relative_imports: false
+        unnecessary_final: false

--- a/packages/neon_lints/pubspec.yaml
+++ b/packages/neon_lints/pubspec.yaml
@@ -7,7 +7,4 @@ environment:
   sdk: '>=3.1.0 <4.0.0'
 
 dev_dependencies:
-  lint_maker:
-    git:
-      url: https://github.com/Leptopoda/lint_maker
-      ref: 15bfdd3881bffc1516975368e86e6ec7d60aa991
+  lint_maker: ^0.2.0


### PR DESCRIPTION
I needed to manually remove `avoid_unstable_final_fields` for now as it is not available in dart `3.1.4` yet but marked as available since `3.1`.