### PR TITLE
refactor(nextcloud): Remove duplicate nested test groups

### DIFF
--- a/packages/nextcloud/test/core_test.dart
+++ b/packages/nextcloud/test/core_test.dart
@@ -5,203 +5,202 @@ import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
-  presets('server', (final preset) {
-    group(
-      'core',
-      () {
-        late DockerContainer container;
-        late NextcloudClient client;
-        setUp(() async {
-          container = await DockerContainer.create(preset);
-          client = await TestNextcloudClient.create(container);
-        });
-        tearDown(() async {
-          if (Invoker.current!.liveTest.errors.isNotEmpty) {
-            print(await container.allLogs());
-          }
-          container.destroy();
-        });
+  presets(
+    'server',
+    'core',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client;
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client = await TestNextcloudClient.create(container);
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
 
-        test('Is supported from capabilities', () async {
+      test('Is supported from capabilities', () async {
+        final response = await client.core.ocs.getCapabilities();
+
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        final result = client.core.getVersionCheck(response.body.ocs.data);
+        expect(result.versions, isNotNull);
+        expect(result.versions, isNotEmpty);
+        expect(result.isSupported, isTrue);
+      });
+
+      test('Is supported from status', () async {
+        final response = await client.core.getStatus();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.versionCheck.isSupported, isTrue);
+      });
+
+      test('Get status', () async {
+        final response = await client.core.getStatus();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.installed, isTrue);
+        expect(response.body.maintenance, isFalse);
+        expect(response.body.needsDbUpgrade, isFalse);
+        expect(response.body.version, isNotEmpty);
+        expect(response.body.versionstring, isNotEmpty);
+        expect(response.body.edition, '');
+        expect(response.body.productname, 'Nextcloud');
+        expect(response.body.extendedSupport, isFalse);
+      });
+
+      group('OCS', () {
+        test('Get capabilities', () async {
           final response = await client.core.ocs.getCapabilities();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          expect(response.body.ocs.data.capabilities.commentsCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.davCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.filesCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.filesSharingCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.filesTrashbinCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.filesVersionsCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.notesCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.notificationsCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.provisioningApiCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.sharebymailCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.spreedPublicCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.themingPublicCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.userStatusCapabilities, isNotNull);
+          expect(response.body.ocs.data.capabilities.weatherStatusCapabilities, isNotNull);
+        });
+      });
+
+      group('Navigation', () {
+        test('Get apps navigation', () async {
+          final response = await client.core.navigation.getAppsNavigation();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+          expect(response.body.ocs.data, hasLength(7));
+
+          expect(response.body.ocs.data[0].id, 'dashboard');
+          expect(response.body.ocs.data[1].id, 'files');
+          expect(response.body.ocs.data[2].id, 'photos');
+          expect(response.body.ocs.data[3].id, 'activity');
+          expect(response.body.ocs.data[4].id, 'spreed');
+          expect(response.body.ocs.data[5].id, 'notes');
+          expect(response.body.ocs.data[6].id, 'news');
+        });
+      });
+
+      group('Autocomplete', () {
+        test('Get', () async {
+          final response = await client.core.autoComplete.$get(
+            search: '',
+            itemType: 'call',
+            itemId: 'new',
+            shareTypes: [core.ShareType.group.index],
+          );
+          expect(response.body.ocs.data, hasLength(1));
+
+          expect(response.body.ocs.data[0].id, 'admin');
+          expect(response.body.ocs.data[0].label, 'admin');
+          expect(response.body.ocs.data[0].icon, '');
+          expect(response.body.ocs.data[0].source, 'groups');
+          expect(response.body.ocs.data[0].status.autocompleteResultStatus0, isNull);
+          expect(response.body.ocs.data[0].status.string, isEmpty);
+          expect(response.body.ocs.data[0].subline, '');
+          expect(response.body.ocs.data[0].shareWithDisplayNameUnique, '');
+        });
+      });
+
+      group('Preview', () {
+        test('Get', () async {
+          final response = await client.core.preview.getPreview(file: 'Nextcloud.png');
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          expect(response.body, isNotEmpty);
+        });
+      });
+
+      group('Avatar', () {
+        test('Get', () async {
+          final response = await client.core.avatar.getAvatar(userId: 'admin', size: 32);
+          expect(response.body, isNotEmpty);
+          expect(response.headers.xNcIscustomavatar?.content, 0);
+        });
+
+        test('Get dark', () async {
+          final response = await client.core.avatar.getAvatarDark(userId: 'admin', size: 32);
+          expect(response.body, isNotEmpty);
+          expect(response.headers.xNcIscustomavatar?.content, 0);
+        });
+      });
+
+      group('App password', () {
+        test('Delete', () async {
+          await client.core.appPassword.deleteAppPassword();
+          expect(
+            () => client.core.appPassword.deleteAppPassword(),
+            throwsA(predicate((final e) => (e! as DynamiteApiException).statusCode == 401)),
+          );
+        });
+      });
+
+      group('Unified search', () {
+        test('Get providers', () async {
+          final response = await client.core.unifiedSearch.getProviders();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          expect(response.body.ocs.data, isNotEmpty);
+        });
+
+        test('Search', () async {
+          final response = await client.core.unifiedSearch.search(
+            providerId: 'settings',
+            term: 'Personal info',
+          );
 
           expect(response.statusCode, 200);
           expect(() => response.headers, isA<void>());
 
-          final result = client.core.getVersionCheck(response.body.ocs.data);
-          expect(result.versions, isNotNull);
-          expect(result.versions, isNotEmpty);
-          expect(result.isSupported, isTrue);
+          expect(response.body.ocs.data.name, 'Settings');
+          expect(response.body.ocs.data.isPaginated, isFalse);
+          expect(response.body.ocs.data.entries, hasLength(1));
+          expect(response.body.ocs.data.entries.single.thumbnailUrl, isEmpty);
+          expect(response.body.ocs.data.entries.single.title, 'Personal info');
+          expect(response.body.ocs.data.entries.single.subline, isEmpty);
+          expect(response.body.ocs.data.entries.single.resourceUrl, isNotEmpty);
+          expect(response.body.ocs.data.entries.single.icon, 'icon-settings-dark');
+          expect(response.body.ocs.data.entries.single.rounded, isFalse);
+          expect(response.body.ocs.data.entries.single.attributes, isEmpty);
         });
+      });
 
-        test('Is supported from status', () async {
-          final response = await client.core.getStatus();
+      group('Client login flow V2', () {
+        test('Init and poll', () async {
+          final response = await client.core.clientFlowLoginV2.init();
           expect(response.statusCode, 200);
           expect(() => response.headers, isA<void>());
 
-          expect(response.body.versionCheck.isSupported, isTrue);
+          expect(response.body.login, startsWith('http://localhost'));
+          expect(response.body.poll.endpoint, startsWith('http://localhost'));
+          expect(response.body.poll.token, isNotEmpty);
+
+          expect(
+            () => client.core.clientFlowLoginV2.poll(token: response.body.poll.token),
+            throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 404)),
+          );
         });
-
-        test('Get status', () async {
-          final response = await client.core.getStatus();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.installed, isTrue);
-          expect(response.body.maintenance, isFalse);
-          expect(response.body.needsDbUpgrade, isFalse);
-          expect(response.body.version, isNotEmpty);
-          expect(response.body.versionstring, isNotEmpty);
-          expect(response.body.edition, '');
-          expect(response.body.productname, 'Nextcloud');
-          expect(response.body.extendedSupport, isFalse);
-        });
-
-        group('OCS', () {
-          test('Get capabilities', () async {
-            final response = await client.core.ocs.getCapabilities();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data.capabilities.commentsCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.davCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.filesCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.filesSharingCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.filesTrashbinCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.filesVersionsCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.notesCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.notificationsCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.provisioningApiCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.sharebymailCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.spreedPublicCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.themingPublicCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.userStatusCapabilities, isNotNull);
-            expect(response.body.ocs.data.capabilities.weatherStatusCapabilities, isNotNull);
-          });
-        });
-
-        group('Navigation', () {
-          test('Get apps navigation', () async {
-            final response = await client.core.navigation.getAppsNavigation();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-            expect(response.body.ocs.data, hasLength(7));
-
-            expect(response.body.ocs.data[0].id, 'dashboard');
-            expect(response.body.ocs.data[1].id, 'files');
-            expect(response.body.ocs.data[2].id, 'photos');
-            expect(response.body.ocs.data[3].id, 'activity');
-            expect(response.body.ocs.data[4].id, 'spreed');
-            expect(response.body.ocs.data[5].id, 'notes');
-            expect(response.body.ocs.data[6].id, 'news');
-          });
-        });
-
-        group('Autocomplete', () {
-          test('Get', () async {
-            final response = await client.core.autoComplete.$get(
-              search: '',
-              itemType: 'call',
-              itemId: 'new',
-              shareTypes: [core.ShareType.group.index],
-            );
-            expect(response.body.ocs.data, hasLength(1));
-
-            expect(response.body.ocs.data[0].id, 'admin');
-            expect(response.body.ocs.data[0].label, 'admin');
-            expect(response.body.ocs.data[0].icon, '');
-            expect(response.body.ocs.data[0].source, 'groups');
-            expect(response.body.ocs.data[0].status.autocompleteResultStatus0, isNull);
-            expect(response.body.ocs.data[0].status.string, isEmpty);
-            expect(response.body.ocs.data[0].subline, '');
-            expect(response.body.ocs.data[0].shareWithDisplayNameUnique, '');
-          });
-        });
-
-        group('Preview', () {
-          test('Get', () async {
-            final response = await client.core.preview.getPreview(file: 'Nextcloud.png');
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body, isNotEmpty);
-          });
-        });
-
-        group('Avatar', () {
-          test('Get', () async {
-            final response = await client.core.avatar.getAvatar(userId: 'admin', size: 32);
-            expect(response.body, isNotEmpty);
-            expect(response.headers.xNcIscustomavatar?.content, 0);
-          });
-
-          test('Get dark', () async {
-            final response = await client.core.avatar.getAvatarDark(userId: 'admin', size: 32);
-            expect(response.body, isNotEmpty);
-            expect(response.headers.xNcIscustomavatar?.content, 0);
-          });
-        });
-
-        group('App password', () {
-          test('Delete', () async {
-            await client.core.appPassword.deleteAppPassword();
-            expect(
-              () => client.core.appPassword.deleteAppPassword(),
-              throwsA(predicate((final e) => (e! as DynamiteApiException).statusCode == 401)),
-            );
-          });
-        });
-
-        group('Unified search', () {
-          test('Get providers', () async {
-            final response = await client.core.unifiedSearch.getProviders();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data, isNotEmpty);
-          });
-
-          test('Search', () async {
-            final response = await client.core.unifiedSearch.search(
-              providerId: 'settings',
-              term: 'Personal info',
-            );
-
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data.name, 'Settings');
-            expect(response.body.ocs.data.isPaginated, isFalse);
-            expect(response.body.ocs.data.entries, hasLength(1));
-            expect(response.body.ocs.data.entries.single.thumbnailUrl, isEmpty);
-            expect(response.body.ocs.data.entries.single.title, 'Personal info');
-            expect(response.body.ocs.data.entries.single.subline, isEmpty);
-            expect(response.body.ocs.data.entries.single.resourceUrl, isNotEmpty);
-            expect(response.body.ocs.data.entries.single.icon, 'icon-settings-dark');
-            expect(response.body.ocs.data.entries.single.rounded, isFalse);
-            expect(response.body.ocs.data.entries.single.attributes, isEmpty);
-          });
-        });
-
-        group('Client login flow V2', () {
-          test('Init and poll', () async {
-            final response = await client.core.clientFlowLoginV2.init();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.login, startsWith('http://localhost'));
-            expect(response.body.poll.endpoint, startsWith('http://localhost'));
-            expect(response.body.poll.token, isNotEmpty);
-
-            expect(
-              () => client.core.clientFlowLoginV2.poll(token: response.body.poll.token),
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 404)),
-            );
-          });
-        });
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+      });
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }

--- a/packages/nextcloud/test/dashboard_test.dart
+++ b/packages/nextcloud/test/dashboard_test.dart
@@ -6,54 +6,53 @@ import 'package:test_api/src/backend/invoker.dart';
 import 'package:version/version.dart';
 
 void main() {
-  presets('server', (final preset) {
-    group(
-      'dashboard',
-      () {
-        late DockerContainer container;
-        late NextcloudClient client;
-        setUp(() async {
-          container = await DockerContainer.create(preset);
-          client = await TestNextcloudClient.create(container);
-        });
-        tearDown(() async {
-          if (Invoker.current!.liveTest.errors.isNotEmpty) {
-            print(await container.allLogs());
-          }
-          container.destroy();
+  presets(
+    'server',
+    'dashboard',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client;
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client = await TestNextcloudClient.create(container);
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
+
+      test('Get widgets', () async {
+        final response = await client.dashboard.dashboardApi.getWidgets();
+        expect(
+          response.body.ocs.data.keys,
+          equals(['activity', 'notes', 'recommendations', 'spreed', 'user_status']),
+        );
+      });
+
+      group('Get widget items', () {
+        test('v1', () async {
+          final response = await client.dashboard.dashboardApi.getWidgetItems();
+          final items = response.body.ocs.data;
+          expect(items.keys, equals(['recommendations', 'spreed']));
+          expect(items['recommendations'], hasLength(7));
+          expect(items['spreed'], hasLength(0));
         });
 
-        test('Get widgets', () async {
-          final response = await client.dashboard.dashboardApi.getWidgets();
-          expect(
-            response.body.ocs.data.keys,
-            equals(['activity', 'notes', 'recommendations', 'spreed', 'user_status']),
-          );
-        });
-
-        group('Get widget items', () {
-          test('v1', () async {
-            final response = await client.dashboard.dashboardApi.getWidgetItems();
-            final items = response.body.ocs.data;
-            expect(items.keys, equals(['recommendations', 'spreed']));
-            expect(items['recommendations'], hasLength(7));
-            expect(items['spreed'], hasLength(0));
-          });
-
-          test(
-            'v2',
-            () async {
-              final response = await client.dashboard.dashboardApi.getWidgetItemsV2();
-              expect(response.body.ocs.data.keys, equals(['recommendations']));
-              final items = response.body.ocs.data['recommendations']!.items;
-              expect(items, hasLength(7));
-            },
-            skip: preset.version.toVersion() < Version(27, 1, 0),
-          );
-        });
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+        test(
+          'v2',
+          () async {
+            final response = await client.dashboard.dashboardApi.getWidgetItemsV2();
+            expect(response.body.ocs.data.keys, equals(['recommendations']));
+            final items = response.body.ocs.data['recommendations']!.items;
+            expect(items, hasLength(7));
+          },
+          skip: preset.version.toVersion() < Version(27, 1, 0),
+        );
+      });
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }

--- a/packages/nextcloud/test/news_test.dart
+++ b/packages/nextcloud/test/news_test.dart
@@ -7,429 +7,428 @@ import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
-  presets('news', (final preset) {
-    group(
-      'news',
-      () {
-        late DockerContainer container;
-        late NextcloudClient client;
-        setUp(() async {
-          container = await DockerContainer.create(preset);
-          client = await TestNextcloudClient.create(container);
-        });
-        tearDown(() async {
-          if (Invoker.current!.liveTest.errors.isNotEmpty) {
-            print(await container.allLogs());
-          }
-          container.destroy();
-        });
+  presets(
+    'news',
+    'news',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client;
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client = await TestNextcloudClient.create(container);
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
 
-        Future<DynamiteResponse<news.ListFeeds, void>> addWikipediaFeed([final int? folderID]) async =>
-            client.news.addFeed(
-              url: 'http://localhost/static/wikipedia.xml',
-              folderId: folderID,
-            );
-
-        Future<DynamiteResponse<news.ListFeeds, void>> addNasaFeed() async => client.news.addFeed(
-              url: 'http://localhost/static/nasa.xml',
-            );
-
-        test('Is supported', () async {
-          final result = await client.news.getVersionCheck();
-          expect(result.versions, isNotNull);
-          expect(result.versions, isNotEmpty);
-          expect(result.isSupported, isTrue);
-        });
-
-        test('Add feed', () async {
-          var response = await client.news.listFeeds();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.starredCount, 0);
-          expect(response.body.newestItemId, null);
-          expect(response.body.feeds, hasLength(0));
-
-          response = await addWikipediaFeed();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.starredCount, null);
-          expect(response.body.newestItemId, isNotNull);
-          expect(response.body.feeds, hasLength(1));
-          expect(response.body.feeds[0].url, 'http://localhost/static/wikipedia.xml');
-
-          response = await client.news.listFeeds();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.starredCount, 0);
-          expect(response.body.newestItemId, isNotNull);
-          expect(response.body.feeds, hasLength(1));
-          expect(response.body.feeds[0].url, 'http://localhost/static/wikipedia.xml');
-        });
-
-        test('Delete feed', () async {
-          var response = await addWikipediaFeed();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.feeds, hasLength(1));
-
-          final deleteResponse = await client.news.deleteFeed(feedId: response.body.feeds.single.id);
-          expect(deleteResponse.statusCode, 200);
-          expect(() => deleteResponse.body, isA<void>());
-          expect(() => deleteResponse.headers, isA<void>());
-
-          response = await client.news.listFeeds();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.feeds, hasLength(0));
-        });
-
-        test('Rename feed', () async {
-          var response = await addWikipediaFeed();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.feeds[0].title, 'Wikipedia featured articles feed');
-
-          await client.news.renameFeed(
-            feedId: 1,
-            feedTitle: 'test1',
+      Future<DynamiteResponse<news.ListFeeds, void>> addWikipediaFeed([final int? folderID]) async =>
+          client.news.addFeed(
+            url: 'http://localhost/static/wikipedia.xml',
+            folderId: folderID,
           );
 
-          response = await client.news.listFeeds();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.feeds[0].title, 'test1');
-        });
-
-        test('Move feed to folder', () async {
-          await client.news.createFolder(name: 'test1');
-          await addWikipediaFeed();
-          await client.news.moveFeed(
-            feedId: 1,
-            folderId: 1,
+      Future<DynamiteResponse<news.ListFeeds, void>> addNasaFeed() async => client.news.addFeed(
+            url: 'http://localhost/static/nasa.xml',
           );
 
-          final response = await client.news.listFolders();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.folders, hasLength(1));
-          expect(response.body.folders[0].id, 1);
-          expect(response.body.folders[0].name, 'test1');
-          expect(response.body.folders[0].opened, true);
-          expect(response.body.folders[0].feeds, hasLength(0));
-        });
+      test('Is supported', () async {
+        final result = await client.news.getVersionCheck();
+        expect(result.versions, isNotNull);
+        expect(result.versions, isNotEmpty);
+        expect(result.isSupported, isTrue);
+      });
+
+      test('Add feed', () async {
+        var response = await client.news.listFeeds();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.starredCount, 0);
+        expect(response.body.newestItemId, null);
+        expect(response.body.feeds, hasLength(0));
+
+        response = await addWikipediaFeed();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.starredCount, null);
+        expect(response.body.newestItemId, isNotNull);
+        expect(response.body.feeds, hasLength(1));
+        expect(response.body.feeds[0].url, 'http://localhost/static/wikipedia.xml');
+
+        response = await client.news.listFeeds();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.starredCount, 0);
+        expect(response.body.newestItemId, isNotNull);
+        expect(response.body.feeds, hasLength(1));
+        expect(response.body.feeds[0].url, 'http://localhost/static/wikipedia.xml');
+      });
+
+      test('Delete feed', () async {
+        var response = await addWikipediaFeed();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.feeds, hasLength(1));
+
+        final deleteResponse = await client.news.deleteFeed(feedId: response.body.feeds.single.id);
+        expect(deleteResponse.statusCode, 200);
+        expect(() => deleteResponse.body, isA<void>());
+        expect(() => deleteResponse.headers, isA<void>());
+
+        response = await client.news.listFeeds();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.feeds, hasLength(0));
+      });
+
+      test('Rename feed', () async {
+        var response = await addWikipediaFeed();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.feeds[0].title, 'Wikipedia featured articles feed');
+
+        await client.news.renameFeed(
+          feedId: 1,
+          feedTitle: 'test1',
+        );
+
+        response = await client.news.listFeeds();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.feeds[0].title, 'test1');
+      });
+
+      test('Move feed to folder', () async {
+        await client.news.createFolder(name: 'test1');
+        await addWikipediaFeed();
+        await client.news.moveFeed(
+          feedId: 1,
+          folderId: 1,
+        );
+
+        final response = await client.news.listFolders();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.folders, hasLength(1));
+        expect(response.body.folders[0].id, 1);
+        expect(response.body.folders[0].name, 'test1');
+        expect(response.body.folders[0].opened, true);
+        expect(response.body.folders[0].feeds, hasLength(0));
+      });
+
+      test('Mark feed as read', () async {
+        final feedsResponse = await addWikipediaFeed();
+
+        var response = await client.news.listArticles(type: news.ListType.unread.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.items.length, greaterThan(0));
+
+        await client.news.markFeedAsRead(
+          feedId: feedsResponse.body.feeds[0].id,
+          newestItemId: feedsResponse.body.newestItemId!,
+        );
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-        test('Mark feed as read', () async {
-          final feedsResponse = await addWikipediaFeed();
-
-          var response = await client.news.listArticles(type: news.ListType.unread.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.items.length, greaterThan(0));
-
-          await client.news.markFeedAsRead(
-            feedId: feedsResponse.body.feeds[0].id,
-            newestItemId: feedsResponse.body.newestItemId!,
-          );
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          response = await client.news.listArticles(type: news.ListType.unread.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.items, hasLength(0));
-        });
-
-        test('List articles', () async {
-          var response = await client.news.listArticles();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        response = await client.news.listArticles(type: news.ListType.unread.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.items, hasLength(0));
+        expect(response.body.items, hasLength(0));
+      });
 
-          await addWikipediaFeed();
+      test('List articles', () async {
+        var response = await client.news.listArticles();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          response = await client.news.listArticles();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        expect(response.body.items, hasLength(0));
 
-          expect(response.body.items.length, greaterThan(0));
-          expect(response.body.items[0].body, isNotNull);
-          expect(response.body.items[0].feedId, 1);
-          expect(response.body.items[0].unread, true);
-          expect(response.body.items[0].starred, false);
-        });
-
-        test('List updated articles', () async {
-          // Testing this is not easy, because we can't depend on an external source to update the feed
-          // Therefore we just add a second feed and check that the articles returned after a certain modified timestamp
-          // are exactly those of the new feed.
-          // Now that I think of it, maybe we could host our own feed and update that way, but this works for now.
+        await addWikipediaFeed();
 
-          await addWikipediaFeed();
-
-          var response = await client.news.listArticles();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        response = await client.news.listArticles();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          final wikipediaArticles = response.body.items.length;
-          expect(wikipediaArticles, greaterThan(0));
+        expect(response.body.items.length, greaterThan(0));
+        expect(response.body.items[0].body, isNotNull);
+        expect(response.body.items[0].feedId, 1);
+        expect(response.body.items[0].unread, true);
+        expect(response.body.items[0].starred, false);
+      });
 
-          await addNasaFeed();
-
-          response = await client.news.listArticles();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('List updated articles', () async {
+        // Testing this is not easy, because we can't depend on an external source to update the feed
+        // Therefore we just add a second feed and check that the articles returned after a certain modified timestamp
+        // are exactly those of the new feed.
+        // Now that I think of it, maybe we could host our own feed and update that way, but this works for now.
 
-          final nasaArticles = response.body.items.length - wikipediaArticles;
-          expect(nasaArticles, greaterThan(0));
-
-          response = await client.news.listUpdatedArticles(
-            lastModified: response.body.items[response.body.items.length - 1 - nasaArticles].lastModified,
-          );
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        await addWikipediaFeed();
 
-          expect(response.body.items, hasLength(nasaArticles));
-        });
-
-        test('Mark article as read', () async {
-          await addWikipediaFeed();
-
-          var response = await client.news.listArticles(type: news.ListType.unread.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          final unreadArticles = response.body.items.length;
-          expect(unreadArticles, greaterThan(0));
+        var response = await client.news.listArticles();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          await client.news.markArticleAsRead(
-            itemId: response.body.items[0].id,
-          );
-          response = await client.news.listArticles(type: news.ListType.unread.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.items, hasLength(unreadArticles - 1));
-        });
-
-        test('Mark article as unread', () async {
-          await addWikipediaFeed();
-
-          var response = await client.news.listArticles(type: news.ListType.unread.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          final readArticle = response.body.items[0];
-          await client.news.markArticleAsRead(itemId: readArticle.id);
-          response = await client.news.listArticles(type: news.ListType.unread.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          final unreadArticles = response.body.items.length;
-          expect(unreadArticles, greaterThan(0));
-
-          await client.news.markArticleAsUnread(itemId: readArticle.id);
-          response = await client.news.listArticles(type: news.ListType.unread.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.items, hasLength(unreadArticles + 1));
-        });
-
-        test('Star article', () async {
-          await addWikipediaFeed();
-
-          var response = await client.news.listArticles(type: news.ListType.starred.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          final starredArticles = response.body.items.length;
-          expect(starredArticles, 0);
-
-          response = await client.news.listArticles();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          await client.news.starArticle(
-            itemId: response.body.items[0].id,
-          );
-          response = await client.news.listArticles(type: news.ListType.starred.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.items, hasLength(1));
-        });
-
-        test('Unstar article', () async {
-          await addWikipediaFeed();
-
-          var response = await client.news.listArticles();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          final item = response.body.items[0];
-
-          await client.news.starArticle(
-            itemId: item.id,
-          );
-          response = await client.news.listArticles(type: news.ListType.starred.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.items, hasLength(1));
-
-          await client.news.unstarArticle(
-            itemId: item.id,
-          );
-          response = await client.news.listArticles(type: news.ListType.starred.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.items, hasLength(0));
-        });
-
-        test('Create folder', () async {
-          var response = await client.news.listFolders();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.folders, hasLength(0));
-
-          response = await client.news.createFolder(name: 'test1');
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.folders, hasLength(1));
-          expect(response.body.folders[0].id, 1);
-          expect(response.body.folders[0].name, 'test1');
-          expect(response.body.folders[0].opened, true);
-          expect(response.body.folders[0].feeds, hasLength(0));
-
-          response = await client.news.listFolders();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.folders, hasLength(1));
-          expect(response.body.folders[0].id, 1);
-          expect(response.body.folders[0].name, 'test1');
-          expect(response.body.folders[0].opened, true);
-          expect(response.body.folders[0].feeds, hasLength(0));
-        });
-
-        test('Delete folder', () async {
-          var response = await client.news.createFolder(name: 'test1');
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.folders, hasLength(1));
-
-          final deleteResponse = await client.news.deleteFolder(folderId: response.body.folders.single.id);
-          expect(deleteResponse.statusCode, 200);
-          expect(() => deleteResponse.body, isA<void>());
-          expect(() => deleteResponse.headers, isA<void>());
-
-          response = await client.news.listFolders();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.folders, hasLength(0));
-        });
-
-        test('Rename folder', () async {
-          var response = await client.news.createFolder(name: 'test1');
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.folders, hasLength(1));
-
-          final deleteResponse = await client.news.renameFolder(
-            folderId: response.body.folders.single.id,
-            name: 'test2',
-          );
-          expect(deleteResponse.statusCode, 200);
-          expect(() => deleteResponse.body, isA<void>());
-          expect(() => deleteResponse.headers, isA<void>());
-
-          response = await client.news.listFolders();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.folders, hasLength(1));
-          expect(response.body.folders.single.name, 'test2');
-        });
-
-        test('List folders', () async {
-          var response = await client.news.listFolders();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.folders, hasLength(0));
-
-          await client.news.createFolder(name: 'test1');
-          await client.news.createFolder(name: 'test2');
-
-          response = response = await client.news.listFolders();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.folders, hasLength(2));
-          expect(response.body.folders[0].id, 1);
-          expect(response.body.folders[0].name, 'test1');
-          expect(response.body.folders[0].opened, true);
-          expect(response.body.folders[0].feeds, hasLength(0));
-          expect(response.body.folders[1].id, 2);
-          expect(response.body.folders[1].name, 'test2');
-          expect(response.body.folders[1].opened, true);
-          expect(response.body.folders[1].feeds, hasLength(0));
-        });
-
-        test('Add feed to folder', () async {
-          await client.news.createFolder(name: 'test1');
-          final response = await addWikipediaFeed(1);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.starredCount, null);
-          expect(response.body.newestItemId, isNotNull);
-          expect(response.body.feeds, hasLength(1));
-          expect(response.body.feeds[0].folderId, 1);
-          expect(response.body.feeds[0].url, 'http://localhost/static/wikipedia.xml');
-        });
-
-        test('Mark folder as read', () async {
-          final foldersResponse = await client.news.createFolder(name: 'test1');
-          final feedsResponse = await addWikipediaFeed(1);
-
-          var response = await client.news.listArticles(type: news.ListType.unread.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.items.length, greaterThan(0));
-
-          await client.news.markFolderAsRead(
-            folderId: foldersResponse.body.folders[0].id,
-            newestItemId: feedsResponse.body.newestItemId!,
-          );
-
-          response = await client.news.listArticles(type: news.ListType.unread.index);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
-
-          expect(response.body.items, hasLength(0));
-        });
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+        final wikipediaArticles = response.body.items.length;
+        expect(wikipediaArticles, greaterThan(0));
+
+        await addNasaFeed();
+
+        response = await client.news.listArticles();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        final nasaArticles = response.body.items.length - wikipediaArticles;
+        expect(nasaArticles, greaterThan(0));
+
+        response = await client.news.listUpdatedArticles(
+          lastModified: response.body.items[response.body.items.length - 1 - nasaArticles].lastModified,
+        );
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.items, hasLength(nasaArticles));
+      });
+
+      test('Mark article as read', () async {
+        await addWikipediaFeed();
+
+        var response = await client.news.listArticles(type: news.ListType.unread.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        final unreadArticles = response.body.items.length;
+        expect(unreadArticles, greaterThan(0));
+
+        await client.news.markArticleAsRead(
+          itemId: response.body.items[0].id,
+        );
+        response = await client.news.listArticles(type: news.ListType.unread.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.items, hasLength(unreadArticles - 1));
+      });
+
+      test('Mark article as unread', () async {
+        await addWikipediaFeed();
+
+        var response = await client.news.listArticles(type: news.ListType.unread.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        final readArticle = response.body.items[0];
+        await client.news.markArticleAsRead(itemId: readArticle.id);
+        response = await client.news.listArticles(type: news.ListType.unread.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        final unreadArticles = response.body.items.length;
+        expect(unreadArticles, greaterThan(0));
+
+        await client.news.markArticleAsUnread(itemId: readArticle.id);
+        response = await client.news.listArticles(type: news.ListType.unread.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.items, hasLength(unreadArticles + 1));
+      });
+
+      test('Star article', () async {
+        await addWikipediaFeed();
+
+        var response = await client.news.listArticles(type: news.ListType.starred.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        final starredArticles = response.body.items.length;
+        expect(starredArticles, 0);
+
+        response = await client.news.listArticles();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        await client.news.starArticle(
+          itemId: response.body.items[0].id,
+        );
+        response = await client.news.listArticles(type: news.ListType.starred.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.items, hasLength(1));
+      });
+
+      test('Unstar article', () async {
+        await addWikipediaFeed();
+
+        var response = await client.news.listArticles();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        final item = response.body.items[0];
+
+        await client.news.starArticle(
+          itemId: item.id,
+        );
+        response = await client.news.listArticles(type: news.ListType.starred.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.items, hasLength(1));
+
+        await client.news.unstarArticle(
+          itemId: item.id,
+        );
+        response = await client.news.listArticles(type: news.ListType.starred.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.items, hasLength(0));
+      });
+
+      test('Create folder', () async {
+        var response = await client.news.listFolders();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.folders, hasLength(0));
+
+        response = await client.news.createFolder(name: 'test1');
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.folders, hasLength(1));
+        expect(response.body.folders[0].id, 1);
+        expect(response.body.folders[0].name, 'test1');
+        expect(response.body.folders[0].opened, true);
+        expect(response.body.folders[0].feeds, hasLength(0));
+
+        response = await client.news.listFolders();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.folders, hasLength(1));
+        expect(response.body.folders[0].id, 1);
+        expect(response.body.folders[0].name, 'test1');
+        expect(response.body.folders[0].opened, true);
+        expect(response.body.folders[0].feeds, hasLength(0));
+      });
+
+      test('Delete folder', () async {
+        var response = await client.news.createFolder(name: 'test1');
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.folders, hasLength(1));
+
+        final deleteResponse = await client.news.deleteFolder(folderId: response.body.folders.single.id);
+        expect(deleteResponse.statusCode, 200);
+        expect(() => deleteResponse.body, isA<void>());
+        expect(() => deleteResponse.headers, isA<void>());
+
+        response = await client.news.listFolders();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.folders, hasLength(0));
+      });
+
+      test('Rename folder', () async {
+        var response = await client.news.createFolder(name: 'test1');
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.folders, hasLength(1));
+
+        final deleteResponse = await client.news.renameFolder(
+          folderId: response.body.folders.single.id,
+          name: 'test2',
+        );
+        expect(deleteResponse.statusCode, 200);
+        expect(() => deleteResponse.body, isA<void>());
+        expect(() => deleteResponse.headers, isA<void>());
+
+        response = await client.news.listFolders();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.folders, hasLength(1));
+        expect(response.body.folders.single.name, 'test2');
+      });
+
+      test('List folders', () async {
+        var response = await client.news.listFolders();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.folders, hasLength(0));
+
+        await client.news.createFolder(name: 'test1');
+        await client.news.createFolder(name: 'test2');
+
+        response = response = await client.news.listFolders();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.folders, hasLength(2));
+        expect(response.body.folders[0].id, 1);
+        expect(response.body.folders[0].name, 'test1');
+        expect(response.body.folders[0].opened, true);
+        expect(response.body.folders[0].feeds, hasLength(0));
+        expect(response.body.folders[1].id, 2);
+        expect(response.body.folders[1].name, 'test2');
+        expect(response.body.folders[1].opened, true);
+        expect(response.body.folders[1].feeds, hasLength(0));
+      });
+
+      test('Add feed to folder', () async {
+        await client.news.createFolder(name: 'test1');
+        final response = await addWikipediaFeed(1);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.starredCount, null);
+        expect(response.body.newestItemId, isNotNull);
+        expect(response.body.feeds, hasLength(1));
+        expect(response.body.feeds[0].folderId, 1);
+        expect(response.body.feeds[0].url, 'http://localhost/static/wikipedia.xml');
+      });
+
+      test('Mark folder as read', () async {
+        final foldersResponse = await client.news.createFolder(name: 'test1');
+        final feedsResponse = await addWikipediaFeed(1);
+
+        var response = await client.news.listArticles(type: news.ListType.unread.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.items.length, greaterThan(0));
+
+        await client.news.markFolderAsRead(
+          folderId: foldersResponse.body.folders[0].id,
+          newestItemId: feedsResponse.body.newestItemId!,
+        );
+
+        response = await client.news.listArticles(type: news.ListType.unread.index);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
+
+        expect(response.body.items, hasLength(0));
+      });
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }

--- a/packages/nextcloud/test/notes_test.dart
+++ b/packages/nextcloud/test/notes_test.dart
@@ -6,185 +6,184 @@ import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
-  presets('notes', (final preset) {
-    group(
-      'notes',
-      () {
-        late DockerContainer container;
-        late NextcloudClient client;
-        setUp(() async {
-          container = await DockerContainer.create(preset);
-          client = await TestNextcloudClient.create(container);
-        });
-        tearDown(() async {
-          if (Invoker.current!.liveTest.errors.isNotEmpty) {
-            print(await container.allLogs());
-          }
-          container.destroy();
-        });
+  presets(
+    'notes',
+    'notes',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client;
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client = await TestNextcloudClient.create(container);
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
 
-        test('Is supported', () async {
-          final response = await client.core.ocs.getCapabilities();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Is supported', () async {
+        final response = await client.core.ocs.getCapabilities();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          final result = client.notes.getVersionCheck(response.body.ocs.data);
-          expect(result.versions, isNotNull);
-          expect(result.versions, isNotEmpty);
-          expect(result.isSupported, isTrue);
-        });
+        final result = client.notes.getVersionCheck(response.body.ocs.data);
+        expect(result.versions, isNotNull);
+        expect(result.versions, isNotEmpty);
+        expect(result.isSupported, isTrue);
+      });
 
-        test('Create note favorite', () async {
-          final response = await client.notes.createNote(
-            title: 'a',
-            content: 'b',
-            category: 'c',
-            favorite: 1,
-          );
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Create note favorite', () async {
+        final response = await client.notes.createNote(
+          title: 'a',
+          content: 'b',
+          category: 'c',
+          favorite: 1,
+        );
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.id, isPositive);
-          expect(response.body.title, 'a');
-          expect(response.body.content, 'b');
-          expect(response.body.category, 'c');
-          expect(response.body.favorite, true);
-          expect(response.body.readonly, false);
-          expect(response.body.etag, isNotNull);
-          expect(response.body.modified, isNotNull);
-        });
+        expect(response.body.id, isPositive);
+        expect(response.body.title, 'a');
+        expect(response.body.content, 'b');
+        expect(response.body.category, 'c');
+        expect(response.body.favorite, true);
+        expect(response.body.readonly, false);
+        expect(response.body.etag, isNotNull);
+        expect(response.body.modified, isNotNull);
+      });
 
-        test('Create note not favorite', () async {
-          final response = await client.notes.createNote(
-            title: 'a',
-            content: 'b',
-            category: 'c',
-          );
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Create note not favorite', () async {
+        final response = await client.notes.createNote(
+          title: 'a',
+          content: 'b',
+          category: 'c',
+        );
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.id, isPositive);
-          expect(response.body.title, 'a');
-          expect(response.body.content, 'b');
-          expect(response.body.category, 'c');
-          expect(response.body.favorite, false);
-          expect(response.body.readonly, false);
-          expect(response.body.etag, isNotNull);
-          expect(response.body.modified, isNotNull);
-        });
+        expect(response.body.id, isPositive);
+        expect(response.body.title, 'a');
+        expect(response.body.content, 'b');
+        expect(response.body.category, 'c');
+        expect(response.body.favorite, false);
+        expect(response.body.readonly, false);
+        expect(response.body.etag, isNotNull);
+        expect(response.body.modified, isNotNull);
+      });
 
-        test('Get notes', () async {
-          await client.notes.createNote(title: 'a');
-          await client.notes.createNote(title: 'b');
+      test('Get notes', () async {
+        await client.notes.createNote(title: 'a');
+        await client.notes.createNote(title: 'b');
 
-          final response = await client.notes.getNotes();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        final response = await client.notes.getNotes();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body, hasLength(2));
-          expect(response.body[0].title, 'a');
-          expect(response.body[1].title, 'b');
-        });
+        expect(response.body, hasLength(2));
+        expect(response.body[0].title, 'a');
+        expect(response.body[1].title, 'b');
+      });
 
-        test('Get note', () async {
-          final response = await client.notes.getNote(
-            id: (await client.notes.createNote(title: 'a')).body.id,
-          );
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Get note', () async {
+        final response = await client.notes.getNote(
+          id: (await client.notes.createNote(title: 'a')).body.id,
+        );
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.title, 'a');
-        });
+        expect(response.body.title, 'a');
+      });
 
-        test('Update note', () async {
-          final id = (await client.notes.createNote(title: 'a')).body.id;
-          await client.notes.updateNote(
-            id: id,
-            title: 'b',
-          );
+      test('Update note', () async {
+        final id = (await client.notes.createNote(title: 'a')).body.id;
+        await client.notes.updateNote(
+          id: id,
+          title: 'b',
+        );
 
-          final response = await client.notes.getNote(id: id);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        final response = await client.notes.getNote(id: id);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.title, 'b');
-        });
+        expect(response.body.title, 'b');
+      });
 
-        test('Update note fail changed on server', () async {
-          final response = await client.notes.createNote(title: 'a');
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Update note fail changed on server', () async {
+        final response = await client.notes.createNote(title: 'a');
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          await client.notes.updateNote(
+        await client.notes.updateNote(
+          id: response.body.id,
+          title: 'b',
+          ifMatch: '"${response.body.etag}"',
+        );
+        expect(
+          () => client.notes.updateNote(
             id: response.body.id,
-            title: 'b',
+            title: 'c',
             ifMatch: '"${response.body.etag}"',
-          );
-          expect(
-            () => client.notes.updateNote(
-              id: response.body.id,
-              title: 'c',
-              ifMatch: '"${response.body.etag}"',
-            ),
-            throwsA(predicate((final e) => (e! as DynamiteApiException).statusCode == 412)),
-          );
-        });
+          ),
+          throwsA(predicate((final e) => (e! as DynamiteApiException).statusCode == 412)),
+        );
+      });
 
-        test('Delete note', () async {
-          final id = (await client.notes.createNote(title: 'a')).body.id;
+      test('Delete note', () async {
+        final id = (await client.notes.createNote(title: 'a')).body.id;
 
-          var response = await client.notes.getNotes();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        var response = await client.notes.getNotes();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body, hasLength(1));
+        expect(response.body, hasLength(1));
 
-          await client.notes.deleteNote(id: id);
+        await client.notes.deleteNote(id: id);
 
-          response = await client.notes.getNotes();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        response = await client.notes.getNotes();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body, hasLength(0));
-        });
+        expect(response.body, hasLength(0));
+      });
 
-        test('Get settings', () async {
-          final response = await client.notes.getSettings();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Get settings', () async {
+        final response = await client.notes.getSettings();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.notesPath, 'Notes');
-          expect(response.body.fileSuffix, '.md');
-          expect(response.body.noteMode, notes.Settings_NoteMode.rich);
-        });
+        expect(response.body.notesPath, 'Notes');
+        expect(response.body.fileSuffix, '.md');
+        expect(response.body.noteMode, notes.Settings_NoteMode.rich);
+      });
 
-        test('Update settings', () async {
-          var response = await client.notes.updateSettings(
-            settings: notes.Settings(
-              (final b) => b
-                ..notesPath = 'Test Notes'
-                ..fileSuffix = '.txt'
-                ..noteMode = notes.Settings_NoteMode.preview,
-            ),
-          );
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Update settings', () async {
+        var response = await client.notes.updateSettings(
+          settings: notes.Settings(
+            (final b) => b
+              ..notesPath = 'Test Notes'
+              ..fileSuffix = '.txt'
+              ..noteMode = notes.Settings_NoteMode.preview,
+          ),
+        );
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.notesPath, 'Test Notes');
-          expect(response.body.fileSuffix, '.txt');
-          expect(response.body.noteMode, notes.Settings_NoteMode.preview);
+        expect(response.body.notesPath, 'Test Notes');
+        expect(response.body.fileSuffix, '.txt');
+        expect(response.body.noteMode, notes.Settings_NoteMode.preview);
 
-          response = await client.notes.getSettings();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        response = await client.notes.getSettings();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.notesPath, 'Test Notes');
-          expect(response.body.fileSuffix, '.txt');
-          expect(response.body.noteMode, notes.Settings_NoteMode.preview);
-        });
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+        expect(response.body.notesPath, 'Test Notes');
+        expect(response.body.fileSuffix, '.txt');
+        expect(response.body.noteMode, notes.Settings_NoteMode.preview);
+      });
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }

--- a/packages/nextcloud/test/notifications_test.dart
+++ b/packages/nextcloud/test/notifications_test.dart
@@ -7,10 +7,114 @@ import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
-  presets('server', (final preset) {
-    group(
-      'notifications',
-      () {
+  presets(
+    'server',
+    'notifications',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client;
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client = await TestNextcloudClient.create(
+          container,
+          username: 'admin',
+        );
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
+
+      Future<void> sendTestNotification() async {
+        await client.notifications.api.generateNotification(
+          userId: 'admin',
+          shortMessage: '123',
+          longMessage: '456',
+        );
+      }
+
+      group('API', () {
+        test('Send admin notification', () async {
+          await sendTestNotification();
+        });
+      });
+
+      group('Endpoint', () {
+        test('List notifications', () async {
+          await sendTestNotification();
+
+          final startTime = DateTime.now().toUtc();
+          final response = (await client.notifications.endpoint.listNotifications()).body;
+          expect(response.ocs.data, hasLength(2));
+          expect(response.ocs.data[0].notificationId, 2);
+          expect(response.ocs.data[0].app, 'admin_notifications');
+          expect(response.ocs.data[0].user, 'admin');
+          expect(
+            DateTime.parse(response.ocs.data[0].datetime).millisecondsSinceEpoch,
+            closeTo(startTime.millisecondsSinceEpoch, 10E3),
+          );
+          expect(response.ocs.data[0].objectType, 'admin_notifications');
+          expect(response.ocs.data[0].objectId, isNotNull);
+          expect(response.ocs.data[0].subject, '123');
+          expect(response.ocs.data[0].message, '456');
+          expect(response.ocs.data[0].link, '');
+          expect(response.ocs.data[0].subjectRich, '');
+          expect(response.ocs.data[0].subjectRichParameters, isEmpty);
+          expect(response.ocs.data[0].messageRich, '');
+          expect(response.ocs.data[0].messageRichParameters, isEmpty);
+          expect(response.ocs.data[0].icon, isNotEmpty);
+          expect(response.ocs.data[0].actions, hasLength(0));
+        });
+
+        test('Get notification', () async {
+          await sendTestNotification();
+
+          final startTime = DateTime.now().toUtc();
+          final response = await client.notifications.endpoint.getNotification(id: 2);
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          expect(response.body.ocs.data.notificationId, 2);
+          expect(response.body.ocs.data.app, 'admin_notifications');
+          expect(response.body.ocs.data.user, 'admin');
+          expect(
+            DateTime.parse(response.body.ocs.data.datetime).millisecondsSinceEpoch,
+            closeTo(startTime.millisecondsSinceEpoch, 10E3),
+          );
+          expect(response.body.ocs.data.objectType, 'admin_notifications');
+          expect(response.body.ocs.data.objectId, isNotNull);
+          expect(response.body.ocs.data.subject, '123');
+          expect(response.body.ocs.data.message, '456');
+          expect(response.body.ocs.data.link, '');
+          expect(response.body.ocs.data.subjectRich, '');
+          expect(response.body.ocs.data.subjectRichParameters, isEmpty);
+          expect(response.body.ocs.data.messageRich, '');
+          expect(response.body.ocs.data.messageRichParameters, isEmpty);
+          expect(response.body.ocs.data.icon, isNotEmpty);
+          expect(response.body.ocs.data.actions, hasLength(0));
+        });
+
+        test('Delete notification', () async {
+          await sendTestNotification();
+          await client.notifications.endpoint.deleteNotification(id: 2);
+
+          final response = (await client.notifications.endpoint.listNotifications()).body;
+          expect(response.ocs.data, hasLength(1));
+        });
+
+        test('Delete all notifications', () async {
+          await sendTestNotification();
+          await sendTestNotification();
+          await client.notifications.endpoint.deleteAllNotifications();
+
+          final response = (await client.notifications.endpoint.listNotifications()).body;
+          expect(response.ocs.data, hasLength(0));
+        });
+      });
+
+      group('Push', () {
         late DockerContainer container;
         late NextcloudClient client;
         setUp(() async {
@@ -27,137 +131,32 @@ void main() {
           container.destroy();
         });
 
-        Future<void> sendTestNotification() async {
-          await client.notifications.api.generateNotification(
-            userId: 'admin',
-            shortMessage: '123',
-            longMessage: '456',
-          );
-        }
+        // The key size has to be 2048, other sizes are not accepted by Nextcloud (at the moment at least)
+        // ignore: avoid_redundant_argument_values
+        RSAKeypair generateKeypair() => RSAKeypair.fromRandom(keySize: 2048);
 
-        group('API', () {
-          test('Send admin notification', () async {
-            await sendTestNotification();
-          });
+        test('Register and remove push device', () async {
+          const pushToken = '789';
+          final keypair = generateKeypair();
+
+          final subscription = (await client.notifications.push.registerDevice(
+            pushTokenHash: generatePushTokenHash(pushToken),
+            devicePublicKey: keypair.publicKey.toFormattedPEM(),
+            proxyServer: 'https://example.com/',
+          ))
+              .body
+              .ocs
+              .data;
+          expect(subscription.publicKey, hasLength(451));
+          RSAPublicKey.fromPEM(subscription.publicKey);
+          expect(subscription.deviceIdentifier, isNotEmpty);
+          expect(subscription.signature, isNotEmpty);
+
+          await client.notifications.push.removeDevice();
         });
-
-        group('Endpoint', () {
-          test('List notifications', () async {
-            await sendTestNotification();
-
-            final startTime = DateTime.now().toUtc();
-            final response = (await client.notifications.endpoint.listNotifications()).body;
-            expect(response.ocs.data, hasLength(2));
-            expect(response.ocs.data[0].notificationId, 2);
-            expect(response.ocs.data[0].app, 'admin_notifications');
-            expect(response.ocs.data[0].user, 'admin');
-            expect(
-              DateTime.parse(response.ocs.data[0].datetime).millisecondsSinceEpoch,
-              closeTo(startTime.millisecondsSinceEpoch, 10E3),
-            );
-            expect(response.ocs.data[0].objectType, 'admin_notifications');
-            expect(response.ocs.data[0].objectId, isNotNull);
-            expect(response.ocs.data[0].subject, '123');
-            expect(response.ocs.data[0].message, '456');
-            expect(response.ocs.data[0].link, '');
-            expect(response.ocs.data[0].subjectRich, '');
-            expect(response.ocs.data[0].subjectRichParameters, isEmpty);
-            expect(response.ocs.data[0].messageRich, '');
-            expect(response.ocs.data[0].messageRichParameters, isEmpty);
-            expect(response.ocs.data[0].icon, isNotEmpty);
-            expect(response.ocs.data[0].actions, hasLength(0));
-          });
-
-          test('Get notification', () async {
-            await sendTestNotification();
-
-            final startTime = DateTime.now().toUtc();
-            final response = await client.notifications.endpoint.getNotification(id: 2);
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data.notificationId, 2);
-            expect(response.body.ocs.data.app, 'admin_notifications');
-            expect(response.body.ocs.data.user, 'admin');
-            expect(
-              DateTime.parse(response.body.ocs.data.datetime).millisecondsSinceEpoch,
-              closeTo(startTime.millisecondsSinceEpoch, 10E3),
-            );
-            expect(response.body.ocs.data.objectType, 'admin_notifications');
-            expect(response.body.ocs.data.objectId, isNotNull);
-            expect(response.body.ocs.data.subject, '123');
-            expect(response.body.ocs.data.message, '456');
-            expect(response.body.ocs.data.link, '');
-            expect(response.body.ocs.data.subjectRich, '');
-            expect(response.body.ocs.data.subjectRichParameters, isEmpty);
-            expect(response.body.ocs.data.messageRich, '');
-            expect(response.body.ocs.data.messageRichParameters, isEmpty);
-            expect(response.body.ocs.data.icon, isNotEmpty);
-            expect(response.body.ocs.data.actions, hasLength(0));
-          });
-
-          test('Delete notification', () async {
-            await sendTestNotification();
-            await client.notifications.endpoint.deleteNotification(id: 2);
-
-            final response = (await client.notifications.endpoint.listNotifications()).body;
-            expect(response.ocs.data, hasLength(1));
-          });
-
-          test('Delete all notifications', () async {
-            await sendTestNotification();
-            await sendTestNotification();
-            await client.notifications.endpoint.deleteAllNotifications();
-
-            final response = (await client.notifications.endpoint.listNotifications()).body;
-            expect(response.ocs.data, hasLength(0));
-          });
-        });
-
-        group('Push', () {
-          late DockerContainer container;
-          late NextcloudClient client;
-          setUp(() async {
-            container = await DockerContainer.create(preset);
-            client = await TestNextcloudClient.create(
-              container,
-              username: 'admin',
-            );
-          });
-          tearDown(() async {
-            if (Invoker.current!.liveTest.errors.isNotEmpty) {
-              print(await container.allLogs());
-            }
-            container.destroy();
-          });
-
-          // The key size has to be 2048, other sizes are not accepted by Nextcloud (at the moment at least)
-          // ignore: avoid_redundant_argument_values
-          RSAKeypair generateKeypair() => RSAKeypair.fromRandom(keySize: 2048);
-
-          test('Register and remove push device', () async {
-            const pushToken = '789';
-            final keypair = generateKeypair();
-
-            final subscription = (await client.notifications.push.registerDevice(
-              pushTokenHash: generatePushTokenHash(pushToken),
-              devicePublicKey: keypair.publicKey.toFormattedPEM(),
-              proxyServer: 'https://example.com/',
-            ))
-                .body
-                .ocs
-                .data;
-            expect(subscription.publicKey, hasLength(451));
-            RSAPublicKey.fromPEM(subscription.publicKey);
-            expect(subscription.deviceIdentifier, isNotEmpty);
-            expect(subscription.signature, isNotEmpty);
-
-            await client.notifications.push.removeDevice();
-          });
-        });
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+      });
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }

--- a/packages/nextcloud/test/provisioning_api_test.dart
+++ b/packages/nextcloud/test/provisioning_api_test.dart
@@ -5,68 +5,67 @@ import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
-  presets('server', (final preset) {
-    group(
-      'provisioning_api',
-      () {
-        late DockerContainer container;
-        late NextcloudClient client;
-        setUp(() async {
-          container = await DockerContainer.create(preset);
-          client = await TestNextcloudClient.create(
-            container,
-            username: 'admin',
-          );
+  presets(
+    'server',
+    'provisioning_api',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client;
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client = await TestNextcloudClient.create(
+          container,
+          username: 'admin',
+        );
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
+
+      group('Users', () {
+        test('Get current user', () async {
+          final response = await client.provisioningApi.users.getCurrentUser();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          expect(response.body.ocs.data.id, 'admin');
+          expect(response.body.ocs.data.displayName, 'admin');
+          expect(response.body.ocs.data.displaynameScope, 'v2-federated');
+          expect(response.body.ocs.data.language, 'en');
         });
-        tearDown(() async {
-          if (Invoker.current!.liveTest.errors.isNotEmpty) {
-            print(await container.allLogs());
+
+        test('Get user by username', () async {
+          final response = await client.provisioningApi.users.getUser(userId: 'user1');
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          expect(response.body.ocs.data.id, 'user1');
+          expect(response.body.ocs.data.displayname, 'User One');
+          expect(response.body.ocs.data.displaynameScope, null);
+          expect(response.body.ocs.data.language, 'en');
+        });
+      });
+
+      group('Apps', () {
+        test('Get', () async {
+          final response = await client.provisioningApi.apps.getApps();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+          expect(response.body.ocs.data.apps, isNotEmpty);
+
+          for (final id in response.body.ocs.data.apps) {
+            final app = await client.provisioningApi.apps.getAppInfo(app: id);
+            expect(response.statusCode, 200);
+            expect(() => response.headers, isA<void>());
+            expect(app.body.ocs.data.id, isNotEmpty);
           }
-          container.destroy();
         });
-
-        group('Users', () {
-          test('Get current user', () async {
-            final response = await client.provisioningApi.users.getCurrentUser();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data.id, 'admin');
-            expect(response.body.ocs.data.displayName, 'admin');
-            expect(response.body.ocs.data.displaynameScope, 'v2-federated');
-            expect(response.body.ocs.data.language, 'en');
-          });
-
-          test('Get user by username', () async {
-            final response = await client.provisioningApi.users.getUser(userId: 'user1');
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data.id, 'user1');
-            expect(response.body.ocs.data.displayname, 'User One');
-            expect(response.body.ocs.data.displaynameScope, null);
-            expect(response.body.ocs.data.language, 'en');
-          });
-        });
-
-        group('Apps', () {
-          test('Get', () async {
-            final response = await client.provisioningApi.apps.getApps();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-            expect(response.body.ocs.data.apps, isNotEmpty);
-
-            for (final id in response.body.ocs.data.apps) {
-              final app = await client.provisioningApi.apps.getAppInfo(app: id);
-              expect(response.statusCode, 200);
-              expect(() => response.headers, isA<void>());
-              expect(app.body.ocs.data.id, isNotEmpty);
-            }
-          });
-        });
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+      });
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }

--- a/packages/nextcloud/test/settings_test.dart
+++ b/packages/nextcloud/test/settings_test.dart
@@ -7,36 +7,35 @@ import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
-  presets('server', (final preset) {
-    group(
-      'settings',
-      () {
-        late DockerContainer container;
-        late NextcloudClient client;
-        setUp(() async {
-          container = await DockerContainer.create(preset);
-          client = await TestNextcloudClient.create(
-            container,
-            username: 'admin',
-          );
-        });
-        tearDown(() async {
-          if (Invoker.current!.liveTest.errors.isNotEmpty) {
-            print(await container.allLogs());
-          }
-          container.destroy();
-        });
+  presets(
+    'server',
+    'settings',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client;
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client = await TestNextcloudClient.create(
+          container,
+          username: 'admin',
+        );
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
 
-        group('Logs', () {
-          test('Download', () async {
-            final response = await client.settings.logSettings.download();
-            final logs = utf8.decode(response.body);
-            expect(logs, await container.nextcloudLogs());
-          });
+      group('Logs', () {
+        test('Download', () async {
+          final response = await client.settings.logSettings.download();
+          final logs = utf8.decode(response.body);
+          expect(logs, await container.nextcloudLogs());
         });
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+      });
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }

--- a/packages/nextcloud/test/spreed_test.dart
+++ b/packages/nextcloud/test/spreed_test.dart
@@ -10,77 +10,116 @@ import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
-  presets('spreed', (final preset) {
-    group(
-      'spreed',
-      () {
-        late DockerContainer container;
-        late NextcloudClient client1;
-        setUp(() async {
-          container = await DockerContainer.create(preset);
-          client1 = await TestNextcloudClient.create(container);
+  presets(
+    'spreed',
+    'spreed',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client1;
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client1 = await TestNextcloudClient.create(container);
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
+
+      Future<spreed.Room> createTestRoom() async => (await client1.spreed.room.createRoom(
+            roomType: spreed.RoomType.public.value,
+            roomName: 'Test',
+          ))
+              .body
+              .ocs
+              .data;
+
+      group('Helpers', () {
+        test('Is supported', () async {
+          final response = await client1.core.ocs.getCapabilities();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          final result = client1.spreed.getVersionCheck(response.body.ocs.data);
+          expect(result.versions, isNotNull);
+          expect(result.versions, isNotEmpty);
+          expect(result.isSupported, isTrue);
         });
-        tearDown(() async {
-          if (Invoker.current!.liveTest.errors.isNotEmpty) {
-            print(await container.allLogs());
-          }
-          container.destroy();
-        });
 
-        Future<spreed.Room> createTestRoom() async => (await client1.spreed.room.createRoom(
-              roomType: spreed.RoomType.public.value,
-              roomName: 'Test',
-            ))
-                .body
-                .ocs
-                .data;
+        test('Participant permissions', () async {
+          expect(spreed.ParticipantPermission.$default.binary, 0);
+          expect(spreed.ParticipantPermission.values.byBinary(0), {spreed.ParticipantPermission.$default});
+          expect({spreed.ParticipantPermission.$default}.binary, 0);
 
-        group('Helpers', () {
-          test('Is supported', () async {
-            final response = await client1.core.ocs.getCapabilities();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            final result = client1.spreed.getVersionCheck(response.body.ocs.data);
-            expect(result.versions, isNotNull);
-            expect(result.versions, isNotEmpty);
-            expect(result.isSupported, isTrue);
+          expect(spreed.ParticipantPermission.custom.binary, 1);
+          expect(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary, 128);
+          expect(spreed.ParticipantPermission.values.byBinary(129), {
+            spreed.ParticipantPermission.custom,
+            spreed.ParticipantPermission.canSendMessageAndShareAndReact,
           });
-
-          test('Participant permissions', () async {
-            expect(spreed.ParticipantPermission.$default.binary, 0);
-            expect(spreed.ParticipantPermission.values.byBinary(0), {spreed.ParticipantPermission.$default});
-            expect({spreed.ParticipantPermission.$default}.binary, 0);
-
-            expect(spreed.ParticipantPermission.custom.binary, 1);
-            expect(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary, 128);
-            expect(spreed.ParticipantPermission.values.byBinary(129), {
+          expect(
+            {
               spreed.ParticipantPermission.custom,
               spreed.ParticipantPermission.canSendMessageAndShareAndReact,
-            });
-            expect(
-              {
-                spreed.ParticipantPermission.custom,
-                spreed.ParticipantPermission.canSendMessageAndShareAndReact,
-              }.binary,
-              129,
-            );
+            }.binary,
+            129,
+          );
+        });
+      });
+
+      group('Room', () {
+        test('Get rooms', () async {
+          final response = await client1.spreed.room.getRooms();
+          expect(response.body.ocs.data, hasLength(1));
+          expect(response.body.ocs.data[0].id, 1);
+          expect(response.body.ocs.data[0].token, isNotEmpty);
+          expect(response.body.ocs.data[0].type, spreed.RoomType.changelog.value);
+          expect(response.body.ocs.data[0].name, 'user1');
+          expect(response.body.ocs.data[0].displayName, 'Talk updates ✅');
+          expect(response.body.ocs.data[0].participantType, spreed.ParticipantType.user.value);
+          expect(spreed.ParticipantPermission.values.byBinary(response.body.ocs.data[0].permissions), {
+            spreed.ParticipantPermission.startCall,
+            spreed.ParticipantPermission.joinCall,
+            spreed.ParticipantPermission.canPublishAudio,
+            spreed.ParticipantPermission.canPublishVideo,
+            spreed.ParticipantPermission.canScreenShare,
+            spreed.ParticipantPermission.canSendMessageAndShareAndReact,
           });
         });
 
-        group('Room', () {
-          test('Get rooms', () async {
-            final response = await client1.spreed.room.getRooms();
-            expect(response.body.ocs.data, hasLength(1));
-            expect(response.body.ocs.data[0].id, 1);
-            expect(response.body.ocs.data[0].token, isNotEmpty);
-            expect(response.body.ocs.data[0].type, spreed.RoomType.changelog.value);
-            expect(response.body.ocs.data[0].name, 'user1');
-            expect(response.body.ocs.data[0].displayName, 'Talk updates ✅');
-            expect(response.body.ocs.data[0].participantType, spreed.ParticipantType.user.value);
-            expect(spreed.ParticipantPermission.values.byBinary(response.body.ocs.data[0].permissions), {
+        test('Session', () async {
+          var room = await createTestRoom();
+          expect(room.sessionId, '0');
+
+          final response = await client1.spreed.room.joinRoom(token: room.token);
+          expect(response.body.ocs.data.id, room.id);
+          expect(response.body.ocs.data.sessionId, isNot(room.sessionId));
+
+          room = (await client1.spreed.room.getSingleRoom(token: room.token)).body.ocs.data;
+          expect(room.sessionId, response.body.ocs.data.sessionId);
+
+          await client1.spreed.room.leaveRoom(token: room.token);
+          room = (await client1.spreed.room.getSingleRoom(token: room.token)).body.ocs.data;
+          expect(room.sessionId, '0');
+        });
+
+        group('Create room', () {
+          test('One-to-One', () async {
+            final response = await client1.spreed.room.createRoom(
+              roomType: spreed.RoomType.oneToOne.value,
+              invite: 'user2',
+            );
+            expect(response.body.ocs.data.id, 1);
+            expect(response.body.ocs.data.token, isNotEmpty);
+            expect(response.body.ocs.data.type, spreed.RoomType.oneToOne.value);
+            expect(response.body.ocs.data.name, 'user2');
+            expect(response.body.ocs.data.displayName, 'User Two');
+            expect(response.body.ocs.data.participantType, spreed.ParticipantType.owner.value);
+            expect(spreed.ParticipantPermission.values.byBinary(response.body.ocs.data.permissions), {
               spreed.ParticipantPermission.startCall,
               spreed.ParticipantPermission.joinCall,
+              spreed.ParticipantPermission.canIgnoreLobby,
               spreed.ParticipantPermission.canPublishAudio,
               spreed.ParticipantPermission.canPublishVideo,
               spreed.ParticipantPermission.canScreenShare,
@@ -88,93 +127,78 @@ void main() {
             });
           });
 
-          test('Session', () async {
-            var room = await createTestRoom();
-            expect(room.sessionId, '0');
-
-            final response = await client1.spreed.room.joinRoom(token: room.token);
-            expect(response.body.ocs.data.id, room.id);
-            expect(response.body.ocs.data.sessionId, isNot(room.sessionId));
-
-            room = (await client1.spreed.room.getSingleRoom(token: room.token)).body.ocs.data;
-            expect(room.sessionId, response.body.ocs.data.sessionId);
-
-            await client1.spreed.room.leaveRoom(token: room.token);
-            room = (await client1.spreed.room.getSingleRoom(token: room.token)).body.ocs.data;
-            expect(room.sessionId, '0');
+          test('Group', () async {
+            final response = await client1.spreed.room.createRoom(
+              roomType: spreed.RoomType.group.value,
+              invite: 'admin',
+            );
+            expect(response.body.ocs.data.id, 1);
+            expect(response.body.ocs.data.token, isNotEmpty);
+            expect(response.body.ocs.data.type, spreed.RoomType.group.value);
+            expect(response.body.ocs.data.name, 'admin');
+            expect(response.body.ocs.data.displayName, 'admin');
+            expect(response.body.ocs.data.participantType, spreed.ParticipantType.owner.value);
+            expect(spreed.ParticipantPermission.values.byBinary(response.body.ocs.data.permissions), {
+              spreed.ParticipantPermission.startCall,
+              spreed.ParticipantPermission.joinCall,
+              spreed.ParticipantPermission.canIgnoreLobby,
+              spreed.ParticipantPermission.canPublishAudio,
+              spreed.ParticipantPermission.canPublishVideo,
+              spreed.ParticipantPermission.canScreenShare,
+              spreed.ParticipantPermission.canSendMessageAndShareAndReact,
+            });
           });
 
-          group('Create room', () {
-            test('One-to-One', () async {
-              final response = await client1.spreed.room.createRoom(
-                roomType: spreed.RoomType.oneToOne.value,
-                invite: 'user2',
-              );
-              expect(response.body.ocs.data.id, 1);
-              expect(response.body.ocs.data.token, isNotEmpty);
-              expect(response.body.ocs.data.type, spreed.RoomType.oneToOne.value);
-              expect(response.body.ocs.data.name, 'user2');
-              expect(response.body.ocs.data.displayName, 'User Two');
-              expect(response.body.ocs.data.participantType, spreed.ParticipantType.owner.value);
-              expect(spreed.ParticipantPermission.values.byBinary(response.body.ocs.data.permissions), {
-                spreed.ParticipantPermission.startCall,
-                spreed.ParticipantPermission.joinCall,
-                spreed.ParticipantPermission.canIgnoreLobby,
-                spreed.ParticipantPermission.canPublishAudio,
-                spreed.ParticipantPermission.canPublishVideo,
-                spreed.ParticipantPermission.canScreenShare,
-                spreed.ParticipantPermission.canSendMessageAndShareAndReact,
-              });
-            });
-
-            test('Group', () async {
-              final response = await client1.spreed.room.createRoom(
-                roomType: spreed.RoomType.group.value,
-                invite: 'admin',
-              );
-              expect(response.body.ocs.data.id, 1);
-              expect(response.body.ocs.data.token, isNotEmpty);
-              expect(response.body.ocs.data.type, spreed.RoomType.group.value);
-              expect(response.body.ocs.data.name, 'admin');
-              expect(response.body.ocs.data.displayName, 'admin');
-              expect(response.body.ocs.data.participantType, spreed.ParticipantType.owner.value);
-              expect(spreed.ParticipantPermission.values.byBinary(response.body.ocs.data.permissions), {
-                spreed.ParticipantPermission.startCall,
-                spreed.ParticipantPermission.joinCall,
-                spreed.ParticipantPermission.canIgnoreLobby,
-                spreed.ParticipantPermission.canPublishAudio,
-                spreed.ParticipantPermission.canPublishVideo,
-                spreed.ParticipantPermission.canScreenShare,
-                spreed.ParticipantPermission.canSendMessageAndShareAndReact,
-              });
-            });
-
-            test('Public', () async {
-              final response = await client1.spreed.room.createRoom(
-                roomType: spreed.RoomType.public.value,
-                roomName: 'abc',
-              );
-              expect(response.body.ocs.data.id, 1);
-              expect(response.body.ocs.data.token, isNotEmpty);
-              expect(response.body.ocs.data.type, spreed.RoomType.public.value);
-              expect(response.body.ocs.data.name, 'abc');
-              expect(response.body.ocs.data.displayName, 'abc');
-              expect(response.body.ocs.data.participantType, spreed.ParticipantType.owner.value);
-              expect(spreed.ParticipantPermission.values.byBinary(response.body.ocs.data.permissions), {
-                spreed.ParticipantPermission.startCall,
-                spreed.ParticipantPermission.joinCall,
-                spreed.ParticipantPermission.canIgnoreLobby,
-                spreed.ParticipantPermission.canPublishAudio,
-                spreed.ParticipantPermission.canPublishVideo,
-                spreed.ParticipantPermission.canScreenShare,
-                spreed.ParticipantPermission.canSendMessageAndShareAndReact,
-              });
+          test('Public', () async {
+            final response = await client1.spreed.room.createRoom(
+              roomType: spreed.RoomType.public.value,
+              roomName: 'abc',
+            );
+            expect(response.body.ocs.data.id, 1);
+            expect(response.body.ocs.data.token, isNotEmpty);
+            expect(response.body.ocs.data.type, spreed.RoomType.public.value);
+            expect(response.body.ocs.data.name, 'abc');
+            expect(response.body.ocs.data.displayName, 'abc');
+            expect(response.body.ocs.data.participantType, spreed.ParticipantType.owner.value);
+            expect(spreed.ParticipantPermission.values.byBinary(response.body.ocs.data.permissions), {
+              spreed.ParticipantPermission.startCall,
+              spreed.ParticipantPermission.joinCall,
+              spreed.ParticipantPermission.canIgnoreLobby,
+              spreed.ParticipantPermission.canPublishAudio,
+              spreed.ParticipantPermission.canPublishVideo,
+              spreed.ParticipantPermission.canScreenShare,
+              spreed.ParticipantPermission.canSendMessageAndShareAndReact,
             });
           });
         });
+      });
 
-        group('Chat', () {
-          test('Send message', () async {
+      group('Chat', () {
+        test('Send message', () async {
+          final startTime = DateTime.now();
+          final room = (await client1.spreed.room.createRoom(
+            roomType: spreed.RoomType.oneToOne.value,
+            invite: 'user2',
+          ))
+              .body
+              .ocs
+              .data;
+
+          final response = await client1.spreed.chat.sendMessage(
+            token: room.token,
+            message: 'bla',
+          );
+          expect(response.body.ocs.data!.id, 2);
+          expect(response.body.ocs.data!.actorType, spreed.ActorType.users.name);
+          expect(response.body.ocs.data!.actorId, 'user1');
+          expect(response.body.ocs.data!.actorDisplayName, 'User One');
+          expect(response.body.ocs.data!.timestamp * 1000, closeTo(startTime.millisecondsSinceEpoch, 10E3));
+          expect(response.body.ocs.data!.message, 'bla');
+          expect(response.body.ocs.data!.messageType, spreed.MessageType.comment.name);
+        });
+
+        group('Get messages', () {
+          test('Directly', () async {
             final startTime = DateTime.now();
             final room = (await client1.spreed.room.createRoom(
               roomType: spreed.RoomType.oneToOne.value,
@@ -183,233 +207,208 @@ void main() {
                 .body
                 .ocs
                 .data;
-
-            final response = await client1.spreed.chat.sendMessage(
+            await client1.spreed.chat.sendMessage(
               token: room.token,
-              message: 'bla',
-            );
-            expect(response.body.ocs.data!.id, 2);
-            expect(response.body.ocs.data!.actorType, spreed.ActorType.users.name);
-            expect(response.body.ocs.data!.actorId, 'user1');
-            expect(response.body.ocs.data!.actorDisplayName, 'User One');
-            expect(response.body.ocs.data!.timestamp * 1000, closeTo(startTime.millisecondsSinceEpoch, 10E3));
-            expect(response.body.ocs.data!.message, 'bla');
-            expect(response.body.ocs.data!.messageType, spreed.MessageType.comment.name);
-          });
-
-          group('Get messages', () {
-            test('Directly', () async {
-              final startTime = DateTime.now();
-              final room = (await client1.spreed.room.createRoom(
-                roomType: spreed.RoomType.oneToOne.value,
-                invite: 'user2',
-              ))
-                  .body
-                  .ocs
-                  .data;
-              await client1.spreed.chat.sendMessage(
-                token: room.token,
-                message: '123',
-                replyTo: (await client1.spreed.chat.sendMessage(
-                  token: room.token,
-                  message: 'bla',
-                ))
-                    .body
-                    .ocs
-                    .data!
-                    .id,
-              );
-
-              final response = await client1.spreed.chat.receiveMessages(
-                token: room.token,
-                lookIntoFuture: 0,
-              );
-              expect(response.headers.xChatLastGiven, '1');
-              expect(response.headers.xChatLastCommonRead, '1');
-
-              expect(response.body.ocs.data, hasLength(3));
-
-              expect(response.body.ocs.data[0].id, 3);
-              expect(response.body.ocs.data[0].actorType, spreed.ActorType.users.name);
-              expect(response.body.ocs.data[0].actorId, 'user1');
-              expect(response.body.ocs.data[0].actorDisplayName, 'User One');
-              expect(response.body.ocs.data[0].timestamp * 1000, closeTo(startTime.millisecondsSinceEpoch, 10E3));
-              expect(response.body.ocs.data[0].message, '123');
-              expect(response.body.ocs.data[0].messageType, spreed.MessageType.comment.name);
-
-              expect(response.body.ocs.data[0].parent!.id, 2);
-              expect(response.body.ocs.data[0].parent!.actorType, spreed.ActorType.users.name);
-              expect(response.body.ocs.data[0].parent!.actorId, 'user1');
-              expect(response.body.ocs.data[0].parent!.actorDisplayName, 'User One');
-              expect(
-                response.body.ocs.data[0].parent!.timestamp * 1000,
-                closeTo(startTime.millisecondsSinceEpoch, 10E3),
-              );
-              expect(response.body.ocs.data[0].parent!.message, 'bla');
-              expect(response.body.ocs.data[0].parent!.messageType, spreed.MessageType.comment.name);
-
-              expect(response.body.ocs.data[1].id, 2);
-              expect(response.body.ocs.data[1].actorType, spreed.ActorType.users.name);
-              expect(response.body.ocs.data[1].actorId, 'user1');
-              expect(response.body.ocs.data[1].actorDisplayName, 'User One');
-              expect(response.body.ocs.data[1].timestamp * 1000, closeTo(startTime.millisecondsSinceEpoch, 10E3));
-              expect(response.body.ocs.data[1].message, 'bla');
-              expect(response.body.ocs.data[1].messageType, spreed.MessageType.comment.name);
-
-              expect(response.body.ocs.data[2].id, 1);
-              expect(response.body.ocs.data[2].actorType, spreed.ActorType.users.name);
-              expect(response.body.ocs.data[2].actorId, 'user1');
-              expect(response.body.ocs.data[2].actorDisplayName, 'User One');
-              expect(response.body.ocs.data[2].timestamp * 1000, closeTo(startTime.millisecondsSinceEpoch, 10E3));
-              expect(response.body.ocs.data[2].message, 'You created the conversation');
-              expect(response.body.ocs.data[2].systemMessage, 'conversation_created');
-              expect(response.body.ocs.data[2].messageType, spreed.MessageType.system.name);
-            });
-
-            test('Polling', () async {
-              final startTime = DateTime.now();
-
-              final room = await createTestRoom();
-              final message = (await client1.spreed.chat.sendMessage(
+              message: '123',
+              replyTo: (await client1.spreed.chat.sendMessage(
                 token: room.token,
                 message: 'bla',
               ))
                   .body
                   .ocs
-                  .data!;
-              unawaited(
-                Future<void>.delayed(const Duration(seconds: 1)).then((final _) async {
-                  await client1.spreed.chat.sendMessage(
-                    token: room.token,
-                    message: '123',
-                  );
-                }),
-              );
+                  .data!
+                  .id,
+            );
 
-              final response = await client1.spreed.chat.receiveMessages(
-                token: room.token,
-                lookIntoFuture: 1,
-                timeout: 3,
-                lastKnownMessageId: message.id,
-              );
-              expect(response.body.ocs.data, hasLength(1));
-              expect(response.body.ocs.data[0].id, 3);
-              expect(response.body.ocs.data[0].actorType, spreed.ActorType.users.name);
-              expect(response.body.ocs.data[0].actorId, 'user1');
-              expect(response.body.ocs.data[0].actorDisplayName, 'User One');
-              expect(response.body.ocs.data[0].timestamp * 1000, closeTo(startTime.millisecondsSinceEpoch, 10E3));
-              expect(response.body.ocs.data[0].message, '123');
-              expect(response.body.ocs.data[0].messageType, spreed.MessageType.comment.name);
-            });
+            final response = await client1.spreed.chat.receiveMessages(
+              token: room.token,
+              lookIntoFuture: 0,
+            );
+            expect(response.headers.xChatLastGiven, '1');
+            expect(response.headers.xChatLastCommonRead, '1');
+
+            expect(response.body.ocs.data, hasLength(3));
+
+            expect(response.body.ocs.data[0].id, 3);
+            expect(response.body.ocs.data[0].actorType, spreed.ActorType.users.name);
+            expect(response.body.ocs.data[0].actorId, 'user1');
+            expect(response.body.ocs.data[0].actorDisplayName, 'User One');
+            expect(response.body.ocs.data[0].timestamp * 1000, closeTo(startTime.millisecondsSinceEpoch, 10E3));
+            expect(response.body.ocs.data[0].message, '123');
+            expect(response.body.ocs.data[0].messageType, spreed.MessageType.comment.name);
+
+            expect(response.body.ocs.data[0].parent!.id, 2);
+            expect(response.body.ocs.data[0].parent!.actorType, spreed.ActorType.users.name);
+            expect(response.body.ocs.data[0].parent!.actorId, 'user1');
+            expect(response.body.ocs.data[0].parent!.actorDisplayName, 'User One');
+            expect(
+              response.body.ocs.data[0].parent!.timestamp * 1000,
+              closeTo(startTime.millisecondsSinceEpoch, 10E3),
+            );
+            expect(response.body.ocs.data[0].parent!.message, 'bla');
+            expect(response.body.ocs.data[0].parent!.messageType, spreed.MessageType.comment.name);
+
+            expect(response.body.ocs.data[1].id, 2);
+            expect(response.body.ocs.data[1].actorType, spreed.ActorType.users.name);
+            expect(response.body.ocs.data[1].actorId, 'user1');
+            expect(response.body.ocs.data[1].actorDisplayName, 'User One');
+            expect(response.body.ocs.data[1].timestamp * 1000, closeTo(startTime.millisecondsSinceEpoch, 10E3));
+            expect(response.body.ocs.data[1].message, 'bla');
+            expect(response.body.ocs.data[1].messageType, spreed.MessageType.comment.name);
+
+            expect(response.body.ocs.data[2].id, 1);
+            expect(response.body.ocs.data[2].actorType, spreed.ActorType.users.name);
+            expect(response.body.ocs.data[2].actorId, 'user1');
+            expect(response.body.ocs.data[2].actorDisplayName, 'User One');
+            expect(response.body.ocs.data[2].timestamp * 1000, closeTo(startTime.millisecondsSinceEpoch, 10E3));
+            expect(response.body.ocs.data[2].message, 'You created the conversation');
+            expect(response.body.ocs.data[2].systemMessage, 'conversation_created');
+            expect(response.body.ocs.data[2].messageType, spreed.MessageType.system.name);
           });
-        });
 
-        group('Call', () {
-          test('Start and end call', () async {
-            var room = await createTestRoom();
-            expect(room.hasCall, isFalse);
-            room = (await client1.spreed.room.joinRoom(token: room.token)).body.ocs.data;
+          test('Polling', () async {
+            final startTime = DateTime.now();
 
-            await client1.spreed.call.joinCall(token: room.token);
-            room = (await client1.spreed.room.getSingleRoom(token: room.token)).body.ocs.data;
-            expect(room.hasCall, isTrue);
-
-            await client1.spreed.call.leaveCall(token: room.token);
-            room = (await client1.spreed.room.getSingleRoom(token: room.token)).body.ocs.data;
-            expect(room.hasCall, isFalse);
-          });
-        });
-
-        group('Signaling', () {
-          test('Get settings', () async {
             final room = await createTestRoom();
-
-            final response = await client1.spreed.signaling.getSettings(token: room.token);
-            expect(response.body.ocs.data.signalingMode, 'internal');
-            expect(response.body.ocs.data.userId, 'user1');
-            expect(response.body.ocs.data.hideWarning, false);
-            expect(response.body.ocs.data.server, '');
-            expect(response.body.ocs.data.ticket, contains(':user1:'));
-            expect(response.body.ocs.data.helloAuthParams.$10.userid, 'user1');
-            expect(response.body.ocs.data.helloAuthParams.$10.ticket, contains(':user1:'));
-            expect(
-              response.body.ocs.data.helloAuthParams.$20.token.split('').where((final x) => x == '.'),
-              hasLength(2),
-            );
-            expect(response.body.ocs.data.stunservers, hasLength(1));
-            expect(response.body.ocs.data.stunservers[0].urls, hasLength(1));
-            expect(response.body.ocs.data.stunservers[0].urls[0], 'stun:stun.nextcloud.com:443');
-            expect(response.body.ocs.data.turnservers, hasLength(1));
-            expect(response.body.ocs.data.turnservers[0].urls, hasLength(4));
-            expect(
-              response.body.ocs.data.turnservers[0].urls[0],
-              'turn:staticauth.openrelay.metered.ca:443?transport=udp',
-            );
-            expect(
-              response.body.ocs.data.turnservers[0].urls[1],
-              'turn:staticauth.openrelay.metered.ca:443?transport=tcp',
-            );
-            expect(
-              response.body.ocs.data.turnservers[0].urls[2],
-              'turns:staticauth.openrelay.metered.ca:443?transport=udp',
-            );
-            expect(
-              response.body.ocs.data.turnservers[0].urls[3],
-              'turns:staticauth.openrelay.metered.ca:443?transport=tcp',
-            );
-            expect(response.body.ocs.data.turnservers[0].username, isNotEmpty);
-            expect((response.body.ocs.data.turnservers[0].credential as StringJsonObject).asString, isNotEmpty);
-            expect(response.body.ocs.data.sipDialinInfo, '');
-          });
-
-          test('Send and receive messages', () async {
-            final room = (await client1.spreed.room.createRoom(
-              roomType: spreed.RoomType.oneToOne.value,
-              invite: 'user2',
+            final message = (await client1.spreed.chat.sendMessage(
+              token: room.token,
+              message: 'bla',
             ))
                 .body
                 .ocs
-                .data;
-
-            final room1 = (await client1.spreed.room.joinRoom(token: room.token)).body.ocs.data;
-            await client1.spreed.call.joinCall(token: room.token);
-
-            final client2 = await TestNextcloudClient.create(
-              container,
-              username: 'user2',
+                .data!;
+            unawaited(
+              Future<void>.delayed(const Duration(seconds: 1)).then((final _) async {
+                await client1.spreed.chat.sendMessage(
+                  token: room.token,
+                  message: '123',
+                );
+              }),
             );
 
-            final room2 = (await client2.spreed.room.joinRoom(token: room.token)).body.ocs.data;
-            await client2.spreed.call.joinCall(token: room.token);
-
-            await client1.spreed.signaling.sendMessages(
+            final response = await client1.spreed.chat.receiveMessages(
               token: room.token,
-              messages: json.encode([
-                {
-                  'ev': 'message',
-                  'sessionId': room1.sessionId,
-                  'fn': json.encode({
-                    'to': room2.sessionId,
-                  }),
-                },
-              ]),
+              lookIntoFuture: 1,
+              timeout: 3,
+              lastKnownMessageId: message.id,
             );
-
-            await Future<void>.delayed(const Duration(seconds: 1));
-
-            final messages = (await client2.spreed.signaling.pullMessages(token: room.token)).body.ocs.data;
-            expect(messages, hasLength(2));
-            expect(messages[0].type, 'message');
-            expect(json.decode(messages[0].data.string!), {'to': room2.sessionId, 'from': room1.sessionId});
-            expect(messages[1].type, 'usersInRoom');
-            expect(messages[1].data.builtListSignalingSession, hasLength(2));
-            expect(messages[1].data.builtListSignalingSession![0].userId, 'user1');
-            expect(messages[1].data.builtListSignalingSession![1].userId, 'user2');
+            expect(response.body.ocs.data, hasLength(1));
+            expect(response.body.ocs.data[0].id, 3);
+            expect(response.body.ocs.data[0].actorType, spreed.ActorType.users.name);
+            expect(response.body.ocs.data[0].actorId, 'user1');
+            expect(response.body.ocs.data[0].actorDisplayName, 'User One');
+            expect(response.body.ocs.data[0].timestamp * 1000, closeTo(startTime.millisecondsSinceEpoch, 10E3));
+            expect(response.body.ocs.data[0].message, '123');
+            expect(response.body.ocs.data[0].messageType, spreed.MessageType.comment.name);
           });
         });
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+      });
+
+      group('Call', () {
+        test('Start and end call', () async {
+          var room = await createTestRoom();
+          expect(room.hasCall, isFalse);
+          room = (await client1.spreed.room.joinRoom(token: room.token)).body.ocs.data;
+
+          await client1.spreed.call.joinCall(token: room.token);
+          room = (await client1.spreed.room.getSingleRoom(token: room.token)).body.ocs.data;
+          expect(room.hasCall, isTrue);
+
+          await client1.spreed.call.leaveCall(token: room.token);
+          room = (await client1.spreed.room.getSingleRoom(token: room.token)).body.ocs.data;
+          expect(room.hasCall, isFalse);
+        });
+      });
+
+      group('Signaling', () {
+        test('Get settings', () async {
+          final room = await createTestRoom();
+
+          final response = await client1.spreed.signaling.getSettings(token: room.token);
+          expect(response.body.ocs.data.signalingMode, 'internal');
+          expect(response.body.ocs.data.userId, 'user1');
+          expect(response.body.ocs.data.hideWarning, false);
+          expect(response.body.ocs.data.server, '');
+          expect(response.body.ocs.data.ticket, contains(':user1:'));
+          expect(response.body.ocs.data.helloAuthParams.$10.userid, 'user1');
+          expect(response.body.ocs.data.helloAuthParams.$10.ticket, contains(':user1:'));
+          expect(
+            response.body.ocs.data.helloAuthParams.$20.token.split('').where((final x) => x == '.'),
+            hasLength(2),
+          );
+          expect(response.body.ocs.data.stunservers, hasLength(1));
+          expect(response.body.ocs.data.stunservers[0].urls, hasLength(1));
+          expect(response.body.ocs.data.stunservers[0].urls[0], 'stun:stun.nextcloud.com:443');
+          expect(response.body.ocs.data.turnservers, hasLength(1));
+          expect(response.body.ocs.data.turnservers[0].urls, hasLength(4));
+          expect(
+            response.body.ocs.data.turnservers[0].urls[0],
+            'turn:staticauth.openrelay.metered.ca:443?transport=udp',
+          );
+          expect(
+            response.body.ocs.data.turnservers[0].urls[1],
+            'turn:staticauth.openrelay.metered.ca:443?transport=tcp',
+          );
+          expect(
+            response.body.ocs.data.turnservers[0].urls[2],
+            'turns:staticauth.openrelay.metered.ca:443?transport=udp',
+          );
+          expect(
+            response.body.ocs.data.turnservers[0].urls[3],
+            'turns:staticauth.openrelay.metered.ca:443?transport=tcp',
+          );
+          expect(response.body.ocs.data.turnservers[0].username, isNotEmpty);
+          expect((response.body.ocs.data.turnservers[0].credential as StringJsonObject).asString, isNotEmpty);
+          expect(response.body.ocs.data.sipDialinInfo, '');
+        });
+
+        test('Send and receive messages', () async {
+          final room = (await client1.spreed.room.createRoom(
+            roomType: spreed.RoomType.oneToOne.value,
+            invite: 'user2',
+          ))
+              .body
+              .ocs
+              .data;
+
+          final room1 = (await client1.spreed.room.joinRoom(token: room.token)).body.ocs.data;
+          await client1.spreed.call.joinCall(token: room.token);
+
+          final client2 = await TestNextcloudClient.create(
+            container,
+            username: 'user2',
+          );
+
+          final room2 = (await client2.spreed.room.joinRoom(token: room.token)).body.ocs.data;
+          await client2.spreed.call.joinCall(token: room.token);
+
+          await client1.spreed.signaling.sendMessages(
+            token: room.token,
+            messages: json.encode([
+              {
+                'ev': 'message',
+                'sessionId': room1.sessionId,
+                'fn': json.encode({
+                  'to': room2.sessionId,
+                }),
+              },
+            ]),
+          );
+
+          await Future<void>.delayed(const Duration(seconds: 1));
+
+          final messages = (await client2.spreed.signaling.pullMessages(token: room.token)).body.ocs.data;
+          expect(messages, hasLength(2));
+          expect(messages[0].type, 'message');
+          expect(json.decode(messages[0].data.string!), {'to': room2.sessionId, 'from': room1.sessionId});
+          expect(messages[1].type, 'usersInRoom');
+          expect(messages[1].data.builtListSignalingSession, hasLength(2));
+          expect(messages[1].data.builtListSignalingSession![0].userId, 'user1');
+          expect(messages[1].data.builtListSignalingSession![1].userId, 'user2');
+        });
+      });
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }

--- a/packages/nextcloud/test/uppush_test.dart
+++ b/packages/nextcloud/test/uppush_test.dart
@@ -5,92 +5,91 @@ import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
-  presets('uppush', (final preset) {
-    group(
-      'uppush',
-      () {
-        late DockerContainer container;
-        late NextcloudClient client;
-        setUp(() async {
-          container = await DockerContainer.create(preset);
-          client = await TestNextcloudClient.create(
-            container,
-            username: 'admin',
-          );
-        });
-        tearDown(() async {
-          if (Invoker.current!.liveTest.errors.isNotEmpty) {
-            print(await container.allLogs());
-          }
-          container.destroy();
-        });
+  presets(
+    'uppush',
+    'uppush',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client;
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client = await TestNextcloudClient.create(
+          container,
+          username: 'admin',
+        );
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
 
-        test('Is installed', () async {
-          final response = await client.uppush.check();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Is installed', () async {
+        final response = await client.uppush.check();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.success, isTrue);
-        });
+        expect(response.body.success, isTrue);
+      });
 
-        test('Set keepalive', () async {
-          final response = await client.uppush.setKeepalive(keepalive: 10);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Set keepalive', () async {
+        final response = await client.uppush.setKeepalive(keepalive: 10);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.success, isTrue);
-        });
+        expect(response.body.success, isTrue);
+      });
 
-        test('Create device', () async {
-          final response = await client.uppush.createDevice(deviceName: 'Test');
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Create device', () async {
+        final response = await client.uppush.createDevice(deviceName: 'Test');
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.success, isTrue);
-          expect(response.body.deviceId, isNotEmpty);
-        });
+        expect(response.body.success, isTrue);
+        expect(response.body.deviceId, isNotEmpty);
+      });
 
-        test('Delete device', () async {
-          final deviceId = (await client.uppush.createDevice(deviceName: 'Test')).body.deviceId;
+      test('Delete device', () async {
+        final deviceId = (await client.uppush.createDevice(deviceName: 'Test')).body.deviceId;
 
-          final response = await client.uppush.deleteDevice(deviceId: deviceId);
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        final response = await client.uppush.deleteDevice(deviceId: deviceId);
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.success, isTrue);
-        });
+        expect(response.body.success, isTrue);
+      });
 
-        test('Create app', () async {
-          final deviceId = (await client.uppush.createDevice(deviceName: 'Test')).body.deviceId;
+      test('Create app', () async {
+        final deviceId = (await client.uppush.createDevice(deviceName: 'Test')).body.deviceId;
 
-          final response = await client.uppush.createApp(deviceId: deviceId, appName: 'Test');
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+        final response = await client.uppush.createApp(deviceId: deviceId, appName: 'Test');
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.success, isTrue);
-          expect(response.body.token, isNotEmpty);
-        });
+        expect(response.body.success, isTrue);
+        expect(response.body.token, isNotEmpty);
+      });
 
-        test('UnifiedPush discovery', () async {
-          final response = await client.uppush.unifiedpushDiscovery(token: 'example');
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('UnifiedPush discovery', () async {
+        final response = await client.uppush.unifiedpushDiscovery(token: 'example');
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.unifiedpush.version, 1);
-        });
+        expect(response.body.unifiedpush.version, 1);
+      });
 
-        test('Matrix gateway discovery', () async {
-          final response = await client.uppush.gatewayMatrixDiscovery();
-          expect(response.statusCode, 200);
-          expect(() => response.headers, isA<void>());
+      test('Matrix gateway discovery', () async {
+        final response = await client.uppush.gatewayMatrixDiscovery();
+        expect(response.statusCode, 200);
+        expect(() => response.headers, isA<void>());
 
-          expect(response.body.unifiedpush.gateway, 'matrix');
-        });
+        expect(response.body.unifiedpush.gateway, 'matrix');
+      });
 
-        // Deleting an app, sending a notification (also via matrix gateway) or listening for notifications is not possible because redis is not set up
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+      // Deleting an app, sending a notification (also via matrix gateway) or listening for notifications is not possible because redis is not set up
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }

--- a/packages/nextcloud/test/user_status_test.dart
+++ b/packages/nextcloud/test/user_status_test.dart
@@ -5,212 +5,211 @@ import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 void main() {
-  presets('server', (final preset) {
-    group(
-      'user_status',
-      () {
-        late DockerContainer container;
-        late NextcloudClient client;
-        setUp(() async {
-          container = await DockerContainer.create(preset);
-          client = await TestNextcloudClient.create(container);
-        });
-        tearDown(() async {
-          if (Invoker.current!.liveTest.errors.isNotEmpty) {
-            print(await container.allLogs());
+  presets(
+    'server',
+    'user_status',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client;
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client = await TestNextcloudClient.create(container);
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
+
+      group('Predefined status', () {
+        test('Find all', () async {
+          final expectedStatusIDs = ['meeting', 'commuting', 'remote-work', 'sick-leave', 'vacationing'];
+          final response = await client.userStatus.predefinedStatus.findAll();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          expect(response.body.ocs.data, hasLength(5));
+          final responseIDs = response.body.ocs.data.map((final status) => status.id);
+          expect(expectedStatusIDs.map(responseIDs.contains).contains(false), false);
+          for (final status in response.body.ocs.data) {
+            expect(status.icon, isNotNull);
+            expect(status.message, isNotNull);
           }
-          container.destroy();
+
+          final meeting = response.body.ocs.data.singleWhere((final s) => s.id == 'meeting').clearAt!;
+          expect(meeting.type, user_status.ClearAt_Type.period);
+          expect(meeting.time.$int, 3600);
+
+          final commuting = response.body.ocs.data.singleWhere((final s) => s.id == 'commuting').clearAt!;
+          expect(commuting.type, user_status.ClearAt_Type.period);
+          expect(commuting.time.$int, 1800);
+
+          final remoteWork = response.body.ocs.data.singleWhere((final s) => s.id == 'remote-work').clearAt!;
+          expect(remoteWork.type, user_status.ClearAt_Type.endOf);
+          expect(remoteWork.time.clearAtTimeType, user_status.ClearAtTimeType.day);
+
+          final sickLeave = response.body.ocs.data.singleWhere((final s) => s.id == 'sick-leave').clearAt!;
+          expect(sickLeave.type, user_status.ClearAt_Type.endOf);
+          expect(sickLeave.time.clearAtTimeType, user_status.ClearAtTimeType.day);
+
+          final vacationing = response.body.ocs.data.singleWhere((final s) => s.id == 'vacationing').clearAt;
+          expect(vacationing, null);
+        });
+      });
+
+      group('User status', () {
+        test('Set', () async {
+          final response = await client.userStatus.userStatus.setStatus(statusType: 'online');
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          expect(response.body.ocs.data.userId, 'user1');
+          expect(response.body.ocs.data.message, null);
+          expect(response.body.ocs.data.messageId, null);
+          expect(response.body.ocs.data.messageIsPredefined, false);
+          expect(response.body.ocs.data.icon, null);
+          expect(response.body.ocs.data.clearAt, null);
+          expect(response.body.ocs.data.status, 'online');
+          expect(response.body.ocs.data.statusIsUserDefined, true);
         });
 
-        group('Predefined status', () {
-          test('Find all', () async {
-            final expectedStatusIDs = ['meeting', 'commuting', 'remote-work', 'sick-leave', 'vacationing'];
-            final response = await client.userStatus.predefinedStatus.findAll();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
+        test('Get', () async {
+          // There seems to be a bug in Nextcloud which makes getting the status fail before it has been set once.
+          // The error message from Nextcloud is "Could not create folder"
+          await client.userStatus.userStatus.setStatus(statusType: 'online');
 
-            expect(response.body.ocs.data, hasLength(5));
-            final responseIDs = response.body.ocs.data.map((final status) => status.id);
-            expect(expectedStatusIDs.map(responseIDs.contains).contains(false), false);
-            for (final status in response.body.ocs.data) {
-              expect(status.icon, isNotNull);
-              expect(status.message, isNotNull);
-            }
+          final response = await client.userStatus.userStatus.getStatus();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
 
-            final meeting = response.body.ocs.data.singleWhere((final s) => s.id == 'meeting').clearAt!;
-            expect(meeting.type, user_status.ClearAt_Type.period);
-            expect(meeting.time.$int, 3600);
-
-            final commuting = response.body.ocs.data.singleWhere((final s) => s.id == 'commuting').clearAt!;
-            expect(commuting.type, user_status.ClearAt_Type.period);
-            expect(commuting.time.$int, 1800);
-
-            final remoteWork = response.body.ocs.data.singleWhere((final s) => s.id == 'remote-work').clearAt!;
-            expect(remoteWork.type, user_status.ClearAt_Type.endOf);
-            expect(remoteWork.time.clearAtTimeType, user_status.ClearAtTimeType.day);
-
-            final sickLeave = response.body.ocs.data.singleWhere((final s) => s.id == 'sick-leave').clearAt!;
-            expect(sickLeave.type, user_status.ClearAt_Type.endOf);
-            expect(sickLeave.time.clearAtTimeType, user_status.ClearAtTimeType.day);
-
-            final vacationing = response.body.ocs.data.singleWhere((final s) => s.id == 'vacationing').clearAt;
-            expect(vacationing, null);
-          });
+          expect(response.body.ocs.data.userId, 'user1');
+          expect(response.body.ocs.data.message, null);
+          expect(response.body.ocs.data.messageId, null);
+          expect(response.body.ocs.data.messageIsPredefined, false);
+          expect(response.body.ocs.data.icon, null);
+          expect(response.body.ocs.data.clearAt, null);
+          expect(response.body.ocs.data.status, 'online');
+          expect(response.body.ocs.data.statusIsUserDefined, true);
         });
 
-        group('User status', () {
-          test('Set', () async {
-            final response = await client.userStatus.userStatus.setStatus(statusType: 'online');
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
+        test('Find', () async {
+          // Same as getting status
+          await client.userStatus.userStatus.setStatus(statusType: 'online');
 
-            expect(response.body.ocs.data.userId, 'user1');
-            expect(response.body.ocs.data.message, null);
-            expect(response.body.ocs.data.messageId, null);
-            expect(response.body.ocs.data.messageIsPredefined, false);
-            expect(response.body.ocs.data.icon, null);
-            expect(response.body.ocs.data.clearAt, null);
-            expect(response.body.ocs.data.status, 'online');
-            expect(response.body.ocs.data.statusIsUserDefined, true);
-          });
+          final response = await client.userStatus.statuses.find(userId: 'user1');
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
 
-          test('Get', () async {
-            // There seems to be a bug in Nextcloud which makes getting the status fail before it has been set once.
-            // The error message from Nextcloud is "Could not create folder"
-            await client.userStatus.userStatus.setStatus(statusType: 'online');
-
-            final response = await client.userStatus.userStatus.getStatus();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data.userId, 'user1');
-            expect(response.body.ocs.data.message, null);
-            expect(response.body.ocs.data.messageId, null);
-            expect(response.body.ocs.data.messageIsPredefined, false);
-            expect(response.body.ocs.data.icon, null);
-            expect(response.body.ocs.data.clearAt, null);
-            expect(response.body.ocs.data.status, 'online');
-            expect(response.body.ocs.data.statusIsUserDefined, true);
-          });
-
-          test('Find', () async {
-            // Same as getting status
-            await client.userStatus.userStatus.setStatus(statusType: 'online');
-
-            final response = await client.userStatus.statuses.find(userId: 'user1');
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data.userId, 'user1');
-            expect(response.body.ocs.data.message, null);
-            expect(response.body.ocs.data.icon, null);
-            expect(response.body.ocs.data.clearAt, null);
-            expect(response.body.ocs.data.status, 'online');
-          });
-
-          test('Set predefined message', () async {
-            final clearAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60;
-            final response = await client.userStatus.userStatus.setPredefinedMessage(
-              messageId: 'meeting',
-              clearAt: clearAt,
-            );
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data.userId, 'user1');
-            expect(response.body.ocs.data.message, null);
-            expect(response.body.ocs.data.messageId, 'meeting');
-            expect(response.body.ocs.data.messageIsPredefined, true);
-            expect(response.body.ocs.data.icon, null);
-            expect(response.body.ocs.data.clearAt, clearAt);
-            expect(response.body.ocs.data.status, 'offline');
-            expect(response.body.ocs.data.statusIsUserDefined, false);
-          });
-
-          test('Set custom message', () async {
-            final clearAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60;
-            final response = await client.userStatus.userStatus.setCustomMessage(
-              statusIcon: '😀',
-              message: 'bla',
-              clearAt: clearAt,
-            );
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data.userId, 'user1');
-            expect(response.body.ocs.data.message, 'bla');
-            expect(response.body.ocs.data.messageId, null);
-            expect(response.body.ocs.data.messageIsPredefined, false);
-            expect(response.body.ocs.data.icon, '😀');
-            expect(response.body.ocs.data.clearAt, clearAt);
-            expect(response.body.ocs.data.status, 'offline');
-            expect(response.body.ocs.data.statusIsUserDefined, false);
-          });
-
-          test('Clear message', () async {
-            final clearAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60;
-            await client.userStatus.userStatus.setCustomMessage(
-              statusIcon: '😀',
-              message: 'bla',
-              clearAt: clearAt,
-            );
-            await client.userStatus.userStatus.clearMessage();
-
-            final response = await client.userStatus.userStatus.getStatus();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-
-            expect(response.body.ocs.data.userId, 'user1');
-            expect(response.body.ocs.data.message, null);
-            expect(response.body.ocs.data.messageId, null);
-            expect(response.body.ocs.data.messageIsPredefined, false);
-            expect(response.body.ocs.data.icon, null);
-            expect(response.body.ocs.data.clearAt, null);
-            expect(response.body.ocs.data.status, 'offline');
-            expect(response.body.ocs.data.statusIsUserDefined, false);
-          });
+          expect(response.body.ocs.data.userId, 'user1');
+          expect(response.body.ocs.data.message, null);
+          expect(response.body.ocs.data.icon, null);
+          expect(response.body.ocs.data.clearAt, null);
+          expect(response.body.ocs.data.status, 'online');
         });
 
-        group('Statuses', () {
-          test('Find all', () async {
-            var response = await client.userStatus.statuses.findAll();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-            expect(response.body.ocs.data, hasLength(0));
+        test('Set predefined message', () async {
+          final clearAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60;
+          final response = await client.userStatus.userStatus.setPredefinedMessage(
+            messageId: 'meeting',
+            clearAt: clearAt,
+          );
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
 
-            await client.userStatus.userStatus.setStatus(statusType: 'online');
-
-            response = await client.userStatus.statuses.findAll();
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
-            expect(response.body.ocs.data, hasLength(1));
-            expect(response.body.ocs.data[0].userId, 'user1');
-            expect(response.body.ocs.data[0].message, null);
-            expect(response.body.ocs.data[0].icon, null);
-            expect(response.body.ocs.data[0].clearAt, null);
-            expect(response.body.ocs.data[0].status, 'online');
-          });
+          expect(response.body.ocs.data.userId, 'user1');
+          expect(response.body.ocs.data.message, null);
+          expect(response.body.ocs.data.messageId, 'meeting');
+          expect(response.body.ocs.data.messageIsPredefined, true);
+          expect(response.body.ocs.data.icon, null);
+          expect(response.body.ocs.data.clearAt, clearAt);
+          expect(response.body.ocs.data.status, 'offline');
+          expect(response.body.ocs.data.statusIsUserDefined, false);
         });
 
-        group('Heartbeat', () {
-          test('Heartbeat', () async {
-            final response = await client.userStatus.heartbeat.heartbeat(status: 'online');
-            expect(response.statusCode, 200);
-            expect(() => response.headers, isA<void>());
+        test('Set custom message', () async {
+          final clearAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60;
+          final response = await client.userStatus.userStatus.setCustomMessage(
+            statusIcon: '😀',
+            message: 'bla',
+            clearAt: clearAt,
+          );
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
 
-            expect(response.body.ocs.data.userId, 'user1');
-            expect(response.body.ocs.data.message, null);
-            expect(response.body.ocs.data.messageId, null);
-            expect(response.body.ocs.data.messageIsPredefined, false);
-            expect(response.body.ocs.data.icon, null);
-            expect(response.body.ocs.data.clearAt, null);
-            expect(response.body.ocs.data.status, 'online');
-            expect(response.body.ocs.data.statusIsUserDefined, false);
-          });
+          expect(response.body.ocs.data.userId, 'user1');
+          expect(response.body.ocs.data.message, 'bla');
+          expect(response.body.ocs.data.messageId, null);
+          expect(response.body.ocs.data.messageIsPredefined, false);
+          expect(response.body.ocs.data.icon, '😀');
+          expect(response.body.ocs.data.clearAt, clearAt);
+          expect(response.body.ocs.data.status, 'offline');
+          expect(response.body.ocs.data.statusIsUserDefined, false);
         });
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+
+        test('Clear message', () async {
+          final clearAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 60;
+          await client.userStatus.userStatus.setCustomMessage(
+            statusIcon: '😀',
+            message: 'bla',
+            clearAt: clearAt,
+          );
+          await client.userStatus.userStatus.clearMessage();
+
+          final response = await client.userStatus.userStatus.getStatus();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          expect(response.body.ocs.data.userId, 'user1');
+          expect(response.body.ocs.data.message, null);
+          expect(response.body.ocs.data.messageId, null);
+          expect(response.body.ocs.data.messageIsPredefined, false);
+          expect(response.body.ocs.data.icon, null);
+          expect(response.body.ocs.data.clearAt, null);
+          expect(response.body.ocs.data.status, 'offline');
+          expect(response.body.ocs.data.statusIsUserDefined, false);
+        });
+      });
+
+      group('Statuses', () {
+        test('Find all', () async {
+          var response = await client.userStatus.statuses.findAll();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+          expect(response.body.ocs.data, hasLength(0));
+
+          await client.userStatus.userStatus.setStatus(statusType: 'online');
+
+          response = await client.userStatus.statuses.findAll();
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+          expect(response.body.ocs.data, hasLength(1));
+          expect(response.body.ocs.data[0].userId, 'user1');
+          expect(response.body.ocs.data[0].message, null);
+          expect(response.body.ocs.data[0].icon, null);
+          expect(response.body.ocs.data[0].clearAt, null);
+          expect(response.body.ocs.data[0].status, 'online');
+        });
+      });
+
+      group('Heartbeat', () {
+        test('Heartbeat', () async {
+          final response = await client.userStatus.heartbeat.heartbeat(status: 'online');
+          expect(response.statusCode, 200);
+          expect(() => response.headers, isA<void>());
+
+          expect(response.body.ocs.data.userId, 'user1');
+          expect(response.body.ocs.data.message, null);
+          expect(response.body.ocs.data.messageId, null);
+          expect(response.body.ocs.data.messageIsPredefined, false);
+          expect(response.body.ocs.data.icon, null);
+          expect(response.body.ocs.data.clearAt, null);
+          expect(response.body.ocs.data.status, 'online');
+          expect(response.body.ocs.data.statusIsUserDefined, false);
+        });
+      });
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }

--- a/packages/nextcloud/test/webdav_test.dart
+++ b/packages/nextcloud/test/webdav_test.dart
@@ -135,524 +135,523 @@ void main() {
     });
   });
 
-  presets('server', (final preset) {
-    group(
-      'webdav',
-      () {
-        late DockerContainer container;
-        late NextcloudClient client;
+  presets(
+    'server',
+    'webdav',
+    (final preset) {
+      late DockerContainer container;
+      late NextcloudClient client;
 
-        setUp(() async {
-          container = await DockerContainer.create(preset);
-          client = await TestNextcloudClient.create(container);
-        });
-        tearDown(() async {
-          if (Invoker.current!.liveTest.errors.isNotEmpty) {
-            print(await container.allLogs());
-          }
-          container.destroy();
-        });
+      setUp(() async {
+        container = await DockerContainer.create(preset);
+        client = await TestNextcloudClient.create(container);
+      });
+      tearDown(() async {
+        if (Invoker.current!.liveTest.errors.isNotEmpty) {
+          print(await container.allLogs());
+        }
+        container.destroy();
+      });
 
-        test('List directory', () async {
-          final responses = (await client.webdav.propfind(
-            PathUri.parse('/'),
-            prop: WebDavPropWithoutValues.fromBools(
-              nchaspreview: true,
-              davgetcontenttype: true,
-              davgetlastmodified: true,
-              ocsize: true,
-            ),
-          ))
-              .responses;
-          expect(responses, isNotEmpty);
-          final props =
-              responses.singleWhere((final response) => response.href!.endsWith('/Nextcloud.png')).propstats.first.prop;
-          expect(props.nchaspreview, isTrue);
-          expect(props.davgetcontenttype, 'image/png');
-          expect(webdavDateFormat.parseUtc(props.davgetlastmodified!).isBefore(DateTime.now()), isTrue);
-          expect(props.ocsize, 50598);
-        });
+      test('List directory', () async {
+        final responses = (await client.webdav.propfind(
+          PathUri.parse('/'),
+          prop: WebDavPropWithoutValues.fromBools(
+            nchaspreview: true,
+            davgetcontenttype: true,
+            davgetlastmodified: true,
+            ocsize: true,
+          ),
+        ))
+            .responses;
+        expect(responses, isNotEmpty);
+        final props =
+            responses.singleWhere((final response) => response.href!.endsWith('/Nextcloud.png')).propstats.first.prop;
+        expect(props.nchaspreview, isTrue);
+        expect(props.davgetcontenttype, 'image/png');
+        expect(webdavDateFormat.parseUtc(props.davgetlastmodified!).isBefore(DateTime.now()), isTrue);
+        expect(props.ocsize, 50598);
+      });
 
-        test('List directory recursively', () async {
-          final responses = (await client.webdav.propfind(
-            PathUri.parse('/'),
-            depth: WebDavDepth.infinity,
-          ))
-              .responses;
-          expect(responses, isNotEmpty);
-        });
+      test('List directory recursively', () async {
+        final responses = (await client.webdav.propfind(
+          PathUri.parse('/'),
+          depth: WebDavDepth.infinity,
+        ))
+            .responses;
+        expect(responses, isNotEmpty);
+      });
 
-        test('Get file props', () async {
-          final response = (await client.webdav.propfind(
-            PathUri.parse('Nextcloud.png'),
-            prop: WebDavPropWithoutValues.fromBools(
-              davgetlastmodified: true,
-              davgetetag: true,
-              davgetcontenttype: true,
-              davgetcontentlength: true,
-              davresourcetype: true,
-              ocid: true,
-              ocfileid: true,
-              ocfavorite: true,
-              occommentshref: true,
-              occommentscount: true,
-              occommentsunread: true,
-              ocdownloadurl: true,
-              ocownerid: true,
-              ocownerdisplayname: true,
-              ocsize: true,
-              ocpermissions: true,
-              ncnote: true,
-              ncdatafingerprint: true,
-              nchaspreview: true,
-              ncmounttype: true,
-              ncisencrypted: true,
-              ncmetadataetag: true,
-              ncuploadtime: true,
-              nccreationtime: true,
-              ncrichworkspace: true,
-              ocssharepermissions: true,
-              ocmsharepermissions: true,
-            ),
-          ))
-              .toWebDavFiles()
-              .single;
+      test('Get file props', () async {
+        final response = (await client.webdav.propfind(
+          PathUri.parse('Nextcloud.png'),
+          prop: WebDavPropWithoutValues.fromBools(
+            davgetlastmodified: true,
+            davgetetag: true,
+            davgetcontenttype: true,
+            davgetcontentlength: true,
+            davresourcetype: true,
+            ocid: true,
+            ocfileid: true,
+            ocfavorite: true,
+            occommentshref: true,
+            occommentscount: true,
+            occommentsunread: true,
+            ocdownloadurl: true,
+            ocownerid: true,
+            ocownerdisplayname: true,
+            ocsize: true,
+            ocpermissions: true,
+            ncnote: true,
+            ncdatafingerprint: true,
+            nchaspreview: true,
+            ncmounttype: true,
+            ncisencrypted: true,
+            ncmetadataetag: true,
+            ncuploadtime: true,
+            nccreationtime: true,
+            ncrichworkspace: true,
+            ocssharepermissions: true,
+            ocmsharepermissions: true,
+          ),
+        ))
+            .toWebDavFiles()
+            .single;
 
-          expect(response.path, PathUri.parse('Nextcloud.png'));
-          expect(response.id, isNotEmpty);
-          expect(response.fileId, isNotEmpty);
-          expect(response.isCollection, isFalse);
-          expect(response.mimeType, 'image/png');
-          expect(response.etag, isNotEmpty);
-          expect(response.size, 50598);
-          expect(response.ownerId, 'user1');
-          expect(response.ownerDisplay, 'User One');
-          expect(response.lastModified!.isBefore(DateTime.now()), isTrue);
-          expect(response.isDirectory, isFalse);
-          expect(response.uploadedDate, DateTime.utc(1970));
-          expect(response.createdDate, DateTime.utc(1970));
-          expect(response.favorite, isFalse);
-          expect(response.hasPreview, isTrue);
-          expect(response.name, 'Nextcloud.png');
-          expect(response.isDirectory, isFalse);
+        expect(response.path, PathUri.parse('Nextcloud.png'));
+        expect(response.id, isNotEmpty);
+        expect(response.fileId, isNotEmpty);
+        expect(response.isCollection, isFalse);
+        expect(response.mimeType, 'image/png');
+        expect(response.etag, isNotEmpty);
+        expect(response.size, 50598);
+        expect(response.ownerId, 'user1');
+        expect(response.ownerDisplay, 'User One');
+        expect(response.lastModified!.isBefore(DateTime.now()), isTrue);
+        expect(response.isDirectory, isFalse);
+        expect(response.uploadedDate, DateTime.utc(1970));
+        expect(response.createdDate, DateTime.utc(1970));
+        expect(response.favorite, isFalse);
+        expect(response.hasPreview, isTrue);
+        expect(response.name, 'Nextcloud.png');
+        expect(response.isDirectory, isFalse);
 
-          expect(webdavDateFormat.parseUtc(response.props.davgetlastmodified!).isBefore(DateTime.now()), isTrue);
-          expect(response.props.davgetetag, isNotEmpty);
-          expect(response.props.davgetcontenttype, 'image/png');
-          expect(response.props.davgetcontentlength, 50598);
-          expect(response.props.davresourcetype!.collection, isNull);
-          expect(response.props.ocid, isNotEmpty);
-          expect(response.props.ocfileid, isNotEmpty);
-          expect(response.props.ocfavorite, 0);
-          expect(response.props.occommentshref, isNotEmpty);
-          expect(response.props.occommentscount, 0);
-          expect(response.props.occommentsunread, 0);
-          expect(response.props.ocdownloadurl, isNull);
-          expect(response.props.ocownerid, 'user1');
-          expect(response.props.ocownerdisplayname, 'User One');
-          expect(response.props.ocsize, 50598);
-          expect(response.props.ocpermissions, 'RGDNVW');
-          expect(response.props.ncnote, isNull);
-          expect(response.props.ncdatafingerprint, isNull);
-          expect(response.props.nchaspreview, isTrue);
-          expect(response.props.ncmounttype, isNull);
-          expect(response.props.ncisencrypted, isNull);
-          expect(response.props.ncmetadataetag, isNull);
-          expect(response.props.ncuploadtime, 0);
-          expect(response.props.nccreationtime, 0);
-          expect(response.props.ncrichworkspace, isNull);
-          expect(response.props.ocssharepermissions, 19);
-          expect(json.decode(response.props.ocmsharepermissions!), ['share', 'read', 'write']);
-        });
+        expect(webdavDateFormat.parseUtc(response.props.davgetlastmodified!).isBefore(DateTime.now()), isTrue);
+        expect(response.props.davgetetag, isNotEmpty);
+        expect(response.props.davgetcontenttype, 'image/png');
+        expect(response.props.davgetcontentlength, 50598);
+        expect(response.props.davresourcetype!.collection, isNull);
+        expect(response.props.ocid, isNotEmpty);
+        expect(response.props.ocfileid, isNotEmpty);
+        expect(response.props.ocfavorite, 0);
+        expect(response.props.occommentshref, isNotEmpty);
+        expect(response.props.occommentscount, 0);
+        expect(response.props.occommentsunread, 0);
+        expect(response.props.ocdownloadurl, isNull);
+        expect(response.props.ocownerid, 'user1');
+        expect(response.props.ocownerdisplayname, 'User One');
+        expect(response.props.ocsize, 50598);
+        expect(response.props.ocpermissions, 'RGDNVW');
+        expect(response.props.ncnote, isNull);
+        expect(response.props.ncdatafingerprint, isNull);
+        expect(response.props.nchaspreview, isTrue);
+        expect(response.props.ncmounttype, isNull);
+        expect(response.props.ncisencrypted, isNull);
+        expect(response.props.ncmetadataetag, isNull);
+        expect(response.props.ncuploadtime, 0);
+        expect(response.props.nccreationtime, 0);
+        expect(response.props.ncrichworkspace, isNull);
+        expect(response.props.ocssharepermissions, 19);
+        expect(json.decode(response.props.ocmsharepermissions!), ['share', 'read', 'write']);
+      });
 
-        test('Get directory props', () async {
-          final data = utf8.encode('test');
-          await client.webdav.mkcol(PathUri.parse('test'));
-          await client.webdav.put(data, PathUri.parse('test/test.txt'));
+      test('Get directory props', () async {
+        final data = utf8.encode('test');
+        await client.webdav.mkcol(PathUri.parse('test'));
+        await client.webdav.put(data, PathUri.parse('test/test.txt'));
 
-          final response = (await client.webdav.propfind(
-            PathUri.parse('test'),
-            prop: WebDavPropWithoutValues.fromBools(
-              davgetcontenttype: true,
-              davgetlastmodified: true,
-              davresourcetype: true,
-              ocsize: true,
-            ),
-            depth: WebDavDepth.zero,
-          ))
-              .toWebDavFiles()
-              .single;
+        final response = (await client.webdav.propfind(
+          PathUri.parse('test'),
+          prop: WebDavPropWithoutValues.fromBools(
+            davgetcontenttype: true,
+            davgetlastmodified: true,
+            davresourcetype: true,
+            ocsize: true,
+          ),
+          depth: WebDavDepth.zero,
+        ))
+            .toWebDavFiles()
+            .single;
 
-          expect(response.path, PathUri.parse('test/'));
-          expect(response.isCollection, isTrue);
-          expect(response.mimeType, isNull);
-          expect(response.size, data.lengthInBytes);
-          expect(
-            response.lastModified!.millisecondsSinceEpoch,
-            closeTo(DateTime.now().millisecondsSinceEpoch, 10E3),
-          );
-          expect(response.name, 'test');
-          expect(response.isDirectory, isTrue);
+        expect(response.path, PathUri.parse('test/'));
+        expect(response.isCollection, isTrue);
+        expect(response.mimeType, isNull);
+        expect(response.size, data.lengthInBytes);
+        expect(
+          response.lastModified!.millisecondsSinceEpoch,
+          closeTo(DateTime.now().millisecondsSinceEpoch, 10E3),
+        );
+        expect(response.name, 'test');
+        expect(response.isDirectory, isTrue);
 
-          expect(response.props.davgetcontenttype, isNull);
-          expect(
-            webdavDateFormat.parseUtc(response.props.davgetlastmodified!).millisecondsSinceEpoch,
-            closeTo(DateTime.now().millisecondsSinceEpoch, 10E3),
-          );
-          expect(response.props.davresourcetype!.collection, isNotNull);
-          expect(response.props.ocsize, data.lengthInBytes);
-        });
+        expect(response.props.davgetcontenttype, isNull);
+        expect(
+          webdavDateFormat.parseUtc(response.props.davgetlastmodified!).millisecondsSinceEpoch,
+          closeTo(DateTime.now().millisecondsSinceEpoch, 10E3),
+        );
+        expect(response.props.davresourcetype!.collection, isNotNull);
+        expect(response.props.ocsize, data.lengthInBytes);
+      });
 
-        test('Filter files', () async {
-          final response = await client.webdav.put(utf8.encode('test'), PathUri.parse('test.txt'));
-          final id = response.headers['oc-fileid']!.first;
-          await client.webdav.proppatch(
-            PathUri.parse('test.txt'),
-            set: WebDavProp(
-              ocfavorite: 1,
-            ),
-          );
+      test('Filter files', () async {
+        final response = await client.webdav.put(utf8.encode('test'), PathUri.parse('test.txt'));
+        final id = response.headers['oc-fileid']!.first;
+        await client.webdav.proppatch(
+          PathUri.parse('test.txt'),
+          set: WebDavProp(
+            ocfavorite: 1,
+          ),
+        );
 
-          final responses = (await client.webdav.report(
-            PathUri.parse('/'),
-            WebDavOcFilterRules(
-              ocfavorite: 1,
-            ),
-            prop: WebDavPropWithoutValues.fromBools(
-              ocid: true,
-              ocfavorite: true,
-            ),
-          ))
-              .responses;
-          expect(responses, hasLength(1));
-          final props =
-              responses.singleWhere((final response) => response.href!.endsWith('/test.txt')).propstats.first.prop;
-          expect(props.ocid, id);
-          expect(props.ocfavorite, 1);
-        });
+        final responses = (await client.webdav.report(
+          PathUri.parse('/'),
+          WebDavOcFilterRules(
+            ocfavorite: 1,
+          ),
+          prop: WebDavPropWithoutValues.fromBools(
+            ocid: true,
+            ocfavorite: true,
+          ),
+        ))
+            .responses;
+        expect(responses, hasLength(1));
+        final props =
+            responses.singleWhere((final response) => response.href!.endsWith('/test.txt')).propstats.first.prop;
+        expect(props.ocid, id);
+        expect(props.ocfavorite, 1);
+      });
 
-        test('Set properties', () async {
-          final lastModifiedDate = DateTime.utc(1972, 3);
-          final createdDate = DateTime.utc(1971, 2);
-          final uploadTime = DateTime.now();
+      test('Set properties', () async {
+        final lastModifiedDate = DateTime.utc(1972, 3);
+        final createdDate = DateTime.utc(1971, 2);
+        final uploadTime = DateTime.now();
 
-          await client.webdav.put(
-            utf8.encode('test'),
-            PathUri.parse('test.txt'),
-            lastModified: lastModifiedDate,
-            created: createdDate,
-          );
+        await client.webdav.put(
+          utf8.encode('test'),
+          PathUri.parse('test.txt'),
+          lastModified: lastModifiedDate,
+          created: createdDate,
+        );
 
-          final updated = await client.webdav.proppatch(
-            PathUri.parse('test.txt'),
-            set: WebDavProp(
-              ocfavorite: 1,
-            ),
-          );
-          expect(updated, isTrue);
+        final updated = await client.webdav.proppatch(
+          PathUri.parse('test.txt'),
+          set: WebDavProp(
+            ocfavorite: 1,
+          ),
+        );
+        expect(updated, isTrue);
 
-          final props = (await client.webdav.propfind(
-            PathUri.parse('test.txt'),
-            prop: WebDavPropWithoutValues.fromBools(
-              ocfavorite: true,
-              davgetlastmodified: true,
-              nccreationtime: true,
-              ncuploadtime: true,
-            ),
-          ))
-              .responses
-              .single
-              .propstats
-              .first
-              .prop;
-          expect(props.ocfavorite, 1);
-          expect(webdavDateFormat.parseUtc(props.davgetlastmodified!), lastModifiedDate);
-          expect(props.nccreationtime! * 1000, createdDate.millisecondsSinceEpoch);
-          expect(props.ncuploadtime! * 1000, closeTo(uploadTime.millisecondsSinceEpoch, 10E3));
-        });
+        final props = (await client.webdav.propfind(
+          PathUri.parse('test.txt'),
+          prop: WebDavPropWithoutValues.fromBools(
+            ocfavorite: true,
+            davgetlastmodified: true,
+            nccreationtime: true,
+            ncuploadtime: true,
+          ),
+        ))
+            .responses
+            .single
+            .propstats
+            .first
+            .prop;
+        expect(props.ocfavorite, 1);
+        expect(webdavDateFormat.parseUtc(props.davgetlastmodified!), lastModifiedDate);
+        expect(props.nccreationtime! * 1000, createdDate.millisecondsSinceEpoch);
+        expect(props.ncuploadtime! * 1000, closeTo(uploadTime.millisecondsSinceEpoch, 10E3));
+      });
 
-        test('Remove properties', () async {
-          await client.webdav.put(utf8.encode('test'), PathUri.parse('test.txt'));
+      test('Remove properties', () async {
+        await client.webdav.put(utf8.encode('test'), PathUri.parse('test.txt'));
 
-          var updated = await client.webdav.proppatch(
-            PathUri.parse('test.txt'),
-            set: WebDavProp(
-              ocfavorite: 1,
-            ),
-          );
-          expect(updated, isTrue);
+        var updated = await client.webdav.proppatch(
+          PathUri.parse('test.txt'),
+          set: WebDavProp(
+            ocfavorite: 1,
+          ),
+        );
+        expect(updated, isTrue);
 
-          var props = (await client.webdav.propfind(
-            PathUri.parse('test.txt'),
-            prop: WebDavPropWithoutValues.fromBools(
-              ocfavorite: true,
-              nccreationtime: true,
-              ncuploadtime: true,
-            ),
-          ))
-              .responses
-              .single
-              .propstats
-              .first
-              .prop;
-          expect(props.ocfavorite, 1);
+        var props = (await client.webdav.propfind(
+          PathUri.parse('test.txt'),
+          prop: WebDavPropWithoutValues.fromBools(
+            ocfavorite: true,
+            nccreationtime: true,
+            ncuploadtime: true,
+          ),
+        ))
+            .responses
+            .single
+            .propstats
+            .first
+            .prop;
+        expect(props.ocfavorite, 1);
 
-          updated = await client.webdav.proppatch(
-            PathUri.parse('test.txt'),
-            remove: WebDavPropWithoutValues.fromBools(
-              ocfavorite: true,
-            ),
-          );
-          expect(updated, isFalse);
+        updated = await client.webdav.proppatch(
+          PathUri.parse('test.txt'),
+          remove: WebDavPropWithoutValues.fromBools(
+            ocfavorite: true,
+          ),
+        );
+        expect(updated, isFalse);
 
-          props = (await client.webdav.propfind(
-            PathUri.parse('test.txt'),
-            prop: WebDavPropWithoutValues.fromBools(
-              ocfavorite: true,
-            ),
-          ))
-              .responses
-              .single
-              .propstats
-              .first
-              .prop;
-          expect(props.ocfavorite, 0);
-        });
+        props = (await client.webdav.propfind(
+          PathUri.parse('test.txt'),
+          prop: WebDavPropWithoutValues.fromBools(
+            ocfavorite: true,
+          ),
+        ))
+            .responses
+            .single
+            .propstats
+            .first
+            .prop;
+        expect(props.ocfavorite, 0);
+      });
 
-        test('Upload and download file', () async {
-          final destinationDir = Directory.systemTemp.createTempSync();
-          final destination = File('${destinationDir.path}/test.png');
-          final source = File('test/files/test.png');
-          final progressValues = <double>[];
+      test('Upload and download file', () async {
+        final destinationDir = Directory.systemTemp.createTempSync();
+        final destination = File('${destinationDir.path}/test.png');
+        final source = File('test/files/test.png');
+        final progressValues = <double>[];
 
-          await client.webdav.putFile(
-            source,
-            source.statSync(),
-            PathUri.parse('test.png'),
-            onProgress: progressValues.add,
-          );
-          await client.webdav.getFile(
-            PathUri.parse('test.png'),
-            destination,
-            onProgress: progressValues.add,
-          );
-          expect(progressValues, containsAll([1.0, 1.0]));
-          expect(destination.readAsBytesSync(), source.readAsBytesSync());
+        await client.webdav.putFile(
+          source,
+          source.statSync(),
+          PathUri.parse('test.png'),
+          onProgress: progressValues.add,
+        );
+        await client.webdav.getFile(
+          PathUri.parse('test.png'),
+          destination,
+          onProgress: progressValues.add,
+        );
+        expect(progressValues, containsAll([1.0, 1.0]));
+        expect(destination.readAsBytesSync(), source.readAsBytesSync());
 
-          destinationDir.deleteSync(recursive: true);
-        });
+        destinationDir.deleteSync(recursive: true);
+      });
 
-        group('litmus', () {
-          group('basic', () {
-            test('options', () async {
-              final options = await client.webdav.options();
-              expect(options.capabilities, contains('1'));
-              expect(options.capabilities, contains('3'));
-              // Nextcloud only contains a fake plugin for Class 2 support: https://github.com/nextcloud/server/blob/master/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php
-              // It does not actually support locking and is only there for compatibility reasons.
-              expect(options.capabilities, isNot(contains('2')));
+      group('litmus', () {
+        group('basic', () {
+          test('options', () async {
+            final options = await client.webdav.options();
+            expect(options.capabilities, contains('1'));
+            expect(options.capabilities, contains('3'));
+            // Nextcloud only contains a fake plugin for Class 2 support: https://github.com/nextcloud/server/blob/master/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php
+            // It does not actually support locking and is only there for compatibility reasons.
+            expect(options.capabilities, isNot(contains('2')));
+          });
+
+          for (final (name, path) in [
+            ('put_get', 'res'),
+            ('put_get_utf8_segment', 'res-%e2%82%ac'),
+          ]) {
+            test(name, () async {
+              final content = utf8.encode('This is a test file');
+
+              final response = await client.webdav.put(content, PathUri.parse(path));
+              expect(response.statusCode, 201);
+
+              final downloadedContent = await client.webdav.get(PathUri.parse(path));
+              expect(downloadedContent, equals(content));
             });
+          }
 
-            for (final (name, path) in [
-              ('put_get', 'res'),
-              ('put_get_utf8_segment', 'res-%e2%82%ac'),
-            ]) {
-              test(name, () async {
-                final content = utf8.encode('This is a test file');
+          test('put_no_parent', () async {
+            expect(
+              () => client.webdav.put(Uint8List(0), PathUri.parse('409me/noparent.txt')),
+              // https://github.com/nextcloud/server/issues/39625
+              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 409)),
+            );
+          });
 
-                final response = await client.webdav.put(content, PathUri.parse(path));
-                expect(response.statusCode, 201);
+          test('delete', () async {
+            await client.webdav.put(Uint8List(0), PathUri.parse('test.txt'));
 
-                final downloadedContent = await client.webdav.get(PathUri.parse(path));
-                expect(downloadedContent, equals(content));
-              });
+            final response = await client.webdav.delete(PathUri.parse('test.txt'));
+            expect(response.statusCode, 204);
+          });
+
+          test('delete_null', () async {
+            expect(
+              () => client.webdav.delete(PathUri.parse('test.txt')),
+              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 404)),
+            );
+          });
+
+          // delete_fragment: This test is not applicable because the fragment is already removed on the client side
+
+          test('mkcol', () async {
+            final response = await client.webdav.mkcol(PathUri.parse('test'));
+            expect(response.statusCode, 201);
+          });
+
+          test('mkcol_again', () async {
+            await client.webdav.mkcol(PathUri.parse('test'));
+
+            expect(
+              () => client.webdav.mkcol(PathUri.parse('test')),
+              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 405)),
+            );
+          });
+
+          test('delete_coll', () async {
+            var response = await client.webdav.mkcol(PathUri.parse('test'));
+
+            response = await client.webdav.delete(PathUri.parse('test'));
+            expect(response.statusCode, 204);
+          });
+
+          test('mkcol_no_parent', () async {
+            expect(
+              () => client.webdav.mkcol(PathUri.parse('409me/noparent')),
+              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 409)),
+            );
+          });
+
+          // mkcol_with_body: This test is not applicable because we only write valid request bodies
+        });
+
+        group('copymove', () {
+          test('copy_simple', () async {
+            await client.webdav.mkcol(PathUri.parse('src'));
+
+            final response = await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst'));
+            expect(response.statusCode, 201);
+          });
+
+          test('copy_overwrite', () async {
+            await client.webdav.mkcol(PathUri.parse('src'));
+            await client.webdav.mkcol(PathUri.parse('dst'));
+
+            expect(
+              () => client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst')),
+              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
+            );
+
+            final response = await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst'), overwrite: true);
+            expect(response.statusCode, 204);
+          });
+
+          test('copy_nodestcoll', () async {
+            await client.webdav.mkcol(PathUri.parse('src'));
+
+            expect(
+              () => client.webdav.copy(PathUri.parse('src'), PathUri.parse('nonesuch/dst')),
+              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 409)),
+            );
+          });
+
+          test('copy_coll', () async {
+            await client.webdav.mkcol(PathUri.parse('src'));
+            await client.webdav.mkcol(PathUri.parse('src/sub'));
+            for (var i = 0; i < 10; i++) {
+              await client.webdav.put(Uint8List(0), PathUri.parse('src/$i.txt'));
+            }
+            await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst1'));
+            await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst2'));
+
+            expect(
+              () => client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst1')),
+              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
+            );
+
+            var response = await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst2'), overwrite: true);
+            expect(response.statusCode, 204);
+
+            for (var i = 0; i < 10; i++) {
+              response = await client.webdav.delete(PathUri.parse('dst1/$i.txt'));
+              expect(response.statusCode, 204);
             }
 
-            test('put_no_parent', () async {
-              expect(
-                () => client.webdav.put(Uint8List(0), PathUri.parse('409me/noparent.txt')),
-                // https://github.com/nextcloud/server/issues/39625
-                throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 409)),
-              );
-            });
+            response = await client.webdav.delete(PathUri.parse('dst1/sub'));
+            expect(response.statusCode, 204);
 
-            test('delete', () async {
-              await client.webdav.put(Uint8List(0), PathUri.parse('test.txt'));
-
-              final response = await client.webdav.delete(PathUri.parse('test.txt'));
-              expect(response.statusCode, 204);
-            });
-
-            test('delete_null', () async {
-              expect(
-                () => client.webdav.delete(PathUri.parse('test.txt')),
-                throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 404)),
-              );
-            });
-
-            // delete_fragment: This test is not applicable because the fragment is already removed on the client side
-
-            test('mkcol', () async {
-              final response = await client.webdav.mkcol(PathUri.parse('test'));
-              expect(response.statusCode, 201);
-            });
-
-            test('mkcol_again', () async {
-              await client.webdav.mkcol(PathUri.parse('test'));
-
-              expect(
-                () => client.webdav.mkcol(PathUri.parse('test')),
-                throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 405)),
-              );
-            });
-
-            test('delete_coll', () async {
-              var response = await client.webdav.mkcol(PathUri.parse('test'));
-
-              response = await client.webdav.delete(PathUri.parse('test'));
-              expect(response.statusCode, 204);
-            });
-
-            test('mkcol_no_parent', () async {
-              expect(
-                () => client.webdav.mkcol(PathUri.parse('409me/noparent')),
-                throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 409)),
-              );
-            });
-
-            // mkcol_with_body: This test is not applicable because we only write valid request bodies
+            response = await client.webdav.delete(PathUri.parse('dst2'));
+            expect(response.statusCode, 204);
           });
 
-          group('copymove', () {
-            test('copy_simple', () async {
-              await client.webdav.mkcol(PathUri.parse('src'));
+          // copy_shallow: Does not work on litmus, let's wait for https://github.com/nextcloud/server/issues/39627
 
-              final response = await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst'));
-              expect(response.statusCode, 201);
-            });
+          test('move', () async {
+            await client.webdav.put(Uint8List(0), PathUri.parse('src1.txt'));
+            await client.webdav.put(Uint8List(0), PathUri.parse('src2.txt'));
+            await client.webdav.mkcol(PathUri.parse('coll'));
 
-            test('copy_overwrite', () async {
-              await client.webdav.mkcol(PathUri.parse('src'));
-              await client.webdav.mkcol(PathUri.parse('dst'));
+            var response = await client.webdav.move(PathUri.parse('src1.txt'), PathUri.parse('dst.txt'));
+            expect(response.statusCode, 201);
 
-              expect(
-                () => client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst')),
-                throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
-              );
+            expect(
+              () => client.webdav.move(PathUri.parse('src2.txt'), PathUri.parse('dst.txt')),
+              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
+            );
 
-              final response = await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst'), overwrite: true);
-              expect(response.statusCode, 204);
-            });
-
-            test('copy_nodestcoll', () async {
-              await client.webdav.mkcol(PathUri.parse('src'));
-
-              expect(
-                () => client.webdav.copy(PathUri.parse('src'), PathUri.parse('nonesuch/dst')),
-                throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 409)),
-              );
-            });
-
-            test('copy_coll', () async {
-              await client.webdav.mkcol(PathUri.parse('src'));
-              await client.webdav.mkcol(PathUri.parse('src/sub'));
-              for (var i = 0; i < 10; i++) {
-                await client.webdav.put(Uint8List(0), PathUri.parse('src/$i.txt'));
-              }
-              await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst1'));
-              await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst2'));
-
-              expect(
-                () => client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst1')),
-                throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
-              );
-
-              var response = await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst2'), overwrite: true);
-              expect(response.statusCode, 204);
-
-              for (var i = 0; i < 10; i++) {
-                response = await client.webdav.delete(PathUri.parse('dst1/$i.txt'));
-                expect(response.statusCode, 204);
-              }
-
-              response = await client.webdav.delete(PathUri.parse('dst1/sub'));
-              expect(response.statusCode, 204);
-
-              response = await client.webdav.delete(PathUri.parse('dst2'));
-              expect(response.statusCode, 204);
-            });
-
-            // copy_shallow: Does not work on litmus, let's wait for https://github.com/nextcloud/server/issues/39627
-
-            test('move', () async {
-              await client.webdav.put(Uint8List(0), PathUri.parse('src1.txt'));
-              await client.webdav.put(Uint8List(0), PathUri.parse('src2.txt'));
-              await client.webdav.mkcol(PathUri.parse('coll'));
-
-              var response = await client.webdav.move(PathUri.parse('src1.txt'), PathUri.parse('dst.txt'));
-              expect(response.statusCode, 201);
-
-              expect(
-                () => client.webdav.move(PathUri.parse('src2.txt'), PathUri.parse('dst.txt')),
-                throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
-              );
-
-              response = await client.webdav.move(PathUri.parse('src2.txt'), PathUri.parse('dst.txt'), overwrite: true);
-              expect(response.statusCode, 204);
-            });
-
-            test('move_coll', () async {
-              await client.webdav.mkcol(PathUri.parse('src'));
-              await client.webdav.mkcol(PathUri.parse('src/sub'));
-              for (var i = 0; i < 10; i++) {
-                await client.webdav.put(Uint8List(0), PathUri.parse('src/$i.txt'));
-              }
-              await client.webdav.put(Uint8List(0), PathUri.parse('noncoll'));
-              await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst2'));
-              await client.webdav.move(PathUri.parse('src'), PathUri.parse('dst1'));
-
-              expect(
-                () => client.webdav.move(PathUri.parse('dst1'), PathUri.parse('dst2')),
-                throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
-              );
-
-              await client.webdav.move(PathUri.parse('dst2'), PathUri.parse('dst1'), overwrite: true);
-              await client.webdav.copy(PathUri.parse('dst1'), PathUri.parse('dst2'));
-
-              for (var i = 0; i < 10; i++) {
-                final response = await client.webdav.delete(PathUri.parse('dst1/$i.txt'));
-                expect(response.statusCode, 204);
-              }
-
-              final response = await client.webdav.delete(PathUri.parse('dst1/sub'));
-              expect(response.statusCode, 204);
-
-              expect(
-                () => client.webdav.move(PathUri.parse('dst2'), PathUri.parse('noncoll')),
-                throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
-              );
-            });
+            response = await client.webdav.move(PathUri.parse('src2.txt'), PathUri.parse('dst.txt'), overwrite: true);
+            expect(response.statusCode, 204);
           });
 
-          group('largefile', () {
-            final largefileSize = pow(10, 9).toInt(); // 1GB
+          test('move_coll', () async {
+            await client.webdav.mkcol(PathUri.parse('src'));
+            await client.webdav.mkcol(PathUri.parse('src/sub'));
+            for (var i = 0; i < 10; i++) {
+              await client.webdav.put(Uint8List(0), PathUri.parse('src/$i.txt'));
+            }
+            await client.webdav.put(Uint8List(0), PathUri.parse('noncoll'));
+            await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst2'));
+            await client.webdav.move(PathUri.parse('src'), PathUri.parse('dst1'));
 
-            // large_put: Already covered by large_get
+            expect(
+              () => client.webdav.move(PathUri.parse('dst1'), PathUri.parse('dst2')),
+              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
+            );
 
-            test('large_get', () async {
-              final response = await client.webdav.put(Uint8List(largefileSize), PathUri.parse('test.txt'));
-              expect(response.statusCode, 201);
+            await client.webdav.move(PathUri.parse('dst2'), PathUri.parse('dst1'), overwrite: true);
+            await client.webdav.copy(PathUri.parse('dst1'), PathUri.parse('dst2'));
 
-              final downloadedContent = await client.webdav.get(PathUri.parse('test.txt'));
-              expect(downloadedContent, hasLength(largefileSize));
-            });
+            for (var i = 0; i < 10; i++) {
+              final response = await client.webdav.delete(PathUri.parse('dst1/$i.txt'));
+              expect(response.statusCode, 204);
+            }
+
+            final response = await client.webdav.delete(PathUri.parse('dst1/sub'));
+            expect(response.statusCode, 204);
+
+            expect(
+              () => client.webdav.move(PathUri.parse('dst2'), PathUri.parse('noncoll')),
+              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
+            );
           });
-
-          // props: Most of them are either not applicable or hard/impossible to implement because we don't allow just writing any props
         });
-      },
-      retry: retryCount,
-      timeout: timeout,
-    );
-  });
+
+        group('largefile', () {
+          final largefileSize = pow(10, 9).toInt(); // 1GB
+
+          // large_put: Already covered by large_get
+
+          test('large_get', () async {
+            final response = await client.webdav.put(Uint8List(largefileSize), PathUri.parse('test.txt'));
+            expect(response.statusCode, 201);
+
+            final downloadedContent = await client.webdav.get(PathUri.parse('test.txt'));
+            expect(downloadedContent, hasLength(largefileSize));
+          });
+        });
+
+        // props: Most of them are either not applicable or hard/impossible to implement because we don't allow just writing any props
+      });
+    },
+    retry: retryCount,
+    timeout: timeout,
+  );
 }


### PR DESCRIPTION
Previously the groups could look something like `notes 4.9 notes ...` while they are just `notes 4.9 ...`. For test that use the server preset though we want to keep the app. For those the groups are now `server notifications 27.1 ...` instead of `server 27.1 notifications ...` which is also better.

Best reviewed without whitespace diff: https://github.com/nextcloud/neon/pull/1266/files?w=1