### PR TITLE
feat(neon_framework): Allow dev servers in version checks

### DIFF
--- a/packages/neon_framework/lib/src/blocs/apps.dart
+++ b/packages/neon_framework/lib/src/blocs/apps.dart
@@ -136,7 +136,7 @@ class AppsBloc extends InteractiveBloc implements AppsBlocEvents, AppsBlocStates
 
     try {
       final coreCheck = _account.client.core.getVersionCheck(capabilities.requireData);
-      if (!coreCheck.isSupported) {
+      if (!coreCheck.isSupported && !capabilities.requireData.version.string.contains('dev')) {
         notSupported['core'] = coreCheck;
       }
     } catch (e, s) {

--- a/packages/neon_framework/lib/src/pages/login_check_server_status.dart
+++ b/packages/neon_framework/lib/src/pages/login_check_server_status.dart
@@ -61,7 +61,7 @@ class _LoginCheckServerStatusPageState extends State<LoginCheckServerStatusPage>
                   subject: bloc.state,
                   builder: (final context, final state) {
                     final success =
-                        state.hasData && state.requireData.versionCheck.isSupported && !state.requireData.maintenance;
+                        state.hasData && _isServerVersionAllowed(state.requireData) && !state.requireData.maintenance;
 
                     return Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -107,6 +107,9 @@ class _LoginCheckServerStatusPageState extends State<LoginCheckServerStatusPage>
     }
   }
 
+  bool _isServerVersionAllowed(final core.Status status) =>
+      status.versionCheck.isSupported || status.versionstring.contains('dev');
+
   Widget _buildServerVersionTile(final Result<core.Status> result) {
     if (result.hasError) {
       return NeonValidationTile(
@@ -122,7 +125,7 @@ class _LoginCheckServerStatusPageState extends State<LoginCheckServerStatusPage>
       );
     }
 
-    if (result.requireData.versionCheck.isSupported) {
+    if (_isServerVersionAllowed(result.requireData)) {
       return NeonValidationTile(
         title: NeonLocalizations.of(context).loginSupportedServerVersion(result.requireData.versionstring),
         state: ValidationState.success,


### PR DESCRIPTION
Useful when testing/developing directly against a git version of Nextcloud.