### PR TITLE
perf(dynamite_runtime): improve the performance of collecting bytes

### DIFF
--- a/packages/dynamite/dynamite_runtime/lib/src/http_extensions.dart
+++ b/packages/dynamite/dynamite_runtime/lib/src/http_extensions.dart
@@ -18,9 +18,12 @@ final _xmlBytesConverter =
 
 /// Extension on byte streams that enable efficient transformations.
 extension BytesStreamExtension on BytesStream {
-  /// Returns the all bytes of the stream.
+  /// Collects all bytes from this stream into one Uint8List.
+  ///
+  /// The collector will assume that the bytes in this stream will not change.
+  /// See [BytesBuilder] for further information.
   Future<Uint8List> get bytes async {
-    final buffer = BytesBuilder();
+    final buffer = BytesBuilder(copy: false);
 
     await forEach(buffer.add);
 


### PR DESCRIPTION
running the `large_get` test with a 5GB payload resulted in a 10% performance gain (21s -> 19s) and 44s -> 39s for a 10GB file.
Tested on my dev machine. Performance gain on low end devices will probably be higher.