### PR TITLE
fix(nextcloud): Only advertise spreed 17.1 compatibility

### DIFF
--- a/packages/nextcloud/lib/src/helpers/spreed.dart
+++ b/packages/nextcloud/lib/src/helpers/spreed.dart
@@ -4,7 +4,7 @@ import 'package:nextcloud/src/api/spreed.openapi.dart' as spreed;
 import 'package:version/version.dart';
 
 /// The minimum version of the spreed app that is supported.
-final minVersion = Version(17, 0, 0);
+final minVersion = Version(17, 1, 0);
 
 /// Extension for checking whether spreed is supported.
 extension SpreedVersionCheck on spreed.Client {


### PR DESCRIPTION
Same as https://github.com/nextcloud/neon/pull/1187
Will be fixed with https://github.com/nextcloud/neon/issues/571