### PR TITLE
refactor(neon_framework): Cleanup settings and options related class names

### DIFF
--- a/packages/neon/neon_dashboard/lib/src/app.dart
+++ b/packages/neon/neon_dashboard/lib/src/app.dart
@@ -9,7 +9,7 @@ import 'package:neon_framework/models.dart';
 import 'package:nextcloud/nextcloud.dart';
 
 /// Implementation of the server `dashboard` app.
-class DashboardApp extends AppImplementation<DashboardBloc, DashboardAppSpecificOptions> {
+class DashboardApp extends AppImplementation<DashboardBloc, DashboardOptions> {
   /// Creates a new Dashboard app implementation instance.
   DashboardApp();
 
@@ -23,7 +23,7 @@ class DashboardApp extends AppImplementation<DashboardBloc, DashboardAppSpecific
   final List<Locale> supportedLocales = DashboardLocalizations.supportedLocales;
 
   @override
-  late final DashboardAppSpecificOptions options = DashboardAppSpecificOptions(storage);
+  late final DashboardOptions options = DashboardOptions(storage);
 
   @override
   DashboardBloc buildBloc(final Account account) => DashboardBloc(account);

--- a/packages/neon/neon_dashboard/lib/src/options.dart
+++ b/packages/neon/neon_dashboard/lib/src/options.dart
@@ -1,9 +1,9 @@
 import 'package:neon_framework/settings.dart';
 
 /// Settings options specific to the dashboard app.
-class DashboardAppSpecificOptions extends NextcloudAppOptions {
+class DashboardOptions extends AppImplementationOptions {
   /// Creates a new dashboard options instance.
-  DashboardAppSpecificOptions(super.storage) {
+  DashboardOptions(super.storage) {
     super.categories = [];
     super.options = [];
   }

--- a/packages/neon/neon_files/lib/src/app.dart
+++ b/packages/neon/neon_files/lib/src/app.dart
@@ -8,7 +8,7 @@ import 'package:neon_files/src/routes.dart';
 import 'package:neon_framework/models.dart';
 import 'package:nextcloud/nextcloud.dart';
 
-class FilesApp extends AppImplementation<FilesBloc, FilesAppSpecificOptions> {
+class FilesApp extends AppImplementation<FilesBloc, FilesOptions> {
   FilesApp();
 
   @override
@@ -21,7 +21,7 @@ class FilesApp extends AppImplementation<FilesBloc, FilesAppSpecificOptions> {
   final List<Locale> supportedLocales = FilesLocalizations.supportedLocales;
 
   @override
-  late final FilesAppSpecificOptions options = FilesAppSpecificOptions(storage);
+  late final FilesOptions options = FilesOptions(storage);
 
   @override
   FilesBloc buildBloc(final Account account) => FilesBloc(

--- a/packages/neon/neon_files/lib/src/blocs/browser.dart
+++ b/packages/neon/neon_files/lib/src/blocs/browser.dart
@@ -32,7 +32,7 @@ class FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBlocEvents
     unawaited(refresh());
   }
 
-  final FilesAppSpecificOptions options;
+  final FilesOptions options;
   final Account account;
 
   @override

--- a/packages/neon/neon_files/lib/src/blocs/files.dart
+++ b/packages/neon/neon_files/lib/src/blocs/files.dart
@@ -53,7 +53,7 @@ class FilesBloc extends InteractiveBloc implements FilesBlocEvents, FilesBlocSta
     options.downloadQueueParallelism.addListener(_downloadParallelismListener);
   }
 
-  final FilesAppSpecificOptions options;
+  final FilesOptions options;
   final Account account;
   late final browser = getNewFilesBrowserBloc();
 

--- a/packages/neon/neon_files/lib/src/options.dart
+++ b/packages/neon/neon_files/lib/src/options.dart
@@ -3,8 +3,8 @@ import 'package:neon_files/l10n/localizations.dart';
 import 'package:neon_framework/settings.dart';
 import 'package:neon_framework/sort_box.dart';
 
-class FilesAppSpecificOptions extends NextcloudAppOptions {
-  FilesAppSpecificOptions(super.storage) {
+class FilesOptions extends AppImplementationOptions {
+  FilesOptions(super.storage) {
     super.categories = [
       generalCategory,
     ];

--- a/packages/neon/neon_news/lib/src/app.dart
+++ b/packages/neon/neon_news/lib/src/app.dart
@@ -13,7 +13,7 @@ import 'package:nextcloud/news.dart' as news;
 import 'package:nextcloud/nextcloud.dart';
 import 'package:rxdart/rxdart.dart';
 
-class NewsApp extends AppImplementation<NewsBloc, NewsAppSpecificOptions> {
+class NewsApp extends AppImplementation<NewsBloc, NewsOptions> {
   NewsApp();
 
   @override
@@ -26,7 +26,7 @@ class NewsApp extends AppImplementation<NewsBloc, NewsAppSpecificOptions> {
   final List<Locale> supportedLocales = NewsLocalizations.supportedLocales;
 
   @override
-  late final NewsAppSpecificOptions options = NewsAppSpecificOptions(storage);
+  late final NewsOptions options = NewsOptions(storage);
 
   @override
   NewsBloc buildBloc(final Account account) => NewsBloc(

--- a/packages/neon/neon_news/lib/src/blocs/articles.dart
+++ b/packages/neon/neon_news/lib/src/blocs/articles.dart
@@ -64,7 +64,7 @@ class NewsArticlesBloc extends InteractiveBloc implements NewsArticlesBlocEvents
   }
 
   final NewsBloc _newsBloc;
-  final NewsAppSpecificOptions options;
+  final NewsOptions options;
   final Account account;
   final int? id;
   final ListType? listType;

--- a/packages/neon/neon_news/lib/src/blocs/news.dart
+++ b/packages/neon/neon_news/lib/src/blocs/news.dart
@@ -53,7 +53,7 @@ class NewsBloc extends InteractiveBloc implements NewsBlocEvents, NewsBlocStates
   }
 
   @override
-  final NewsAppSpecificOptions options;
+  final NewsOptions options;
   @override
   @override
   final Account account;

--- a/packages/neon/neon_news/lib/src/options.dart
+++ b/packages/neon/neon_news/lib/src/options.dart
@@ -4,8 +4,8 @@ import 'package:neon_framework/sort_box.dart';
 import 'package:neon_news/l10n/localizations.dart';
 import 'package:neon_news/src/blocs/articles.dart';
 
-class NewsAppSpecificOptions extends NextcloudAppOptions {
-  NewsAppSpecificOptions(super.storage) {
+class NewsOptions extends AppImplementationOptions {
+  NewsOptions(super.storage) {
     super.categories = [
       generalCategory,
       articlesCategory,

--- a/packages/neon/neon_notes/lib/src/app.dart
+++ b/packages/neon/neon_notes/lib/src/app.dart
@@ -10,7 +10,7 @@ import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/notes.dart' as notes;
 
-class NotesApp extends AppImplementation<NotesBloc, NotesAppSpecificOptions> {
+class NotesApp extends AppImplementation<NotesBloc, NotesOptions> {
   NotesApp();
 
   @override
@@ -23,7 +23,7 @@ class NotesApp extends AppImplementation<NotesBloc, NotesAppSpecificOptions> {
   final LocalizationsDelegate<NotesLocalizations> localizationsDelegate = NotesLocalizations.delegate;
 
   @override
-  late final NotesAppSpecificOptions options = NotesAppSpecificOptions(storage);
+  late final NotesOptions options = NotesOptions(storage);
 
   @override
   NotesBloc buildBloc(final Account account) => NotesBloc(

--- a/packages/neon/neon_notes/lib/src/blocs/note.dart
+++ b/packages/neon/neon_notes/lib/src/blocs/note.dart
@@ -52,7 +52,7 @@ class NotesNoteBloc extends InteractiveBloc implements NotesNoteBlocEvents, Note
     });
   }
 
-  late final NotesAppSpecificOptions options = _notesBloc.options;
+  late final NotesOptions options = _notesBloc.options;
   final NotesBloc _notesBloc;
   final _updateQueue = Queue();
 

--- a/packages/neon/neon_notes/lib/src/blocs/notes.dart
+++ b/packages/neon/neon_notes/lib/src/blocs/notes.dart
@@ -38,7 +38,7 @@ class NotesBloc extends InteractiveBloc implements NotesBlocEvents, NotesBlocSta
     unawaited(refresh());
   }
 
-  final NotesAppSpecificOptions options;
+  final NotesOptions options;
   final Account account;
 
   @override

--- a/packages/neon/neon_notes/lib/src/options.dart
+++ b/packages/neon/neon_notes/lib/src/options.dart
@@ -2,8 +2,8 @@ import 'package:neon_framework/settings.dart';
 import 'package:neon_framework/sort_box.dart';
 import 'package:neon_notes/l10n/localizations.dart';
 
-class NotesAppSpecificOptions extends NextcloudAppOptions {
-  NotesAppSpecificOptions(super.storage) {
+class NotesOptions extends AppImplementationOptions {
+  NotesOptions(super.storage) {
     super.categories = [
       generalCategory,
       notesCategory,

--- a/packages/neon/neon_notifications/lib/src/app.dart
+++ b/packages/neon/neon_notifications/lib/src/app.dart
@@ -9,10 +9,10 @@ import 'package:neon_notifications/src/routes.dart';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:rxdart/rxdart.dart';
 
-class NotificationsApp extends AppImplementation<NotificationsBloc, NotificationsAppSpecificOptions>
+class NotificationsApp extends AppImplementation<NotificationsBloc, NotificationsOptions>
     implements
         // ignore: avoid_implementing_value_types
-        NotificationsAppInterface<NotificationsBloc, NotificationsAppSpecificOptions> {
+        NotificationsAppInterface<NotificationsBloc, NotificationsOptions> {
   NotificationsApp();
 
   @override
@@ -25,7 +25,7 @@ class NotificationsApp extends AppImplementation<NotificationsBloc, Notification
   final List<Locale> supportedLocales = NotificationsLocalizations.supportedLocales;
 
   @override
-  late final NotificationsAppSpecificOptions options = NotificationsAppSpecificOptions(storage);
+  late final NotificationsOptions options = NotificationsOptions(storage);
 
   @override
   NotificationsBloc buildBloc(final Account account) => NotificationsBloc(

--- a/packages/neon/neon_notifications/lib/src/blocs/notifications.dart
+++ b/packages/neon/neon_notifications/lib/src/blocs/notifications.dart
@@ -36,7 +36,7 @@ class NotificationsBloc extends InteractiveBloc
   }
 
   @override
-  final NotificationsAppSpecificOptions options;
+  final NotificationsOptions options;
   final Account _account;
   late final NeonTimer _timer;
 

--- a/packages/neon/neon_notifications/lib/src/options.dart
+++ b/packages/neon/neon_notifications/lib/src/options.dart
@@ -1,8 +1,8 @@
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/settings.dart';
 
-class NotificationsAppSpecificOptions extends NextcloudAppOptions implements NotificationsOptionsInterface {
-  NotificationsAppSpecificOptions(super.storage) {
+class NotificationsOptions extends AppImplementationOptions implements NotificationsOptionsInterface {
+  NotificationsOptions(super.storage) {
     super.categories = [];
     super.options = [];
   }

--- a/packages/neon_framework/lib/src/blocs/accounts.dart
+++ b/packages/neon_framework/lib/src/blocs/accounts.dart
@@ -125,7 +125,7 @@ class AccountsBloc extends Bloc implements AccountsBlocEvents, AccountsBlocState
   final GlobalOptions _globalOptions;
   final Iterable<AppImplementation> _allAppImplementations;
 
-  final _accountsOptions = AccountCache<AccountSpecificOptions>();
+  final _accountsOptions = AccountCache<AccountOptions>();
   final _appsBlocs = AccountCache<AppsBloc>();
   final _capabilitiesBlocs = AccountCache<CapabilitiesBloc>();
   final _userDetailsBlocs = AccountCache<UserDetailsBloc>();
@@ -228,12 +228,12 @@ class AccountsBloc extends Bloc implements AccountsBlocEvents, AccountsBlocState
   /// The options for the [activeAccount].
   ///
   /// Convenience method for [getOptionsFor] with the currently active account.
-  AccountSpecificOptions get activeOptions => getOptionsFor(aa);
+  AccountOptions get activeOptions => getOptionsFor(aa);
 
   /// The options for the specified [account].
   ///
   /// Use [activeOptions] to get them for the [activeAccount].
-  AccountSpecificOptions getOptionsFor(final Account account) => _accountsOptions[account] ??= AccountSpecificOptions(
+  AccountOptions getOptionsFor(final Account account) => _accountsOptions[account] ??= AccountOptions(
         AppStorage(StorageKeys.accounts, account.id),
         getAppsBlocFor(account),
       );

--- a/packages/neon_framework/lib/src/blocs/apps.dart
+++ b/packages/neon_framework/lib/src/blocs/apps.dart
@@ -200,7 +200,7 @@ class AppsBloc extends InteractiveBloc implements AppsBlocEvents, AppsBlocStates
   BehaviorSubject<AppImplementation> activeApp = BehaviorSubject();
 
   @override
-  BehaviorSubject<Result<Iterable<AppImplementation<Bloc, NextcloudAppOptions>>>> appImplementations =
+  BehaviorSubject<Result<Iterable<AppImplementation<Bloc, AppImplementationOptions>>>> appImplementations =
       BehaviorSubject();
 
   @override

--- a/packages/neon_framework/lib/src/models/app_implementation.dart
+++ b/packages/neon_framework/lib/src/models/app_implementation.dart
@@ -25,7 +25,7 @@ import 'package:vector_graphics/vector_graphics.dart';
 /// It is mandatory to provide a precompiled SVG under `assets/app.svg.vec`.
 /// SVGs can be precompiled with `https://pub.dev/packages/vector_graphics_compiler`
 @immutable
-abstract class AppImplementation<T extends Bloc, R extends NextcloudAppOptions> implements Disposable, Findable {
+abstract class AppImplementation<T extends Bloc, R extends AppImplementationOptions> implements Disposable, Findable {
   /// The unique id of an app.
   ///
   /// It is common to specify them in `AppIDs`.

--- a/packages/neon_framework/lib/src/models/notifications_interface.dart
+++ b/packages/neon_framework/lib/src/models/notifications_interface.dart
@@ -29,7 +29,7 @@ abstract interface class NotificationsBlocInterface extends InteractiveBloc {
 }
 
 /// The interface of the app options used by the notifications client.
-abstract interface class NotificationsOptionsInterface extends NextcloudAppOptions {
+abstract interface class NotificationsOptionsInterface extends AppImplementationOptions {
   /// Creates the nextcloud app options for the notifications client.
   NotificationsOptionsInterface(super.storage);
 }

--- a/packages/neon_framework/lib/src/pages/app_implementation_settings.dart
+++ b/packages/neon_framework/lib/src/pages/app_implementation_settings.dart
@@ -10,8 +10,8 @@ import 'package:neon_framework/src/theme/dialog.dart';
 import 'package:neon_framework/src/utils/confirmation_dialog.dart';
 
 @internal
-class NextcloudAppSettingsPage extends StatelessWidget {
-  const NextcloudAppSettingsPage({
+class AppImplementationSettingsPage extends StatelessWidget {
+  const AppImplementationSettingsPage({
     required this.appImplementation,
     super.key,
   });

--- a/packages/neon_framework/lib/src/pages/settings.dart
+++ b/packages/neon_framework/lib/src/pages/settings.dart
@@ -34,7 +34,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 /// the settings page.
 @internal
 enum SettingsCategories {
-  /// `NextcloudAppOptions` category.
+  /// `AppImplementationOptions` category.
   ///
   /// Each activated `AppImplementation` has an entry if it has any options specified.
   apps,
@@ -56,7 +56,7 @@ enum SettingsCategories {
 
   /// Account management category.
   ///
-  /// Also includes the `AccountSpecificOptions`.
+  /// Also includes the `AccountOptions`.
   accounts,
 
   /// Other category.
@@ -127,7 +127,7 @@ class _SettingsPageState extends State<SettingsPage> {
                   leading: appImplementation.buildIcon(),
                   title: Text(appImplementation.name(context)),
                   onTap: () {
-                    NextcloudAppSettingsRoute(appid: appImplementation.id).go(context);
+                    AppImplementationSettingsRoute(appid: appImplementation.id).go(context);
                   },
                 ),
               ],

--- a/packages/neon_framework/lib/src/router.dart
+++ b/packages/neon_framework/lib/src/router.dart
@@ -10,13 +10,13 @@ import 'package:neon_framework/src/blocs/accounts.dart';
 import 'package:neon_framework/src/models/account.dart';
 import 'package:neon_framework/src/models/app_implementation.dart';
 import 'package:neon_framework/src/pages/account_settings.dart';
+import 'package:neon_framework/src/pages/app_implementation_settings.dart';
 import 'package:neon_framework/src/pages/home.dart';
 import 'package:neon_framework/src/pages/login.dart';
 import 'package:neon_framework/src/pages/login_check_account.dart';
 import 'package:neon_framework/src/pages/login_check_server_status.dart';
 import 'package:neon_framework/src/pages/login_flow.dart';
 import 'package:neon_framework/src/pages/login_qr_code.dart';
-import 'package:neon_framework/src/pages/nextcloud_app_settings.dart';
 import 'package:neon_framework/src/pages/route_not_found.dart';
 import 'package:neon_framework/src/pages/settings.dart';
 import 'package:neon_framework/src/utils/findable.dart';
@@ -109,9 +109,9 @@ class AccountSettingsRoute extends GoRouteData {
       path: 'settings',
       name: 'Settings',
       routes: [
-        TypedGoRoute<NextcloudAppSettingsRoute>(
+        TypedGoRoute<AppImplementationSettingsRoute>(
           path: 'apps/:appid',
-          name: 'NextcloudAppSettings',
+          name: 'AppImplementationSettings',
         ),
         TypedGoRoute<_AddAccountRoute>(
           path: 'account/add',
@@ -440,13 +440,13 @@ class _AddAccountCheckAccountRoute extends LoginCheckAccountRoute {
   String get password => super.password;
 }
 
-/// {@template AppRoutes.NextcloudAppSettingsRoute}
-/// Route for the the [NextcloudAppSettingsPage].
+/// {@template AppRoutes.AppImplementationSettingsRoute}
+/// Route for the the [AppImplementationSettingsPage].
 /// {@endtemplate}
 @immutable
-class NextcloudAppSettingsRoute extends GoRouteData {
-  /// {@macro AppRoutes.NextcloudAppSettingsRoute}
-  const NextcloudAppSettingsRoute({
+class AppImplementationSettingsRoute extends GoRouteData {
+  /// {@macro AppRoutes.AppImplementationSettingsRoute}
+  const AppImplementationSettingsRoute({
     required this.appid,
   });
 
@@ -458,7 +458,7 @@ class NextcloudAppSettingsRoute extends GoRouteData {
     final appImplementations = NeonProvider.of<Iterable<AppImplementation>>(context);
     final appImplementation = appImplementations.tryFind(appid)!;
 
-    return NextcloudAppSettingsPage(appImplementation: appImplementation);
+    return AppImplementationSettingsPage(appImplementation: appImplementation);
   }
 }
 

--- a/packages/neon_framework/lib/src/router.g.dart
+++ b/packages/neon_framework/lib/src/router.g.dart
@@ -23,8 +23,8 @@ RouteBase get $homeRoute => GoRouteData.$route(
           routes: [
             GoRouteData.$route(
               path: 'apps/:appid',
-              name: 'NextcloudAppSettings',
-              factory: $NextcloudAppSettingsRouteExtension._fromState,
+              name: 'AppImplementationSettings',
+              factory: $AppImplementationSettingsRouteExtension._fromState,
             ),
             GoRouteData.$route(
               path: 'account/add',
@@ -108,8 +108,8 @@ const _$SettingsCategoriesEnumMap = {
   SettingsCategories.other: 'other',
 };
 
-extension $NextcloudAppSettingsRouteExtension on NextcloudAppSettingsRoute {
-  static NextcloudAppSettingsRoute _fromState(GoRouterState state) => NextcloudAppSettingsRoute(
+extension $AppImplementationSettingsRouteExtension on AppImplementationSettingsRoute {
+  static AppImplementationSettingsRoute _fromState(GoRouterState state) => AppImplementationSettingsRoute(
         appid: state.pathParameters['appid']!,
       );
 

--- a/packages/neon_framework/lib/src/settings/models/options_collection.dart
+++ b/packages/neon_framework/lib/src/settings/models/options_collection.dart
@@ -58,9 +58,9 @@ abstract class OptionsCollection implements Exportable, Disposable {
 }
 
 /// OptionsCollection primarily used by `AppImplementation`s.
-abstract class NextcloudAppOptions extends OptionsCollection {
-  /// Creates a new Nextcloud options collection.
-  NextcloudAppOptions(super.storage);
+abstract class AppImplementationOptions extends OptionsCollection {
+  /// Creates a new options collection.
+  AppImplementationOptions(super.storage);
 
   /// Collection of categories to display the options in the settings.
   late final Iterable<OptionsCategory> categories;

--- a/packages/neon_framework/lib/src/settings/models/storage.dart
+++ b/packages/neon_framework/lib/src/settings/models/storage.dart
@@ -67,7 +67,7 @@ enum StorageKeys implements Storable {
   /// The key for the `AppImplementation`s.
   apps._('app'),
 
-  /// The key for the `Account`s and their `AccountSpecificOptions`.
+  /// The key for the `Account`s and their `AccountOptions`.
   accounts._('accounts'),
 
   /// The key for the `GlobalOptions`.

--- a/packages/neon_framework/lib/src/utils/account_options.dart
+++ b/packages/neon_framework/lib/src/utils/account_options.dart
@@ -8,9 +8,9 @@ import 'package:neon_framework/src/settings/models/storage.dart';
 /// Account related options.
 @internal
 @immutable
-class AccountSpecificOptions extends OptionsCollection {
+class AccountOptions extends OptionsCollection {
   /// Creates a new account options collection.
-  AccountSpecificOptions(
+  AccountOptions(
     super.storage,
     this._appsBloc,
   ) {
@@ -44,10 +44,10 @@ class AccountSpecificOptions extends OptionsCollection {
   );
 }
 
-/// Storage keys for the [AccountSpecificOptions].
+/// Storage keys for the [AccountOptions].
 @internal
 enum AccountOptionKeys implements Storable {
-  /// The storage key for [AccountSpecificOptions.initialApp]
+  /// The storage key for [AccountOptions.initialApp]
   initialApp._('initial-app');
 
   const AccountOptionKeys._(this.value);

--- a/packages/neon_framework/test/options_collection_test.dart
+++ b/packages/neon_framework/test/options_collection_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 // ignore: missing_override_of_must_be_overridden
 class OptionMock extends Mock implements ToggleOption {}
 
-class Collection extends NextcloudAppOptions {
+class Collection extends AppImplementationOptions {
   Collection(final List<Option<Object>> options) : super(const AppStorage(StorageKeys.apps)) {
     super.options = options;
   }

--- a/packages/neon_framework/test/settings_export_test.dart
+++ b/packages/neon_framework/test/settings_export_test.dart
@@ -15,14 +15,14 @@ import 'package:test/test.dart';
 // ignore: missing_override_of_must_be_overridden, avoid_implementing_value_types
 class FakeAppImplementation extends Mock implements AppImplementation {}
 
-class NextcloudAppOptionsMock extends Mock implements NextcloudAppOptions {}
+class AppImplementationOptionsMock extends Mock implements AppImplementationOptions {}
 
 class AccountsBlocMock extends Mock implements AccountsBloc {}
 
 // ignore: avoid_implementing_value_types
 class FakeAccount extends Mock implements Account {}
 
-class AccountSpecificOptionsMock extends Mock implements AccountSpecificOptions {}
+class AccountOptionsMock extends Mock implements AccountOptions {}
 
 class ExporterMock extends Mock implements Exportable {}
 
@@ -35,7 +35,7 @@ void main() {
       expect(Map.fromEntries([export]), {'app': <String, dynamic>{}});
 
       final fakeApp = FakeAppImplementation();
-      final fakeOptions = NextcloudAppOptionsMock();
+      final fakeOptions = AppImplementationOptionsMock();
       exporter = AppImplementationsExporter([fakeApp]);
 
       const appValue = MapEntry('appID', 'value');
@@ -68,7 +68,7 @@ void main() {
       expect(Map.fromEntries([export]), {'accounts': <String, dynamic>{}});
 
       final fakeAccount = FakeAccount();
-      final fakeOptions = AccountSpecificOptionsMock();
+      final fakeOptions = AccountOptionsMock();
       when(() => bloc.accounts).thenAnswer((final _) => BehaviorSubject.seeded([fakeAccount]));
       when(() => bloc.getOptionsFor(fakeAccount)).thenReturn(fakeOptions);
       when(fakeOptions.export).thenReturn(accountValue);


### PR DESCRIPTION
Needed for https://github.com/nextcloud/neon/pull/600
The `Specific` and `App` parts were never needed in the class names. Also more aligned with the rest, using `AppImplementation` instead of `NextcloudApp`.