### PR TITLE
fix(ci): Upgrade dependencies of internal packages with renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,13 @@
         "minor",
         "patch"
       ],
+      "excludeDepNames": [
+        "app",
+        "dynamite_end_to_end_test",
+        "dynamite_petstore_example",
+        "neon_lints",
+        "nextcloud_test"
+      ],
       "enabled": false
     },
     {


### PR DESCRIPTION
https://github.com/nextcloud/neon/pull/1296#issuecomment-1855452982

Fixes the problem where the dependencies in nextcloud_test are not updated on minor/patch updates leading to conflicts with the dev_dependencies in other packages that got updated.

I used the exclude pattern instead of the include pattern so we don't accidentally update minor/patch versions for a package where it is not intended.