### PR TITLE
feat(dynamite): Support default responses

### DIFF
--- a/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.dart
@@ -1,0 +1,245 @@
+// ignore_for_file: camel_case_types
+// ignore_for_file: discarded_futures
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: unreachable_switch_case
+import 'dart:typed_data';
+
+import 'package:built_value/serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
+import 'package:dynamite_runtime/built_value.dart';
+import 'package:dynamite_runtime/http_client.dart';
+import 'package:meta/meta.dart';
+import 'package:universal_io/io.dart';
+
+class Client extends DynamiteClient {
+  Client(
+    super.baseURL, {
+    super.baseHeaders,
+    super.userAgent,
+    super.httpClient,
+    super.cookieJar,
+  });
+
+  Client.fromClient(final DynamiteClient client)
+      : super(
+          client.baseURL,
+          baseHeaders: client.baseHeaders,
+          httpClient: client.httpClient,
+          cookieJar: client.cookieJar,
+          authentications: client.authentications,
+        );
+
+  /// Returns a [Future] containing a [DynamiteResponse] with the status code, deserialized body and headers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [$getRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
+  Future<DynamiteResponse<String, void>> $get() async {
+    final rawResponse = $getRaw();
+
+    return rawResponse.future;
+  }
+
+  /// This method and the response it returns is experimental. The API might change without a major version bump.
+  ///
+  /// Returns a [Future] containing a [DynamiteRawResponse] with the raw [HttpClientResponse] and serialization helpers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
+  @experimental
+  DynamiteRawResponse<String, void> $getRaw() {
+    final queryParameters = <String, dynamic>{};
+    final headers = <String, String>{
+      'Accept': 'application/json',
+    };
+    Uint8List? body;
+
+    const path = '/';
+    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+
+    return DynamiteRawResponse<String, void>(
+      response: executeRequest(
+        'get',
+        uri,
+        headers,
+        body,
+        null,
+      ),
+      bodyType: const FullType(String),
+      headersType: null,
+      serializers: _jsonSerializers,
+    );
+  }
+
+  /// Returns a [Future] containing a [DynamiteResponse] with the status code, deserialized body and headers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200
+  ///   * 201
+  ///
+  /// See:
+  ///  * [putRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
+  Future<DynamiteResponse<String, void>> put() async {
+    final rawResponse = putRaw();
+
+    return rawResponse.future;
+  }
+
+  /// This method and the response it returns is experimental. The API might change without a major version bump.
+  ///
+  /// Returns a [Future] containing a [DynamiteRawResponse] with the raw [HttpClientResponse] and serialization helpers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200
+  ///   * 201
+  ///
+  /// See:
+  ///  * [put] for an operation that returns a [DynamiteResponse] with a stable API.
+  @experimental
+  DynamiteRawResponse<String, void> putRaw() {
+    final queryParameters = <String, dynamic>{};
+    final headers = <String, String>{
+      'Accept': 'application/json',
+    };
+    Uint8List? body;
+
+    const path = '/';
+    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+
+    return DynamiteRawResponse<String, void>(
+      response: executeRequest(
+        'put',
+        uri,
+        headers,
+        body,
+        const {200},
+      ),
+      bodyType: const FullType(String),
+      headersType: null,
+      serializers: _jsonSerializers,
+    );
+  }
+
+  /// Returns a [Future] containing a [DynamiteResponse] with the status code, deserialized body and headers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///   * 200
+  ///   * 201
+  ///
+  /// See:
+  ///  * [postRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
+  Future<DynamiteResponse<String, void>> post() async {
+    final rawResponse = postRaw();
+
+    return rawResponse.future;
+  }
+
+  /// This method and the response it returns is experimental. The API might change without a major version bump.
+  ///
+  /// Returns a [Future] containing a [DynamiteRawResponse] with the raw [HttpClientResponse] and serialization helpers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///   * 200
+  ///   * 201
+  ///
+  /// See:
+  ///  * [post] for an operation that returns a [DynamiteResponse] with a stable API.
+  @experimental
+  DynamiteRawResponse<String, void> postRaw() {
+    final queryParameters = <String, dynamic>{};
+    final headers = <String, String>{
+      'Accept': 'application/json',
+    };
+    Uint8List? body;
+
+    const path = '/';
+    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+
+    return DynamiteRawResponse<String, void>(
+      response: executeRequest(
+        'post',
+        uri,
+        headers,
+        body,
+        null,
+      ),
+      bodyType: const FullType(String),
+      headersType: null,
+      serializers: _jsonSerializers,
+    );
+  }
+
+  /// Returns a [Future] containing a [DynamiteResponse] with the status code, deserialized body and headers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200
+  ///   * 201
+  ///
+  /// See:
+  ///  * [patchRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
+  Future<DynamiteResponse<String, void>> patch() async {
+    final rawResponse = patchRaw();
+
+    return rawResponse.future;
+  }
+
+  /// This method and the response it returns is experimental. The API might change without a major version bump.
+  ///
+  /// Returns a [Future] containing a [DynamiteRawResponse] with the raw [HttpClientResponse] and serialization helpers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200
+  ///   * 201
+  ///
+  /// See:
+  ///  * [patch] for an operation that returns a [DynamiteResponse] with a stable API.
+  @experimental
+  DynamiteRawResponse<String, void> patchRaw() {
+    final queryParameters = <String, dynamic>{};
+    final headers = <String, String>{
+      'Accept': 'application/json',
+    };
+    Uint8List? body;
+
+    const path = '/';
+    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+
+    return DynamiteRawResponse<String, void>(
+      response: executeRequest(
+        'patch',
+        uri,
+        headers,
+        body,
+        const {200, 201},
+      ),
+      bodyType: const FullType(String),
+      headersType: null,
+      serializers: _jsonSerializers,
+    );
+  }
+}
+
+// coverage:ignore-start
+final Serializers _serializers = Serializers().toBuilder().build();
+
+final Serializers _jsonSerializers = (_serializers.toBuilder()
+      ..add(DynamiteDoubleSerializer())
+      ..addPlugin(StandardJsonPlugin())
+      ..addPlugin(const ContentStringPlugin()))
+    .build();
+// coverage:ignore-end

--- a/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.json
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.json
@@ -1,0 +1,108 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "responses test",
+    "version": "0.0.1"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags": []
+}


### PR DESCRIPTION
Closes https://github.com/nextcloud/neon/issues/871

I had this laying around from the petstore example. Might as well merge it already now that we have tests for dynamite.