### PR TITLE
chore(app): Remove record audio permission

### DIFF
--- a/packages/app/android/app/src/main/AndroidManifest.xml
+++ b/packages/app/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="de.provokateurin.neon">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO" tools:node="remove"/>
 
     <application
         android:label="@string/app_name"


### PR DESCRIPTION
https://github.com/nextcloud/neon/issues/566
Comes from the camera plugin, we don't need it.