### PR TITLE
fix(dynamite): serialization of someOfs with an array member

### DIFF
--- a/packages/dynamite/dynamite/lib/src/builder/serializer.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/serializer.dart
@@ -62,7 +62,17 @@ List<Spec> buildSerializer(State state) => [
               ])
               .cascade('addPlugin')
               .call([
-                refer('StandardJsonPlugin', 'package:built_value/standard_json_plugin.dart').newInstance(const []),
+                refer('StandardJsonPlugin', 'package:built_value/standard_json_plugin.dart').newInstance(const [], {
+                  if (state.uniqueSomeOfTypes.isNotEmpty)
+                    'typesToLeaveAsList': literalConstSet(
+                      state.uniqueSomeOfTypes
+                          .where((e) => e.optimizedSubTypes.length > 1)
+                          .map(
+                            (e) => refer('_${e.typeName}'),
+                          )
+                          .toSet(),
+                    ),
+                }),
               ])
               .cascade('addPlugin')
               .call([refer('HeaderPlugin', 'package:dynamite_runtime/built_value.dart').constInstance(const [])])

--- a/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.dart
@@ -407,7 +407,15 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i3.DynamiteDoubleSerializer())
-      ..addPlugin(_i4.StandardJsonPlugin())
+      ..addPlugin(
+        _i4.StandardJsonPlugin(
+          typesToLeaveAsList: const {
+            _$0c9017d9a03ba2eb2f15acadeab85bbe,
+            _$fba45e085ee99d64c5141852d4323e3d,
+            _$b6d67dc2a96424d2f407f8e51557f3de,
+          },
+        ),
+      )
       ..addPlugin(const _i3.HeaderPlugin())
       ..addPlugin(const _i3.ContentStringPlugin()))
     .build();

--- a/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
@@ -440,7 +440,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())
-      ..addPlugin(_i6.StandardJsonPlugin())
+      ..addPlugin(_i6.StandardJsonPlugin(typesToLeaveAsList: const {_$b2c4857c0136baea42828d89c87c757d}))
       ..addPlugin(const _i5.HeaderPlugin())
       ..addPlugin(const _i5.ContentStringPlugin()))
     .build();

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
@@ -718,7 +718,17 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i3.DynamiteDoubleSerializer())
-      ..addPlugin(_i4.StandardJsonPlugin())
+      ..addPlugin(
+        _i4.StandardJsonPlugin(
+          typesToLeaveAsList: const {
+            _$fc0451dbdd462718bd075afd2e3ce0ec,
+            _$ce3c7b262d1c503446a436c461be5be9,
+            _$8da5087c0b3f2cce06998d453af8ad19,
+            _$523892e2348458a2bdb28f9f942dca37,
+            _$abe6d27882a5771a98ede04cd64de567,
+          },
+        ),
+      )
       ..addPlugin(const _i3.HeaderPlugin())
       ..addPlugin(const _i3.ContentStringPlugin()))
     .build();

--- a/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.dart
@@ -8,7 +8,9 @@
 /// one of test Version: 0.0.1.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
+import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart' as _i4;
 import 'package:dynamite_runtime/built_value.dart' as _i3;
@@ -135,6 +137,68 @@ abstract class OneObjectOneOf0 implements $OneObjectOneOf0Interface, Built<OneOb
 /// One of with an integer, double and other value.
 typedef OneOfIntDoubleOther = ({num? $num, String? string});
 
+@BuiltValue(instantiable: false)
+abstract interface class $OneOfUnspecifiedArray0Interface {
+  @BuiltValueField(wireName: 'attribute-oneOf')
+  String get attributeOneOf;
+}
+
+abstract class OneOfUnspecifiedArray0
+    implements $OneOfUnspecifiedArray0Interface, Built<OneOfUnspecifiedArray0, OneOfUnspecifiedArray0Builder> {
+  /// Creates a new OneOfUnspecifiedArray0 object using the builder pattern.
+  factory OneOfUnspecifiedArray0([void Function(OneOfUnspecifiedArray0Builder)? b]) = _$OneOfUnspecifiedArray0;
+
+  const OneOfUnspecifiedArray0._();
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  factory OneOfUnspecifiedArray0.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+
+  /// Serializer for OneOfUnspecifiedArray0.
+  static Serializer<OneOfUnspecifiedArray0> get serializer => _$oneOfUnspecifiedArray0Serializer;
+}
+
+typedef OneOfUnspecifiedArray = ({
+  BuiltList<JsonObject>? builtListJsonObject,
+  OneOfUnspecifiedArray0? oneOfUnspecifiedArray0
+});
+
+@BuiltValue(instantiable: false)
+abstract interface class $OneOfStringArray0Interface {
+  @BuiltValueField(wireName: 'attribute-oneOf')
+  String get attributeOneOf;
+}
+
+abstract class OneOfStringArray0
+    implements $OneOfStringArray0Interface, Built<OneOfStringArray0, OneOfStringArray0Builder> {
+  /// Creates a new OneOfStringArray0 object using the builder pattern.
+  factory OneOfStringArray0([void Function(OneOfStringArray0Builder)? b]) = _$OneOfStringArray0;
+
+  const OneOfStringArray0._();
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  factory OneOfStringArray0.fromJson(Map<String, dynamic> json) => _$jsonSerializers.deserializeWith(serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+
+  /// Serializer for OneOfStringArray0.
+  static Serializer<OneOfStringArray0> get serializer => _$oneOfStringArray0Serializer;
+}
+
+typedef OneOfStringArray = ({BuiltList<String>? builtListString, OneOfStringArray0? oneOfStringArray0});
+
 /// Serialization extension for `ObjectOneOf`.
 extension $ObjectOneOfExtension on ObjectOneOf {
   /// Serializer for ObjectOneOf.
@@ -169,6 +233,30 @@ extension $OneOfIntDoubleOtherExtension on OneOfIntDoubleOther {
   ///
   /// Use `toJson` to serialize it back into json.
   static OneOfIntDoubleOther fromJson(Object? json) => $b6d67dc2a96424d2f407f8e51557f3deExtension._fromJson(json);
+}
+
+/// Serialization extension for `OneOfUnspecifiedArray`.
+extension $OneOfUnspecifiedArrayExtension on OneOfUnspecifiedArray {
+  /// Serializer for OneOfUnspecifiedArray.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<OneOfUnspecifiedArray> get serializer => $00f31f9753d01398a2c3705cd335c56eExtension._serializer;
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use `toJson` to serialize it back into json.
+  static OneOfUnspecifiedArray fromJson(Object? json) => $00f31f9753d01398a2c3705cd335c56eExtension._fromJson(json);
+}
+
+/// Serialization extension for `OneOfStringArray`.
+extension $OneOfStringArrayExtension on OneOfStringArray {
+  /// Serializer for OneOfStringArray.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<OneOfStringArray> get serializer => $5fb8a7f8bbb305dd61a4a05d6996c58bExtension._serializer;
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use `toJson` to serialize it back into json.
+  static OneOfStringArray fromJson(Object? json) => $5fb8a7f8bbb305dd61a4a05d6996c58bExtension._fromJson(json);
 }
 
 typedef _$6c828020e1dac1d58ded0a29ef8b0c41 = ({ObjectOneOf0? objectOneOf0, ObjectOneOf1? objectOneOf1});
@@ -378,6 +466,156 @@ class _$b6d67dc2a96424d2f407f8e51557f3deSerializer implements PrimitiveSerialize
   }
 }
 
+typedef _$00f31f9753d01398a2c3705cd335c56e = ({
+  BuiltList<JsonObject>? builtListJsonObject,
+  OneOfUnspecifiedArray0? oneOfUnspecifiedArray0
+});
+
+/// @nodoc
+// ignore: library_private_types_in_public_api
+extension $00f31f9753d01398a2c3705cd335c56eExtension on _$00f31f9753d01398a2c3705cd335c56e {
+  List<dynamic> get _values => [builtListJsonObject, oneOfUnspecifiedArray0];
+
+  /// {@macro Dynamite.validateOneOf}
+  void validateOneOf() => _i1.validateOneOf(_values);
+
+  /// {@macro Dynamite.validateAnyOf}
+  void validateAnyOf() => _i1.validateAnyOf(_values);
+  static Serializer<_$00f31f9753d01398a2c3705cd335c56e> get _serializer =>
+      const _$00f31f9753d01398a2c3705cd335c56eSerializer();
+  static _$00f31f9753d01398a2c3705cd335c56e _fromJson(Object? json) =>
+      _$jsonSerializers.deserializeWith(_serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Object? toJson() => _$jsonSerializers.serializeWith(_serializer, this);
+}
+
+class _$00f31f9753d01398a2c3705cd335c56eSerializer implements PrimitiveSerializer<_$00f31f9753d01398a2c3705cd335c56e> {
+  const _$00f31f9753d01398a2c3705cd335c56eSerializer();
+
+  @override
+  Iterable<Type> get types => const [_$00f31f9753d01398a2c3705cd335c56e];
+
+  @override
+  String get wireName => r'_$00f31f9753d01398a2c3705cd335c56e';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    _$00f31f9753d01398a2c3705cd335c56e object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    dynamic value;
+    value = object.builtListJsonObject;
+    if (value != null) {
+      return serializers.serialize(value, specifiedType: const FullType(BuiltList, [FullType(JsonObject)]))!;
+    }
+    value = object.oneOfUnspecifiedArray0;
+    if (value != null) {
+      return serializers.serialize(value, specifiedType: const FullType(OneOfUnspecifiedArray0))!;
+    }
+// Should not be possible after validation.
+    throw StateError('Tried to serialize without any value.');
+  }
+
+  @override
+  _$00f31f9753d01398a2c3705cd335c56e deserialize(
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    BuiltList<JsonObject>? builtListJsonObject;
+    try {
+      builtListJsonObject = serializers.deserialize(
+        data,
+        specifiedType: const FullType(BuiltList, [FullType(JsonObject)]),
+      )! as BuiltList<JsonObject>;
+    } catch (_) {}
+    OneOfUnspecifiedArray0? oneOfUnspecifiedArray0;
+    try {
+      oneOfUnspecifiedArray0 = serializers.deserialize(data, specifiedType: const FullType(OneOfUnspecifiedArray0))!
+          as OneOfUnspecifiedArray0;
+    } catch (_) {}
+    return (builtListJsonObject: builtListJsonObject, oneOfUnspecifiedArray0: oneOfUnspecifiedArray0);
+  }
+}
+
+typedef _$5fb8a7f8bbb305dd61a4a05d6996c58b = ({
+  BuiltList<String>? builtListString,
+  OneOfStringArray0? oneOfStringArray0
+});
+
+/// @nodoc
+// ignore: library_private_types_in_public_api
+extension $5fb8a7f8bbb305dd61a4a05d6996c58bExtension on _$5fb8a7f8bbb305dd61a4a05d6996c58b {
+  List<dynamic> get _values => [builtListString, oneOfStringArray0];
+
+  /// {@macro Dynamite.validateOneOf}
+  void validateOneOf() => _i1.validateOneOf(_values);
+
+  /// {@macro Dynamite.validateAnyOf}
+  void validateAnyOf() => _i1.validateAnyOf(_values);
+  static Serializer<_$5fb8a7f8bbb305dd61a4a05d6996c58b> get _serializer =>
+      const _$5fb8a7f8bbb305dd61a4a05d6996c58bSerializer();
+  static _$5fb8a7f8bbb305dd61a4a05d6996c58b _fromJson(Object? json) =>
+      _$jsonSerializers.deserializeWith(_serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Object? toJson() => _$jsonSerializers.serializeWith(_serializer, this);
+}
+
+class _$5fb8a7f8bbb305dd61a4a05d6996c58bSerializer implements PrimitiveSerializer<_$5fb8a7f8bbb305dd61a4a05d6996c58b> {
+  const _$5fb8a7f8bbb305dd61a4a05d6996c58bSerializer();
+
+  @override
+  Iterable<Type> get types => const [_$5fb8a7f8bbb305dd61a4a05d6996c58b];
+
+  @override
+  String get wireName => r'_$5fb8a7f8bbb305dd61a4a05d6996c58b';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    _$5fb8a7f8bbb305dd61a4a05d6996c58b object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    dynamic value;
+    value = object.builtListString;
+    if (value != null) {
+      return serializers.serialize(value, specifiedType: const FullType(BuiltList, [FullType(String)]))!;
+    }
+    value = object.oneOfStringArray0;
+    if (value != null) {
+      return serializers.serialize(value, specifiedType: const FullType(OneOfStringArray0))!;
+    }
+// Should not be possible after validation.
+    throw StateError('Tried to serialize without any value.');
+  }
+
+  @override
+  _$5fb8a7f8bbb305dd61a4a05d6996c58b deserialize(
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    BuiltList<String>? builtListString;
+    try {
+      builtListString = serializers.deserialize(data, specifiedType: const FullType(BuiltList, [FullType(String)]))!
+          as BuiltList<String>;
+    } catch (_) {}
+    OneOfStringArray0? oneOfStringArray0;
+    try {
+      oneOfStringArray0 =
+          serializers.deserialize(data, specifiedType: const FullType(OneOfStringArray0))! as OneOfStringArray0;
+    } catch (_) {}
+    return (builtListString: builtListString, oneOfStringArray0: oneOfStringArray0);
+  }
+}
+
 // coverage:ignore-start
 /// Serializer for all values in this library.
 ///
@@ -396,7 +634,15 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add($d1b40dfcebdca2dfa1f3e52ac98462a5Extension._serializer)
       ..addBuilderFactory(const FullType(OneObjectOneOf0), OneObjectOneOf0Builder.new)
       ..add(OneObjectOneOf0.serializer)
-      ..add($b6d67dc2a96424d2f407f8e51557f3deExtension._serializer))
+      ..add($b6d67dc2a96424d2f407f8e51557f3deExtension._serializer)
+      ..addBuilderFactory(const FullType(OneOfUnspecifiedArray0), OneOfUnspecifiedArray0Builder.new)
+      ..add(OneOfUnspecifiedArray0.serializer)
+      ..addBuilderFactory(const FullType(BuiltList, [FullType(JsonObject)]), ListBuilder<JsonObject>.new)
+      ..add($00f31f9753d01398a2c3705cd335c56eExtension._serializer)
+      ..addBuilderFactory(const FullType(OneOfStringArray0), OneOfStringArray0Builder.new)
+      ..add(OneOfStringArray0.serializer)
+      ..addBuilderFactory(const FullType(BuiltList, [FullType(String)]), ListBuilder<String>.new)
+      ..add($5fb8a7f8bbb305dd61a4a05d6996c58bExtension._serializer))
     .build();
 
 /// Serializer for all values in this library.
@@ -407,7 +653,17 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i3.DynamiteDoubleSerializer())
-      ..addPlugin(_i4.StandardJsonPlugin())
+      ..addPlugin(
+        _i4.StandardJsonPlugin(
+          typesToLeaveAsList: const {
+            _$6c828020e1dac1d58ded0a29ef8b0c41,
+            _$d1b40dfcebdca2dfa1f3e52ac98462a5,
+            _$b6d67dc2a96424d2f407f8e51557f3de,
+            _$00f31f9753d01398a2c3705cd335c56e,
+            _$5fb8a7f8bbb305dd61a4a05d6996c58b,
+          },
+        ),
+      )
       ..addPlugin(const _i3.HeaderPlugin())
       ..addPlugin(const _i3.ContentStringPlugin()))
     .build();

--- a/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.g.dart
@@ -10,6 +10,8 @@ Serializer<ObjectOneOf0> _$objectOneOf0Serializer = _$ObjectOneOf0Serializer();
 Serializer<ObjectOneOf1> _$objectOneOf1Serializer = _$ObjectOneOf1Serializer();
 Serializer<MixedOneOf1> _$mixedOneOf1Serializer = _$MixedOneOf1Serializer();
 Serializer<OneObjectOneOf0> _$oneObjectOneOf0Serializer = _$OneObjectOneOf0Serializer();
+Serializer<OneOfUnspecifiedArray0> _$oneOfUnspecifiedArray0Serializer = _$OneOfUnspecifiedArray0Serializer();
+Serializer<OneOfStringArray0> _$oneOfStringArray0Serializer = _$OneOfStringArray0Serializer();
 
 class _$ObjectOneOf0Serializer implements StructuredSerializer<ObjectOneOf0> {
   @override
@@ -146,6 +148,82 @@ class _$OneObjectOneOf0Serializer implements StructuredSerializer<OneObjectOneOf
   OneObjectOneOf0 deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = OneObjectOneOf0Builder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'attribute-oneOf':
+          result.attributeOneOf = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$OneOfUnspecifiedArray0Serializer implements StructuredSerializer<OneOfUnspecifiedArray0> {
+  @override
+  final Iterable<Type> types = const [OneOfUnspecifiedArray0, _$OneOfUnspecifiedArray0];
+  @override
+  final String wireName = 'OneOfUnspecifiedArray0';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, OneOfUnspecifiedArray0 object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'attribute-oneOf',
+      serializers.serialize(object.attributeOneOf, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  OneOfUnspecifiedArray0 deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = OneOfUnspecifiedArray0Builder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'attribute-oneOf':
+          result.attributeOneOf = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$OneOfStringArray0Serializer implements StructuredSerializer<OneOfStringArray0> {
+  @override
+  final Iterable<Type> types = const [OneOfStringArray0, _$OneOfStringArray0];
+  @override
+  final String wireName = 'OneOfStringArray0';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, OneOfStringArray0 object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'attribute-oneOf',
+      serializers.serialize(object.attributeOneOf, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  OneOfStringArray0 deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = OneOfStringArray0Builder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -502,6 +580,181 @@ class OneObjectOneOf0Builder
         _$OneObjectOneOf0._(
             attributeOneOf:
                 BuiltValueNullFieldError.checkNotNull(attributeOneOf, r'OneObjectOneOf0', 'attributeOneOf'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $OneOfUnspecifiedArray0InterfaceBuilder {
+  void replace($OneOfUnspecifiedArray0Interface other);
+  void update(void Function($OneOfUnspecifiedArray0InterfaceBuilder) updates);
+  String? get attributeOneOf;
+  set attributeOneOf(String? attributeOneOf);
+}
+
+class _$OneOfUnspecifiedArray0 extends OneOfUnspecifiedArray0 {
+  @override
+  final String attributeOneOf;
+
+  factory _$OneOfUnspecifiedArray0([void Function(OneOfUnspecifiedArray0Builder)? updates]) =>
+      (OneOfUnspecifiedArray0Builder()..update(updates))._build();
+
+  _$OneOfUnspecifiedArray0._({required this.attributeOneOf}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(attributeOneOf, r'OneOfUnspecifiedArray0', 'attributeOneOf');
+  }
+
+  @override
+  OneOfUnspecifiedArray0 rebuild(void Function(OneOfUnspecifiedArray0Builder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OneOfUnspecifiedArray0Builder toBuilder() => OneOfUnspecifiedArray0Builder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OneOfUnspecifiedArray0 && attributeOneOf == other.attributeOneOf;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, attributeOneOf.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OneOfUnspecifiedArray0')..add('attributeOneOf', attributeOneOf)).toString();
+  }
+}
+
+class OneOfUnspecifiedArray0Builder
+    implements Builder<OneOfUnspecifiedArray0, OneOfUnspecifiedArray0Builder>, $OneOfUnspecifiedArray0InterfaceBuilder {
+  _$OneOfUnspecifiedArray0? _$v;
+
+  String? _attributeOneOf;
+  String? get attributeOneOf => _$this._attributeOneOf;
+  set attributeOneOf(covariant String? attributeOneOf) => _$this._attributeOneOf = attributeOneOf;
+
+  OneOfUnspecifiedArray0Builder();
+
+  OneOfUnspecifiedArray0Builder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _attributeOneOf = $v.attributeOneOf;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OneOfUnspecifiedArray0 other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OneOfUnspecifiedArray0;
+  }
+
+  @override
+  void update(void Function(OneOfUnspecifiedArray0Builder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OneOfUnspecifiedArray0 build() => _build();
+
+  _$OneOfUnspecifiedArray0 _build() {
+    final _$result = _$v ??
+        _$OneOfUnspecifiedArray0._(
+            attributeOneOf:
+                BuiltValueNullFieldError.checkNotNull(attributeOneOf, r'OneOfUnspecifiedArray0', 'attributeOneOf'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $OneOfStringArray0InterfaceBuilder {
+  void replace($OneOfStringArray0Interface other);
+  void update(void Function($OneOfStringArray0InterfaceBuilder) updates);
+  String? get attributeOneOf;
+  set attributeOneOf(String? attributeOneOf);
+}
+
+class _$OneOfStringArray0 extends OneOfStringArray0 {
+  @override
+  final String attributeOneOf;
+
+  factory _$OneOfStringArray0([void Function(OneOfStringArray0Builder)? updates]) =>
+      (OneOfStringArray0Builder()..update(updates))._build();
+
+  _$OneOfStringArray0._({required this.attributeOneOf}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(attributeOneOf, r'OneOfStringArray0', 'attributeOneOf');
+  }
+
+  @override
+  OneOfStringArray0 rebuild(void Function(OneOfStringArray0Builder) updates) => (toBuilder()..update(updates)).build();
+
+  @override
+  OneOfStringArray0Builder toBuilder() => OneOfStringArray0Builder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OneOfStringArray0 && attributeOneOf == other.attributeOneOf;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, attributeOneOf.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OneOfStringArray0')..add('attributeOneOf', attributeOneOf)).toString();
+  }
+}
+
+class OneOfStringArray0Builder
+    implements Builder<OneOfStringArray0, OneOfStringArray0Builder>, $OneOfStringArray0InterfaceBuilder {
+  _$OneOfStringArray0? _$v;
+
+  String? _attributeOneOf;
+  String? get attributeOneOf => _$this._attributeOneOf;
+  set attributeOneOf(covariant String? attributeOneOf) => _$this._attributeOneOf = attributeOneOf;
+
+  OneOfStringArray0Builder();
+
+  OneOfStringArray0Builder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _attributeOneOf = $v.attributeOneOf;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OneOfStringArray0 other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OneOfStringArray0;
+  }
+
+  @override
+  void update(void Function(OneOfStringArray0Builder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OneOfStringArray0 build() => _build();
+
+  _$OneOfStringArray0 _build() {
+    final _$result = _$v ??
+        _$OneOfStringArray0._(
+            attributeOneOf:
+                BuiltValueNullFieldError.checkNotNull(attributeOneOf, r'OneOfStringArray0', 'attributeOneOf'));
     replace(_$result);
     return _$result;
   }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.json
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.json
@@ -117,6 +117,45 @@
                         "type": "string"
                     }
                 ]
+            },
+            "OneOfUnspecifiedArray": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "required": [
+                            "attribute-oneOf"
+                        ],
+                        "properties": {
+                            "attribute-oneOf": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "array"
+                    }
+                ]
+            },
+            "OneOfStringArray": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "required": [
+                            "attribute-oneOf"
+                        ],
+                        "properties": {
+                            "attribute-oneOf": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         }
     },

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
@@ -850,7 +850,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())
-      ..addPlugin(_i6.StandardJsonPlugin())
+      ..addPlugin(_i6.StandardJsonPlugin(typesToLeaveAsList: const {_$93403da1a64cb6a7b1597c7a05e9b2be}))
       ..addPlugin(const _i5.HeaderPlugin())
       ..addPlugin(const _i5.ContentStringPlugin()))
     .build();

--- a/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.dart
@@ -193,7 +193,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i3.DynamiteDoubleSerializer())
-      ..addPlugin(_i4.StandardJsonPlugin())
+      ..addPlugin(_i4.StandardJsonPlugin(typesToLeaveAsList: const {_$b6d67dc2a96424d2f407f8e51557f3de}))
       ..addPlugin(const _i3.HeaderPlugin())
       ..addPlugin(const _i3.ContentStringPlugin()))
     .build();

--- a/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.dart
@@ -190,7 +190,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i3.DynamiteDoubleSerializer())
-      ..addPlugin(_i4.StandardJsonPlugin())
+      ..addPlugin(_i4.StandardJsonPlugin(typesToLeaveAsList: const {_$e1c7ecea8e5fdae7b94cd86c0dc4f1ba}))
       ..addPlugin(const _i3.HeaderPlugin())
       ..addPlugin(const _i3.ContentStringPlugin()))
     .build();

--- a/packages/dynamite/dynamite_end_to_end_test/test/one_of_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/one_of_test.dart
@@ -1,3 +1,5 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
 import 'package:dynamite_end_to_end_test/one_of.openapi.dart';
 import 'package:test/test.dart';
 
@@ -109,5 +111,49 @@ void main() {
 
     expect(object.toJson(), equals(json));
     expect($OneOfIntDoubleOtherExtension.fromJson(json), equals(object));
+  });
+
+  test('OneOfUnspecifiedArray', () {
+    OneOfUnspecifiedArray object = (
+      builtListJsonObject: BuiltList([]),
+      oneOfUnspecifiedArray0: null,
+    );
+
+    Object? json = [];
+
+    expect(object.toJson(), equals(json));
+    expect($OneOfUnspecifiedArrayExtension.fromJson(json), equals(object));
+
+    object = (
+      builtListJsonObject: BuiltList([JsonObject('value1'), JsonObject('value2'), JsonObject('value3')]),
+      oneOfUnspecifiedArray0: null,
+    );
+
+    json = ['value1', 'value2', 'value3'];
+
+    expect(object.toJson(), equals(json));
+    expect($OneOfUnspecifiedArrayExtension.fromJson(json), equals(object));
+  });
+
+  test('OneOfStringArray', () {
+    OneOfStringArray object = (
+      builtListString: BuiltList<String>(),
+      oneOfStringArray0: null,
+    );
+
+    Object? json = [];
+
+    expect(object.toJson(), equals(json));
+    expect($OneOfStringArrayExtension.fromJson(json), equals(object));
+
+    object = (
+      builtListString: BuiltList<String>(['value1', 'value2', 'value3']),
+      oneOfStringArray0: null,
+    );
+
+    json = ['value1', 'value2', 'value3'];
+
+    expect(object.toJson(), equals(json));
+    expect($OneOfStringArrayExtension.fromJson(json), equals(object));
   });
 }

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -14475,7 +14475,17 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())
-      ..addPlugin(_i6.StandardJsonPlugin())
+      ..addPlugin(
+        _i6.StandardJsonPlugin(
+          typesToLeaveAsList: const {
+            _$87e48e5649cd72b4d2947aaaea13ccd8,
+            _$b2c4857c0136baea42828d89c87c757d,
+            _$46564992d3ed3482aa6c1162698aac99,
+            _$06c2e47196a84ebc3718dccf9eb4b29d,
+            _$3dc1754764311166375258bea55197c8,
+          },
+        ),
+      )
       ..addPlugin(const _i5.HeaderPlugin())
       ..addPlugin(const _i5.ContentStringPlugin()))
     .build();

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -6148,7 +6148,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())
-      ..addPlugin(_i6.StandardJsonPlugin())
+      ..addPlugin(_i6.StandardJsonPlugin(typesToLeaveAsList: const {_$07eaa0304017ba8abe7f9f20d6a736f3}))
       ..addPlugin(const _i5.HeaderPlugin())
       ..addPlugin(const _i5.ContentStringPlugin()))
     .build();

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -9099,7 +9099,17 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())
-      ..addPlugin(_i6.StandardJsonPlugin())
+      ..addPlugin(
+        _i6.StandardJsonPlugin(
+          typesToLeaveAsList: const {
+            _$c4bc4131e74e61dae681408e87e2e2bd,
+            _$b6d67dc2a96424d2f407f8e51557f3de,
+            _$b20d370ea28764b414e70ac5df151f1b,
+            _$1e1cd5e43e0a1022a23a294e58225d74,
+            _$f9d75e948689049b3f3e23e024d4be73,
+          },
+        ),
+      )
       ..addPlugin(const _i5.HeaderPlugin())
       ..addPlugin(const _i5.ContentStringPlugin()))
     .build();

--- a/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
+++ b/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
@@ -382,7 +382,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i3.DynamiteDoubleSerializer())
-      ..addPlugin(_i4.StandardJsonPlugin())
+      ..addPlugin(_i4.StandardJsonPlugin(typesToLeaveAsList: const {_$7f1b9936cf688676379074249fff891b}))
       ..addPlugin(const _i3.HeaderPlugin())
       ..addPlugin(const _i3.ContentStringPlugin()))
     .build();

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -40913,7 +40913,17 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())
-      ..addPlugin(_i6.StandardJsonPlugin())
+      ..addPlugin(
+        _i6.StandardJsonPlugin(
+          typesToLeaveAsList: const {
+            _$e620970959f428e934829e52f32b7089,
+            _$bd993fb3f40af33e8594d0d698208560,
+            _$b2c4857c0136baea42828d89c87c757d,
+            _$1df642f5035aea3b22543ab331c3fb01,
+            _$bc4aac45771b11649d372f39a92b1cf3,
+          },
+        ),
+      )
       ..addPlugin(const _i5.HeaderPlugin())
       ..addPlugin(const _i5.ContentStringPlugin()))
     .build();

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -2471,7 +2471,14 @@ final Serializers _$serializers = (Serializers().toBuilder()
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())
-      ..addPlugin(_i6.StandardJsonPlugin())
+      ..addPlugin(
+        _i6.StandardJsonPlugin(
+          typesToLeaveAsList: const {
+            _$557344b3ba734aacc7109e5420fcb6c5,
+            _$d77829de8b7590d2e16cdb714800f5be,
+          },
+        ),
+      )
       ..addPlugin(const _i5.HeaderPlugin())
       ..addPlugin(const _i5.ContentStringPlugin()))
     .build();


### PR DESCRIPTION
towards #1058 

Looks like that migrating to records already fixed the deserialization. And now only serialization is broken.
This is due to a limitation/oversight in the upstream `StandartJsonPlugin` that is responsible to convert the intermediate built_value wire format into a Json output.

```dart
  @override
  Object? afterSerialize(Object? object, FullType specifiedType) {
    if (object is List &&
        specifiedType.root != BuiltList &&
        specifiedType.root != BuiltSet &&
        specifiedType.root != JsonObject) {
      if (specifiedType.isUnspecified) {
        return _toMapWithDiscriminator(object);
      } else {
        return _toMap(object, _needsEncodedKeys(specifiedType));
      }
    } else {
      return object;
    }
  }
  ```
  
  I'll ask upstream. Maybe we can find a simple solution (I don't really want to write a replacement to the json plugin).