### PR TITLE
feat(dynamite): Use URI templates for path parameters

### DIFF
--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -1254,6 +1254,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
+  uri:
+    dependency: transitive
+    description:
+      name: uri
+      sha256: "889eea21e953187c6099802b7b4cf5219ba8f3518f604a1033064d45b1b8268a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   url_launcher:
     dependency: transitive
     description:

--- a/packages/dynamite/dynamite/lib/src/builder/imports.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/imports.dart
@@ -27,6 +27,7 @@ Iterable<Spec> generateImports(final AssetId outputId, final State state) sync* 
     Directive.import('package:dynamite_runtime/utils.dart'),
     Directive.import('package:meta/meta.dart'),
     Directive.import('package:universal_io/io.dart'),
+    Directive.import('package:uri/uri.dart'),
     const Code(''),
   ];
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
@@ -11,6 +11,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'headers.openapi.g.dart';
 
@@ -58,12 +59,15 @@ class Client extends DynamiteClient {
   ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, GetHeaders> $getRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
 
-    const path = '/';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, GetHeaders>(
       response: executeRequest(
@@ -105,12 +109,15 @@ class Client extends DynamiteClient {
   ///  * [withContentOperationId] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, WithContentOperationIdHeaders> withContentOperationIdRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
 
-    const path = '/with_content/operation_id';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/with_content/operation_id').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, WithContentOperationIdHeaders>(
       response: executeRequest(
@@ -152,14 +159,17 @@ class Client extends DynamiteClient {
   ///  * [getWithContent] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, GetWithContentHeaders> getWithContentRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/octet-stream',
     };
     Uint8List? body;
 
-    const path = '/with_content';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/with_content').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, GetWithContentHeaders>(
       response: executeRequest(

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
@@ -13,6 +13,7 @@ import 'package:dynamite_runtime/http_client.dart';
 import 'package:dynamite_runtime/models.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 class Client extends DynamiteClient {
   Client(
@@ -75,6 +76,7 @@ class Client extends DynamiteClient {
     final ContentString<BuiltMap<String, JsonObject>>? contentString,
     final ContentString<BuiltMap<String, JsonObject>>? contentParameter,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -97,8 +99,65 @@ class Client extends DynamiteClient {
         ]),
       );
     }
-    const path = '/';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
+
+    return DynamiteRawResponse<JsonObject, void>(
+      response: executeRequest(
+        'get',
+        uri,
+        headers,
+        body,
+        const {200},
+      ),
+      bodyType: const FullType(JsonObject),
+      headersType: null,
+      serializers: _jsonSerializers,
+    );
+  }
+
+  /// Returns a [Future] containing a [DynamiteResponse] with the status code, deserialized body and headers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200
+  ///
+  /// See:
+  ///  * [getPathParameterRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
+  Future<DynamiteResponse<JsonObject, void>> getPathParameter({required final String pathParameter}) async {
+    final rawResponse = getPathParameterRaw(
+      pathParameter: pathParameter,
+    );
+
+    return rawResponse.future;
+  }
+
+  /// This method and the response it returns is experimental. The API might change without a major version bump.
+  ///
+  /// Returns a [Future] containing a [DynamiteRawResponse] with the raw [HttpClientResponse] and serialization helpers.
+  /// Throws a [DynamiteApiException] if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * 200
+  ///
+  /// See:
+  ///  * [getPathParameter] for an operation that returns a [DynamiteResponse] with a stable API.
+  @experimental
+  DynamiteRawResponse<JsonObject, void> getPathParameterRaw({required final String pathParameter}) {
+    final pathParameters = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final headers = <String, String>{
+      'Accept': 'application/json',
+    };
+    Uint8List? body;
+
+    pathParameters['path-parameter'] = pathParameter;
+    var uri = Uri.parse(UriTemplate('/{path-parameter}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<JsonObject, void>(
       response: executeRequest(

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.json
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.json
@@ -44,6 +44,30 @@
                     }
                 }
             }
+        },
+        "/{path-parameter}": {
+            "parameters": [
+                {
+                    "name": "path-parameter",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "tags": []

--- a/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
@@ -11,6 +11,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 class Client extends DynamiteClient {
   Client(
@@ -58,6 +59,7 @@ class Client extends DynamiteClient {
   ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> $getRaw({final Uint8List? uint8List}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -66,8 +68,10 @@ class Client extends DynamiteClient {
     if (uint8List != null) {
       body = uint8List;
     }
-    const path = '/';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -111,6 +115,7 @@ class Client extends DynamiteClient {
   ///  * [post] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> postRaw({final String? string}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -119,8 +124,10 @@ class Client extends DynamiteClient {
     if (string != null) {
       body = utf8.encode(string);
     }
-    const path = '/';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(

--- a/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.dart
@@ -10,6 +10,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 class Client extends DynamiteClient {
   Client(
@@ -55,14 +56,17 @@ class Client extends DynamiteClient {
   ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<String, void> $getRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
     };
     Uint8List? body;
 
-    const path = '/';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<String, void>(
       response: executeRequest(
@@ -106,14 +110,17 @@ class Client extends DynamiteClient {
   ///  * [put] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<String, void> putRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
     };
     Uint8List? body;
 
-    const path = '/';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<String, void>(
       response: executeRequest(
@@ -159,14 +166,17 @@ class Client extends DynamiteClient {
   ///  * [post] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<String, void> postRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
     };
     Uint8List? body;
 
-    const path = '/';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<String, void>(
       response: executeRequest(
@@ -210,14 +220,17 @@ class Client extends DynamiteClient {
   ///  * [patch] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<String, void> patchRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
     };
     Uint8List? body;
 
-    const path = '/';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<String, void>(
       response: executeRequest(

--- a/packages/dynamite/dynamite_end_to_end_test/pubspec.yaml
+++ b/packages/dynamite/dynamite_end_to_end_test/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
       path: packages/dynamite/dynamite_runtime
   meta: ^1.0.0
   universal_io: ^2.0.0
+  uri: ^1.0.0
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/packages/dynamite/dynamite_petstore_example/lib/petstore.openapi.dart
+++ b/packages/dynamite/dynamite_petstore_example/lib/petstore.openapi.dart
@@ -13,6 +13,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'petstore.openapi.g.dart';
 
@@ -91,6 +92,7 @@ class Client extends DynamiteClient {
     List<String>? tags,
     int? limit,
   }) {
+    final _pathParameters = <String, dynamic>{};
     final _queryParameters = <String, dynamic>{};
     final _headers = <String, String>{
       'Accept': 'application/json',
@@ -103,8 +105,10 @@ class Client extends DynamiteClient {
     if (limit != null) {
       _queryParameters['limit'] = limit.toString();
     }
-    final _path = '/pets';
-    final _uri = Uri(path: _path, queryParameters: _queryParameters.isNotEmpty ? _queryParameters : null);
+    var _uri = Uri.parse(UriTemplate('/pets').expand(_pathParameters));
+    if (_queryParameters.isNotEmpty) {
+      _uri = _uri.replace(queryParameters: _queryParameters);
+    }
 
     return DynamiteRawResponse<BuiltList<Pet>, void>(
       response: this.executeRequest(
@@ -154,6 +158,7 @@ class Client extends DynamiteClient {
   ///  * [addPet] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Pet, void> addPetRaw({required NewPet newPet}) {
+    final _pathParameters = <String, dynamic>{};
     final _queryParameters = <String, dynamic>{};
     final _headers = <String, String>{
       'Accept': 'application/json',
@@ -162,8 +167,10 @@ class Client extends DynamiteClient {
 
     _headers['Content-Type'] = 'application/json';
     _body = utf8.encode(json.encode(_jsonSerializers.serialize(newPet, specifiedType: const FullType(NewPet))));
-    final _path = '/pets';
-    final _uri = Uri(path: _path, queryParameters: _queryParameters.isNotEmpty ? _queryParameters : null);
+    var _uri = Uri.parse(UriTemplate('/pets').expand(_pathParameters));
+    if (_queryParameters.isNotEmpty) {
+      _uri = _uri.replace(queryParameters: _queryParameters);
+    }
 
     return DynamiteRawResponse<Pet, void>(
       response: this.executeRequest(
@@ -219,15 +226,18 @@ class Client extends DynamiteClient {
   ///  * [findPetById] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Pet, void> findPetByIdRaw({required int id}) {
+    final _pathParameters = <String, dynamic>{};
     final _queryParameters = <String, dynamic>{};
     final _headers = <String, String>{
       'Accept': 'application/json',
     };
     Uint8List? _body;
 
-    final _id = Uri.encodeQueryComponent(id.toString());
-    final _path = '/pets/$_id';
-    final _uri = Uri(path: _path, queryParameters: _queryParameters.isNotEmpty ? _queryParameters : null);
+    _pathParameters['id'] = id.toString();
+    var _uri = Uri.parse(UriTemplate('/pets/{id}').expand(_pathParameters));
+    if (_queryParameters.isNotEmpty) {
+      _uri = _uri.replace(queryParameters: _queryParameters);
+    }
 
     return DynamiteRawResponse<Pet, void>(
       response: this.executeRequest(
@@ -283,13 +293,16 @@ class Client extends DynamiteClient {
   ///  * [deletePet] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> deletePetRaw({required int id}) {
+    final _pathParameters = <String, dynamic>{};
     final _queryParameters = <String, dynamic>{};
     final _headers = <String, String>{};
     Uint8List? _body;
 
-    final _id = Uri.encodeQueryComponent(id.toString());
-    final _path = '/pets/$_id';
-    final _uri = Uri(path: _path, queryParameters: _queryParameters.isNotEmpty ? _queryParameters : null);
+    _pathParameters['id'] = id.toString();
+    var _uri = Uri.parse(UriTemplate('/pets/{id}').expand(_pathParameters));
+    if (_queryParameters.isNotEmpty) {
+      _uri = _uri.replace(queryParameters: _queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: this.executeRequest(

--- a/packages/dynamite/dynamite_petstore_example/pubspec.yaml
+++ b/packages/dynamite/dynamite_petstore_example/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/dynamite/dynamite_runtime
+  uri: ^1.0.0
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -16,6 +16,7 @@ import 'package:dynamite_runtime/http_client.dart';
 import 'package:dynamite_runtime/models.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'core.openapi.g.dart';
 
@@ -104,14 +105,17 @@ class Client extends DynamiteClient {
   ///  * [getStatus] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Status, void> getStatusRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
     };
     Uint8List? body;
 
-    const path = '/status.php';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/status.php').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Status, void>(
       response: executeRequest(
@@ -177,6 +181,7 @@ class AppPasswordClient {
   DynamiteRawResponse<AppPasswordGetAppPasswordResponseApplicationJson, void> getAppPasswordRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -201,8 +206,10 @@ class AppPasswordClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/core/getapppassword';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/core/getapppassword').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppPasswordGetAppPasswordResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -262,6 +269,7 @@ class AppPasswordClient {
   DynamiteRawResponse<AppPasswordRotateAppPasswordResponseApplicationJson, void> rotateAppPasswordRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -286,8 +294,10 @@ class AppPasswordClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/core/apppassword/rotate';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/core/apppassword/rotate').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppPasswordRotateAppPasswordResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -347,6 +357,7 @@ class AppPasswordClient {
   DynamiteRawResponse<AppPasswordDeleteAppPasswordResponseApplicationJson, void> deleteAppPasswordRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -371,8 +382,10 @@ class AppPasswordClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/core/apppassword';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/core/apppassword').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppPasswordDeleteAppPasswordResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -466,6 +479,7 @@ class AutoCompleteClient {
     final int limit = 10,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -506,8 +520,10 @@ class AutoCompleteClient {
       queryParameters['limit'] = limit.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/core/autocomplete/get';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/core/autocomplete/get').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AutoCompleteGetResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -579,6 +595,7 @@ class AvatarClient {
     required final String userId,
     required final int size,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -600,10 +617,12 @@ class AvatarClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
-    final size0 = Uri.encodeQueryComponent(size.toString());
-    final path = '/index.php/avatar/$userId0/$size0/dark';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['userId'] = userId;
+    pathParameters['size'] = size.toString();
+    var uri = Uri.parse(UriTemplate('/index.php/avatar/{userId}/{size}/dark').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, AvatarAvatarGetAvatarDarkHeaders>(
       response: _rootClient.executeRequest(
@@ -668,6 +687,7 @@ class AvatarClient {
     required final String userId,
     required final int size,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -689,10 +709,12 @@ class AvatarClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
-    final size0 = Uri.encodeQueryComponent(size.toString());
-    final path = '/index.php/avatar/$userId0/$size0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['userId'] = userId;
+    pathParameters['size'] = size.toString();
+    var uri = Uri.parse(UriTemplate('/index.php/avatar/{userId}/{size}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, AvatarAvatarGetAvatarHeaders>(
       response: _rootClient.executeRequest(
@@ -754,6 +776,7 @@ class ClientFlowLoginV2Client {
   ///  * [poll] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<LoginFlowV2Credentials, void> pollRaw({required final String token}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -776,8 +799,10 @@ class ClientFlowLoginV2Client {
 
 // coverage:ignore-end
     queryParameters['token'] = token;
-    const path = '/index.php/login/v2/poll';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/login/v2/poll').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<LoginFlowV2Credentials, void>(
       response: _rootClient.executeRequest(
@@ -823,6 +848,7 @@ class ClientFlowLoginV2Client {
   ///  * [init] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<LoginFlowV2, void> initRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -844,8 +870,10 @@ class ClientFlowLoginV2Client {
     }
 
 // coverage:ignore-end
-    const path = '/index.php/login/v2';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/login/v2').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<LoginFlowV2, void>(
       response: _rootClient.executeRequest(
@@ -916,6 +944,7 @@ class CollaborationResourcesClient {
     required final String filter,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -939,10 +968,14 @@ class CollaborationResourcesClient {
     }
 
 // coverage:ignore-end
-    final filter0 = Uri.encodeQueryComponent(filter);
+    pathParameters['filter'] = filter;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/collaboration/resources/collections/search/$filter0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/collaboration/resources/collections/search/{filter}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CollaborationResourcesSearchCollectionsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1009,6 +1042,7 @@ class CollaborationResourcesClient {
     required final int collectionId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1032,10 +1066,14 @@ class CollaborationResourcesClient {
     }
 
 // coverage:ignore-end
-    final collectionId0 = Uri.encodeQueryComponent(collectionId.toString());
+    pathParameters['collectionId'] = collectionId.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/collaboration/resources/collections/$collectionId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CollaborationResourcesListCollectionResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1107,6 +1145,7 @@ class CollaborationResourcesClient {
     required final int collectionId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1131,10 +1170,14 @@ class CollaborationResourcesClient {
 
 // coverage:ignore-end
     queryParameters['collectionName'] = collectionName;
-    final collectionId0 = Uri.encodeQueryComponent(collectionId.toString());
+    pathParameters['collectionId'] = collectionId.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/collaboration/resources/collections/$collectionId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CollaborationResourcesRenameCollectionResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1211,6 +1254,7 @@ class CollaborationResourcesClient {
     required final int collectionId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1236,10 +1280,14 @@ class CollaborationResourcesClient {
 // coverage:ignore-end
     queryParameters['resourceType'] = resourceType;
     queryParameters['resourceId'] = resourceId;
-    final collectionId0 = Uri.encodeQueryComponent(collectionId.toString());
+    pathParameters['collectionId'] = collectionId.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/collaboration/resources/collections/$collectionId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CollaborationResourcesAddResourceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1316,6 +1364,7 @@ class CollaborationResourcesClient {
     required final int collectionId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1341,10 +1390,14 @@ class CollaborationResourcesClient {
 // coverage:ignore-end
     queryParameters['resourceType'] = resourceType;
     queryParameters['resourceId'] = resourceId;
-    final collectionId0 = Uri.encodeQueryComponent(collectionId.toString());
+    pathParameters['collectionId'] = collectionId.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/collaboration/resources/collections/$collectionId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CollaborationResourcesRemoveResourceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1416,6 +1469,7 @@ class CollaborationResourcesClient {
     required final String resourceId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1439,11 +1493,15 @@ class CollaborationResourcesClient {
     }
 
 // coverage:ignore-end
-    final resourceType0 = Uri.encodeQueryComponent(resourceType);
-    final resourceId0 = Uri.encodeQueryComponent(resourceId);
+    pathParameters['resourceType'] = resourceType;
+    pathParameters['resourceId'] = resourceId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/collaboration/resources/$resourceType0/$resourceId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/collaboration/resources/{resourceType}/{resourceId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1524,6 +1582,7 @@ class CollaborationResourcesClient {
     required final String baseResourceId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1548,11 +1607,15 @@ class CollaborationResourcesClient {
 
 // coverage:ignore-end
     queryParameters['name'] = name;
-    final baseResourceType0 = Uri.encodeQueryComponent(baseResourceType);
-    final baseResourceId0 = Uri.encodeQueryComponent(baseResourceId);
+    pathParameters['baseResourceType'] = baseResourceType;
+    pathParameters['baseResourceId'] = baseResourceId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/collaboration/resources/$baseResourceType0/$baseResourceId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/collaboration/resources/{baseResourceType}/{baseResourceId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1626,6 +1689,7 @@ class GuestAvatarClient {
     required final String guestName,
     required final String size,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -1647,10 +1711,12 @@ class GuestAvatarClient {
     }
 
 // coverage:ignore-end
-    final guestName0 = Uri.encodeQueryComponent(guestName);
-    final size0 = Uri.encodeQueryComponent(size);
-    final path = '/index.php/avatar/guest/$guestName0/$size0/dark';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['guestName'] = guestName;
+    pathParameters['size'] = size;
+    var uri = Uri.parse(UriTemplate('/index.php/avatar/guest/{guestName}/{size}/dark').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -1722,6 +1788,7 @@ class GuestAvatarClient {
     required final String size,
     final int? darkTheme = 0,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -1743,13 +1810,15 @@ class GuestAvatarClient {
     }
 
 // coverage:ignore-end
-    final guestName0 = Uri.encodeQueryComponent(guestName);
-    final size0 = Uri.encodeQueryComponent(size);
+    pathParameters['guestName'] = guestName;
+    pathParameters['size'] = size;
     if (darkTheme != null && darkTheme != 0) {
       queryParameters['darkTheme'] = darkTheme.toString();
     }
-    final path = '/index.php/avatar/guest/$guestName0/$size0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/avatar/guest/{guestName}/{size}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -1820,6 +1889,7 @@ class HoverCardClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1843,10 +1913,12 @@ class HoverCardClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/hovercard/v1/$userId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/hovercard/v1/{userId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<HoverCardGetUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1917,6 +1989,7 @@ class NavigationClient {
     final int absolute = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1944,8 +2017,10 @@ class NavigationClient {
       queryParameters['absolute'] = absolute.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/core/navigation/apps';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/core/navigation/apps').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<NavigationGetAppsNavigationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2010,6 +2085,7 @@ class NavigationClient {
     final int absolute = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2037,8 +2113,10 @@ class NavigationClient {
       queryParameters['absolute'] = absolute.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/core/navigation/settings';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/core/navigation/settings').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<NavigationGetSettingsNavigationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2093,6 +2171,7 @@ class OcmClient {
   ///  * [discovery] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<OcmDiscoveryResponseApplicationJson, OcmOcmDiscoveryHeaders> discoveryRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2114,8 +2193,10 @@ class OcmClient {
     }
 
 // coverage:ignore-end
-    const path = '/index.php/ocm-provider';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/ocm-provider').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<OcmDiscoveryResponseApplicationJson, OcmOcmDiscoveryHeaders>(
       response: _rootClient.executeRequest(
@@ -2179,6 +2260,7 @@ class OcsClient {
   DynamiteRawResponse<OcsGetCapabilitiesResponseApplicationJson, void> getCapabilitiesRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2201,8 +2283,10 @@ class OcsClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/capabilities';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/capabilities').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<OcsGetCapabilitiesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2304,6 +2388,7 @@ class PreviewClient {
     final String mode = 'fill',
     final int mimeFallback = 0,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -2348,8 +2433,10 @@ class PreviewClient {
     if (mimeFallback != 0) {
       queryParameters['mimeFallback'] = mimeFallback.toString();
     }
-    const path = '/index.php/core/preview';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/core/preview').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -2445,6 +2532,7 @@ class PreviewClient {
     final String mode = 'fill',
     final int mimeFallback = 0,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -2489,8 +2577,10 @@ class PreviewClient {
     if (mimeFallback != 0) {
       queryParameters['mimeFallback'] = mimeFallback.toString();
     }
-    const path = '/index.php/core/preview.png';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/core/preview.png').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -2575,6 +2665,7 @@ class ProfileApiClient {
     required final String targetUserId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2600,10 +2691,12 @@ class ProfileApiClient {
 // coverage:ignore-end
     queryParameters['paramId'] = paramId;
     queryParameters['visibility'] = visibility;
-    final targetUserId0 = Uri.encodeQueryComponent(targetUserId);
+    pathParameters['targetUserId'] = targetUserId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/profile/$targetUserId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/profile/{targetUserId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ProfileApiSetVisibilityResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2665,6 +2758,7 @@ class ReferenceClient {
   ///  * [preview] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> previewRaw({required final String referenceId}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -2686,9 +2780,11 @@ class ReferenceClient {
     }
 
 // coverage:ignore-end
-    final referenceId0 = Uri.encodeQueryComponent(referenceId);
-    final path = '/index.php/core/references/preview/$referenceId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['referenceId'] = referenceId;
+    var uri = Uri.parse(UriTemplate('/index.php/core/references/preview/{referenceId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -2757,6 +2853,7 @@ class ReferenceApiClient {
     required final String reference,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2782,8 +2879,10 @@ class ReferenceApiClient {
 // coverage:ignore-end
     queryParameters['reference'] = reference;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/references/resolve';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/references/resolve').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ReferenceApiResolveOneResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2851,6 +2950,7 @@ class ReferenceApiClient {
     final int limit = 1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2879,8 +2979,10 @@ class ReferenceApiClient {
       queryParameters['limit'] = limit.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/references/resolve';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/references/resolve').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ReferenceApiResolveResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2953,6 +3055,7 @@ class ReferenceApiClient {
     final int limit = 1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2984,8 +3087,10 @@ class ReferenceApiClient {
       queryParameters['limit'] = limit.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/references/extract';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/references/extract').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ReferenceApiExtractResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3043,6 +3148,7 @@ class ReferenceApiClient {
   DynamiteRawResponse<ReferenceApiGetProvidersInfoResponseApplicationJson, void> getProvidersInfoRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3067,8 +3173,10 @@ class ReferenceApiClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/references/providers';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/references/providers').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ReferenceApiGetProvidersInfoResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3136,6 +3244,7 @@ class ReferenceApiClient {
     final int? timestamp,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3159,13 +3268,15 @@ class ReferenceApiClient {
     }
 
 // coverage:ignore-end
-    final providerId0 = Uri.encodeQueryComponent(providerId);
+    pathParameters['providerId'] = providerId;
     if (timestamp != null) {
       queryParameters['timestamp'] = timestamp.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/references/provider/$providerId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/references/provider/{providerId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ReferenceApiTouchProviderResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3229,6 +3340,7 @@ class TextProcessingApiClient {
   DynamiteRawResponse<TextProcessingApiTaskTypesResponseApplicationJson, void> taskTypesRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3251,8 +3363,10 @@ class TextProcessingApiClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/textprocessing/tasktypes';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/textprocessing/tasktypes').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TextProcessingApiTaskTypesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3334,6 +3448,7 @@ class TextProcessingApiClient {
     final String identifier = '',
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3362,8 +3477,10 @@ class TextProcessingApiClient {
       queryParameters['identifier'] = identifier;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/textprocessing/schedule';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/textprocessing/schedule').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TextProcessingApiScheduleResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3430,6 +3547,7 @@ class TextProcessingApiClient {
     required final int id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3451,10 +3569,12 @@ class TextProcessingApiClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/textprocessing/task/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/textprocessing/task/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TextProcessingApiGetTaskResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3521,6 +3641,7 @@ class TextProcessingApiClient {
     required final int id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3544,10 +3665,12 @@ class TextProcessingApiClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/textprocessing/task/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/textprocessing/task/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TextProcessingApiDeleteTaskResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3617,6 +3740,7 @@ class TextProcessingApiClient {
     final String? identifier,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3640,13 +3764,15 @@ class TextProcessingApiClient {
     }
 
 // coverage:ignore-end
-    final appId0 = Uri.encodeQueryComponent(appId);
+    pathParameters['appId'] = appId;
     if (identifier != null) {
       queryParameters['identifier'] = identifier;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/textprocessing/tasks/app/$appId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/textprocessing/tasks/app/{appId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TextProcessingApiListTasksByAppResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3710,6 +3836,7 @@ class TextToImageApiClient {
   DynamiteRawResponse<TextToImageApiIsAvailableResponseApplicationJson, void> isAvailableRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3732,8 +3859,10 @@ class TextToImageApiClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/text2image/is_available';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/text2image/is_available').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TextToImageApiIsAvailableResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3815,6 +3944,7 @@ class TextToImageApiClient {
     final int numberOfImages = 8,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3845,8 +3975,10 @@ class TextToImageApiClient {
       queryParameters['numberOfImages'] = numberOfImages.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/text2image/schedule';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/text2image/schedule').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TextToImageApiScheduleResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3913,6 +4045,7 @@ class TextToImageApiClient {
     required final int id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3934,10 +4067,12 @@ class TextToImageApiClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/text2image/task/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/text2image/task/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TextToImageApiGetTaskResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4004,6 +4139,7 @@ class TextToImageApiClient {
     required final int id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4027,10 +4163,12 @@ class TextToImageApiClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/text2image/task/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/text2image/task/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TextToImageApiDeleteTaskResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4102,6 +4240,7 @@ class TextToImageApiClient {
     required final int index,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -4123,11 +4262,13 @@ class TextToImageApiClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
-    final index0 = Uri.encodeQueryComponent(index.toString());
+    pathParameters['id'] = id.toString();
+    pathParameters['index'] = index.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/text2image/task/$id0/image/$index0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/text2image/task/{id}/image/{index}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -4197,6 +4338,7 @@ class TextToImageApiClient {
     final String? identifier,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4220,13 +4362,15 @@ class TextToImageApiClient {
     }
 
 // coverage:ignore-end
-    final appId0 = Uri.encodeQueryComponent(appId);
+    pathParameters['appId'] = appId;
     if (identifier != null) {
       queryParameters['identifier'] = identifier;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/text2image/tasks/app/$appId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/text2image/tasks/app/{appId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TextToImageApiListTasksByAppResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4290,6 +4434,7 @@ class TranslationApiClient {
   DynamiteRawResponse<TranslationApiLanguagesResponseApplicationJson, void> languagesRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4312,8 +4457,10 @@ class TranslationApiClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/translation/languages';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/translation/languages').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TranslationApiLanguagesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4392,6 +4539,7 @@ class TranslationApiClient {
     final String? fromLanguage,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4419,8 +4567,10 @@ class TranslationApiClient {
       queryParameters['fromLanguage'] = fromLanguage;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/translation/translate';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/translation/translate').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TranslationApiTranslateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4489,6 +4639,7 @@ class UnifiedSearchClient {
     final String from = '',
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4516,8 +4667,10 @@ class UnifiedSearchClient {
       queryParameters['from'] = from;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/search/providers';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/search/providers').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UnifiedSearchGetProvidersResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4607,6 +4760,7 @@ class UnifiedSearchClient {
     final String from = '',
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4630,7 +4784,7 @@ class UnifiedSearchClient {
     }
 
 // coverage:ignore-end
-    final providerId0 = Uri.encodeQueryComponent(providerId);
+    pathParameters['providerId'] = providerId;
     if (term != '') {
       queryParameters['term'] = term;
     }
@@ -4650,8 +4804,10 @@ class UnifiedSearchClient {
       queryParameters['from'] = from;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/search/providers/$providerId0/search';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/search/providers/{providerId}/search').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UnifiedSearchSearchResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4713,6 +4869,7 @@ class WhatsNewClient {
   ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<WhatsNewGetResponseApplicationJson, void> $getRaw({final bool oCSAPIRequest = true}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4737,8 +4894,10 @@ class WhatsNewClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/core/whatsnew';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/core/whatsnew').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<WhatsNewGetResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4803,6 +4962,7 @@ class WhatsNewClient {
     required final String version,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4828,8 +4988,10 @@ class WhatsNewClient {
 // coverage:ignore-end
     queryParameters['version'] = version;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/core/whatsnew';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/core/whatsnew').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<WhatsNewDismissResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4891,6 +5053,7 @@ class WipeClient {
   ///  * [checkWipe] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<WipeCheckWipeResponseApplicationJson, void> checkWipeRaw({required final String token}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4913,8 +5076,10 @@ class WipeClient {
 
 // coverage:ignore-end
     queryParameters['token'] = token;
-    const path = '/index.php/core/wipe/check';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/core/wipe/check').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<WipeCheckWipeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4970,6 +5135,7 @@ class WipeClient {
   ///  * [wipeDone] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<JsonObject, void> wipeDoneRaw({required final String token}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4992,8 +5158,10 @@ class WipeClient {
 
 // coverage:ignore-end
     queryParameters['token'] = token;
-    const path = '/index.php/core/wipe/success';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/core/wipe/success').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<JsonObject, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.dart
@@ -14,6 +14,7 @@ import 'package:dynamite_runtime/http_client.dart';
 import 'package:dynamite_runtime/models.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'dashboard.openapi.g.dart';
 
@@ -86,6 +87,7 @@ class DashboardApiClient {
   DynamiteRawResponse<DashboardApiGetWidgetsResponseApplicationJson, void> getWidgetsRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -110,8 +112,10 @@ class DashboardApiClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/dashboard/api/v1/widgets';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/dashboard/api/v1/widgets').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DashboardApiGetWidgetsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -184,6 +188,7 @@ class DashboardApiClient {
     final List<String> widgets = const <String>[],
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -222,8 +227,10 @@ class DashboardApiClient {
       queryParameters['widgets[]'] = widgets.map((final e) => e);
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/dashboard/api/v1/widget-items';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/dashboard/api/v1/widget-items').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DashboardApiGetWidgetItemsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -296,6 +303,7 @@ class DashboardApiClient {
     final List<String> widgets = const <String>[],
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -334,8 +342,10 @@ class DashboardApiClient {
       queryParameters['widgets[]'] = widgets.map((final e) => e);
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/dashboard/api/v2/widget-items';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/dashboard/api/v2/widget-items').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DashboardApiGetWidgetItemsV2ResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -12,6 +12,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'dav.openapi.g.dart';
 
@@ -100,6 +101,7 @@ class DirectClient {
     final int? expirationTime,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -128,8 +130,10 @@ class DirectClient {
       queryParameters['expirationTime'] = expirationTime.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/dav/api/v1/direct';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/dav/api/v1/direct').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DirectGetUrlResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -15,6 +15,7 @@ import 'package:dynamite_runtime/http_client.dart';
 import 'package:dynamite_runtime/utils.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'files.openapi.g.dart';
 
@@ -109,6 +110,7 @@ class ApiClient {
     required final int y,
     required final String file,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -132,12 +134,14 @@ class ApiClient {
     }
 
 // coverage:ignore-end
-    final x0 = Uri.encodeQueryComponent(x.toString());
-    final y0 = Uri.encodeQueryComponent(y.toString());
+    pathParameters['x'] = x.toString();
+    pathParameters['y'] = y.toString();
     checkPattern(file, RegExp(r'^.+$'), 'file'); // coverage:ignore-line
-    final file0 = Uri.encodeQueryComponent(file);
-    final path = '/index.php/apps/files/api/v1/thumbnail/$x0/$y0/$file0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['file'] = file;
+    var uri = Uri.parse(UriTemplate('/index.php/apps/files/api/v1/thumbnail/{x}/{y}/{file}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -199,6 +203,7 @@ class DirectEditingClient {
   ///  * [info] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DirectEditingInfoResponseApplicationJson, void> infoRaw({final bool oCSAPIRequest = true}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -223,8 +228,10 @@ class DirectEditingClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files/api/v1/directEditing';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DirectEditingInfoResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -294,6 +301,7 @@ class DirectEditingClient {
     required final String creatorId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -317,11 +325,16 @@ class DirectEditingClient {
     }
 
 // coverage:ignore-end
-    final editorId0 = Uri.encodeQueryComponent(editorId);
-    final creatorId0 = Uri.encodeQueryComponent(creatorId);
+    pathParameters['editorId'] = editorId;
+    pathParameters['creatorId'] = creatorId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files/api/v1/directEditing/templates/$editorId0/$creatorId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/templates/{editorId}/{creatorId}')
+          .expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DirectEditingTemplatesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -398,6 +411,7 @@ class DirectEditingClient {
     final int? fileId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -429,8 +443,10 @@ class DirectEditingClient {
       queryParameters['fileId'] = fileId.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path0 = '/ocs/v2.php/apps/files/api/v1/directEditing/open';
-    final uri = Uri(path: path0, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/open').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DirectEditingOpenResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -512,6 +528,7 @@ class DirectEditingClient {
     final String? templateId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -542,8 +559,10 @@ class DirectEditingClient {
       queryParameters['templateId'] = templateId;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path0 = '/ocs/v2.php/apps/files/api/v1/directEditing/create';
-    final uri = Uri(path: path0, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/create').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DirectEditingCreateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -614,6 +633,7 @@ class OpenLocalEditorClient {
     required final String path,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -639,8 +659,10 @@ class OpenLocalEditorClient {
 // coverage:ignore-end
     queryParameters['path'] = path;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path0 = '/ocs/v2.php/apps/files/api/v1/openlocaleditor';
-    final uri = Uri(path: path0, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<OpenLocalEditorCreateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -710,6 +732,7 @@ class OpenLocalEditorClient {
     required final String token,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -734,10 +757,12 @@ class OpenLocalEditorClient {
 
 // coverage:ignore-end
     queryParameters['path'] = path;
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path0 = '/ocs/v2.php/apps/files/api/v1/openlocaleditor/$token0';
-    final uri = Uri(path: path0, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<OpenLocalEditorValidateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -797,6 +822,7 @@ class TemplateClient {
   ///  * [list] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TemplateListResponseApplicationJson, void> listRaw({final bool oCSAPIRequest = true}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -821,8 +847,10 @@ class TemplateClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files/api/v1/templates';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/templates').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TemplateListResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -897,6 +925,7 @@ class TemplateClient {
     final String templateType = 'user',
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -928,8 +957,10 @@ class TemplateClient {
       queryParameters['templateType'] = templateType;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files/api/v1/templates/create';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/templates/create').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TemplateCreateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -999,6 +1030,7 @@ class TemplateClient {
     final int copySystemTemplates = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1029,8 +1061,10 @@ class TemplateClient {
       queryParameters['copySystemTemplates'] = copySystemTemplates.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files/api/v1/templates/path';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/templates/path').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TemplatePathResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1108,6 +1142,7 @@ class TransferOwnershipClient {
     required final String path,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1134,8 +1169,10 @@ class TransferOwnershipClient {
     queryParameters['recipient'] = recipient;
     queryParameters['path'] = path;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path0 = '/ocs/v2.php/apps/files/api/v1/transferownership';
-    final uri = Uri(path: path0, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TransferOwnershipTransferResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1202,6 +1239,7 @@ class TransferOwnershipClient {
     required final int id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1225,10 +1263,12 @@ class TransferOwnershipClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files/api/v1/transferownership/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TransferOwnershipAcceptResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1295,6 +1335,7 @@ class TransferOwnershipClient {
     required final int id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1318,10 +1359,12 @@ class TransferOwnershipClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files/api/v1/transferownership/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TransferOwnershipRejectResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/files_external.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.dart
@@ -14,6 +14,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'files_external.openapi.g.dart';
 
@@ -86,6 +87,7 @@ class ApiClient {
   DynamiteRawResponse<ApiGetUserMountsResponseApplicationJson, void> getUserMountsRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -110,8 +112,10 @@ class ApiClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files_external/api/v1/mounts';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_external/api/v1/mounts').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ApiGetUserMountsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
@@ -14,6 +14,7 @@ import 'package:dynamite_runtime/http_client.dart';
 import 'package:dynamite_runtime/utils.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'files_reminders.openapi.g.dart';
 
@@ -98,6 +99,7 @@ class ApiClient {
     required final int fileId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -122,11 +124,13 @@ class ApiClient {
 
 // coverage:ignore-end
     checkPattern(version, RegExp(r'^1$'), 'version'); // coverage:ignore-line
-    final version0 = Uri.encodeQueryComponent(version);
-    final fileId0 = Uri.encodeQueryComponent(fileId.toString());
+    pathParameters['version'] = version;
+    pathParameters['fileId'] = fileId.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_reminders/api/v$version0/$fileId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ApiGetResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -207,6 +211,7 @@ class ApiClient {
     required final int fileId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -232,11 +237,13 @@ class ApiClient {
 // coverage:ignore-end
     queryParameters['dueDate'] = dueDate;
     checkPattern(version, RegExp(r'^1$'), 'version'); // coverage:ignore-line
-    final version0 = Uri.encodeQueryComponent(version);
-    final fileId0 = Uri.encodeQueryComponent(fileId.toString());
+    pathParameters['version'] = version;
+    pathParameters['fileId'] = fileId.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_reminders/api/v$version0/$fileId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ApiSetResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -308,6 +315,7 @@ class ApiClient {
     required final int fileId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -332,11 +340,13 @@ class ApiClient {
 
 // coverage:ignore-end
     checkPattern(version, RegExp(r'^1$'), 'version'); // coverage:ignore-line
-    final version0 = Uri.encodeQueryComponent(version);
-    final fileId0 = Uri.encodeQueryComponent(fileId.toString());
+    pathParameters['version'] = version;
+    pathParameters['fileId'] = fileId.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_reminders/api/v$version0/$fileId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ApiRemoveResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -15,6 +15,7 @@ import 'package:dynamite_runtime/http_client.dart';
 import 'package:dynamite_runtime/models.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'files_sharing.openapi.g.dart';
 
@@ -95,6 +96,7 @@ class DeletedShareapiClient {
   ///  * [list] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DeletedShareapiListResponseApplicationJson, void> listRaw({final bool oCSAPIRequest = true}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -119,8 +121,10 @@ class DeletedShareapiClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files_sharing/api/v1/deletedshares';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/deletedshares').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DeletedShareapiListResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -185,6 +189,7 @@ class DeletedShareapiClient {
     required final String id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -208,10 +213,12 @@ class DeletedShareapiClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id);
+    pathParameters['id'] = id;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_sharing/api/v1/deletedshares/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/deletedshares/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DeletedShareapiUndeleteResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -286,6 +293,7 @@ class PublicPreviewClient {
     required final String token,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -307,10 +315,12 @@ class PublicPreviewClient {
     }
 
 // coverage:ignore-end
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/index.php/s/$token0/preview';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/s/{token}/preview').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -399,6 +409,7 @@ class PublicPreviewClient {
     final int a = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -420,7 +431,7 @@ class PublicPreviewClient {
     }
 
 // coverage:ignore-end
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (file != '') {
       queryParameters['file'] = file;
     }
@@ -434,8 +445,10 @@ class PublicPreviewClient {
       queryParameters['a'] = a.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/index.php/apps/files_sharing/publicpreview/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/files_sharing/publicpreview/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -497,6 +510,7 @@ class RemoteClient {
   ///  * [getShares] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RemoteGetSharesResponseApplicationJson, void> getSharesRaw({final bool oCSAPIRequest = true}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -521,8 +535,10 @@ class RemoteClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files_sharing/api/v1/remote_shares';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RemoteGetSharesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -580,6 +596,7 @@ class RemoteClient {
   DynamiteRawResponse<RemoteGetOpenSharesResponseApplicationJson, void> getOpenSharesRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -604,8 +621,11 @@ class RemoteClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RemoteGetOpenSharesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -670,6 +690,7 @@ class RemoteClient {
     required final int id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -693,10 +714,14 @@ class RemoteClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/{id}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RemoteAcceptShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -761,6 +786,7 @@ class RemoteClient {
     required final int id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -784,10 +810,14 @@ class RemoteClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/{id}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RemoteDeclineShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -852,6 +882,7 @@ class RemoteClient {
     required final int id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -875,10 +906,12 @@ class RemoteClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RemoteGetShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -945,6 +978,7 @@ class RemoteClient {
     required final int id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -968,10 +1002,12 @@ class RemoteClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RemoteUnshareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1054,6 +1090,7 @@ class ShareInfoClient {
     final String? dir,
     final int depth = -1,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1085,8 +1122,10 @@ class ShareInfoClient {
     if (depth != -1) {
       queryParameters['depth'] = depth.toString();
     }
-    const path = '/index.php/apps/files_sharing/shareinfo';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/files_sharing/shareinfo').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareInfo, void>(
       response: _rootClient.executeRequest(
@@ -1177,6 +1216,7 @@ class ShareapiClient {
     final String includeTags = 'false',
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1216,8 +1256,10 @@ class ShareapiClient {
       queryParameters['include_tags'] = includeTags;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path0 = '/ocs/v2.php/apps/files_sharing/api/v1/shares';
-    final uri = Uri(path: path0, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareapiGetSharesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1336,6 +1378,7 @@ class ShareapiClient {
     final String? attributes,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1393,8 +1436,10 @@ class ShareapiClient {
       queryParameters['attributes'] = attributes;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path0 = '/ocs/v2.php/apps/files_sharing/api/v1/shares';
-    final uri = Uri(path: path0, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareapiCreateShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1461,6 +1506,7 @@ class ShareapiClient {
     required final String path,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1486,8 +1532,10 @@ class ShareapiClient {
 // coverage:ignore-end
     queryParameters['path'] = path;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path0 = '/ocs/v2.php/apps/files_sharing/api/v1/shares/inherited';
-    final uri = Uri(path: path0, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/inherited').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareapiGetInheritedSharesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1545,6 +1593,7 @@ class ShareapiClient {
   DynamiteRawResponse<ShareapiPendingSharesResponseApplicationJson, void> pendingSharesRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1569,8 +1618,10 @@ class ShareapiClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files_sharing/api/v1/shares/pending';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/pending').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareapiPendingSharesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1640,6 +1691,7 @@ class ShareapiClient {
     final int includeTags = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1663,13 +1715,15 @@ class ShareapiClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id);
+    pathParameters['id'] = id;
     if (includeTags != 0) {
       queryParameters['include_tags'] = includeTags.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_sharing/api/v1/shares/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareapiGetShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1783,6 +1837,7 @@ class ShareapiClient {
     final String? attributes,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1806,7 +1861,7 @@ class ShareapiClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id);
+    pathParameters['id'] = id;
     if (permissions != null) {
       queryParameters['permissions'] = permissions.toString();
     }
@@ -1835,8 +1890,10 @@ class ShareapiClient {
       queryParameters['attributes'] = attributes;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_sharing/api/v1/shares/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareapiUpdateShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1903,6 +1960,7 @@ class ShareapiClient {
     required final String id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1926,10 +1984,12 @@ class ShareapiClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id);
+    pathParameters['id'] = id;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_sharing/api/v1/shares/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareapiDeleteShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1996,6 +2056,7 @@ class ShareapiClient {
     required final String id,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2019,10 +2080,13 @@ class ShareapiClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id);
+    pathParameters['id'] = id;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/files_sharing/api/v1/shares/pending/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/pending/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareapiAcceptShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2118,6 +2182,7 @@ class ShareesapiClient {
     final int lookup = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2163,8 +2228,10 @@ class ShareesapiClient {
       queryParameters['lookup'] = lookup.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files_sharing/api/v1/sharees';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/sharees').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareesapiSearchResponseApplicationJson, ShareesapiShareesapiSearchHeaders>(
       response: _rootClient.executeRequest(
@@ -2232,6 +2299,7 @@ class ShareesapiClient {
     final ContentString<ShareesapiFindRecommendedShareType>? shareType,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2263,8 +2331,11 @@ class ShareesapiClient {
       );
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/files_sharing/api/v1/sharees_recommended';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/sharees_recommended').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ShareesapiFindRecommendedResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -12,6 +12,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'files_trashbin.openapi.g.dart';
 
@@ -103,6 +104,7 @@ class PreviewClient {
     final int y = 32,
     final int a = 0,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -138,8 +140,10 @@ class PreviewClient {
     if (a != 0) {
       queryParameters['a'] = a.toString();
     }
-    const path = '/index.php/apps/files_trashbin/preview';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/files_trashbin/preview').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.dart
@@ -12,6 +12,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'files_versions.openapi.g.dart';
 
@@ -103,6 +104,7 @@ class PreviewClient {
     final int y = 44,
     final String version = '',
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -138,8 +140,10 @@ class PreviewClient {
     if (version != '') {
       queryParameters['version'] = version;
     }
-    const path = '/index.php/apps/files_versions/preview';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/files_versions/preview').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/news.openapi.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.dart
@@ -14,6 +14,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'news.openapi.g.dart';
 
@@ -62,6 +63,7 @@ class Client extends DynamiteClient {
   ///  * [getSupportedApiVersions] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SupportedAPIVersions, void> getSupportedApiVersionsRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -85,8 +87,10 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    const path = '/index.php/apps/news/api';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SupportedAPIVersions, void>(
       response: executeRequest(
@@ -128,6 +132,7 @@ class Client extends DynamiteClient {
   ///  * [listFolders] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ListFolders, void> listFoldersRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -151,8 +156,10 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    const path = '/index.php/apps/news/api/v1-3/folders';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/folders').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ListFolders, void>(
       response: executeRequest(
@@ -202,6 +209,7 @@ class Client extends DynamiteClient {
   ///  * [createFolder] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ListFolders, void> createFolderRaw({required final String name}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -226,8 +234,10 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-end
     queryParameters['name'] = name;
-    const path = '/index.php/apps/news/api/v1-3/folders';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/folders').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ListFolders, void>(
       response: executeRequest(
@@ -284,6 +294,7 @@ class Client extends DynamiteClient {
     required final int folderId,
     required final String name,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -305,10 +316,12 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final folderId0 = Uri.encodeQueryComponent(folderId.toString());
+    pathParameters['folderId'] = folderId.toString();
     queryParameters['name'] = name;
-    final path = '/index.php/apps/news/api/v1-3/folders/$folderId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -352,6 +365,7 @@ class Client extends DynamiteClient {
   ///  * [deleteFolder] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> deleteFolderRaw({required final int folderId}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -373,9 +387,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final folderId0 = Uri.encodeQueryComponent(folderId.toString());
-    final path = '/index.php/apps/news/api/v1-3/folders/$folderId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['folderId'] = folderId.toString();
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -432,6 +448,7 @@ class Client extends DynamiteClient {
     required final int folderId,
     required final int newestItemId,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -453,10 +470,12 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final folderId0 = Uri.encodeQueryComponent(folderId.toString());
+    pathParameters['folderId'] = folderId.toString();
     queryParameters['newestItemId'] = newestItemId.toString();
-    final path = '/index.php/apps/news/api/v1-3/folders/$folderId0/read';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}/read').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -498,6 +517,7 @@ class Client extends DynamiteClient {
   ///  * [listFeeds] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ListFeeds, void> listFeedsRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -521,8 +541,10 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    const path = '/index.php/apps/news/api/v1-3/feeds';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/feeds').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ListFeeds, void>(
       response: executeRequest(
@@ -581,6 +603,7 @@ class Client extends DynamiteClient {
     required final String url,
     final int? folderId,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -608,8 +631,10 @@ class Client extends DynamiteClient {
     if (folderId != null) {
       queryParameters['folderId'] = folderId.toString();
     }
-    const path = '/index.php/apps/news/api/v1-3/feeds';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/feeds').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ListFeeds, void>(
       response: executeRequest(
@@ -653,6 +678,7 @@ class Client extends DynamiteClient {
   ///  * [deleteFeed] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> deleteFeedRaw({required final int feedId}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -674,9 +700,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final feedId0 = Uri.encodeQueryComponent(feedId.toString());
-    final path = '/index.php/apps/news/api/v1-3/feeds/$feedId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['feedId'] = feedId.toString();
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -733,6 +761,7 @@ class Client extends DynamiteClient {
     required final int feedId,
     final int? folderId,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -754,12 +783,14 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final feedId0 = Uri.encodeQueryComponent(feedId.toString());
+    pathParameters['feedId'] = feedId.toString();
     if (folderId != null) {
       queryParameters['folderId'] = folderId.toString();
     }
-    final path = '/index.php/apps/news/api/v1-3/feeds/$feedId0/move';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/move').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -816,6 +847,7 @@ class Client extends DynamiteClient {
     required final int feedId,
     required final String feedTitle,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -837,10 +869,12 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final feedId0 = Uri.encodeQueryComponent(feedId.toString());
+    pathParameters['feedId'] = feedId.toString();
     queryParameters['feedTitle'] = feedTitle;
-    final path = '/index.php/apps/news/api/v1-3/feeds/$feedId0/rename';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/rename').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -897,6 +931,7 @@ class Client extends DynamiteClient {
     required final int feedId,
     required final int newestItemId,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -918,10 +953,12 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final feedId0 = Uri.encodeQueryComponent(feedId.toString());
+    pathParameters['feedId'] = feedId.toString();
     queryParameters['newestItemId'] = newestItemId.toString();
-    final path = '/index.php/apps/news/api/v1-3/feeds/$feedId0/read';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/read').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -1000,6 +1037,7 @@ class Client extends DynamiteClient {
     final int offset = 0,
     final int oldestFirst = 0,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1041,8 +1079,10 @@ class Client extends DynamiteClient {
     if (oldestFirst != 0) {
       queryParameters['oldestFirst'] = oldestFirst.toString();
     }
-    const path = '/index.php/apps/news/api/v1-3/items';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/items').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ListArticles, void>(
       response: executeRequest(
@@ -1106,6 +1146,7 @@ class Client extends DynamiteClient {
     final int id = 0,
     final int lastModified = 0,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1138,8 +1179,10 @@ class Client extends DynamiteClient {
     if (lastModified != 0) {
       queryParameters['lastModified'] = lastModified.toString();
     }
-    const path = '/index.php/apps/news/api/v1-3/items/updated';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/items/updated').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ListArticles, void>(
       response: executeRequest(
@@ -1183,6 +1226,7 @@ class Client extends DynamiteClient {
   ///  * [markArticleAsRead] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> markArticleAsReadRaw({required final int itemId}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -1204,9 +1248,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final itemId0 = Uri.encodeQueryComponent(itemId.toString());
-    final path = '/index.php/apps/news/api/v1-3/items/$itemId0/read';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['itemId'] = itemId.toString();
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/read').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -1250,6 +1296,7 @@ class Client extends DynamiteClient {
   ///  * [markArticleAsUnread] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> markArticleAsUnreadRaw({required final int itemId}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -1271,9 +1318,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final itemId0 = Uri.encodeQueryComponent(itemId.toString());
-    final path = '/index.php/apps/news/api/v1-3/items/$itemId0/unread';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['itemId'] = itemId.toString();
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/unread').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -1317,6 +1366,7 @@ class Client extends DynamiteClient {
   ///  * [starArticle] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> starArticleRaw({required final int itemId}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -1338,9 +1388,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final itemId0 = Uri.encodeQueryComponent(itemId.toString());
-    final path = '/index.php/apps/news/api/v1-3/items/$itemId0/star';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['itemId'] = itemId.toString();
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/star').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(
@@ -1384,6 +1436,7 @@ class Client extends DynamiteClient {
   ///  * [unstarArticle] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> unstarArticleRaw({required final int itemId}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -1405,9 +1458,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final itemId0 = Uri.encodeQueryComponent(itemId.toString());
-    final path = '/index.php/apps/news/api/v1-3/items/$itemId0/unstar';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['itemId'] = itemId.toString();
+    var uri = Uri.parse(UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/unstar').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<void, void>(
       response: executeRequest(

--- a/packages/nextcloud/lib/src/api/notes.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.dart
@@ -15,6 +15,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'notes.openapi.g.dart';
 
@@ -100,6 +101,7 @@ class Client extends DynamiteClient {
     final String? chunkCursor,
     final String? ifNoneMatch,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -141,8 +143,10 @@ class Client extends DynamiteClient {
     if (ifNoneMatch != null) {
       headers['If-None-Match'] = ifNoneMatch;
     }
-    const path = '/index.php/apps/notes/api/v1/notes';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/notes/api/v1/notes').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BuiltList<Note>, void>(
       response: executeRequest(
@@ -216,6 +220,7 @@ class Client extends DynamiteClient {
     final int modified = 0,
     final int favorite = 0,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -254,8 +259,10 @@ class Client extends DynamiteClient {
     if (favorite != 0) {
       queryParameters['favorite'] = favorite.toString();
     }
-    const path = '/index.php/apps/notes/api/v1/notes';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/notes/api/v1/notes').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Note, void>(
       response: executeRequest(
@@ -317,6 +324,7 @@ class Client extends DynamiteClient {
     final String exclude = '',
     final String? ifNoneMatch,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -340,15 +348,17 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     if (exclude != '') {
       queryParameters['exclude'] = exclude;
     }
     if (ifNoneMatch != null) {
       headers['If-None-Match'] = ifNoneMatch;
     }
-    final path = '/index.php/apps/notes/api/v1/notes/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/notes/api/v1/notes/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Note, void>(
       response: executeRequest(
@@ -430,6 +440,7 @@ class Client extends DynamiteClient {
     final int? favorite,
     final String? ifMatch,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -453,7 +464,7 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
+    pathParameters['id'] = id.toString();
     if (content != null) {
       queryParameters['content'] = content;
     }
@@ -472,8 +483,10 @@ class Client extends DynamiteClient {
     if (ifMatch != null) {
       headers['If-Match'] = ifMatch;
     }
-    final path = '/index.php/apps/notes/api/v1/notes/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/notes/api/v1/notes/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Note, void>(
       response: executeRequest(
@@ -517,6 +530,7 @@ class Client extends DynamiteClient {
   ///  * [deleteNote] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<String, void> deleteNoteRaw({required final int id}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -540,9 +554,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
-    final path = '/index.php/apps/notes/api/v1/notes/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['id'] = id.toString();
+    var uri = Uri.parse(UriTemplate('/index.php/apps/notes/api/v1/notes/{id}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<String, void>(
       response: executeRequest(
@@ -584,6 +600,7 @@ class Client extends DynamiteClient {
   ///  * [getSettings] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Settings, void> getSettingsRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -607,8 +624,10 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    const path = '/index.php/apps/notes/api/v1/settings';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/notes/api/v1/settings').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Settings, void>(
       response: executeRequest(
@@ -652,6 +671,7 @@ class Client extends DynamiteClient {
   ///  * [updateSettings] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Settings, void> updateSettingsRaw({required final Settings settings}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -677,8 +697,10 @@ class Client extends DynamiteClient {
 // coverage:ignore-end
     headers['Content-Type'] = 'application/json';
     body = utf8.encode(json.encode(_jsonSerializers.serialize(settings, specifiedType: const FullType(Settings))));
-    const path = '/index.php/apps/notes/api/v1/settings';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/notes/api/v1/settings').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Settings, void>(
       response: executeRequest(

--- a/packages/nextcloud/lib/src/api/notifications.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.dart
@@ -14,6 +14,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'notifications.openapi.g.dart';
 
@@ -122,6 +123,7 @@ class ApiClient {
     final ApiGenerateNotificationApiVersion apiVersion = ApiGenerateNotificationApiVersion.v2,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -146,14 +148,19 @@ class ApiClient {
 
 // coverage:ignore-end
     queryParameters['shortMessage'] = shortMessage;
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     if (longMessage != '') {
       queryParameters['longMessage'] = longMessage;
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/notifications/api/$apiVersion0/admin_notifications/$userId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/admin_notifications/{userId}')
+          .expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ApiGenerateNotificationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -226,6 +233,7 @@ class EndpointClient {
     final EndpointListNotificationsApiVersion apiVersion = EndpointListNotificationsApiVersion.v2,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -249,10 +257,13 @@ class EndpointClient {
     }
 
 // coverage:ignore-end
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/notifications/api/$apiVersion0/notifications';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<EndpointListNotificationsResponseApplicationJson,
         EndpointEndpointListNotificationsHeaders>(
@@ -318,6 +329,7 @@ class EndpointClient {
     final EndpointDeleteAllNotificationsApiVersion apiVersion = EndpointDeleteAllNotificationsApiVersion.v2,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -341,10 +353,13 @@ class EndpointClient {
     }
 
 // coverage:ignore-end
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/notifications/api/$apiVersion0/notifications';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<EndpointDeleteAllNotificationsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -414,6 +429,7 @@ class EndpointClient {
     final EndpointGetNotificationApiVersion apiVersion = EndpointGetNotificationApiVersion.v2,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -437,11 +453,15 @@ class EndpointClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['id'] = id.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/notifications/api/$apiVersion0/notifications/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/{id}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<EndpointGetNotificationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -513,6 +533,7 @@ class EndpointClient {
     final EndpointDeleteNotificationApiVersion apiVersion = EndpointDeleteNotificationApiVersion.v2,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -536,11 +557,15 @@ class EndpointClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['id'] = id.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/notifications/api/$apiVersion0/notifications/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/{id}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<EndpointDeleteNotificationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -610,6 +635,7 @@ class EndpointClient {
     final EndpointConfirmIdsForUserApiVersion apiVersion = EndpointConfirmIdsForUserApiVersion.v2,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -634,10 +660,14 @@ class EndpointClient {
 
 // coverage:ignore-end
     queryParameters['ids[]'] = ids.map((final e) => e.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/notifications/api/$apiVersion0/notifications/exists';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/exists').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<EndpointConfirmIdsForUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -727,6 +757,7 @@ class PushClient {
     final PushRegisterDeviceApiVersion apiVersion = PushRegisterDeviceApiVersion.v2,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -753,10 +784,12 @@ class PushClient {
     queryParameters['pushTokenHash'] = pushTokenHash;
     queryParameters['devicePublicKey'] = devicePublicKey;
     queryParameters['proxyServer'] = proxyServer;
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/notifications/api/$apiVersion0/push';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/push').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PushRegisterDeviceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -825,6 +858,7 @@ class PushClient {
     final PushRemoveDeviceApiVersion apiVersion = PushRemoveDeviceApiVersion.v2,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -848,10 +882,12 @@ class PushClient {
     }
 
 // coverage:ignore-end
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/notifications/api/$apiVersion0/push';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/push').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PushRemoveDeviceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -935,6 +971,7 @@ class SettingsClient {
     final SettingsPersonalApiVersion apiVersion = SettingsPersonalApiVersion.v2,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -961,10 +998,12 @@ class SettingsClient {
     queryParameters['batchSetting'] = batchSetting.toString();
     queryParameters['soundNotification'] = soundNotification;
     queryParameters['soundTalk'] = soundTalk;
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/notifications/api/$apiVersion0/settings';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/settings').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SettingsPersonalResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1046,6 +1085,7 @@ class SettingsClient {
     final SettingsAdminApiVersion apiVersion = SettingsAdminApiVersion.v2,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1072,10 +1112,14 @@ class SettingsClient {
     queryParameters['batchSetting'] = batchSetting.toString();
     queryParameters['soundNotification'] = soundNotification;
     queryParameters['soundTalk'] = soundTalk;
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/notifications/api/$apiVersion0/settings/admin';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/settings/admin').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SettingsAdminResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -16,6 +16,7 @@ import 'package:dynamite_runtime/models.dart';
 import 'package:dynamite_runtime/utils.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'provisioning_api.openapi.g.dart';
 
@@ -98,6 +99,7 @@ class AppConfigClient {
   ///  * [getApps] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppConfigGetAppsResponseApplicationJson, void> getAppsRaw({final bool oCSAPIRequest = true}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -122,8 +124,10 @@ class AppConfigClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/provisioning_api/api/v1/config/apps';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppConfigGetAppsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -192,6 +196,7 @@ class AppConfigClient {
     required final String app,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -215,10 +220,13 @@ class AppConfigClient {
     }
 
 // coverage:ignore-end
-    final app0 = Uri.encodeQueryComponent(app);
+    pathParameters['app'] = app;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/$app0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppConfigGetKeysResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -297,6 +305,7 @@ class AppConfigClient {
     final String defaultValue = '',
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -320,14 +329,18 @@ class AppConfigClient {
     }
 
 // coverage:ignore-end
-    final app0 = Uri.encodeQueryComponent(app);
-    final key0 = Uri.encodeQueryComponent(key);
+    pathParameters['app'] = app;
+    pathParameters['key'] = key;
     if (defaultValue != '') {
       queryParameters['defaultValue'] = defaultValue;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/$app0/$key0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}/{key}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppConfigGetValueResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -402,6 +415,7 @@ class AppConfigClient {
     required final String key,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -426,11 +440,15 @@ class AppConfigClient {
 
 // coverage:ignore-end
     queryParameters['value'] = value;
-    final app0 = Uri.encodeQueryComponent(app);
-    final key0 = Uri.encodeQueryComponent(key);
+    pathParameters['app'] = app;
+    pathParameters['key'] = key;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/$app0/$key0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}/{key}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppConfigSetValueResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -504,6 +522,7 @@ class AppConfigClient {
     required final String key,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -527,11 +546,15 @@ class AppConfigClient {
     }
 
 // coverage:ignore-end
-    final app0 = Uri.encodeQueryComponent(app);
-    final key0 = Uri.encodeQueryComponent(key);
+    pathParameters['app'] = app;
+    pathParameters['key'] = key;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/$app0/$key0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}/{key}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppConfigDeleteKeyResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -604,6 +627,7 @@ class AppsClient {
     final String? filter,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -631,8 +655,10 @@ class AppsClient {
       queryParameters['filter'] = filter;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/apps';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/apps').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppsGetAppsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -699,6 +725,7 @@ class AppsClient {
     required final String app,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -722,10 +749,12 @@ class AppsClient {
     }
 
 // coverage:ignore-end
-    final app0 = Uri.encodeQueryComponent(app);
+    pathParameters['app'] = app;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/apps/$app0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppsGetAppInfoResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -792,6 +821,7 @@ class AppsClient {
     required final String app,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -815,10 +845,12 @@ class AppsClient {
     }
 
 // coverage:ignore-end
-    final app0 = Uri.encodeQueryComponent(app);
+    pathParameters['app'] = app;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/apps/$app0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppsEnableResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -885,6 +917,7 @@ class AppsClient {
     required final String app,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -908,10 +941,12 @@ class AppsClient {
     }
 
 // coverage:ignore-end
-    final app0 = Uri.encodeQueryComponent(app);
+    pathParameters['app'] = app;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/apps/$app0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AppsDisableResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -990,6 +1025,7 @@ class GroupsClient {
     final int offset = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1023,8 +1059,10 @@ class GroupsClient {
       queryParameters['offset'] = offset.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/groups';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/groups').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GroupsGetGroupsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1096,6 +1134,7 @@ class GroupsClient {
     final String displayname = '',
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1124,8 +1163,10 @@ class GroupsClient {
       queryParameters['displayname'] = displayname;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/groups';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/groups').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GroupsAddGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1198,6 +1239,7 @@ class GroupsClient {
     final int offset = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1231,8 +1273,10 @@ class GroupsClient {
       queryParameters['offset'] = offset.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/groups/details';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/groups/details').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GroupsGetGroupsDetailsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1299,6 +1343,7 @@ class GroupsClient {
     required final String groupId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1323,10 +1368,12 @@ class GroupsClient {
 
 // coverage:ignore-end
     checkPattern(groupId, RegExp(r'^.+$'), 'groupId'); // coverage:ignore-line
-    final groupId0 = Uri.encodeQueryComponent(groupId);
+    pathParameters['groupId'] = groupId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/groups/$groupId0/users';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/users').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GroupsGetGroupUsersResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1404,6 +1451,7 @@ class GroupsClient {
     final int offset = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1428,7 +1476,7 @@ class GroupsClient {
 
 // coverage:ignore-end
     checkPattern(groupId, RegExp(r'^.+$'), 'groupId'); // coverage:ignore-line
-    final groupId0 = Uri.encodeQueryComponent(groupId);
+    pathParameters['groupId'] = groupId;
     if (search != '') {
       queryParameters['search'] = search;
     }
@@ -1439,8 +1487,10 @@ class GroupsClient {
       queryParameters['offset'] = offset.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/groups/$groupId0/users/details';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/users/details').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GroupsGetGroupUsersDetailsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1507,6 +1557,7 @@ class GroupsClient {
     required final String groupId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1531,10 +1582,12 @@ class GroupsClient {
 
 // coverage:ignore-end
     checkPattern(groupId, RegExp(r'^.+$'), 'groupId'); // coverage:ignore-line
-    final groupId0 = Uri.encodeQueryComponent(groupId);
+    pathParameters['groupId'] = groupId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/groups/$groupId0/subadmins';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/subadmins').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GroupsGetSubAdminsOfGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1599,6 +1652,7 @@ class GroupsClient {
     required final String groupId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1623,10 +1677,12 @@ class GroupsClient {
 
 // coverage:ignore-end
     checkPattern(groupId, RegExp(r'^.+$'), 'groupId'); // coverage:ignore-line
-    final groupId0 = Uri.encodeQueryComponent(groupId);
+    pathParameters['groupId'] = groupId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/groups/$groupId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/groups/{groupId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GroupsGetGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1703,6 +1759,7 @@ class GroupsClient {
     required final String groupId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1729,10 +1786,12 @@ class GroupsClient {
     queryParameters['key'] = key;
     queryParameters['value'] = value;
     checkPattern(groupId, RegExp(r'^.+$'), 'groupId'); // coverage:ignore-line
-    final groupId0 = Uri.encodeQueryComponent(groupId);
+    pathParameters['groupId'] = groupId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/groups/$groupId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/groups/{groupId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GroupsUpdateGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1799,6 +1858,7 @@ class GroupsClient {
     required final String groupId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1823,10 +1883,12 @@ class GroupsClient {
 
 // coverage:ignore-end
     checkPattern(groupId, RegExp(r'^.+$'), 'groupId'); // coverage:ignore-line
-    final groupId0 = Uri.encodeQueryComponent(groupId);
+    pathParameters['groupId'] = groupId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/groups/$groupId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/groups/{groupId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GroupsDeleteGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1907,6 +1969,7 @@ class PreferencesClient {
     required final String configKey,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1931,11 +1994,15 @@ class PreferencesClient {
 
 // coverage:ignore-end
     queryParameters['configValue'] = configValue;
-    final appId0 = Uri.encodeQueryComponent(appId);
-    final configKey0 = Uri.encodeQueryComponent(configKey);
+    pathParameters['appId'] = appId;
+    pathParameters['configKey'] = configKey;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/provisioning_api/api/v1/config/users/$appId0/$configKey0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PreferencesSetPreferenceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2005,6 +2072,7 @@ class PreferencesClient {
     required final String configKey,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2028,11 +2096,15 @@ class PreferencesClient {
     }
 
 // coverage:ignore-end
-    final appId0 = Uri.encodeQueryComponent(appId);
-    final configKey0 = Uri.encodeQueryComponent(configKey);
+    pathParameters['appId'] = appId;
+    pathParameters['configKey'] = configKey;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/provisioning_api/api/v1/config/users/$appId0/$configKey0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PreferencesDeletePreferenceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2102,6 +2174,7 @@ class PreferencesClient {
     required final String appId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2131,10 +2204,13 @@ class PreferencesClient {
         FullType(BuiltMap, [FullType(String), FullType(String)]),
       ]),
     );
-    final appId0 = Uri.encodeQueryComponent(appId);
+    pathParameters['appId'] = appId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/provisioning_api/api/v1/config/users/$appId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PreferencesSetMultiplePreferencesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2204,6 +2280,7 @@ class PreferencesClient {
     required final String appId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2228,10 +2305,13 @@ class PreferencesClient {
 
 // coverage:ignore-end
     queryParameters['configKeys[]'] = configKeys.map((final e) => e);
-    final appId0 = Uri.encodeQueryComponent(appId);
+    pathParameters['appId'] = appId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/provisioning_api/api/v1/config/users/$appId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PreferencesDeleteMultiplePreferenceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2310,6 +2390,7 @@ class UsersClient {
     final int offset = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2343,8 +2424,10 @@ class UsersClient {
       queryParameters['offset'] = offset.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/users';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersGetUsersResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2449,6 +2532,7 @@ class UsersClient {
     final String? manager,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2498,8 +2582,10 @@ class UsersClient {
       queryParameters['manager'] = manager;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/users';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersAddUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2572,6 +2658,7 @@ class UsersClient {
     final int offset = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2605,8 +2692,10 @@ class UsersClient {
       queryParameters['offset'] = offset.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/users/details';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/details').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersGetUsersDetailsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2674,6 +2763,7 @@ class UsersClient {
     final int offset = 0,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2704,8 +2794,10 @@ class UsersClient {
       queryParameters['offset'] = offset.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/users/disabled';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/disabled').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersGetDisabledUsersDetailsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2775,6 +2867,7 @@ class UsersClient {
     required final ContentString<BuiltMap<String, BuiltList<String>>> search,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2809,8 +2902,10 @@ class UsersClient {
       ]),
     );
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/users/search/by-phone';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/search/by-phone').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersSearchByPhoneNumbersResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2873,6 +2968,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2896,10 +2992,12 @@ class UsersClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersGetUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2972,6 +3070,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2997,10 +3096,12 @@ class UsersClient {
 // coverage:ignore-end
     queryParameters['key'] = key;
     queryParameters['value'] = value;
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersEditUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3063,6 +3164,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3086,10 +3188,12 @@ class UsersClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersDeleteUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3147,6 +3251,7 @@ class UsersClient {
   DynamiteRawResponse<UsersGetCurrentUserResponseApplicationJson, void> getCurrentUserRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3171,8 +3276,10 @@ class UsersClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/user';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/user').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersGetCurrentUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3230,6 +3337,7 @@ class UsersClient {
   DynamiteRawResponse<UsersGetEditableFieldsResponseApplicationJson, void> getEditableFieldsRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3254,8 +3362,10 @@ class UsersClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/cloud/user/fields';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/user/fields').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersGetEditableFieldsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3318,6 +3428,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3341,10 +3452,12 @@ class UsersClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/user/fields/$userId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/user/fields/{userId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersGetEditableFieldsForUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3422,6 +3535,7 @@ class UsersClient {
     required final String collectionName,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3447,16 +3561,18 @@ class UsersClient {
 // coverage:ignore-end
     queryParameters['key'] = key;
     queryParameters['value'] = value;
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     checkPattern(
       collectionName,
       RegExp(r'^(?!enable$|disable$)[a-zA-Z0-9_]*$'),
       'collectionName',
     ); // coverage:ignore-line
-    final collectionName0 = Uri.encodeQueryComponent(collectionName);
+    pathParameters['collectionName'] = collectionName;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/$collectionName0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/{collectionName}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersEditUserMultiValueResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3519,6 +3635,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3542,10 +3659,12 @@ class UsersClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/wipe';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/wipe').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersWipeUserDevicesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3608,6 +3727,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3631,10 +3751,12 @@ class UsersClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/enable';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/enable').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersEnableUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3697,6 +3819,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3720,10 +3843,12 @@ class UsersClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/disable';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/disable').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersDisableUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3786,6 +3911,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3809,10 +3935,12 @@ class UsersClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/groups';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersGetUsersGroupsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3880,6 +4008,7 @@ class UsersClient {
     final String groupid = '',
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3903,13 +4032,15 @@ class UsersClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     if (groupid != '') {
       queryParameters['groupid'] = groupid;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/groups';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersAddToGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3977,6 +4108,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4001,10 +4133,12 @@ class UsersClient {
 
 // coverage:ignore-end
     queryParameters['groupid'] = groupid;
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/groups';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersRemoveFromGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4071,6 +4205,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4094,10 +4229,12 @@ class UsersClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/subadmins';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersGetUserSubAdminGroupsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4169,6 +4306,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4193,10 +4331,12 @@ class UsersClient {
 
 // coverage:ignore-end
     queryParameters['groupid'] = groupid;
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/subadmins';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersAddSubAdminResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4268,6 +4408,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4292,10 +4433,12 @@ class UsersClient {
 
 // coverage:ignore-end
     queryParameters['groupid'] = groupid;
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/subadmins';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersRemoveSubAdminResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4358,6 +4501,7 @@ class UsersClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4381,10 +4525,12 @@ class UsersClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/cloud/users/$userId0/welcome';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/cloud/users/{userId}/welcome').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UsersResendWelcomeMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/settings.openapi.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.dart
@@ -12,6 +12,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'settings.openapi.g.dart';
 
@@ -76,6 +77,7 @@ class LogSettingsClient {
   ///  * [download] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, LogSettingsLogSettingsDownloadHeaders> downloadRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/octet-stream',
@@ -99,8 +101,10 @@ class LogSettingsClient {
     }
 
 // coverage:ignore-end
-    const path = '/index.php/settings/admin/log/download';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/settings/admin/log/download').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, LogSettingsLogSettingsDownloadHeaders>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -17,6 +17,7 @@ import 'package:dynamite_runtime/models.dart';
 import 'package:dynamite_runtime/utils.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'spreed.openapi.g.dart';
 
@@ -142,6 +143,7 @@ class AvatarClient {
     final AvatarGetAvatarApiVersion apiVersion = AvatarGetAvatarApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -164,14 +166,17 @@ class AvatarClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (darkTheme != 0) {
       queryParameters['darkTheme'] = darkTheme.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/avatar';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -241,6 +246,7 @@ class AvatarClient {
     final AvatarUploadAvatarApiVersion apiVersion = AvatarUploadAvatarApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -263,11 +269,14 @@ class AvatarClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/avatar';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AvatarUploadAvatarResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -335,6 +344,7 @@ class AvatarClient {
     final AvatarDeleteAvatarApiVersion apiVersion = AvatarDeleteAvatarApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -357,11 +367,14 @@ class AvatarClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/avatar';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AvatarDeleteAvatarResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -441,6 +454,7 @@ class AvatarClient {
     final AvatarEmojiAvatarApiVersion apiVersion = AvatarEmojiAvatarApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -464,14 +478,18 @@ class AvatarClient {
 // coverage:ignore-end
     queryParameters['emoji'] = emoji;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (color != null) {
       queryParameters['color'] = color;
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/avatar/emoji';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar/emoji').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<AvatarEmojiAvatarResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -539,6 +557,7 @@ class AvatarClient {
     final AvatarGetAvatarDarkApiVersion apiVersion = AvatarGetAvatarDarkApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -561,11 +580,15 @@ class AvatarClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/avatar/dark';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar/dark').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -669,6 +692,7 @@ class BotClient {
     final BotSendMessageApiVersion apiVersion = BotSendMessageApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -692,7 +716,7 @@ class BotClient {
 // coverage:ignore-end
     queryParameters['message'] = message;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (referenceId != '') {
       queryParameters['referenceId'] = referenceId;
     }
@@ -702,10 +726,13 @@ class BotClient {
     if (silent != 0) {
       queryParameters['silent'] = silent.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bot/$token0/message';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/message').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BotSendMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -791,6 +818,7 @@ class BotClient {
     final BotReactApiVersion apiVersion = BotReactApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -814,12 +842,16 @@ class BotClient {
 // coverage:ignore-end
     queryParameters['reaction'] = reaction;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final messageId0 = Uri.encodeQueryComponent(messageId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['messageId'] = messageId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bot/$token0/reaction/$messageId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BotReactResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -903,6 +935,7 @@ class BotClient {
     final BotDeleteReactionApiVersion apiVersion = BotDeleteReactionApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -926,12 +959,16 @@ class BotClient {
 // coverage:ignore-end
     queryParameters['reaction'] = reaction;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final messageId0 = Uri.encodeQueryComponent(messageId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['messageId'] = messageId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bot/$token0/reaction/$messageId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BotDeleteReactionResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -998,6 +1035,7 @@ class BotClient {
     final BotAdminListBotsApiVersion apiVersion = BotAdminListBotsApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1021,10 +1059,12 @@ class BotClient {
     }
 
 // coverage:ignore-end
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bot/admin';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/admin').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BotAdminListBotsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1092,6 +1132,7 @@ class BotClient {
     final BotListBotsApiVersion apiVersion = BotListBotsApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1116,11 +1157,13 @@ class BotClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bot/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BotListBotsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1197,6 +1240,7 @@ class BotClient {
     final BotEnableBotApiVersion apiVersion = BotEnableBotApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1221,12 +1265,15 @@ class BotClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final botId0 = Uri.encodeQueryComponent(botId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['botId'] = botId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bot/$token0/$botId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/{botId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BotEnableBotResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1301,6 +1348,7 @@ class BotClient {
     final BotDisableBotApiVersion apiVersion = BotDisableBotApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1325,12 +1373,15 @@ class BotClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final botId0 = Uri.encodeQueryComponent(botId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['botId'] = botId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bot/$token0/$botId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/{botId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BotDisableBotResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1421,6 +1472,7 @@ class BreakoutRoomClient {
     final BreakoutRoomConfigureBreakoutRoomsApiVersion apiVersion = BreakoutRoomConfigureBreakoutRoomsApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1447,14 +1499,18 @@ class BreakoutRoomClient {
     queryParameters['mode'] = mode.toString();
     queryParameters['amount'] = amount.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (attendeeMap != '[]') {
       queryParameters['attendeeMap'] = attendeeMap;
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/breakout-rooms/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1522,6 +1578,7 @@ class BreakoutRoomClient {
     final BreakoutRoomRemoveBreakoutRoomsApiVersion apiVersion = BreakoutRoomRemoveBreakoutRoomsApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1546,11 +1603,15 @@ class BreakoutRoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/breakout-rooms/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1627,6 +1688,7 @@ class BreakoutRoomClient {
     final BreakoutRoomBroadcastChatMessageApiVersion apiVersion = BreakoutRoomBroadcastChatMessageApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1652,11 +1714,15 @@ class BreakoutRoomClient {
 // coverage:ignore-end
     queryParameters['message'] = message;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/breakout-rooms/$token0/broadcast';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/broadcast').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BreakoutRoomBroadcastChatMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1731,6 +1797,7 @@ class BreakoutRoomClient {
     final BreakoutRoomApplyAttendeeMapApiVersion apiVersion = BreakoutRoomApplyAttendeeMapApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1756,11 +1823,15 @@ class BreakoutRoomClient {
 // coverage:ignore-end
     queryParameters['attendeeMap'] = attendeeMap;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/breakout-rooms/$token0/attendees';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/attendees').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BreakoutRoomApplyAttendeeMapResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1830,6 +1901,7 @@ class BreakoutRoomClient {
     final BreakoutRoomRequestAssistanceApiVersion apiVersion = BreakoutRoomRequestAssistanceApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1854,11 +1926,16 @@ class BreakoutRoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/breakout-rooms/$token0/request-assistance';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/request-assistance')
+          .expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BreakoutRoomRequestAssistanceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1931,6 +2008,7 @@ class BreakoutRoomClient {
         BreakoutRoomResetRequestForAssistanceApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1955,11 +2033,16 @@ class BreakoutRoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/breakout-rooms/$token0/request-assistance';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/request-assistance')
+          .expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BreakoutRoomResetRequestForAssistanceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2029,6 +2112,7 @@ class BreakoutRoomClient {
     final BreakoutRoomStartBreakoutRoomsApiVersion apiVersion = BreakoutRoomStartBreakoutRoomsApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2053,11 +2137,15 @@ class BreakoutRoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/breakout-rooms/$token0/rooms';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/rooms').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BreakoutRoomStartBreakoutRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2127,6 +2215,7 @@ class BreakoutRoomClient {
     final BreakoutRoomStopBreakoutRoomsApiVersion apiVersion = BreakoutRoomStopBreakoutRoomsApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2151,11 +2240,15 @@ class BreakoutRoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/breakout-rooms/$token0/rooms';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/rooms').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BreakoutRoomStopBreakoutRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2230,6 +2323,7 @@ class BreakoutRoomClient {
     final BreakoutRoomSwitchBreakoutRoomApiVersion apiVersion = BreakoutRoomSwitchBreakoutRoomApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2255,11 +2349,15 @@ class BreakoutRoomClient {
 // coverage:ignore-end
     queryParameters['target'] = target;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/breakout-rooms/$token0/switch';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/switch').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2333,6 +2431,7 @@ class CallClient {
     final CallGetPeersForCallApiVersion apiVersion = CallGetPeersForCallApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2355,11 +2454,13 @@ class CallClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/call/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CallGetPeersForCallResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2436,6 +2537,7 @@ class CallClient {
     final CallUpdateCallFlagsApiVersion apiVersion = CallUpdateCallFlagsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2459,11 +2561,13 @@ class CallClient {
 // coverage:ignore-end
     queryParameters['flags'] = flags.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/call/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CallUpdateCallFlagsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2555,6 +2659,7 @@ class CallClient {
     final CallJoinCallApiVersion apiVersion = CallJoinCallApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2577,7 +2682,7 @@ class CallClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (flags != null) {
       queryParameters['flags'] = flags.toString();
     }
@@ -2590,10 +2695,12 @@ class CallClient {
     if (recordingConsent != 0) {
       queryParameters['recordingConsent'] = recordingConsent.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/call/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CallJoinCallResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2668,6 +2775,7 @@ class CallClient {
     final CallLeaveCallApiVersion apiVersion = CallLeaveCallApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2690,14 +2798,16 @@ class CallClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (all != 0) {
       queryParameters['all'] = all.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/call/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CallLeaveCallResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2772,6 +2882,7 @@ class CallClient {
     final CallRingAttendeeApiVersion apiVersion = CallRingAttendeeApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2794,12 +2905,16 @@ class CallClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final attendeeId0 = Uri.encodeQueryComponent(attendeeId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['attendeeId'] = attendeeId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/call/$token0/ring/$attendeeId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/ring/{attendeeId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CallRingAttendeeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2878,6 +2993,7 @@ class CallClient {
     final CallSipDialOutApiVersion apiVersion = CallSipDialOutApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2900,12 +3016,16 @@ class CallClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final attendeeId0 = Uri.encodeQueryComponent(attendeeId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['attendeeId'] = attendeeId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/call/$token0/dialout/$attendeeId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/dialout/{attendeeId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CallSipDialOutResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2985,6 +3105,7 @@ class CertificateClient {
     final CertificateGetCertificateExpirationApiVersion apiVersion = CertificateGetCertificateExpirationApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3009,10 +3130,14 @@ class CertificateClient {
 
 // coverage:ignore-end
     queryParameters['host'] = host;
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/certificate/expiration';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/certificate/expiration').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CertificateGetCertificateExpirationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3141,6 +3266,7 @@ class ChatClient {
     final ChatReceiveMessagesApiVersion apiVersion = ChatReceiveMessagesApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3164,7 +3290,7 @@ class ChatClient {
 // coverage:ignore-end
     queryParameters['lookIntoFuture'] = lookIntoFuture.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (limit != 100) {
       queryParameters['limit'] = limit.toString();
     }
@@ -3189,10 +3315,12 @@ class ChatClient {
     if (markNotificationsAsRead != 1) {
       queryParameters['markNotificationsAsRead'] = markNotificationsAsRead.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatReceiveMessagesResponseApplicationJson, ChatChatReceiveMessagesHeaders>(
       response: _rootClient.executeRequest(
@@ -3295,6 +3423,7 @@ class ChatClient {
     final ChatSendMessageApiVersion apiVersion = ChatSendMessageApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3318,7 +3447,7 @@ class ChatClient {
 // coverage:ignore-end
     queryParameters['message'] = message;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (actorDisplayName != '') {
       queryParameters['actorDisplayName'] = actorDisplayName;
     }
@@ -3331,10 +3460,12 @@ class ChatClient {
     if (silent != 0) {
       queryParameters['silent'] = silent.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatSendMessageResponseApplicationJson, ChatChatSendMessageHeaders>(
       response: _rootClient.executeRequest(
@@ -3406,6 +3537,7 @@ class ChatClient {
     final ChatClearHistoryApiVersion apiVersion = ChatClearHistoryApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3430,11 +3562,13 @@ class ChatClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatClearHistoryResponseApplicationJson, ChatChatClearHistoryHeaders>(
       response: _rootClient.executeRequest(
@@ -3517,6 +3651,7 @@ class ChatClient {
     final ChatDeleteMessageApiVersion apiVersion = ChatDeleteMessageApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3541,12 +3676,16 @@ class ChatClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final messageId0 = Uri.encodeQueryComponent(messageId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['messageId'] = messageId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/$messageId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatDeleteMessageResponseApplicationJson, ChatChatDeleteMessageHeaders>(
       response: _rootClient.executeRequest(
@@ -3628,6 +3767,7 @@ class ChatClient {
     final ChatGetMessageContextApiVersion apiVersion = ChatGetMessageContextApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3650,15 +3790,19 @@ class ChatClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final messageId0 = Uri.encodeQueryComponent(messageId.toString());
+    pathParameters['token'] = token;
+    pathParameters['messageId'] = messageId.toString();
     if (limit != 50) {
       queryParameters['limit'] = limit.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/$messageId0/context';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/context').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatGetMessageContextResponseApplicationJson, ChatChatGetMessageContextHeaders>(
       response: _rootClient.executeRequest(
@@ -3733,6 +3877,7 @@ class ChatClient {
     final ChatGetReminderApiVersion apiVersion = ChatGetReminderApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3757,12 +3902,16 @@ class ChatClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final messageId0 = Uri.encodeQueryComponent(messageId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['messageId'] = messageId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/$messageId0/reminder';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatGetReminderResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3842,6 +3991,7 @@ class ChatClient {
     final ChatSetReminderApiVersion apiVersion = ChatSetReminderApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3867,12 +4017,16 @@ class ChatClient {
 // coverage:ignore-end
     queryParameters['timestamp'] = timestamp.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final messageId0 = Uri.encodeQueryComponent(messageId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['messageId'] = messageId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/$messageId0/reminder';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatSetReminderResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3947,6 +4101,7 @@ class ChatClient {
     final ChatDeleteReminderApiVersion apiVersion = ChatDeleteReminderApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3971,12 +4126,16 @@ class ChatClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final messageId0 = Uri.encodeQueryComponent(messageId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['messageId'] = messageId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/$messageId0/reminder';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatDeleteReminderResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4049,6 +4208,7 @@ class ChatClient {
     final ChatSetReadMarkerApiVersion apiVersion = ChatSetReadMarkerApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4074,11 +4234,14 @@ class ChatClient {
 // coverage:ignore-end
     queryParameters['lastReadMessage'] = lastReadMessage.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/read';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/read').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatSetReadMarkerResponseApplicationJson, ChatChatSetReadMarkerHeaders>(
       response: _rootClient.executeRequest(
@@ -4146,6 +4309,7 @@ class ChatClient {
     final ChatMarkUnreadApiVersion apiVersion = ChatMarkUnreadApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4170,11 +4334,14 @@ class ChatClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/read';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/read').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatMarkUnreadResponseApplicationJson, ChatChatMarkUnreadHeaders>(
       response: _rootClient.executeRequest(
@@ -4257,6 +4424,7 @@ class ChatClient {
     final ChatMentionsApiVersion apiVersion = ChatMentionsApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4280,17 +4448,21 @@ class ChatClient {
 // coverage:ignore-end
     queryParameters['search'] = search;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (limit != 20) {
       queryParameters['limit'] = limit.toString();
     }
     if (includeStatus != 0) {
       queryParameters['includeStatus'] = includeStatus.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/mentions';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/mentions').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatMentionsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4375,6 +4547,7 @@ class ChatClient {
     final ChatGetObjectsSharedInRoomApiVersion apiVersion = ChatGetObjectsSharedInRoomApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4398,17 +4571,20 @@ class ChatClient {
 // coverage:ignore-end
     queryParameters['objectType'] = objectType;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (lastKnownMessageId != 0) {
       queryParameters['lastKnownMessageId'] = lastKnownMessageId.toString();
     }
     if (limit != 100) {
       queryParameters['limit'] = limit.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/share';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatGetObjectsSharedInRoomResponseApplicationJson,
         ChatChatGetObjectsSharedInRoomHeaders>(
@@ -4514,6 +4690,7 @@ class ChatClient {
     final ChatShareObjectToChatApiVersion apiVersion = ChatShareObjectToChatApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4538,7 +4715,7 @@ class ChatClient {
     queryParameters['objectType'] = objectType;
     queryParameters['objectId'] = objectId;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (metaData != '') {
       queryParameters['metaData'] = metaData;
     }
@@ -4548,10 +4725,13 @@ class ChatClient {
     if (referenceId != '') {
       queryParameters['referenceId'] = referenceId;
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/share';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatShareObjectToChatResponseApplicationJson, ChatChatShareObjectToChatHeaders>(
       response: _rootClient.executeRequest(
@@ -4626,6 +4806,7 @@ class ChatClient {
     final ChatGetObjectsSharedInRoomOverviewApiVersion apiVersion = ChatGetObjectsSharedInRoomOverviewApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4648,14 +4829,18 @@ class ChatClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (limit != 7) {
       queryParameters['limit'] = limit.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/chat/$token0/share/overview';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share/overview').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4731,6 +4916,7 @@ class FederationClient {
     final FederationAcceptShareApiVersion apiVersion = FederationAcceptShareApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4754,11 +4940,15 @@ class FederationClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['id'] = id.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/federation/invitation/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/federation/invitation/{id}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<FederationAcceptShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4828,6 +5018,7 @@ class FederationClient {
     final FederationRejectShareApiVersion apiVersion = FederationRejectShareApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4851,11 +5042,15 @@ class FederationClient {
     }
 
 // coverage:ignore-end
-    final id0 = Uri.encodeQueryComponent(id.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['id'] = id.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/federation/invitation/$id0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/federation/invitation/{id}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<FederationRejectShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4918,6 +5113,7 @@ class FederationClient {
     final FederationGetSharesApiVersion apiVersion = FederationGetSharesApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4941,10 +5137,14 @@ class FederationClient {
     }
 
 // coverage:ignore-end
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/federation/invitation';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/federation/invitation').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<FederationGetSharesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5030,6 +5230,7 @@ class FilesIntegrationClient {
     final FilesIntegrationGetRoomByFileIdApiVersion apiVersion = FilesIntegrationGetRoomByFileIdApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5054,11 +5255,13 @@ class FilesIntegrationClient {
 
 // coverage:ignore-end
     checkPattern(fileId, RegExp(r'^.+$'), 'fileId'); // coverage:ignore-line
-    final fileId0 = Uri.encodeQueryComponent(fileId);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['fileId'] = fileId;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/file/$fileId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/file/{fileId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<FilesIntegrationGetRoomByFileIdResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5140,6 +5343,7 @@ class FilesIntegrationClient {
     final FilesIntegrationGetRoomByShareTokenApiVersion apiVersion = FilesIntegrationGetRoomByShareTokenApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5162,11 +5366,15 @@ class FilesIntegrationClient {
 
 // coverage:ignore-end
     checkPattern(shareToken, RegExp(r'^.+$'), 'shareToken'); // coverage:ignore-line
-    final shareToken0 = Uri.encodeQueryComponent(shareToken);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['shareToken'] = shareToken;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/publicshare/$shareToken0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/publicshare/{shareToken}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<FilesIntegrationGetRoomByShareTokenResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5249,6 +5457,7 @@ class GuestClient {
     final GuestSetDisplayNameApiVersion apiVersion = GuestSetDisplayNameApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5272,11 +5481,14 @@ class GuestClient {
 // coverage:ignore-end
     queryParameters['displayName'] = displayName;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/guest/$token0/name';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/guest/{token}/name').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GuestSetDisplayNameResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5378,6 +5590,7 @@ class HostedSignalingServerClient {
     final HostedSignalingServerRequestTrialApiVersion apiVersion = HostedSignalingServerRequestTrialApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5406,10 +5619,14 @@ class HostedSignalingServerClient {
     queryParameters['email'] = email;
     queryParameters['language'] = language;
     queryParameters['country'] = country;
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/hostedsignalingserver/requesttrial';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/hostedsignalingserver/requesttrial').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<HostedSignalingServerRequestTrialResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5480,6 +5697,7 @@ class HostedSignalingServerClient {
     final HostedSignalingServerDeleteAccountApiVersion apiVersion = HostedSignalingServerDeleteAccountApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5503,10 +5721,14 @@ class HostedSignalingServerClient {
     }
 
 // coverage:ignore-end
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/hostedsignalingserver/delete';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/hostedsignalingserver/delete').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<HostedSignalingServerDeleteAccountResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5580,6 +5802,7 @@ class MatterbridgeClient {
     final MatterbridgeGetBridgeOfRoomApiVersion apiVersion = MatterbridgeGetBridgeOfRoomApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5604,11 +5827,13 @@ class MatterbridgeClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bridge/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<MatterbridgeGetBridgeOfRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5688,6 +5913,7 @@ class MatterbridgeClient {
     final MatterbridgeEditBridgeOfRoomApiVersion apiVersion = MatterbridgeEditBridgeOfRoomApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5713,7 +5939,7 @@ class MatterbridgeClient {
 // coverage:ignore-end
     queryParameters['enabled'] = enabled.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (parts != null) {
       queryParameters['parts'] = _jsonSerializers.serialize(
         parts,
@@ -5724,10 +5950,12 @@ class MatterbridgeClient {
         ]),
       );
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bridge/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5797,6 +6025,7 @@ class MatterbridgeClient {
     final MatterbridgeDeleteBridgeOfRoomApiVersion apiVersion = MatterbridgeDeleteBridgeOfRoomApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5821,11 +6050,13 @@ class MatterbridgeClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bridge/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5893,6 +6124,7 @@ class MatterbridgeClient {
     final MatterbridgeGetBridgeProcessStateApiVersion apiVersion = MatterbridgeGetBridgeProcessStateApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5917,11 +6149,15 @@ class MatterbridgeClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bridge/$token0/process';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}/process').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<MatterbridgeGetBridgeProcessStateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5996,6 +6232,7 @@ class MatterbridgeSettingsClient {
     final MatterbridgeSettingsStopAllBridgesApiVersion apiVersion = MatterbridgeSettingsStopAllBridgesApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -6019,10 +6256,12 @@ class MatterbridgeSettingsClient {
     }
 
 // coverage:ignore-end
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bridge';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<MatterbridgeSettingsStopAllBridgesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6095,6 +6334,7 @@ class MatterbridgeSettingsClient {
         MatterbridgeSettingsGetMatterbridgeVersionApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -6118,10 +6358,12 @@ class MatterbridgeSettingsClient {
     }
 
 // coverage:ignore-end
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/bridge/version';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/version').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6217,6 +6459,7 @@ class PollClient {
     final PollCreatePollApiVersion apiVersion = PollCreatePollApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -6243,11 +6486,13 @@ class PollClient {
     queryParameters['resultMode'] = resultMode.toString();
     queryParameters['maxVotes'] = maxVotes.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/poll/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PollCreatePollResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6322,6 +6567,7 @@ class PollClient {
     final PollShowPollApiVersion apiVersion = PollShowPollApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -6344,12 +6590,16 @@ class PollClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final pollId0 = Uri.encodeQueryComponent(pollId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['pollId'] = pollId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/poll/$token0/$pollId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PollShowPollResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6431,6 +6681,7 @@ class PollClient {
     final PollVotePollApiVersion apiVersion = PollVotePollApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -6453,15 +6704,19 @@ class PollClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final pollId0 = Uri.encodeQueryComponent(pollId.toString());
+    pathParameters['token'] = token;
+    pathParameters['pollId'] = pollId.toString();
     if (optionIds != const <int>[]) {
       queryParameters['optionIds[]'] = optionIds.map((final e) => e.toString());
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/poll/$token0/$pollId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PollVotePollResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6542,6 +6797,7 @@ class PollClient {
     final PollClosePollApiVersion apiVersion = PollClosePollApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -6564,12 +6820,16 @@ class PollClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final pollId0 = Uri.encodeQueryComponent(pollId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['pollId'] = pollId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/poll/$token0/$pollId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PollClosePollResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6651,6 +6911,7 @@ class PublicShareAuthClient {
     final PublicShareAuthCreateRoomApiVersion apiVersion = PublicShareAuthCreateRoomApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -6673,10 +6934,12 @@ class PublicShareAuthClient {
 
 // coverage:ignore-end
     queryParameters['shareToken'] = shareToken;
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/publicshareauth';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/publicshareauth').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PublicShareAuthCreateRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6762,6 +7025,7 @@ class ReactionClient {
     final ReactionGetReactionsApiVersion apiVersion = ReactionGetReactionsApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -6784,15 +7048,19 @@ class ReactionClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final messageId0 = Uri.encodeQueryComponent(messageId.toString());
+    pathParameters['token'] = token;
+    pathParameters['messageId'] = messageId.toString();
     if (reaction != null) {
       queryParameters['reaction'] = reaction;
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/reaction/$token0/$messageId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ReactionGetReactionsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6876,6 +7144,7 @@ class ReactionClient {
     final ReactionReactApiVersion apiVersion = ReactionReactApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -6899,12 +7168,16 @@ class ReactionClient {
 // coverage:ignore-end
     queryParameters['reaction'] = reaction;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final messageId0 = Uri.encodeQueryComponent(messageId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['messageId'] = messageId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/reaction/$token0/$messageId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ReactionReactResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6986,6 +7259,7 @@ class ReactionClient {
     final ReactionDeleteApiVersion apiVersion = ReactionDeleteApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -7009,12 +7283,16 @@ class ReactionClient {
 // coverage:ignore-end
     queryParameters['reaction'] = reaction;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final messageId0 = Uri.encodeQueryComponent(messageId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['messageId'] = messageId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/reaction/$token0/$messageId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ReactionDeleteResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7096,6 +7374,7 @@ class RecordingClient {
     final RecordingGetWelcomeMessageApiVersion apiVersion = RecordingGetWelcomeMessageApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -7119,11 +7398,15 @@ class RecordingClient {
     }
 
 // coverage:ignore-end
-    final serverId0 = Uri.encodeQueryComponent(serverId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['serverId'] = serverId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/recording/welcome/$serverId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/welcome/{serverId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RecordingGetWelcomeMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7198,6 +7481,7 @@ class RecordingClient {
     final RecordingStartApiVersion apiVersion = RecordingStartApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -7223,11 +7507,14 @@ class RecordingClient {
 // coverage:ignore-end
     queryParameters['status'] = status.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/recording/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RecordingStartResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7297,6 +7584,7 @@ class RecordingClient {
     final RecordingStopApiVersion apiVersion = RecordingStopApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -7321,11 +7609,14 @@ class RecordingClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/recording/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RecordingStopResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7402,6 +7693,7 @@ class RecordingClient {
     final RecordingStoreApiVersion apiVersion = RecordingStoreApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -7425,11 +7717,15 @@ class RecordingClient {
 // coverage:ignore-end
     queryParameters['owner'] = owner;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/recording/$token0/store';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/store').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RecordingStoreResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7504,6 +7800,7 @@ class RecordingClient {
     final RecordingNotificationDismissApiVersion apiVersion = RecordingNotificationDismissApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -7529,11 +7826,15 @@ class RecordingClient {
 // coverage:ignore-end
     queryParameters['timestamp'] = timestamp.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/recording/$token0/notification';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/notification').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RecordingNotificationDismissResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7613,6 +7914,7 @@ class RecordingClient {
     final RecordingShareToChatApiVersion apiVersion = RecordingShareToChatApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -7639,11 +7941,15 @@ class RecordingClient {
     queryParameters['fileId'] = fileId.toString();
     queryParameters['timestamp'] = timestamp.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/recording/$token0/share-chat';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/share-chat').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RecordingShareToChatResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7727,6 +8033,7 @@ class RoomClient {
     final RoomGetRoomsApiVersion apiVersion = RoomGetRoomsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -7759,10 +8066,12 @@ class RoomClient {
     if (modifiedSince != 0) {
       queryParameters['modifiedSince'] = modifiedSince.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders>(
       response: _rootClient.executeRequest(
@@ -7863,6 +8172,7 @@ class RoomClient {
     final RoomCreateRoomApiVersion apiVersion = RoomCreateRoomApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -7902,10 +8212,12 @@ class RoomClient {
     if (objectId != '') {
       queryParameters['objectId'] = objectId;
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomCreateRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7973,6 +8285,7 @@ class RoomClient {
     final RoomGetListedRoomsApiVersion apiVersion = RoomGetListedRoomsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -7999,10 +8312,12 @@ class RoomClient {
     if (searchTerm != '') {
       queryParameters['searchTerm'] = searchTerm;
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/listed-room';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/listed-room').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomGetListedRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -8072,6 +8387,7 @@ class RoomClient {
     final RoomGetNoteToSelfConversationApiVersion apiVersion = RoomGetNoteToSelfConversationApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -8095,10 +8411,13 @@ class RoomClient {
     }
 
 // coverage:ignore-end
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/note-to-self';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/note-to-self').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomGetNoteToSelfConversationResponseApplicationJson,
         RoomRoomGetNoteToSelfConversationHeaders>(
@@ -8171,6 +8490,7 @@ class RoomClient {
     final RoomGetSingleRoomApiVersion apiVersion = RoomGetSingleRoomApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -8193,11 +8513,13 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomGetSingleRoomResponseApplicationJson, RoomRoomGetSingleRoomHeaders>(
       response: _rootClient.executeRequest(
@@ -8272,6 +8594,7 @@ class RoomClient {
     final RoomRenameRoomApiVersion apiVersion = RoomRenameRoomApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -8295,11 +8618,13 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['roomName'] = roomName;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomRenameRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -8369,6 +8694,7 @@ class RoomClient {
     final RoomDeleteRoomApiVersion apiVersion = RoomDeleteRoomApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -8391,11 +8717,13 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomDeleteRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -8465,6 +8793,7 @@ class RoomClient {
     final RoomGetBreakoutRoomsApiVersion apiVersion = RoomGetBreakoutRoomsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -8489,11 +8818,15 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/breakout-rooms';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/breakout-rooms').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomGetBreakoutRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -8563,6 +8896,7 @@ class RoomClient {
     final RoomMakePublicApiVersion apiVersion = RoomMakePublicApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -8587,11 +8921,14 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/public';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/public').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomMakePublicResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -8661,6 +8998,7 @@ class RoomClient {
     final RoomMakePrivateApiVersion apiVersion = RoomMakePrivateApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -8685,11 +9023,14 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/public';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/public').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomMakePrivateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -8764,6 +9105,7 @@ class RoomClient {
     final RoomSetDescriptionApiVersion apiVersion = RoomSetDescriptionApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -8787,11 +9129,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['description'] = description;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/description';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/description').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetDescriptionResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -8866,6 +9212,7 @@ class RoomClient {
     final RoomSetReadOnlyApiVersion apiVersion = RoomSetReadOnlyApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -8891,11 +9238,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['state'] = state.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/read-only';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/read-only').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetReadOnlyResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -8970,6 +9321,7 @@ class RoomClient {
     final RoomSetListableApiVersion apiVersion = RoomSetListableApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -8995,11 +9347,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['scope'] = scope.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/listable';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/listable').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetListableResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -9076,6 +9432,7 @@ class RoomClient {
     final RoomSetPasswordApiVersion apiVersion = RoomSetPasswordApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -9099,11 +9456,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['password'] = password;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/password';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/password').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetPasswordResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -9183,6 +9544,7 @@ class RoomClient {
     final RoomSetPermissionsApiVersion apiVersion = RoomSetPermissionsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -9206,13 +9568,17 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['permissions'] = permissions.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     checkPattern(mode, RegExp(r'^(call|default)$'), 'mode'); // coverage:ignore-line
-    final mode0 = Uri.encodeQueryComponent(mode);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['mode'] = mode;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/permissions/$mode0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/permissions/{mode}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetPermissionsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -9287,6 +9653,7 @@ class RoomClient {
     final RoomGetParticipantsApiVersion apiVersion = RoomGetParticipantsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -9309,14 +9676,18 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (includeStatus != 0) {
       queryParameters['includeStatus'] = includeStatus.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/participants';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>(
       response: _rootClient.executeRequest(
@@ -9400,6 +9771,7 @@ class RoomClient {
     final RoomAddParticipantToRoomApiVersion apiVersion = RoomAddParticipantToRoomApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -9425,14 +9797,18 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['newParticipant'] = newParticipant;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (source != 'users') {
       queryParameters['source'] = source;
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/participants';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomAddParticipantToRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -9512,6 +9888,7 @@ class RoomClient {
     final RoomGetBreakoutRoomParticipantsApiVersion apiVersion = RoomGetBreakoutRoomParticipantsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -9534,14 +9911,19 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (includeStatus != 0) {
       queryParameters['includeStatus'] = includeStatus.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/breakout-rooms/participants';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/breakout-rooms/participants')
+          .expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
         RoomRoomGetBreakoutRoomParticipantsHeaders>(
@@ -9614,6 +9996,7 @@ class RoomClient {
     final RoomRemoveSelfFromRoomApiVersion apiVersion = RoomRemoveSelfFromRoomApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -9638,11 +10021,15 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/participants/self';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/self').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomRemoveSelfFromRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -9721,6 +10108,7 @@ class RoomClient {
     final RoomRemoveAttendeeFromRoomApiVersion apiVersion = RoomRemoveAttendeeFromRoomApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -9744,11 +10132,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['attendeeId'] = attendeeId.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/attendees';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomRemoveAttendeeFromRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -9837,6 +10229,7 @@ class RoomClient {
     final RoomSetAttendeePermissionsApiVersion apiVersion = RoomSetAttendeePermissionsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -9862,11 +10255,15 @@ class RoomClient {
     queryParameters['method'] = method;
     queryParameters['permissions'] = permissions.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/attendees/permissions';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees/permissions').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetAttendeePermissionsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -9946,6 +10343,7 @@ class RoomClient {
     final RoomSetAllAttendeesPermissionsApiVersion apiVersion = RoomSetAllAttendeesPermissionsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -9970,11 +10368,16 @@ class RoomClient {
     queryParameters['method'] = method;
     queryParameters['permissions'] = permissions.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/attendees/permissions/all';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees/permissions/all')
+          .expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetAllAttendeesPermissionsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10058,6 +10461,7 @@ class RoomClient {
     final RoomJoinRoomApiVersion apiVersion = RoomJoinRoomApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -10080,17 +10484,21 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (password != '') {
       queryParameters['password'] = password;
     }
     if (force != 1) {
       queryParameters['force'] = force.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/participants/active';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/active').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomJoinRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10158,6 +10566,7 @@ class RoomClient {
     final RoomLeaveRoomApiVersion apiVersion = RoomLeaveRoomApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -10180,11 +10589,15 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/participants/active';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/active').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomLeaveRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10259,6 +10672,7 @@ class RoomClient {
     final RoomResendInvitationsApiVersion apiVersion = RoomResendInvitationsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -10283,14 +10697,19 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (attendeeId != null) {
       queryParameters['attendeeId'] = attendeeId.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/participants/resend-invitations';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/resend-invitations')
+          .expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomResendInvitationsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10365,6 +10784,7 @@ class RoomClient {
     final RoomSetSessionStateApiVersion apiVersion = RoomSetSessionStateApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -10388,11 +10808,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['state'] = state.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/participants/state';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/state').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetSessionStateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10471,6 +10895,7 @@ class RoomClient {
     final RoomPromoteModeratorApiVersion apiVersion = RoomPromoteModeratorApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -10494,11 +10919,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['attendeeId'] = attendeeId.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/moderators';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomPromoteModeratorResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10577,6 +11006,7 @@ class RoomClient {
     final RoomDemoteModeratorApiVersion apiVersion = RoomDemoteModeratorApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -10600,11 +11030,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['attendeeId'] = attendeeId.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/moderators';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomDemoteModeratorResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10672,6 +11106,7 @@ class RoomClient {
     final RoomAddToFavoritesApiVersion apiVersion = RoomAddToFavoritesApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -10696,11 +11131,15 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/favorite';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomAddToFavoritesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10768,6 +11207,7 @@ class RoomClient {
     final RoomRemoveFromFavoritesApiVersion apiVersion = RoomRemoveFromFavoritesApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -10792,11 +11232,15 @@ class RoomClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/favorite';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomRemoveFromFavoritesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10871,6 +11315,7 @@ class RoomClient {
     final RoomSetNotificationLevelApiVersion apiVersion = RoomSetNotificationLevelApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -10896,11 +11341,14 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['level'] = level.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/notify';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetNotificationLevelResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10975,6 +11423,7 @@ class RoomClient {
     final RoomSetNotificationCallsApiVersion apiVersion = RoomSetNotificationCallsApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -11000,11 +11449,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['level'] = level.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/notify-calls';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify-calls').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetNotificationCallsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11084,6 +11537,7 @@ class RoomClient {
     final RoomSetLobbyApiVersion apiVersion = RoomSetLobbyApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -11109,14 +11563,18 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['state'] = state.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
+    pathParameters['token'] = token;
     if (timer != null) {
       queryParameters['timer'] = timer.toString();
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/webinar/lobby';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/lobby').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetLobbyResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11197,6 +11655,7 @@ class RoomClient {
     final RoomSetsipEnabledApiVersion apiVersion = RoomSetsipEnabledApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -11222,11 +11681,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['state'] = state.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/webinar/sip';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/sip').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetsipEnabledResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11303,6 +11766,7 @@ class RoomClient {
     final RoomSetRecordingConsentApiVersion apiVersion = RoomSetRecordingConsentApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -11328,11 +11792,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['recordingConsent'] = recordingConsent.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/recording-consent';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/recording-consent').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetRecordingConsentResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11407,6 +11875,7 @@ class RoomClient {
     final RoomSetMessageExpirationApiVersion apiVersion = RoomSetMessageExpirationApiVersion.v4,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -11430,11 +11899,15 @@ class RoomClient {
 // coverage:ignore-end
     queryParameters['seconds'] = seconds.toString();
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/room/$token0/message-expiration';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/message-expiration').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<RoomSetMessageExpirationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11522,6 +11995,7 @@ class SettingsClient {
     final SettingsSetsipSettingsApiVersion apiVersion = SettingsSetsipSettingsApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -11554,10 +12028,12 @@ class SettingsClient {
     if (sharedSecret != '') {
       queryParameters['sharedSecret'] = sharedSecret;
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/settings/sip';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/sip').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SettingsSetsipSettingsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11632,6 +12108,7 @@ class SettingsClient {
     final SettingsSetUserSettingApiVersion apiVersion = SettingsSetUserSettingApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -11662,10 +12139,12 @@ class SettingsClient {
         specifiedType: const FullType(ContentString, [FullType(SettingsSetUserSettingValue)]),
       );
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/settings/user';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/user').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SettingsSetUserSettingResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11743,6 +12222,7 @@ class SignalingClient {
     final SignalingGetSettingsApiVersion apiVersion = SignalingGetSettingsApiVersion.v3,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -11767,10 +12247,13 @@ class SignalingClient {
     if (token != '') {
       queryParameters['token'] = token;
     }
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/signaling/settings';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/settings').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SignalingGetSettingsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11848,6 +12331,7 @@ class SignalingClient {
     final SignalingGetWelcomeMessageApiVersion apiVersion = SignalingGetWelcomeMessageApiVersion.v3,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -11871,11 +12355,15 @@ class SignalingClient {
     }
 
 // coverage:ignore-end
-    final serverId0 = Uri.encodeQueryComponent(serverId.toString());
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['serverId'] = serverId.toString();
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/signaling/welcome/$serverId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/welcome/{serverId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SignalingGetWelcomeMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11949,6 +12437,7 @@ class SignalingClient {
     final SignalingPullMessagesApiVersion apiVersion = SignalingPullMessagesApiVersion.v3,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -11971,11 +12460,14 @@ class SignalingClient {
 
 // coverage:ignore-end
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/signaling/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SignalingPullMessagesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -12050,6 +12542,7 @@ class SignalingClient {
     final SignalingSendMessagesApiVersion apiVersion = SignalingSendMessagesApiVersion.v3,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -12073,11 +12566,14 @@ class SignalingClient {
 // coverage:ignore-end
     queryParameters['messages'] = messages;
     checkPattern(token, RegExp(r'^[a-z0-9]{4,30}$'), 'token'); // coverage:ignore-line
-    final token0 = Uri.encodeQueryComponent(token);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['token'] = token;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/spreed/api/$apiVersion0/signaling/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri =
+        Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SignalingSendMessagesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -12143,6 +12639,7 @@ class TempAvatarClient {
   DynamiteRawResponse<TempAvatarPostAvatarResponseApplicationJson, void> postAvatarRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -12167,8 +12664,10 @@ class TempAvatarClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/spreed/temp-user-avatar';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/temp-user-avatar').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TempAvatarPostAvatarResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -12228,6 +12727,7 @@ class TempAvatarClient {
   DynamiteRawResponse<TempAvatarDeleteAvatarResponseApplicationJson, void> deleteAvatarRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -12252,8 +12752,10 @@ class TempAvatarClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/spreed/temp-user-avatar';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/spreed/temp-user-avatar').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<TempAvatarDeleteAvatarResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -15,6 +15,7 @@ import 'package:dynamite_runtime/http_client.dart';
 import 'package:dynamite_runtime/utils.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'theming.openapi.g.dart';
 
@@ -91,6 +92,7 @@ class IconClient {
   ///  * [getFavicon] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getFaviconRaw({final String app = 'core'}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'image/x-icon',
@@ -112,9 +114,11 @@ class IconClient {
     }
 
 // coverage:ignore-end
-    final app0 = Uri.encodeQueryComponent(app);
-    final path = '/index.php/apps/theming/favicon/$app0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['app'] = app;
+    var uri = Uri.parse(UriTemplate('/index.php/apps/theming/favicon/{app}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -172,6 +176,7 @@ class IconClient {
   ///  * [getTouchIcon] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getTouchIconRaw({final String app = 'core'}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'image/png',
@@ -193,9 +198,11 @@ class IconClient {
     }
 
 // coverage:ignore-end
-    final app0 = Uri.encodeQueryComponent(app);
-    final path = '/index.php/apps/theming/icon/$app0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['app'] = app;
+    var uri = Uri.parse(UriTemplate('/index.php/apps/theming/icon/{app}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -262,6 +269,7 @@ class IconClient {
     required final String app,
     required final String image,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'image/svg+xml',
@@ -283,11 +291,13 @@ class IconClient {
     }
 
 // coverage:ignore-end
-    final app0 = Uri.encodeQueryComponent(app);
+    pathParameters['app'] = app;
     checkPattern(image, RegExp(r'^.+$'), 'image'); // coverage:ignore-line
-    final image0 = Uri.encodeQueryComponent(image);
-    final path = '/index.php/apps/theming/img/$app0/$image0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['image'] = image;
+    var uri = Uri.parse(UriTemplate('/index.php/apps/theming/img/{app}/{image}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -365,6 +375,7 @@ class ThemingClient {
     final int plain = 0,
     final int withCustomCss = 0,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'text/css',
@@ -386,15 +397,17 @@ class ThemingClient {
     }
 
 // coverage:ignore-end
-    final themeId0 = Uri.encodeQueryComponent(themeId);
+    pathParameters['themeId'] = themeId;
     if (plain != 0) {
       queryParameters['plain'] = plain.toString();
     }
     if (withCustomCss != 0) {
       queryParameters['withCustomCss'] = withCustomCss.toString();
     }
-    final path = '/index.php/apps/theming/theme/$themeId0.css';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/theming/theme/{themeId}.css').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<String, void>(
       response: _rootClient.executeRequest(
@@ -461,6 +474,7 @@ class ThemingClient {
     required final String key,
     final int useSvg = 1,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -482,12 +496,14 @@ class ThemingClient {
     }
 
 // coverage:ignore-end
-    final key0 = Uri.encodeQueryComponent(key);
+    pathParameters['key'] = key;
     if (useSvg != 1) {
       queryParameters['useSvg'] = useSvg.toString();
     }
-    final path = '/index.php/apps/theming/image/$key0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/theming/image/{key}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -543,6 +559,7 @@ class ThemingClient {
   ///  * [getManifest] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ThemingGetManifestResponseApplicationJson, void> getManifestRaw({required final String app}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -564,9 +581,11 @@ class ThemingClient {
     }
 
 // coverage:ignore-end
-    final app0 = Uri.encodeQueryComponent(app);
-    final path = '/index.php/apps/theming/manifest/$app0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['app'] = app;
+    var uri = Uri.parse(UriTemplate('/index.php/apps/theming/manifest/{app}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ThemingGetManifestResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -628,6 +647,7 @@ class UserThemeClient {
   ///  * [getBackground] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getBackgroundRaw({final bool oCSAPIRequest = true}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -652,8 +672,10 @@ class UserThemeClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/index.php/apps/theming/background';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/theming/background').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -730,6 +752,7 @@ class UserThemeClient {
     final String? color,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -753,7 +776,7 @@ class UserThemeClient {
     }
 
 // coverage:ignore-end
-    final type0 = Uri.encodeQueryComponent(type);
+    pathParameters['type'] = type;
     if (value != '') {
       queryParameters['value'] = value;
     }
@@ -761,8 +784,10 @@ class UserThemeClient {
       queryParameters['color'] = color;
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/index.php/apps/theming/background/$type0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/theming/background/{type}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Background, void>(
       response: _rootClient.executeRequest(
@@ -816,6 +841,7 @@ class UserThemeClient {
   ///  * [deleteBackground] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Background, void> deleteBackgroundRaw({final bool oCSAPIRequest = true}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -840,8 +866,10 @@ class UserThemeClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/index.php/apps/theming/background/custom';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/theming/background/custom').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<Background, void>(
       response: _rootClient.executeRequest(
@@ -908,6 +936,7 @@ class UserThemeClient {
     required final String themeId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -931,10 +960,12 @@ class UserThemeClient {
     }
 
 // coverage:ignore-end
-    final themeId0 = Uri.encodeQueryComponent(themeId);
+    pathParameters['themeId'] = themeId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/theming/api/v1/theme/$themeId0/enable';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/theming/api/v1/theme/{themeId}/enable').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UserThemeEnableThemeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1001,6 +1032,7 @@ class UserThemeClient {
     required final String themeId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1024,10 +1056,12 @@ class UserThemeClient {
     }
 
 // coverage:ignore-end
-    final themeId0 = Uri.encodeQueryComponent(themeId);
+    pathParameters['themeId'] = themeId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/theming/api/v1/theme/$themeId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/theming/api/v1/theme/{themeId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UserThemeDisableThemeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
@@ -13,6 +13,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'updatenotification.openapi.g.dart';
 
@@ -101,6 +102,7 @@ class ApiClient {
     final ApiGetAppListApiVersion apiVersion = ApiGetAppListApiVersion.v1,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -124,11 +126,15 @@ class ApiClient {
     }
 
 // coverage:ignore-end
-    final newVersion0 = Uri.encodeQueryComponent(newVersion);
-    final apiVersion0 = Uri.encodeQueryComponent(apiVersion.name);
+    pathParameters['newVersion'] = newVersion;
+    pathParameters['apiVersion'] = apiVersion.name;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/updatenotification/api/$apiVersion0/applist/$newVersion0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/updatenotification/api/{apiVersion}/applist/{newVersion}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<ApiGetAppListResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/uppush.openapi.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.dart
@@ -13,6 +13,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'uppush.openapi.g.dart';
 
@@ -65,6 +66,7 @@ class Client extends DynamiteClient {
   ///  * [check] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CheckResponseApplicationJson, void> checkRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -88,8 +90,10 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    const path = '/index.php/apps/uppush';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CheckResponseApplicationJson, void>(
       response: executeRequest(
@@ -149,6 +153,7 @@ class Client extends DynamiteClient {
   ///  * [setKeepalive] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SetKeepaliveResponseApplicationJson, void> setKeepaliveRaw({required final int keepalive}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -173,8 +178,10 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-end
     queryParameters['keepalive'] = keepalive.toString();
-    const path = '/index.php/apps/uppush/keepalive';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush/keepalive').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SetKeepaliveResponseApplicationJson, void>(
       response: executeRequest(
@@ -230,6 +237,7 @@ class Client extends DynamiteClient {
   ///  * [createDevice] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CreateDeviceResponseApplicationJson, void> createDeviceRaw({required final String deviceName}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -254,8 +262,10 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-end
     queryParameters['deviceName'] = deviceName;
-    const path = '/index.php/apps/uppush/device';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush/device').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CreateDeviceResponseApplicationJson, void>(
       response: executeRequest(
@@ -307,6 +317,7 @@ class Client extends DynamiteClient {
   ///  * [syncDevice] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SyncDeviceResponseApplicationJson, void> syncDeviceRaw({required final String deviceId}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -330,9 +341,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final deviceId0 = Uri.encodeQueryComponent(deviceId);
-    final path = '/index.php/apps/uppush/device/$deviceId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['deviceId'] = deviceId;
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush/device/{deviceId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<SyncDeviceResponseApplicationJson, void>(
       response: executeRequest(
@@ -382,6 +395,7 @@ class Client extends DynamiteClient {
   ///  * [deleteDevice] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DeleteDeviceResponseApplicationJson, void> deleteDeviceRaw({required final String deviceId}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -405,9 +419,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final deviceId0 = Uri.encodeQueryComponent(deviceId);
-    final path = '/index.php/apps/uppush/device/$deviceId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['deviceId'] = deviceId;
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush/device/{deviceId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DeleteDeviceResponseApplicationJson, void>(
       response: executeRequest(
@@ -470,6 +486,7 @@ class Client extends DynamiteClient {
     required final String deviceId,
     required final String appName,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -495,8 +512,10 @@ class Client extends DynamiteClient {
 // coverage:ignore-end
     queryParameters['deviceId'] = deviceId;
     queryParameters['appName'] = appName;
-    const path = '/index.php/apps/uppush/app';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush/app').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<CreateAppResponseApplicationJson, void>(
       response: executeRequest(
@@ -544,6 +563,7 @@ class Client extends DynamiteClient {
   ///  * [deleteApp] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DeleteAppResponseApplicationJson, void> deleteAppRaw({required final String token}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -567,9 +587,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final token0 = Uri.encodeQueryComponent(token);
-    final path = '/index.php/apps/uppush/app/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['token'] = token;
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush/app/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<DeleteAppResponseApplicationJson, void>(
       response: executeRequest(
@@ -621,6 +643,7 @@ class Client extends DynamiteClient {
   DynamiteRawResponse<UnifiedpushDiscoveryResponseApplicationJson, void> unifiedpushDiscoveryRaw({
     required final String token,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -644,9 +667,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final token0 = Uri.encodeQueryComponent(token);
-    final path = '/index.php/apps/uppush/push/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['token'] = token;
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush/push/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UnifiedpushDiscoveryResponseApplicationJson, void>(
       response: executeRequest(
@@ -694,6 +719,7 @@ class Client extends DynamiteClient {
   ///  * [push] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PushResponseApplicationJson, void> pushRaw({required final String token}) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -717,9 +743,11 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    final token0 = Uri.encodeQueryComponent(token);
-    final path = '/index.php/apps/uppush/push/$token0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    pathParameters['token'] = token;
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush/push/{token}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PushResponseApplicationJson, void>(
       response: executeRequest(
@@ -765,6 +793,7 @@ class Client extends DynamiteClient {
   ///  * [gatewayMatrixDiscovery] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GatewayMatrixDiscoveryResponseApplicationJson, void> gatewayMatrixDiscoveryRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -788,8 +817,10 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    const path = '/index.php/apps/uppush/gateway/matrix';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush/gateway/matrix').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GatewayMatrixDiscoveryResponseApplicationJson, void>(
       response: executeRequest(
@@ -835,6 +866,7 @@ class Client extends DynamiteClient {
   ///  * [gatewayMatrix] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GatewayMatrixResponseApplicationJson, void> gatewayMatrixRaw() {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -858,8 +890,10 @@ class Client extends DynamiteClient {
     }
 
 // coverage:ignore-end
-    const path = '/index.php/apps/uppush/gateway/matrix';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/index.php/apps/uppush/gateway/matrix').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<GatewayMatrixResponseApplicationJson, void>(
       response: executeRequest(

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -14,6 +14,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'user_status.openapi.g.dart';
 
@@ -103,6 +104,7 @@ class HeartbeatClient {
     required final String status,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -128,8 +130,10 @@ class HeartbeatClient {
 // coverage:ignore-end
     queryParameters['status'] = status;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/user_status/api/v1/heartbeat';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/user_status/api/v1/heartbeat').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<HeartbeatHeartbeatResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -193,6 +197,7 @@ class PredefinedStatusClient {
   DynamiteRawResponse<PredefinedStatusFindAllResponseApplicationJson, void> findAllRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -217,8 +222,10 @@ class PredefinedStatusClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/user_status/api/v1/predefined_statuses';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/user_status/api/v1/predefined_statuses').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<PredefinedStatusFindAllResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -292,6 +299,7 @@ class StatusesClient {
     final int? offset,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -322,8 +330,10 @@ class StatusesClient {
       queryParameters['offset'] = offset.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/user_status/api/v1/statuses';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<StatusesFindAllResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -388,6 +398,7 @@ class StatusesClient {
     required final String userId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -411,10 +422,12 @@ class StatusesClient {
     }
 
 // coverage:ignore-end
-    final userId0 = Uri.encodeQueryComponent(userId);
+    pathParameters['userId'] = userId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/user_status/api/v1/statuses/$userId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses/{userId}').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<StatusesFindResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -480,6 +493,7 @@ class UserStatusClient {
   DynamiteRawResponse<UserStatusGetStatusResponseApplicationJson, void> getStatusRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -504,8 +518,10 @@ class UserStatusClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/user_status/api/v1/user_status';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UserStatusGetStatusResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -570,6 +586,7 @@ class UserStatusClient {
     required final String statusType,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -595,8 +612,10 @@ class UserStatusClient {
 // coverage:ignore-end
     queryParameters['statusType'] = statusType;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/user_status/api/v1/user_status/status';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/status').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UserStatusSetStatusResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -666,6 +685,7 @@ class UserStatusClient {
     final int? clearAt,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -694,8 +714,12 @@ class UserStatusClient {
       queryParameters['clearAt'] = clearAt.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/user_status/api/v1/user_status/message/predefined';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/message/predefined').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UserStatusSetPredefinedMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -770,6 +794,7 @@ class UserStatusClient {
     final int? clearAt,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -803,8 +828,12 @@ class UserStatusClient {
       queryParameters['clearAt'] = clearAt.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/user_status/api/v1/user_status/message/custom';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/message/custom').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UserStatusSetCustomMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -862,6 +891,7 @@ class UserStatusClient {
   DynamiteRawResponse<UserStatusClearMessageResponseApplicationJson, void> clearMessageRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -886,8 +916,10 @@ class UserStatusClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/user_status/api/v1/user_status/message';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/message').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UserStatusClearMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -950,6 +982,7 @@ class UserStatusClient {
     required final String messageId,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -973,10 +1006,14 @@ class UserStatusClient {
     }
 
 // coverage:ignore-end
-    final messageId0 = Uri.encodeQueryComponent(messageId);
+    pathParameters['messageId'] = messageId;
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    final path = '/ocs/v2.php/apps/user_status/api/v1/user_status/revert/$messageId0';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(
+      UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/revert/{messageId}').expand(pathParameters),
+    );
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<UserStatusRevertStatusResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -13,6 +13,7 @@ import 'package:dynamite_runtime/built_value.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:meta/meta.dart';
 import 'package:universal_io/io.dart';
+import 'package:uri/uri.dart';
 
 part 'weather_status.openapi.g.dart';
 
@@ -90,6 +91,7 @@ class WeatherStatusClient {
     required final int mode,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -115,8 +117,10 @@ class WeatherStatusClient {
 // coverage:ignore-end
     queryParameters['mode'] = mode.toString();
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/weather_status/api/v1/mode';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/mode').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<WeatherStatusSetModeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -174,6 +178,7 @@ class WeatherStatusClient {
   DynamiteRawResponse<WeatherStatusUsePersonalAddressResponseApplicationJson, void> usePersonalAddressRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -198,8 +203,10 @@ class WeatherStatusClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/weather_status/api/v1/use-personal';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/use-personal').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<WeatherStatusUsePersonalAddressResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -257,6 +264,7 @@ class WeatherStatusClient {
   DynamiteRawResponse<WeatherStatusGetLocationResponseApplicationJson, void> getLocationRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -281,8 +289,10 @@ class WeatherStatusClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/weather_status/api/v1/location';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/location').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<WeatherStatusGetLocationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -355,6 +365,7 @@ class WeatherStatusClient {
     final double? lon,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -388,8 +399,10 @@ class WeatherStatusClient {
       queryParameters['lon'] = lon.toString();
     }
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/weather_status/api/v1/location';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/location').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<WeatherStatusSetLocationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -449,6 +462,7 @@ class WeatherStatusClient {
   DynamiteRawResponse<WeatherStatusGetForecastResponseApplicationJson, void> getForecastRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -473,8 +487,10 @@ class WeatherStatusClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/weather_status/api/v1/forecast';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/forecast').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<WeatherStatusGetForecastResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -532,6 +548,7 @@ class WeatherStatusClient {
   DynamiteRawResponse<WeatherStatusGetFavoritesResponseApplicationJson, void> getFavoritesRaw({
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -556,8 +573,10 @@ class WeatherStatusClient {
 
 // coverage:ignore-end
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/weather_status/api/v1/favorites';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/favorites').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<WeatherStatusGetFavoritesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -620,6 +639,7 @@ class WeatherStatusClient {
     required final List<String> favorites,
     final bool oCSAPIRequest = true,
   }) {
+    final pathParameters = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -645,8 +665,10 @@ class WeatherStatusClient {
 // coverage:ignore-end
     queryParameters['favorites[]'] = favorites.map((final e) => e);
     headers['OCS-APIRequest'] = oCSAPIRequest.toString();
-    const path = '/ocs/v2.php/apps/weather_status/api/v1/favorites';
-    final uri = Uri(path: path, queryParameters: queryParameters.isNotEmpty ? queryParameters : null);
+    var uri = Uri.parse(UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/favorites').expand(pathParameters));
+    if (queryParameters.isNotEmpty) {
+      uri = uri.replace(queryParameters: queryParameters);
+    }
 
     return DynamiteRawResponse<WeatherStatusSetFavoritesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(

--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   json_annotation: ^4.8.1
   meta: ^1.0.0
   universal_io: ^2.0.0
+  uri: ^1.0.0
   version: ^3.0.0
   xml: ^6.0.0
   xml_annotation: ^2.1.0


### PR DESCRIPTION
https://github.com/nextcloud/neon/issues/1097

I'm not sure if this really a good improvement but at least it makes our code a little less complex. It would be possible to also put the query parameters into the template, but I think there the risk to introduce bugs is higher than with the current way.

@Leptopoda I'm not sure if you wanted something more from this or not.

I have some ideas to refactor the parameter serialization code to remove make it cleaner, but that's not related to this change.