### PR TITLE
feat(nextcloud): Expose custom HttpClient

### DIFF
--- a/packages/nextcloud/lib/src/client.dart
+++ b/packages/nextcloud/lib/src/client.dart
@@ -30,6 +30,7 @@ class NextcloudClient extends DynamiteClient {
     final String? language,
     final AppType appType = AppType.unknown,
     final String? userAgentOverride,
+    super.httpClient,
     super.cookieJar,
   }) : super(
           baseHeaders: language != null ? {'Accept-Language': language} : null,

--- a/packages/nextcloud/lib/src/webdav/client.dart
+++ b/packages/nextcloud/lib/src/webdav/client.dart
@@ -29,7 +29,7 @@ class WebDavClient {
   }) async {
     assert(dataStream == null || data == null, 'Only one of dataStream or data can be specified.');
 
-    final request = await HttpClient().openUrl(method, url)
+    final request = await rootClient.httpClient.openUrl(method, url)
       ..persistentConnection = true;
     for (final header in {
       HttpHeaders.contentTypeHeader: 'application/xml',


### PR DESCRIPTION
In widget tests we need to be able to mock the HttpClient.