### PR TITLE
Fix/dynamite/header type resolver

### DIFF
--- a/packages/dynamite/dynamite/lib/src/builder/generate_schemas.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/generate_schemas.dart
@@ -3,7 +3,6 @@ import 'package:dynamite/src/builder/resolve_type.dart';
 import 'package:dynamite/src/builder/state.dart';
 import 'package:dynamite/src/helpers/dart_helpers.dart';
 import 'package:dynamite/src/models/openapi.dart' as openapi;
-import 'package:dynamite/src/models/type_result.dart';
 
 Iterable<Spec> generateSchemas(
   final openapi.OpenAPI spec,
@@ -12,27 +11,13 @@ Iterable<Spec> generateSchemas(
   if (spec.components?.schemas != null) {
     for (final schema in spec.components!.schemas!.entries) {
       final identifier = toDartName(schema.key, uppercaseFirstCharacter: true);
-      if (schema.value.type == null && schema.value.ref == null && schema.value.ofs == null) {
-        yield TypeDef(
-          (final b) => b
-            ..name = identifier
-            ..definition = refer('dynamic'),
-        );
-      } else {
-        final result = resolveType(
-          spec,
-          state,
-          identifier,
-          schema.value,
-        );
-        if (result is TypeResultBase) {
-          yield TypeDef(
-            (final b) => b
-              ..name = identifier
-              ..definition = refer(result.name),
-          );
-        }
-      }
+
+      resolveType(
+        spec,
+        state,
+        identifier,
+        schema.value,
+      );
     }
   }
 

--- a/packages/dynamite/dynamite/lib/src/builder/generate_schemas.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/generate_schemas.dart
@@ -1,0 +1,40 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dynamite/src/builder/resolve_type.dart';
+import 'package:dynamite/src/builder/state.dart';
+import 'package:dynamite/src/helpers/dart_helpers.dart';
+import 'package:dynamite/src/models/openapi.dart' as openapi;
+import 'package:dynamite/src/models/type_result.dart';
+
+Iterable<Spec> generateSchemas(
+  final openapi.OpenAPI spec,
+  final State state,
+) sync* {
+  if (spec.components?.schemas != null) {
+    for (final schema in spec.components!.schemas!.entries) {
+      final identifier = toDartName(schema.key, uppercaseFirstCharacter: true);
+      if (schema.value.type == null && schema.value.ref == null && schema.value.ofs == null) {
+        yield TypeDef(
+          (final b) => b
+            ..name = identifier
+            ..definition = refer('dynamic'),
+        );
+      } else {
+        final result = resolveType(
+          spec,
+          state,
+          identifier,
+          schema.value,
+        );
+        if (result is TypeResultBase) {
+          yield TypeDef(
+            (final b) => b
+              ..name = identifier
+              ..definition = refer(result.name),
+          );
+        }
+      }
+    }
+  }
+
+  yield* state.output;
+}

--- a/packages/dynamite/dynamite/lib/src/builder/imports.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/imports.dart
@@ -24,7 +24,7 @@ List<Spec> generateImports(final AssetId outputId, final State state) => [
       Directive.import('package:meta/meta.dart'),
       Directive.import('package:universal_io/io.dart'),
       const Code(''),
-      if (state.resolvedTypes.isNotEmpty) ...[
+      if (state.hasResolvedBuiltTypes) ...[
         Directive.part(p.basename(outputId.changeExtension('.g.dart').path)),
         const Code(''),
       ],

--- a/packages/dynamite/dynamite/lib/src/builder/state.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/state.dart
@@ -7,4 +7,11 @@ class State {
   final output = <Spec>[];
   final resolvedTypes = <TypeResult>{};
   final resolvedInterfaces = <TypeResult>{};
+
+  /// Wether the state contains resolved types that need the built_value generator.
+  bool get hasResolvedBuiltTypes => resolvedTypes
+      .where(
+        (final type) => type is TypeResultEnum || (type is TypeResultObject && type.className != 'ContentString'),
+      )
+      .isNotEmpty;
 }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
@@ -1,0 +1,393 @@
+// ignore_for_file: camel_case_types
+// ignore_for_file: discarded_futures
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: unreachable_switch_case
+import 'dart:typed_data';
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
+import 'package:dynamite_runtime/built_value.dart';
+import 'package:dynamite_runtime/http_client.dart';
+import 'package:meta/meta.dart';
+import 'package:universal_io/io.dart';
+
+part 'headers.openapi.g.dart';
+
+class Client extends DynamiteClient {
+  Client(
+    super.baseURL, {
+    super.baseHeaders,
+    super.userAgent,
+    super.httpClient,
+    super.cookieJar,
+  });
+
+  Client.fromClient(final DynamiteClient client)
+      : super(
+          client.baseURL,
+          baseHeaders: client.baseHeaders,
+          httpClient: client.httpClient,
+          cookieJar: client.cookieJar,
+          authentications: client.authentications,
+        );
+
+  /// Returns a [Future] containing a [DynamiteResponse] with the status code, deserialized body and headers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200: Returns a header only
+  ///
+  /// See:
+  ///  * [$getRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
+  Future<DynamiteResponse<void, GetHeaders>> $get() async {
+    final rawResponse = $getRaw();
+
+    return rawResponse.future;
+  }
+
+  /// This method and the response it returns is experimental. The API might change without a major version bump.
+  ///
+  /// Returns a [Future] containing a [DynamiteRawResponse] with the raw [HttpClientResponse] and serialization helpers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200: Returns a header only
+  ///
+  /// See:
+  ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
+  @experimental
+  DynamiteRawResponse<void, GetHeaders> $getRaw() {
+    final queryParameters = <String, dynamic>{};
+    final headers = <String, String>{};
+    Uint8List? body;
+
+    const path = '/';
+    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+
+    return DynamiteRawResponse<void, GetHeaders>(
+      response: executeRequest(
+        'get',
+        uri,
+        headers,
+        body,
+        const {200},
+      ),
+      bodyType: null,
+      headersType: const FullType(GetHeaders),
+      serializers: _jsonSerializers,
+    );
+  }
+
+  /// Returns a [Future] containing a [DynamiteResponse] with the status code, deserialized body and headers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200: Returns a header only
+  ///
+  /// See:
+  ///  * [withContentOperationIdRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
+  Future<DynamiteResponse<void, WithContentOperationIdHeaders>> withContentOperationId() async {
+    final rawResponse = withContentOperationIdRaw();
+
+    return rawResponse.future;
+  }
+
+  /// This method and the response it returns is experimental. The API might change without a major version bump.
+  ///
+  /// Returns a [Future] containing a [DynamiteRawResponse] with the raw [HttpClientResponse] and serialization helpers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200: Returns a header only
+  ///
+  /// See:
+  ///  * [withContentOperationId] for an operation that returns a [DynamiteResponse] with a stable API.
+  @experimental
+  DynamiteRawResponse<void, WithContentOperationIdHeaders> withContentOperationIdRaw() {
+    final queryParameters = <String, dynamic>{};
+    final headers = <String, String>{};
+    Uint8List? body;
+
+    const path = '/with_content/operation_id';
+    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+
+    return DynamiteRawResponse<void, WithContentOperationIdHeaders>(
+      response: executeRequest(
+        'get',
+        uri,
+        headers,
+        body,
+        const {200},
+      ),
+      bodyType: null,
+      headersType: const FullType(WithContentOperationIdHeaders),
+      serializers: _jsonSerializers,
+    );
+  }
+
+  /// Returns a [Future] containing a [DynamiteResponse] with the status code, deserialized body and headers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200: Returns both a header and a body.
+  ///
+  /// See:
+  ///  * [getWithContentRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
+  Future<DynamiteResponse<Uint8List, GetWithContentHeaders>> getWithContent() async {
+    final rawResponse = getWithContentRaw();
+
+    return rawResponse.future;
+  }
+
+  /// This method and the response it returns is experimental. The API might change without a major version bump.
+  ///
+  /// Returns a [Future] containing a [DynamiteRawResponse] with the raw [HttpClientResponse] and serialization helpers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200: Returns both a header and a body.
+  ///
+  /// See:
+  ///  * [getWithContent] for an operation that returns a [DynamiteResponse] with a stable API.
+  @experimental
+  DynamiteRawResponse<Uint8List, GetWithContentHeaders> getWithContentRaw() {
+    final queryParameters = <String, dynamic>{};
+    final headers = <String, String>{
+      'Accept': 'application/octet-stream',
+    };
+    Uint8List? body;
+
+    const path = '/with_content';
+    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+
+    return DynamiteRawResponse<Uint8List, GetWithContentHeaders>(
+      response: executeRequest(
+        'get',
+        uri,
+        headers,
+        body,
+        const {200},
+      ),
+      bodyType: const FullType(Uint8List),
+      headersType: const FullType(GetWithContentHeaders),
+      serializers: _jsonSerializers,
+    );
+  }
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class GetHeadersInterface {
+  @BuiltValueField(wireName: 'my-header')
+  String? get myHeader;
+}
+
+abstract class GetHeaders implements GetHeadersInterface, Built<GetHeaders, GetHeadersBuilder> {
+  factory GetHeaders([final void Function(GetHeadersBuilder)? b]) = _$GetHeaders;
+
+  // coverage:ignore-start
+  const GetHeaders._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory GetHeaders.fromJson(final Map<String, dynamic> json) => _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  @BuiltValueSerializer(custom: true)
+  static Serializer<GetHeaders> get serializer => _$GetHeadersSerializer();
+}
+
+class _$GetHeadersSerializer implements StructuredSerializer<GetHeaders> {
+  @override
+  final Iterable<Type> types = const [GetHeaders, _$GetHeaders];
+
+  @override
+  final String wireName = 'GetHeaders';
+
+  @override
+  Iterable<Object?> serialize(
+    final Serializers serializers,
+    final GetHeaders object, {
+    final FullType specifiedType = FullType.unspecified,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  GetHeaders deserialize(
+    final Serializers serializers,
+    final Iterable<Object?> serialized, {
+    final FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = GetHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final value = iterator.current! as String;
+      switch (key) {
+        case 'my-header':
+          result.myHeader = value;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class WithContentOperationIdHeadersInterface {
+  @BuiltValueField(wireName: 'my-header')
+  String? get myHeader;
+}
+
+abstract class WithContentOperationIdHeaders
+    implements
+        WithContentOperationIdHeadersInterface,
+        Built<WithContentOperationIdHeaders, WithContentOperationIdHeadersBuilder> {
+  factory WithContentOperationIdHeaders([final void Function(WithContentOperationIdHeadersBuilder)? b]) =
+      _$WithContentOperationIdHeaders;
+
+  // coverage:ignore-start
+  const WithContentOperationIdHeaders._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory WithContentOperationIdHeaders.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  @BuiltValueSerializer(custom: true)
+  static Serializer<WithContentOperationIdHeaders> get serializer => _$WithContentOperationIdHeadersSerializer();
+}
+
+class _$WithContentOperationIdHeadersSerializer implements StructuredSerializer<WithContentOperationIdHeaders> {
+  @override
+  final Iterable<Type> types = const [WithContentOperationIdHeaders, _$WithContentOperationIdHeaders];
+
+  @override
+  final String wireName = 'WithContentOperationIdHeaders';
+
+  @override
+  Iterable<Object?> serialize(
+    final Serializers serializers,
+    final WithContentOperationIdHeaders object, {
+    final FullType specifiedType = FullType.unspecified,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  WithContentOperationIdHeaders deserialize(
+    final Serializers serializers,
+    final Iterable<Object?> serialized, {
+    final FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = WithContentOperationIdHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final value = iterator.current! as String;
+      switch (key) {
+        case 'my-header':
+          result.myHeader = value;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class GetWithContentHeadersInterface {
+  @BuiltValueField(wireName: 'my-header')
+  String? get myHeader;
+}
+
+abstract class GetWithContentHeaders
+    implements GetWithContentHeadersInterface, Built<GetWithContentHeaders, GetWithContentHeadersBuilder> {
+  factory GetWithContentHeaders([final void Function(GetWithContentHeadersBuilder)? b]) = _$GetWithContentHeaders;
+
+  // coverage:ignore-start
+  const GetWithContentHeaders._();
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  factory GetWithContentHeaders.fromJson(final Map<String, dynamic> json) =>
+      _jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  @BuiltValueSerializer(custom: true)
+  static Serializer<GetWithContentHeaders> get serializer => _$GetWithContentHeadersSerializer();
+}
+
+class _$GetWithContentHeadersSerializer implements StructuredSerializer<GetWithContentHeaders> {
+  @override
+  final Iterable<Type> types = const [GetWithContentHeaders, _$GetWithContentHeaders];
+
+  @override
+  final String wireName = 'GetWithContentHeaders';
+
+  @override
+  Iterable<Object?> serialize(
+    final Serializers serializers,
+    final GetWithContentHeaders object, {
+    final FullType specifiedType = FullType.unspecified,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  GetWithContentHeaders deserialize(
+    final Serializers serializers,
+    final Iterable<Object?> serialized, {
+    final FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = GetWithContentHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final value = iterator.current! as String;
+      switch (key) {
+        case 'my-header':
+          result.myHeader = value;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+// coverage:ignore-start
+final Serializers _serializers = (Serializers().toBuilder()
+      ..addBuilderFactory(const FullType(GetHeaders), GetHeaders.new)
+      ..add(GetHeaders.serializer)
+      ..addBuilderFactory(const FullType(WithContentOperationIdHeaders), WithContentOperationIdHeaders.new)
+      ..add(WithContentOperationIdHeaders.serializer)
+      ..addBuilderFactory(const FullType(GetWithContentHeaders), GetWithContentHeaders.new)
+      ..add(GetWithContentHeaders.serializer))
+    .build();
+
+final Serializers _jsonSerializers = (_serializers.toBuilder()
+      ..add(DynamiteDoubleSerializer())
+      ..addPlugin(StandardJsonPlugin())
+      ..addPlugin(const ContentStringPlugin()))
+    .build();
+// coverage:ignore-end

--- a/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.g.dart
@@ -1,0 +1,257 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'headers.openapi.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+abstract mixin class GetHeadersInterfaceBuilder {
+  void replace(GetHeadersInterface other);
+  void update(void Function(GetHeadersInterfaceBuilder) updates);
+  String? get myHeader;
+  set myHeader(String? myHeader);
+}
+
+class _$GetHeaders extends GetHeaders {
+  @override
+  final String? myHeader;
+
+  factory _$GetHeaders([void Function(GetHeadersBuilder)? updates]) => (GetHeadersBuilder()..update(updates))._build();
+
+  _$GetHeaders._({this.myHeader}) : super._();
+
+  @override
+  GetHeaders rebuild(void Function(GetHeadersBuilder) updates) => (toBuilder()..update(updates)).build();
+
+  @override
+  GetHeadersBuilder toBuilder() => GetHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GetHeaders && myHeader == other.myHeader;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, myHeader.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GetHeaders')..add('myHeader', myHeader)).toString();
+  }
+}
+
+class GetHeadersBuilder implements Builder<GetHeaders, GetHeadersBuilder>, GetHeadersInterfaceBuilder {
+  _$GetHeaders? _$v;
+
+  String? _myHeader;
+  String? get myHeader => _$this._myHeader;
+  set myHeader(covariant String? myHeader) => _$this._myHeader = myHeader;
+
+  GetHeadersBuilder();
+
+  GetHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _myHeader = $v.myHeader;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant GetHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GetHeaders;
+  }
+
+  @override
+  void update(void Function(GetHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GetHeaders build() => _build();
+
+  _$GetHeaders _build() {
+    final _$result = _$v ?? _$GetHeaders._(myHeader: myHeader);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class WithContentOperationIdHeadersInterfaceBuilder {
+  void replace(WithContentOperationIdHeadersInterface other);
+  void update(void Function(WithContentOperationIdHeadersInterfaceBuilder) updates);
+  String? get myHeader;
+  set myHeader(String? myHeader);
+}
+
+class _$WithContentOperationIdHeaders extends WithContentOperationIdHeaders {
+  @override
+  final String? myHeader;
+
+  factory _$WithContentOperationIdHeaders([void Function(WithContentOperationIdHeadersBuilder)? updates]) =>
+      (WithContentOperationIdHeadersBuilder()..update(updates))._build();
+
+  _$WithContentOperationIdHeaders._({this.myHeader}) : super._();
+
+  @override
+  WithContentOperationIdHeaders rebuild(void Function(WithContentOperationIdHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WithContentOperationIdHeadersBuilder toBuilder() => WithContentOperationIdHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is WithContentOperationIdHeaders && myHeader == other.myHeader;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, myHeader.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'WithContentOperationIdHeaders')..add('myHeader', myHeader)).toString();
+  }
+}
+
+class WithContentOperationIdHeadersBuilder
+    implements
+        Builder<WithContentOperationIdHeaders, WithContentOperationIdHeadersBuilder>,
+        WithContentOperationIdHeadersInterfaceBuilder {
+  _$WithContentOperationIdHeaders? _$v;
+
+  String? _myHeader;
+  String? get myHeader => _$this._myHeader;
+  set myHeader(covariant String? myHeader) => _$this._myHeader = myHeader;
+
+  WithContentOperationIdHeadersBuilder();
+
+  WithContentOperationIdHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _myHeader = $v.myHeader;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant WithContentOperationIdHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$WithContentOperationIdHeaders;
+  }
+
+  @override
+  void update(void Function(WithContentOperationIdHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  WithContentOperationIdHeaders build() => _build();
+
+  _$WithContentOperationIdHeaders _build() {
+    final _$result = _$v ?? _$WithContentOperationIdHeaders._(myHeader: myHeader);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class GetWithContentHeadersInterfaceBuilder {
+  void replace(GetWithContentHeadersInterface other);
+  void update(void Function(GetWithContentHeadersInterfaceBuilder) updates);
+  String? get myHeader;
+  set myHeader(String? myHeader);
+}
+
+class _$GetWithContentHeaders extends GetWithContentHeaders {
+  @override
+  final String? myHeader;
+
+  factory _$GetWithContentHeaders([void Function(GetWithContentHeadersBuilder)? updates]) =>
+      (GetWithContentHeadersBuilder()..update(updates))._build();
+
+  _$GetWithContentHeaders._({this.myHeader}) : super._();
+
+  @override
+  GetWithContentHeaders rebuild(void Function(GetWithContentHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GetWithContentHeadersBuilder toBuilder() => GetWithContentHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GetWithContentHeaders && myHeader == other.myHeader;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, myHeader.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GetWithContentHeaders')..add('myHeader', myHeader)).toString();
+  }
+}
+
+class GetWithContentHeadersBuilder
+    implements Builder<GetWithContentHeaders, GetWithContentHeadersBuilder>, GetWithContentHeadersInterfaceBuilder {
+  _$GetWithContentHeaders? _$v;
+
+  String? _myHeader;
+  String? get myHeader => _$this._myHeader;
+  set myHeader(covariant String? myHeader) => _$this._myHeader = myHeader;
+
+  GetWithContentHeadersBuilder();
+
+  GetWithContentHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _myHeader = $v.myHeader;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant GetWithContentHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GetWithContentHeaders;
+  }
+
+  @override
+  void update(void Function(GetWithContentHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GetWithContentHeaders build() => _build();
+
+  _$GetWithContentHeaders _build() {
+    final _$result = _$v ?? _$GetWithContentHeaders._(myHeader: myHeader);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.json
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.json
@@ -1,0 +1,67 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "headers test",
+        "version": "0.0.1"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Returns a header only",
+                        "headers": {
+                            "My-Header": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/with_content/operation_id": {
+            "get": {
+                "operationId": "with_content-operation_id",
+                "responses": {
+                    "200": {
+                        "description": "Returns a header only",
+                        "headers": {
+                            "My-Header": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/with_content": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Returns both a header and a body.",
+                        "headers": {
+                            "My-Header": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/octet-stream": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "tags": []
+}

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
@@ -116,7 +116,19 @@ class Client extends DynamiteClient {
 }
 
 // coverage:ignore-start
-final Serializers _serializers = Serializers().toBuilder().build();
+final Serializers _serializers = (Serializers().toBuilder()
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
+        MapBuilder<String, JsonObject>.new,
+      )
+      ..addBuilderFactory(
+        const FullType(ContentString, [
+          FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
+        ]),
+        ContentString<BuiltMap<String, JsonObject>>.new,
+      )
+      ..add(ContentString.serializer))
+    .build();
 
 final Serializers _jsonSerializers = (_serializers.toBuilder()
       ..add(DynamiteDoubleSerializer())

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.json
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.json
@@ -38,8 +38,7 @@
                         "description": "",
                         "content": {
                             "application/json": {
-                                "schema": {
-                                }
+                                "schema": {}
                             }
                         }
                     }


### PR DESCRIPTION
This was a funny bug :)

1. We use generator functions where possible in dynamite for performance reasons. The problem is that they only get invoked lazily (when iterating). This means that they where only executed in the `addAll` code segment. Because `generateImports` was called before adding the code generated by `generateClients` we where not taking the resolved types from these methods into account.

2. an empty operationId caused our code to fail (fb01f7eaf1f714235774bf59d25c013857af4164)

3. We didn't hit it but we where calling `output.add` for the TypeDefs before we added the imports to the output meaning that we could potentially have code before the imports. 