### PR TITLE
fix(ci): Group test packages in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,6 +59,14 @@
         "json_annotation",
         "json_serializable"
       ]
+    },
+    {
+      "groupName": "test",
+      "matchPackageNames": [
+        "test",
+        "test_api",
+        "test_core"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Will fix the problems in https://github.com/nextcloud/neon/pull/1290 and https://github.com/nextcloud/neon/pull/1291