### PR TITLE
chore(neon_framework): Fix license symlink

### DIFF
--- a/packages/neon_framework/LICENSE
+++ b/packages/neon_framework/LICENSE
@@ -1,1 +1,1 @@
-../../../assets/AGPL-3.0.txt
+../../assets/AGPL-3.0.txt


### PR DESCRIPTION
Forgot to adjust it in https://github.com/nextcloud/neon/pull/1230