### PR TITLE
fix(nextcloud): Fix dashboard tests for real

### DIFF
--- a/packages/nextcloud/test/dashboard_test.dart
+++ b/packages/nextcloud/test/dashboard_test.dart
@@ -25,7 +25,7 @@ void main() {
           final response = await client.dashboard.dashboardApi.getWidgetItems();
           final items = response.body.ocs.data;
           expect(items.keys, equals(['recommendations', 'spreed']));
-          expect(items['recommendations'], hasLength(0));
+          expect(items['recommendations'], hasLength(7));
           expect(items['spreed'], hasLength(0));
         });
 
@@ -33,7 +33,7 @@ void main() {
           final response = await client.dashboard.dashboardApi.getWidgetItemsV2();
           expect(response.body.ocs.data.keys, equals(['recommendations']));
           final items = response.body.ocs.data['recommendations']!.items;
-          expect(items, hasLength(0));
+          expect(items, hasLength(7));
         });
       });
     },

--- a/tool/Dockerfile.dev
+++ b/tool/Dockerfile.dev
@@ -8,11 +8,17 @@ USER www-data
 RUN ./occ maintenance:install --admin-pass admin --admin-email admin@example.com
 RUN ./occ config:system:set allow_local_remote_servers --value=true
 RUN ./occ config:system:set trusted_domains 1 --value="*"
-RUN ./occ app:disable password_policy
 
+RUN ./occ app:disable password_policy
 RUN OC_PASS="user1" ./occ user:add --password-from-env --display-name "User One" user1
 RUN OC_PASS="user2" ./occ user:add --password-from-env --display-name "User Two" user2
 RUN OC_PASS="demo" ./occ user:add --password-from-env --display-name "Demo" demo
+RUN ./occ app:enable password_policy
+
+RUN (sh /entrypoint.sh php -S 0.0.0.0:80 &) && \
+    until curl -s -o /dev/null http://localhost/status.php; do true; done && \
+    # Do not setup the demo user here
+    for user in admin user1 user2; do curl -u "$user:$user" -H "ocs-apirequest: true" -s -o /dev/null http://localhost/ocs/v2.php/cloud/user; done
 
 ADD dev/install_app_version /usr/local/bin/
 
@@ -29,11 +35,6 @@ ARG SPREED_VERSION=17.1.2
 RUN install_app_version spreed https://github.com/nextcloud-releases/spreed/releases/download/v$SPREED_VERSION/spreed-v$SPREED_VERSION.tar.gz
 RUN ./occ talk:turn:add turn,turns staticauth.openrelay.metered.ca:443 udp,tcp --secret openrelayprojectsecret
 
-RUN ./occ app:enable password_policy
-RUN (sh /entrypoint.sh php -S 0.0.0.0:80 &) && \
-    until curl -s -o /dev/null http://localhost/status.php; do true; done && \
-    # Do not setup the demo user here
-    for user in admin user1 user2; do curl -u "$user:$user" -H "ocs-apirequest: true" -s -o /dev/null http://localhost/ocs/v2.php/cloud/user; done
 COPY --chown=www-data:www-data dev/static /usr/src/nextcloud/static
 
 ENV PHP_CLI_SERVER_WORKERS=10


### PR DESCRIPTION
Reverts https://github.com/nextcloud/neon/pull/1145 and also changes the order of setting up users and installing apps.
As far as I understand this problem comes from the user initialization. With Talk being installed it gets broken because it creates a Talk/ folder and makes the recommendations empty (which sounds like a bug itself).