### PR TITLE
fix(nextcloud): Fix dashboard tests

### DIFF
--- a/packages/nextcloud/test/dashboard_test.dart
+++ b/packages/nextcloud/test/dashboard_test.dart
@@ -25,7 +25,7 @@ void main() {
           final response = await client.dashboard.dashboardApi.getWidgetItems();
           final items = response.body.ocs.data;
           expect(items.keys, equals(['recommendations', 'spreed']));
-          expect(items['recommendations'], hasLength(7));
+          expect(items['recommendations'], hasLength(0));
           expect(items['spreed'], hasLength(0));
         });
 
@@ -33,7 +33,7 @@ void main() {
           final response = await client.dashboard.dashboardApi.getWidgetItemsV2();
           expect(response.body.ocs.data.keys, equals(['recommendations']));
           final items = response.body.ocs.data['recommendations']!.items;
-          expect(items, hasLength(7));
+          expect(items, hasLength(0));
         });
       });
     },


### PR DESCRIPTION
These got broken with https://github.com/nextcloud/neon/pull/980. I assumed this was the case and a git bisect confirmed it (automatic git bisect is quite cool hehe).

Looking at the [last CI run of that PR](https://github.com/nextcloud/neon/actions/runs/6695950172/job/18192627269) the tests passed just fine. There were no relevant changes to the docker image since then that could have caused this. This is completely reproducible locally, even on the exact commit that ran in the CI.

What is even weirder is that since then the CI ran these tests a bunch of times and was completely fine (and locally it was the same). I honestly have no clue how this happened.