### PR TITLE
chore(deps): update dependency test to ^1.24.9

### DIFF
--- a/packages/dynamite/dynamite/pubspec.yaml
+++ b/packages/dynamite/dynamite/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/neon_lints
-  test: ^1.24.8
+  test: ^1.24.9

--- a/packages/dynamite/dynamite_end_to_end_test/pubspec.yaml
+++ b/packages/dynamite/dynamite_end_to_end_test/pubspec.yaml
@@ -28,4 +28,4 @@ dev_dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/neon_lints
-  test: ^1.24.8
+  test: ^1.24.9

--- a/packages/dynamite/dynamite_runtime/pubspec.yaml
+++ b/packages/dynamite/dynamite_runtime/pubspec.yaml
@@ -19,4 +19,4 @@ dev_dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/neon_lints
-  test: ^1.24.8
+  test: ^1.24.9

--- a/packages/neon/neon/pubspec.yaml
+++ b/packages/neon/neon/pubspec.yaml
@@ -65,7 +65,7 @@ dev_dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/neon_lints
-  test: ^1.24.8
+  test: ^1.24.9
   vector_graphics_compiler: ^1.1.9
 
 flutter:

--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -38,5 +38,5 @@ dev_dependencies:
       path: packages/neon_lints
   path: ^1.8.3
   process_run: ^0.13.2
-  test: ^1.24.8
+  test: ^1.24.9
   xml_serializable: ^2.4.0

--- a/packages/sort_box/pubspec.yaml
+++ b/packages/sort_box/pubspec.yaml
@@ -9,4 +9,4 @@ dev_dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/neon_lints
-  test: ^1.24.8
+  test: ^1.24.9


### PR DESCRIPTION
Replaces https://github.com/nextcloud/neon/pull/1002 because it is broken