### PR TITLE
chore: run melos bootstrap from a clean state

### DIFF
--- a/packages/app/pubspec_overrides.yaml
+++ b/packages/app/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon,neon_files,neon_news,neon_notes,neon_notifications,nextcloud,sort_box,neon_lints,neon_dashboard
+# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon,neon_dashboard,neon_files,neon_lints,neon_news,neon_notes,neon_notifications,nextcloud,sort_box
 dependency_overrides:
   dynamite_runtime:
     path: ../dynamite/dynamite_runtime

--- a/packages/neon/neon/pubspec_overrides.yaml
+++ b/packages/neon/neon/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,nextcloud,sort_box,neon_lints
+# melos_managed_dependency_overrides: dynamite_runtime,neon_lints,nextcloud,sort_box
 dependency_overrides:
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime

--- a/packages/neon/neon_files/pubspec_overrides.yaml
+++ b/packages/neon/neon_files/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon,nextcloud,sort_box,neon_lints
+# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon,neon_lints,nextcloud,sort_box
 dependency_overrides:
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime

--- a/packages/neon/neon_news/pubspec_overrides.yaml
+++ b/packages/neon/neon_news/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon,nextcloud,sort_box,neon_lints
+# melos_managed_dependency_overrides: dynamite_runtime,neon,neon_lints,nextcloud,sort_box
 dependency_overrides:
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime

--- a/packages/neon/neon_notes/pubspec_overrides.yaml
+++ b/packages/neon/neon_notes/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon,nextcloud,sort_box,neon_lints
+# melos_managed_dependency_overrides: dynamite_runtime,neon,neon_lints,nextcloud,sort_box
 dependency_overrides:
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime

--- a/packages/neon/neon_notifications/pubspec_overrides.yaml
+++ b/packages/neon/neon_notifications/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon,nextcloud,sort_box,neon_lints
+# melos_managed_dependency_overrides: dynamite_runtime,neon,neon_lints,nextcloud,sort_box
 dependency_overrides:
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime


### PR DESCRIPTION
Ever since `neon_lints` and now with `neon_dashboard` the overrides weren't sorted alphabetically anymore.
This means running `melos bs` on a fresh clone (or after a `melos clean`) would generate a diff. This is really annoying as I regularly run into this.

Looks like it also cleans up a leftover transitive dependency that still had a registered  plugin.