### PR TITLE
fix(nextcloud): Fix 27.1.3 tests

### DIFF
--- a/packages/nextcloud/test/core_test.dart
+++ b/packages/nextcloud/test/core_test.dart
@@ -138,7 +138,7 @@ void main() {
         expect(response.statusCode, 200);
         expect(() => response.headers, isA<void>());
 
-        expect(response.body.ocs.data, hasLength(13));
+        expect(response.body.ocs.data, hasLength(14));
       });
 
       test('Unified search', () async {


### PR DESCRIPTION
This broke with https://github.com/nextcloud/neon/pull/1043, but we didn't notice because it didn't trigger the nextcloud tests.