### PR TITLE
fix(ci): Fix renovate fvm exclusion

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,7 @@
   },
   "packageRules": [
     {
+      "matchManagers": ["pub"],
       "matchDatasources": ["dart-version", "flutter-version"],
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
fvm is currently ignored because it uses the same data source. Restricting this rule to the pub manager makes it work.