### PR TITLE
chore(dynamite_petstore_example): Remove wrong patch notice

### DIFF
--- a/packages/dynamite/dynamite_petstore_example/README.md
+++ b/packages/dynamite/dynamite_petstore_example/README.md
@@ -1,5 +1,3 @@
 # dynamite petstore example
 
 An example showcasing the [dynamite generator](../dynamite) for OpenAPI using the [Swagger Petstore](https://github.com/swagger-api/swagger-petstore).
-
-Because dynamite does not support dynamic authentication yet a [patch](patch.json) is applied to the specification to make it work. It will be removed once dynamite supports API key and Oauth 2.0 authentication.


### PR DESCRIPTION
The patch was never there because we switched to a different spec.