### PR TITLE
chore(ci): Run publish workflow once per day

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,8 @@
 name: Publish
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron:  '0 5 * * *'
 
 concurrency:
   group: publish


### PR DESCRIPTION
Closes https://github.com/nextcloud/neon/issues/476

I chose 5am because it seems to be the time when the runners are least used during the night. Many other repos create jobs during the nights so we don't want add ours on top.