### PR TITLE
DynamiteRawResponse deserialize headers while waiting for the body

### DIFF
--- a/packages/dynamite/dynamite_runtime/lib/src/dynamite_client.dart
+++ b/packages/dynamite/dynamite_runtime/lib/src/dynamite_client.dart
@@ -73,15 +73,15 @@ class DynamiteRawResponse<B, H> {
     // ignore: discarded_futures
     response.then(
       (final response) async {
+        _rawHeaders = response.responseHeaders;
+        final headers = deserializeHeaders<H>(_rawHeaders, serializers, headersType);
+
         _rawBody = switch (bodyType) {
           const FullType(Uint8List) => await response.bytes,
           const FullType(String) => await response.string,
           _ => await response.json,
         };
-        _rawHeaders = response.responseHeaders;
-
         final body = deserializeBody<B>(_rawBody, serializers, bodyType);
-        final headers = deserializeHeaders<H>(_rawHeaders, serializers, headersType);
 
         _response = DynamiteResponse<B, H>(
           response.statusCode,


### PR DESCRIPTION
I don't expect any performance gains from this as deserializing the headers usually isn't expensive.