### PR TITLE
fix(tool): Fix finding untested APIs for multiple clients

### DIFF
--- a/tool/find-untested-neon-apis.sh
+++ b/tool/find-untested-neon-apis.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")/.."
 
 function find_apis() {
     path="$1"
-    grep -r "$path" --include "*\.dart" -e "client\.[^.]*.[^(]*(" -oh | sed "s/^client\.//" | sed "s/($//" | sed "s/Raw$//" | grep -v "^executeRawRequest" | sort | uniq
+    grep -r "$path" --include "*\.dart" -e "client\([0-9]\)\?\.[^.]*.[^(]*(" -oh | sed "s/^client\([0-9]\)\?\.//" | sed "s/($//" | sed "s/Raw$//" | grep -v "^executeRawRequest" | sort | uniq
 }
 
 used_apis=("$(find_apis "packages/neon")")


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/neon/pull/366.
Now it is also allowed to use `client[0-9]` in the unit tests instead of just `client`.