### PR TITLE
fix(nextcloud): Only advertise server 27.1 compatibility

### DIFF
--- a/packages/nextcloud/lib/src/helpers/core.dart
+++ b/packages/nextcloud/lib/src/helpers/core.dart
@@ -5,7 +5,7 @@ import 'package:nextcloud/src/helpers/common.dart';
 import 'package:version/version.dart';
 
 /// Minimum version of core/Server supported
-final minVersion = Version(27, 0, 0);
+final minVersion = Version(27, 1, 0);
 
 extension CoreVersionCheck on core.Client {
   /// Check if the core/Server version is supported by this client


### PR DESCRIPTION
We actually don't support 27.0 because of the new dashboard API.
Will be fixed with https://github.com/nextcloud/neon/issues/571