### PR TITLE
fix(dynamite): do not await writing the output string.

### DIFF
--- a/packages/dynamite/dynamite/lib/src/openapi_builder.dart
+++ b/packages/dynamite/dynamite/lib/src/openapi_builder.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:build/build.dart';
@@ -89,9 +90,11 @@ class OpenAPIBuilder implements Builder {
       }
 
       final formatter = DartFormatter(pageWidth: buildConfig.pageWidth);
-      await buildStep.writeAsString(
-        outputId,
-        formatter.format(outputString),
+      unawaited(
+        buildStep.writeAsString(
+          outputId,
+          formatter.format(outputString),
+        ),
       );
     } catch (e, s) {
       print(s);


### PR DESCRIPTION
from the dart builder documentation:
> NOTE: Most Builder implementations should not need to await this Future since the runner will be responsible for waiting until all outputs are written.

