### PR TITLE
nextcloud: Add Content-Length headers in WebDavClient.put

### DIFF
--- a/packages/nextcloud/lib/src/webdav/client.dart
+++ b/packages/nextcloud/lib/src/webdav/client.dart
@@ -134,7 +134,7 @@ class WebDavClient {
         headers: _getUploadHeaders(
           lastModified: lastModified,
           created: created,
-          contentLength: null,
+          contentLength: localData.length,
         ),
       );
 


### PR DESCRIPTION
Missing Content-Length causes Nextcloud to write empty files.

Please see the discussion here:
https://github.com/saber-notes/saber/issues/945#issuecomment-1848069199