### PR TITLE
feat(nextcloud): Print logs on test failure

### DIFF
--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -44,4 +44,5 @@ dev_dependencies:
   path: ^1.9.0
   process_run: ^0.13.3
   test: ^1.24.9
+  test_api: ^0.6.1
   xml_serializable: ^2.4.0

--- a/packages/nextcloud/test/core_test.dart
+++ b/packages/nextcloud/test/core_test.dart
@@ -2,6 +2,7 @@ import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
   presets('server', (final preset) {
@@ -14,7 +15,12 @@ void main() {
           container = await DockerContainer.create(preset);
           client = await TestNextcloudClient.create(container);
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         test('Is supported from capabilities', () async {
           final response = await client.core.ocs.getCapabilities();

--- a/packages/nextcloud/test/dashboard_test.dart
+++ b/packages/nextcloud/test/dashboard_test.dart
@@ -2,6 +2,7 @@ import 'package:nextcloud/dashboard.dart';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 import 'package:version/version.dart';
 
 void main() {
@@ -15,7 +16,12 @@ void main() {
           container = await DockerContainer.create(preset);
           client = await TestNextcloudClient.create(container);
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         test('Get widgets', () async {
           final response = await client.dashboard.dashboardApi.getWidgets();

--- a/packages/nextcloud/test/news_test.dart
+++ b/packages/nextcloud/test/news_test.dart
@@ -4,6 +4,7 @@ import 'package:nextcloud/news.dart' as news;
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
   presets('news', (final preset) {
@@ -16,7 +17,12 @@ void main() {
           container = await DockerContainer.create(preset);
           client = await TestNextcloudClient.create(container);
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         Future<DynamiteResponse<news.ListFeeds, void>> addWikipediaFeed([final int? folderID]) async =>
             client.news.addFeed(

--- a/packages/nextcloud/test/notes_test.dart
+++ b/packages/nextcloud/test/notes_test.dart
@@ -3,6 +3,7 @@ import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/notes.dart' as notes;
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
   presets('notes', (final preset) {
@@ -15,7 +16,12 @@ void main() {
           container = await DockerContainer.create(preset);
           client = await TestNextcloudClient.create(container);
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         test('Is supported', () async {
           final response = await client.core.ocs.getCapabilities();

--- a/packages/nextcloud/test/notifications_test.dart
+++ b/packages/nextcloud/test/notifications_test.dart
@@ -4,6 +4,7 @@ import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/notifications.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
   presets('server', (final preset) {
@@ -19,7 +20,12 @@ void main() {
             username: 'admin',
           );
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         Future<void> sendTestNotification() async {
           await client.notifications.api.generateNotification(
@@ -118,7 +124,12 @@ void main() {
               username: 'admin',
             );
           });
-          tearDown(() => container.destroy());
+          tearDown(() async {
+            if (Invoker.current!.liveTest.errors.isNotEmpty) {
+              print(await container.allLogs());
+            }
+            container.destroy();
+          });
 
           // The key size has to be 2048, other sizes are not accepted by Nextcloud (at the moment at least)
           // ignore: avoid_redundant_argument_values

--- a/packages/nextcloud/test/provisioning_api_test.dart
+++ b/packages/nextcloud/test/provisioning_api_test.dart
@@ -2,6 +2,7 @@ import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/provisioning_api.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
   presets('server', (final preset) {
@@ -17,7 +18,12 @@ void main() {
             username: 'admin',
           );
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         group('Users', () {
           test('Get current user', () async {

--- a/packages/nextcloud/test/settings_test.dart
+++ b/packages/nextcloud/test/settings_test.dart
@@ -4,6 +4,7 @@ import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/settings.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
   presets('server', (final preset) {
@@ -19,7 +20,12 @@ void main() {
             username: 'admin',
           );
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         group('Logs', () {
           test('Download', () async {

--- a/packages/nextcloud/test/spreed_test.dart
+++ b/packages/nextcloud/test/spreed_test.dart
@@ -7,6 +7,7 @@ import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/spreed.dart' as spreed;
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
   presets('spreed', (final preset) {
@@ -19,7 +20,12 @@ void main() {
           container = await DockerContainer.create(preset);
           client1 = await TestNextcloudClient.create(container);
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         Future<spreed.Room> createTestRoom() async => (await client1.spreed.room.createRoom(
               roomType: spreed.RoomType.public.value,

--- a/packages/nextcloud/test/uppush_test.dart
+++ b/packages/nextcloud/test/uppush_test.dart
@@ -2,6 +2,7 @@ import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/uppush.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
   presets('uppush', (final preset) {
@@ -17,7 +18,12 @@ void main() {
             username: 'admin',
           );
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         test('Is installed', () async {
           final response = await client.uppush.check();

--- a/packages/nextcloud/test/user_status_test.dart
+++ b/packages/nextcloud/test/user_status_test.dart
@@ -2,6 +2,7 @@ import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/user_status.dart' as user_status;
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
   presets('server', (final preset) {
@@ -14,7 +15,12 @@ void main() {
           container = await DockerContainer.create(preset);
           client = await TestNextcloudClient.create(container);
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         group('Predefined status', () {
           test('Find all', () async {

--- a/packages/nextcloud/test/webdav_test.dart
+++ b/packages/nextcloud/test/webdav_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
+import 'package:test_api/src/backend/invoker.dart';
 import 'package:universal_io/io.dart';
 
 void main() {
@@ -145,7 +146,12 @@ void main() {
           container = await DockerContainer.create(preset);
           client = await TestNextcloudClient.create(container);
         });
-        tearDown(() => container.destroy());
+        tearDown(() async {
+          if (Invoker.current!.liveTest.errors.isNotEmpty) {
+            print(await container.allLogs());
+          }
+          container.destroy();
+        });
 
         test('List directory', () async {
           final responses = (await client.webdav.propfind(

--- a/packages/nextcloud_test/lib/src/docker_container.dart
+++ b/packages/nextcloud_test/lib/src/docker_container.dart
@@ -82,18 +82,18 @@ class DockerContainer {
         ),
       );
 
-  /// Reads the server logs.
-  Future<String> serverLogs() async {
+  /// Reads the web server logs.
+  Future<String> webServerLogs() async {
     final result = await runExecutableArguments(
       'docker',
       [
         'logs',
         id,
       ],
-      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
     );
 
-    return result.stdout as String;
+    return result.stderr as String;
   }
 
   /// Reads the Nextcloud logs.
@@ -114,6 +114,6 @@ class DockerContainer {
 
   /// Reads all logs.
   ///
-  /// Combines the output of [serverLogs] and [nextcloudLogs].
-  Future<String> allLogs() async => '${await serverLogs()}\n\n${await nextcloudLogs()}';
+  /// Combines the output of [webServerLogs] and [nextcloudLogs].
+  Future<String> allLogs() async => 'Web server:\n${await webServerLogs()}\nNextcloud:\n${await nextcloudLogs()}';
 }


### PR DESCRIPTION
We don't want to use the `printOnFailure` method directly because collecting the logs is expensive and would slow down our test (especially since the logs will almost always get discarded because the tests pass).