### PR TITLE
fix(neon_dashboard): Fix localizations class name

### DIFF
--- a/packages/neon/neon_dashboard/l10n.yaml
+++ b/packages/neon/neon_dashboard/l10n.yaml
@@ -2,5 +2,6 @@ arb-dir: lib/l10n
 template-arb-file: en.arb
 output-localization-file: localizations.dart
 synthetic-package: false
+output-class: DashboardLocalizations
 output-dir: lib/l10n
 nullable-getter: false

--- a/packages/neon/neon_dashboard/lib/l10n/localizations.dart
+++ b/packages/neon/neon_dashboard/lib/l10n/localizations.dart
@@ -7,10 +7,10 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations_en.dart';
 
-/// Callers can lookup localized strings with an instance of AppLocalizations
-/// returned by `AppLocalizations.of(context)`.
+/// Callers can lookup localized strings with an instance of DashboardLocalizations
+/// returned by `DashboardLocalizations.of(context)`.
 ///
-/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// Applications need to include `DashboardLocalizations.delegate()` in their app's
 /// `localizationDelegates` list, and the locales they support in the app's
 /// `supportedLocales` list. For example:
 ///
@@ -18,8 +18,8 @@ import 'localizations_en.dart';
 /// import 'l10n/localizations.dart';
 ///
 /// return MaterialApp(
-///   localizationsDelegates: AppLocalizations.localizationsDelegates,
-///   supportedLocales: AppLocalizations.supportedLocales,
+///   localizationsDelegates: DashboardLocalizations.localizationsDelegates,
+///   supportedLocales: DashboardLocalizations.supportedLocales,
 ///   home: MyApplicationHome(),
 /// );
 /// ```
@@ -56,18 +56,18 @@ import 'localizations_en.dart';
 /// Select and expand the newly-created Localizations item then, for each
 /// locale your application supports, add a new item and select the locale
 /// you wish to add from the pop-up menu in the Value field. This list should
-/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// be consistent with the languages listed in the DashboardLocalizations.supportedLocales
 /// property.
-abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+abstract class DashboardLocalizations {
+  DashboardLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
-  static AppLocalizations of(BuildContext context) {
-    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  static DashboardLocalizations of(BuildContext context) {
+    return Localizations.of<DashboardLocalizations>(context, DashboardLocalizations)!;
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<DashboardLocalizations> delegate = _DashboardLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -96,29 +96,29 @@ abstract class AppLocalizations {
   String get noEntries;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
-  const _AppLocalizationsDelegate();
+class _DashboardLocalizationsDelegate extends LocalizationsDelegate<DashboardLocalizations> {
+  const _DashboardLocalizationsDelegate();
 
   @override
-  Future<AppLocalizations> load(Locale locale) {
-    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  Future<DashboardLocalizations> load(Locale locale) {
+    return SynchronousFuture<DashboardLocalizations>(lookupDashboardLocalizations(locale));
   }
 
   @override
   bool isSupported(Locale locale) => <String>['en'].contains(locale.languageCode);
 
   @override
-  bool shouldReload(_AppLocalizationsDelegate old) => false;
+  bool shouldReload(_DashboardLocalizationsDelegate old) => false;
 }
 
-AppLocalizations lookupAppLocalizations(Locale locale) {
+DashboardLocalizations lookupDashboardLocalizations(Locale locale) {
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
     case 'en':
-      return AppLocalizationsEn();
+      return DashboardLocalizationsEn();
   }
 
-  throw FlutterError('AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+  throw FlutterError('DashboardLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
       'an issue with the localizations generation tool. Please file an issue '
       'on GitHub with a reproducible sample app and the gen-l10n configuration '
       'that was used.');

--- a/packages/neon/neon_dashboard/lib/l10n/localizations_en.dart
+++ b/packages/neon/neon_dashboard/lib/l10n/localizations_en.dart
@@ -1,8 +1,8 @@
 import 'localizations.dart';
 
 /// The translations for English (`en`).
-class AppLocalizationsEn extends AppLocalizations {
-  AppLocalizationsEn([String locale = 'en']) : super(locale);
+class DashboardLocalizationsEn extends DashboardLocalizations {
+  DashboardLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
   String get noEntries => 'No entries';

--- a/packages/neon/neon_dashboard/lib/src/app.dart
+++ b/packages/neon/neon_dashboard/lib/src/app.dart
@@ -18,10 +18,10 @@ class DashboardApp extends AppImplementation<DashboardBloc, DashboardAppSpecific
   final String id = AppIDs.dashboard;
 
   @override
-  final LocalizationsDelegate<AppLocalizations> localizationsDelegate = AppLocalizations.delegate;
+  final LocalizationsDelegate<DashboardLocalizations> localizationsDelegate = DashboardLocalizations.delegate;
 
   @override
-  final List<Locale> supportedLocales = AppLocalizations.supportedLocales;
+  final List<Locale> supportedLocales = DashboardLocalizations.supportedLocales;
 
   @override
   late final DashboardAppSpecificOptions options = DashboardAppSpecificOptions(storage);

--- a/packages/neon/neon_dashboard/lib/src/widgets/widget.dart
+++ b/packages/neon/neon_dashboard/lib/src/widgets/widget.dart
@@ -60,7 +60,7 @@ class DashboardWidget extends StatelessWidget {
               if (halfEmptyContentMessage != null) halfEmptyContentMessage,
               if (emptyContentMessage != null) emptyContentMessage,
               if (halfEmptyContentMessage == null && emptyContentMessage == null && (items?.items.isEmpty ?? true))
-                _renderMessage(AppLocalizations.of(context).noEntries)!,
+                _renderMessage(DashboardLocalizations.of(context).noEntries)!,
               ...?items?.items.map(
                 (final item) => DashboardWidgetItem(
                   item: item,

--- a/packages/neon/neon_dashboard/test/widget_test.dart
+++ b/packages/neon/neon_dashboard/test/widget_test.dart
@@ -17,8 +17,8 @@ import 'package:rxdart/rxdart.dart';
 class MockAccountsBloc extends Mock implements AccountsBloc {}
 
 Widget wrapWidget(final AccountsBloc accountsBloc, final Widget child) => MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: DashboardLocalizations.localizationsDelegates,
+      supportedLocales: DashboardLocalizations.supportedLocales,
       home: Scaffold(
         backgroundColor: Colors.transparent,
         body: NeonProvider<AccountsBloc>.value(


### PR DESCRIPTION
This slipped through the cracks because the dashboard functionality was built while the localization class names were changed.