### PR TITLE
fix(neon): Fix SVG code compilation for web

### DIFF
--- a/packages/neon/neon/lib/src/utils/push_utils.dart
+++ b/packages/neon/neon/lib/src/utils/push_utils.dart
@@ -7,7 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter_svg/flutter_svg.dart' show SvgFileLoader, vg;
+import 'package:flutter_svg/flutter_svg.dart' show vg;
 import 'package:image/image.dart' as img;
 import 'package:meta/meta.dart';
 import 'package:neon/src/blocs/accounts.dart';
@@ -17,6 +17,7 @@ import 'package:neon/src/settings/models/storage.dart';
 import 'package:neon/src/theme/colors.dart';
 import 'package:neon/src/utils/global.dart';
 import 'package:neon/src/utils/localizations.dart';
+import 'package:neon/src/utils/universal_svg_file_loader.dart';
 import 'package:nextcloud/notifications.dart' as notifications;
 
 @internal
@@ -106,7 +107,7 @@ class PushUtils {
               final cacheManager = DefaultCacheManager();
               final file = await cacheManager.getSingleFile(notification.icon!);
 
-              final pictureInfo = await vg.loadPicture(SvgFileLoader(file), null);
+              final pictureInfo = await vg.loadPicture(UniversalSvgFileLoader(file), null);
 
               const largeIconSize = 256;
               final scale = largeIconSize / pictureInfo.size.longestSide;

--- a/packages/neon/neon/lib/src/utils/universal_svg_file_loader.dart
+++ b/packages/neon/neon/lib/src/utils/universal_svg_file_loader.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:universal_io/io.dart';
+
+/// A [BytesLoader] that decodes SVG data from a file in an isolate and creates
+/// a vector_graphics binary representation.
+///
+/// It has the same logic as [SvgFileLoader], but uses universal_io to also work on web.
+class UniversalSvgFileLoader extends SvgLoader<void> {
+  /// Creates a new universal SVG file loader.
+  const UniversalSvgFileLoader(
+    this.file, {
+    super.theme,
+    super.colorMapper,
+  });
+
+  /// The file containing the SVG data to decode and render.
+  final File file;
+
+  @override
+  String provideSvg(final void message) => utf8.decode(file.readAsBytesSync(), allowMalformed: true);
+
+  @override
+  int get hashCode => Object.hash(file, theme, colorMapper);
+
+  @override
+  bool operator ==(final Object other) =>
+      other is UniversalSvgFileLoader && other.file == file && other.theme == theme && other.colorMapper == colorMapper;
+}


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/neon/pull/372
This wasn't compiling before because it was relying on dart:io code internally.