### PR TITLE
fix(dynamite_runtime): Require cookie_jar ^4.0.7 for web support

### DIFF
--- a/packages/dynamite/dynamite_runtime/pubspec.yaml
+++ b/packages/dynamite/dynamite_runtime/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   built_collection: ^5.0.0
   built_value: ^8.0.1
-  cookie_jar: ^4.0.0
+  cookie_jar: ^4.0.7
   meta: ^1.0.0
   universal_io: ^2.0.0
 


### PR DESCRIPTION
Towards https://github.com/nextcloud/neon/pull/372

Before this version using the cookie jar on web would lead to an exception.