### PR TITLE
perf(nextcloud): do not use the spread operator for building lists

### DIFF
--- a/packages/nextcloud/lib/src/client.dart
+++ b/packages/nextcloud/lib/src/client.dart
@@ -35,17 +35,15 @@ class NextcloudClient extends DynamiteClient {
           baseHeaders: language != null ? {'Accept-Language': language} : null,
           userAgent: userAgentOverride ?? appType.userAgent,
           authentications: [
-            if (appPassword != null) ...[
+            if (appPassword != null)
               DynamiteHttpBearerAuthentication(
                 token: appPassword,
               ),
-            ],
-            if (loginName != null && (password ?? appPassword) != null) ...[
+            if (loginName != null && (password ?? appPassword) != null)
               DynamiteHttpBasicAuthentication(
                 username: loginName,
                 password: (password ?? appPassword)!,
               ),
-            ],
           ],
         );
 


### PR DESCRIPTION
towards: #696 

The nextcloud package still uses them in the dev only generation script but it would make the code uglier and isn't released so performance isn't a concern.