### PR TITLE
style: change parameter style to avoid_final_parameters

### DIFF
--- a/packages/app/analysis_options.yaml
+++ b/packages/app/analysis_options.yaml
@@ -1,7 +1,1 @@
 include: package:neon_lints/flutter.yaml
-
-linter:
-  rules:
-    # TODO: migrate package to new lint rules
-    prefer_final_parameters: true
-    avoid_final_parameters: false

--- a/packages/app/analysis_options.yaml
+++ b/packages/app/analysis_options.yaml
@@ -1,1 +1,7 @@
 include: package:neon_lints/flutter.yaml
+
+linter:
+  rules:
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false

--- a/packages/app/integration_test/screenshot_test.dart
+++ b/packages/app/integration_test/screenshot_test.dart
@@ -18,9 +18,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:universal_io/io.dart';
 
 Future<void> runTestApp(
-  final WidgetTester tester,
-  final IntegrationTestWidgetsFlutterBinding binding, {
-  final Account? account,
+  WidgetTester tester,
+  IntegrationTestWidgetsFlutterBinding binding, {
+  Account? account,
 }) async {
   await runNeon(
     appImplementations: appImplementations,
@@ -33,23 +33,23 @@ Future<void> runTestApp(
   await tester.pumpAndSettle();
 }
 
-Future<void> openDrawer(final WidgetTester tester) async {
+Future<void> openDrawer(WidgetTester tester) async {
   await tester.tap(find.byTooltip('Open navigation menu'));
   await tester.pumpAndSettle();
 }
 
-Future<void> switchPage(final WidgetTester tester, final String name) async {
+Future<void> switchPage(WidgetTester tester, String name) async {
   await openDrawer(tester);
   await tester.tap(find.text(name).last);
   await tester.pumpAndSettle();
 }
 
-Future<void> prepareScreenshot(final WidgetTester tester, final IntegrationTestWidgetsFlutterBinding binding) async {
+Future<void> prepareScreenshot(WidgetTester tester, IntegrationTestWidgetsFlutterBinding binding) async {
   await binding.convertFlutterSurfaceToImage();
   await tester.pumpAndSettle();
 }
 
-Future<Account> getAccount(final String username) async {
+Future<Account> getAccount(String username) async {
   final host = Uri(scheme: 'http', host: '10.0.2.2');
   final appPassword = (await NextcloudClient(
     host,
@@ -85,7 +85,7 @@ Future<void> main() async {
     SharedPreferences.setMockInitialValues({});
   });
 
-  testWidgets('login', (final tester) async {
+  testWidgets('login', (tester) async {
     await runTestApp(
       tester,
       binding,
@@ -94,7 +94,7 @@ Future<void> main() async {
     await binding.takeScreenshot('login_server_selection');
   });
 
-  testWidgets('home', (final tester) async {
+  testWidgets('home', (tester) async {
     await runTestApp(
       tester,
       binding,
@@ -107,7 +107,7 @@ Future<void> main() async {
     await binding.takeScreenshot('home_drawer');
   });
 
-  testWidgets('files', (final tester) async {
+  testWidgets('files', (tester) async {
     await runTestApp(
       tester,
       binding,
@@ -146,7 +146,7 @@ Future<void> main() async {
     await binding.takeScreenshot('files_create');
   });
 
-  testWidgets('news', (final tester) async {
+  testWidgets('news', (tester) async {
     const wikipediaFeedURL = 'https://en.wikipedia.org/w/api.php?action=featuredfeed&feed=featured&feedformat=atom';
     const nasaFeedURL = 'https://www.nasa.gov/rss/dyn/breaking_news.rss';
 
@@ -220,7 +220,7 @@ Future<void> main() async {
     await binding.takeScreenshot('news_articles_starred_list');
   });
 
-  testWidgets('notes', (final tester) async {
+  testWidgets('notes', (tester) async {
     await account.client.notes.createNote(
       title: 'Wishlist',
       category: 'Financial',
@@ -282,7 +282,7 @@ Future<void> main() async {
     await binding.takeScreenshot('notes_categories_list');
   });
 
-  testWidgets('notifications', (final tester) async {
+  testWidgets('notifications', (tester) async {
     await (await getAccount('admin')).client.notifications.api.generateNotification(
           userId: account.username,
           shortMessage: 'Notifications demo',
@@ -304,7 +304,7 @@ Future<void> main() async {
     await binding.takeScreenshot('notifications_list');
   });
 
-  testWidgets('settings', (final tester) async {
+  testWidgets('settings', (tester) async {
     await runTestApp(
       tester,
       binding,

--- a/packages/app/test_driver/integration_test.dart
+++ b/packages/app/test_driver/integration_test.dart
@@ -6,7 +6,7 @@ Future<void> main() async {
   Directory('screenshots').createSync();
   try {
     await integrationDriver(
-      onScreenshot: (final screenshotName, final screenshotBytes, [final args]) async {
+      onScreenshot: (screenshotName, screenshotBytes, [args]) async {
         final file = File('screenshots/$screenshotName.png');
         if (!file.existsSync()) {
           file.writeAsBytesSync(screenshotBytes);

--- a/packages/dynamite/dynamite/analysis_options.yaml
+++ b/packages/dynamite/dynamite/analysis_options.yaml
@@ -3,6 +3,9 @@ include: package:neon_lints/dart.yaml
 linter:
   rules:
     public_member_api_docs: false
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false
 
 analyzer:
   exclude:

--- a/packages/dynamite/dynamite/lib/src/builder/client.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/client.dart
@@ -483,7 +483,7 @@ Iterable<String> buildAuthCheck(
   yield '''
 // coverage:ignore-start
 final authentication = $client.authentications.firstWhereOrNull(
-    (final auth) => switch (auth) {
+    (auth) => switch (auth) {
 ''';
 
   yield* securityRequirements.map((final requirement) {

--- a/packages/dynamite/dynamite/lib/src/models/type_result/list.dart
+++ b/packages/dynamite/dynamite/lib/src/models/type_result/list.dart
@@ -22,7 +22,7 @@ class TypeResultList extends TypeResult {
     final String? mimeType,
   }) {
     if (onlyChildren) {
-      return '($object as List).map<String>((final e) => ${subType.encode('e', mimeType: mimeType)}).join()';
+      return '($object as List).map<String>((e) => ${subType.encode('e', mimeType: mimeType)}).join()';
     }
 
     return super.encode(object, mimeType: mimeType);

--- a/packages/dynamite/dynamite_end_to_end_test/analysis_options.yaml
+++ b/packages/dynamite/dynamite_end_to_end_test/analysis_options.yaml
@@ -1,1 +1,7 @@
 include: package:neon_lints/dart.yaml
+
+linter:
+  rules:
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false

--- a/packages/dynamite/dynamite_end_to_end_test/analysis_options.yaml
+++ b/packages/dynamite/dynamite_end_to_end_test/analysis_options.yaml
@@ -1,7 +1,1 @@
 include: package:neon_lints/dart.yaml
-
-linter:
-  rules:
-    # TODO: migrate package to new lint rules
-    prefer_final_parameters: true
-    avoid_final_parameters: false

--- a/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.dart
@@ -22,7 +22,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -48,11 +48,11 @@ abstract interface class $ObjectAllOf_1Interface {
 abstract interface class $ObjectAllOfInterface implements $ObjectAllOf_0Interface, $ObjectAllOf_1Interface {}
 
 abstract class ObjectAllOf implements $ObjectAllOfInterface, Built<ObjectAllOf, ObjectAllOfBuilder> {
-  factory ObjectAllOf([final void Function(ObjectAllOfBuilder)? b]) = _$ObjectAllOf;
+  factory ObjectAllOf([void Function(ObjectAllOfBuilder)? b]) = _$ObjectAllOf;
 
   const ObjectAllOf._();
 
-  factory ObjectAllOf.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ObjectAllOf.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -69,12 +69,11 @@ abstract interface class $OneObjectAllOf_0Interface {
 abstract interface class $OneObjectAllOfInterface implements $OneObjectAllOf_0Interface {}
 
 abstract class OneObjectAllOf implements $OneObjectAllOfInterface, Built<OneObjectAllOf, OneObjectAllOfBuilder> {
-  factory OneObjectAllOf([final void Function(OneObjectAllOfBuilder)? b]) = _$OneObjectAllOf;
+  factory OneObjectAllOf([void Function(OneObjectAllOfBuilder)? b]) = _$OneObjectAllOf;
 
   const OneObjectAllOf._();
 
-  factory OneObjectAllOf.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory OneObjectAllOf.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -90,12 +89,11 @@ abstract interface class $PrimitiveAllOfInterface {
 }
 
 abstract class PrimitiveAllOf implements $PrimitiveAllOfInterface, Built<PrimitiveAllOf, PrimitiveAllOfBuilder> {
-  factory PrimitiveAllOf([final void Function(PrimitiveAllOfBuilder)? b]) = _$PrimitiveAllOf;
+  factory PrimitiveAllOf([void Function(PrimitiveAllOfBuilder)? b]) = _$PrimitiveAllOf;
 
   const PrimitiveAllOf._();
 
-  factory PrimitiveAllOf.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory PrimitiveAllOf.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -115,11 +113,11 @@ abstract interface class $MixedAllOfInterface implements $MixedAllOf_1Interface 
 }
 
 abstract class MixedAllOf implements $MixedAllOfInterface, Built<MixedAllOf, MixedAllOfBuilder> {
-  factory MixedAllOf([final void Function(MixedAllOfBuilder)? b]) = _$MixedAllOf;
+  factory MixedAllOf([void Function(MixedAllOfBuilder)? b]) = _$MixedAllOf;
 
   const MixedAllOf._();
 
-  factory MixedAllOf.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory MixedAllOf.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -133,11 +131,11 @@ abstract interface class $OneValueAllOfInterface {
 }
 
 abstract class OneValueAllOf implements $OneValueAllOfInterface, Built<OneValueAllOf, OneValueAllOfBuilder> {
-  factory OneValueAllOf([final void Function(OneValueAllOfBuilder)? b]) = _$OneValueAllOf;
+  factory OneValueAllOf([void Function(OneValueAllOfBuilder)? b]) = _$OneValueAllOf;
 
   const OneValueAllOf._();
 
-  factory OneValueAllOf.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OneValueAllOf.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.dart
@@ -23,7 +23,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -48,11 +48,11 @@ abstract interface class $ObjectAnyOf0Interface {
 }
 
 abstract class ObjectAnyOf0 implements $ObjectAnyOf0Interface, Built<ObjectAnyOf0, ObjectAnyOf0Builder> {
-  factory ObjectAnyOf0([final void Function(ObjectAnyOf0Builder)? b]) = _$ObjectAnyOf0;
+  factory ObjectAnyOf0([void Function(ObjectAnyOf0Builder)? b]) = _$ObjectAnyOf0;
 
   const ObjectAnyOf0._();
 
-  factory ObjectAnyOf0.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ObjectAnyOf0.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -66,11 +66,11 @@ abstract interface class $ObjectAnyOf1Interface {
 }
 
 abstract class ObjectAnyOf1 implements $ObjectAnyOf1Interface, Built<ObjectAnyOf1, ObjectAnyOf1Builder> {
-  factory ObjectAnyOf1([final void Function(ObjectAnyOf1Builder)? b]) = _$ObjectAnyOf1;
+  factory ObjectAnyOf1([void Function(ObjectAnyOf1Builder)? b]) = _$ObjectAnyOf1;
 
   const ObjectAnyOf1._();
 
-  factory ObjectAnyOf1.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ObjectAnyOf1.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -84,11 +84,11 @@ abstract interface class $MixedAnyOf1Interface {
 }
 
 abstract class MixedAnyOf1 implements $MixedAnyOf1Interface, Built<MixedAnyOf1, MixedAnyOf1Builder> {
-  factory MixedAnyOf1([final void Function(MixedAnyOf1Builder)? b]) = _$MixedAnyOf1;
+  factory MixedAnyOf1([void Function(MixedAnyOf1Builder)? b]) = _$MixedAnyOf1;
 
   const MixedAnyOf1._();
 
-  factory MixedAnyOf1.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory MixedAnyOf1.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -102,12 +102,11 @@ abstract interface class $OneObjectAnyOf0Interface {
 }
 
 abstract class OneObjectAnyOf0 implements $OneObjectAnyOf0Interface, Built<OneObjectAnyOf0, OneObjectAnyOf0Builder> {
-  factory OneObjectAnyOf0([final void Function(OneObjectAnyOf0Builder)? b]) = _$OneObjectAnyOf0;
+  factory OneObjectAnyOf0([void Function(OneObjectAnyOf0Builder)? b]) = _$OneObjectAnyOf0;
 
   const OneObjectAnyOf0._();
 
-  factory OneObjectAnyOf0.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory OneObjectAnyOf0.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -127,7 +126,7 @@ extension $ObjectAnyOf0ObjectAnyOf1Extension on $ObjectAnyOf0ObjectAnyOf1 {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$ObjectAnyOf0ObjectAnyOf1> get serializer => const _$ObjectAnyOf0ObjectAnyOf1Serializer();
-  static $ObjectAnyOf0ObjectAnyOf1 fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $ObjectAnyOf0ObjectAnyOf1 fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -142,9 +141,9 @@ class _$ObjectAnyOf0ObjectAnyOf1Serializer implements PrimitiveSerializer<$Objec
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $ObjectAnyOf0ObjectAnyOf1 object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $ObjectAnyOf0ObjectAnyOf1 object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.objectAnyOf0;
@@ -161,9 +160,9 @@ class _$ObjectAnyOf0ObjectAnyOf1Serializer implements PrimitiveSerializer<$Objec
 
   @override
   $ObjectAnyOf0ObjectAnyOf1 deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     ObjectAnyOf0? objectAnyOf0;
     try {
@@ -184,7 +183,7 @@ extension $MixedAnyOf1StringExtension on $MixedAnyOf1String {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$MixedAnyOf1String> get serializer => const _$MixedAnyOf1StringSerializer();
-  static $MixedAnyOf1String fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $MixedAnyOf1String fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -199,9 +198,9 @@ class _$MixedAnyOf1StringSerializer implements PrimitiveSerializer<$MixedAnyOf1S
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $MixedAnyOf1String object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $MixedAnyOf1String object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.mixedAnyOf1;
@@ -218,9 +217,9 @@ class _$MixedAnyOf1StringSerializer implements PrimitiveSerializer<$MixedAnyOf1S
 
   @override
   $MixedAnyOf1String deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     MixedAnyOf1? mixedAnyOf1;
     try {
@@ -241,7 +240,7 @@ extension $NumStringExtension on $NumString {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$NumString> get serializer => const _$NumStringSerializer();
-  static $NumString fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $NumString fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -256,9 +255,9 @@ class _$NumStringSerializer implements PrimitiveSerializer<$NumString> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $NumString object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $NumString object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.$num;
@@ -275,9 +274,9 @@ class _$NumStringSerializer implements PrimitiveSerializer<$NumString> {
 
   @override
   $NumString deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     num? $num;
     try {

--- a/packages/dynamite/dynamite_end_to_end_test/lib/enum.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/enum.openapi.dart
@@ -23,7 +23,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -43,7 +43,7 @@ class EnumString extends EnumClass {
 
   static BuiltSet<EnumString> get values => _$enumStringValues;
 
-  static EnumString valueOf(final String name) => _$valueOfEnumString(name);
+  static EnumString valueOf(String name) => _$valueOfEnumString(name);
 
   static Serializer<EnumString> get serializer => _$enumStringSerializer;
 }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
@@ -25,7 +25,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -179,11 +179,11 @@ abstract interface class $GetHeadersInterface {
 }
 
 abstract class GetHeaders implements $GetHeadersInterface, Built<GetHeaders, GetHeadersBuilder> {
-  factory GetHeaders([final void Function(GetHeadersBuilder)? b]) = _$GetHeaders;
+  factory GetHeaders([void Function(GetHeadersBuilder)? b]) = _$GetHeaders;
 
   const GetHeaders._();
 
-  factory GetHeaders.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory GetHeaders.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -200,12 +200,12 @@ abstract class WithContentOperationIdHeaders
     implements
         $WithContentOperationIdHeadersInterface,
         Built<WithContentOperationIdHeaders, WithContentOperationIdHeadersBuilder> {
-  factory WithContentOperationIdHeaders([final void Function(WithContentOperationIdHeadersBuilder)? b]) =
+  factory WithContentOperationIdHeaders([void Function(WithContentOperationIdHeadersBuilder)? b]) =
       _$WithContentOperationIdHeaders;
 
   const WithContentOperationIdHeaders._();
 
-  factory WithContentOperationIdHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory WithContentOperationIdHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
@@ -221,11 +221,11 @@ abstract interface class $GetWithContentHeadersInterface {
 
 abstract class GetWithContentHeaders
     implements $GetWithContentHeadersInterface, Built<GetWithContentHeaders, GetWithContentHeadersBuilder> {
-  factory GetWithContentHeaders([final void Function(GetWithContentHeadersBuilder)? b]) = _$GetWithContentHeaders;
+  factory GetWithContentHeaders([void Function(GetWithContentHeadersBuilder)? b]) = _$GetWithContentHeaders;
 
   const GetWithContentHeaders._();
 
-  factory GetWithContentHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory GetWithContentHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;

--- a/packages/dynamite/dynamite_end_to_end_test/lib/interfaces.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/interfaces.openapi.dart
@@ -22,7 +22,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -38,11 +38,11 @@ abstract interface class $BaseInterface {
 }
 
 abstract class Base implements $BaseInterface, Built<Base, BaseBuilder> {
-  factory Base([final void Function(BaseBuilder)? b]) = _$Base;
+  factory Base([void Function(BaseBuilder)? b]) = _$Base;
 
   const Base._();
 
-  factory Base.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Base.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -55,11 +55,11 @@ abstract interface class $BaseInterfaceInterface {
 }
 
 abstract class BaseInterface implements $BaseInterfaceInterface, Built<BaseInterface, BaseInterfaceBuilder> {
-  factory BaseInterface([final void Function(BaseInterfaceBuilder)? b]) = _$BaseInterface;
+  factory BaseInterface([void Function(BaseInterfaceBuilder)? b]) = _$BaseInterface;
 
   const BaseInterface._();
 
-  factory BaseInterface.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory BaseInterface.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
@@ -23,7 +23,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -46,11 +46,11 @@ abstract interface class $BaseAllOfInterface implements $BaseAllOf_1Interface {
 }
 
 abstract class BaseAllOf implements $BaseAllOfInterface, Built<BaseAllOf, BaseAllOfBuilder> {
-  factory BaseAllOf([final void Function(BaseAllOfBuilder)? b]) = _$BaseAllOf;
+  factory BaseAllOf([void Function(BaseAllOfBuilder)? b]) = _$BaseAllOf;
 
   const BaseAllOf._();
 
-  factory BaseAllOf.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory BaseAllOf.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -64,11 +64,11 @@ abstract interface class $BaseOneOf1Interface {
 }
 
 abstract class BaseOneOf1 implements $BaseOneOf1Interface, Built<BaseOneOf1, BaseOneOf1Builder> {
-  factory BaseOneOf1([final void Function(BaseOneOf1Builder)? b]) = _$BaseOneOf1;
+  factory BaseOneOf1([void Function(BaseOneOf1Builder)? b]) = _$BaseOneOf1;
 
   const BaseOneOf1._();
 
-  factory BaseOneOf1.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory BaseOneOf1.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -82,11 +82,11 @@ abstract interface class $BaseAnyOf1Interface {
 }
 
 abstract class BaseAnyOf1 implements $BaseAnyOf1Interface, Built<BaseAnyOf1, BaseAnyOf1Builder> {
-  factory BaseAnyOf1([final void Function(BaseAnyOf1Builder)? b]) = _$BaseAnyOf1;
+  factory BaseAnyOf1([void Function(BaseAnyOf1Builder)? b]) = _$BaseAnyOf1;
 
   const BaseAnyOf1._();
 
-  factory BaseAnyOf1.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory BaseAnyOf1.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -108,12 +108,11 @@ abstract interface class $BaseNestedAllOfInterface implements $BaseAllOfInterfac
 }
 
 abstract class BaseNestedAllOf implements $BaseNestedAllOfInterface, Built<BaseNestedAllOf, BaseNestedAllOfBuilder> {
-  factory BaseNestedAllOf([final void Function(BaseNestedAllOfBuilder)? b]) = _$BaseNestedAllOf;
+  factory BaseNestedAllOf([void Function(BaseNestedAllOfBuilder)? b]) = _$BaseNestedAllOf;
 
   const BaseNestedAllOf._();
 
-  factory BaseNestedAllOf.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory BaseNestedAllOf.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -128,12 +127,11 @@ abstract interface class $BaseNestedOneOf3Interface {
 
 abstract class BaseNestedOneOf3
     implements $BaseNestedOneOf3Interface, Built<BaseNestedOneOf3, BaseNestedOneOf3Builder> {
-  factory BaseNestedOneOf3([final void Function(BaseNestedOneOf3Builder)? b]) = _$BaseNestedOneOf3;
+  factory BaseNestedOneOf3([void Function(BaseNestedOneOf3Builder)? b]) = _$BaseNestedOneOf3;
 
   const BaseNestedOneOf3._();
 
-  factory BaseNestedOneOf3.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory BaseNestedOneOf3.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -148,12 +146,11 @@ abstract interface class $BaseNestedAnyOf3Interface {
 
 abstract class BaseNestedAnyOf3
     implements $BaseNestedAnyOf3Interface, Built<BaseNestedAnyOf3, BaseNestedAnyOf3Builder> {
-  factory BaseNestedAnyOf3([final void Function(BaseNestedAnyOf3Builder)? b]) = _$BaseNestedAnyOf3;
+  factory BaseNestedAnyOf3([void Function(BaseNestedAnyOf3Builder)? b]) = _$BaseNestedAnyOf3;
 
   const BaseNestedAnyOf3._();
 
-  factory BaseNestedAnyOf3.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory BaseNestedAnyOf3.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -189,7 +186,7 @@ extension $BaseOneOf1DoubleExtension on $BaseOneOf1Double {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BaseOneOf1Double> get serializer => const _$BaseOneOf1DoubleSerializer();
-  static $BaseOneOf1Double fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BaseOneOf1Double fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -204,9 +201,9 @@ class _$BaseOneOf1DoubleSerializer implements PrimitiveSerializer<$BaseOneOf1Dou
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BaseOneOf1Double object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BaseOneOf1Double object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.baseOneOf1;
@@ -223,9 +220,9 @@ class _$BaseOneOf1DoubleSerializer implements PrimitiveSerializer<$BaseOneOf1Dou
 
   @override
   $BaseOneOf1Double deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BaseOneOf1? baseOneOf1;
     try {
@@ -246,7 +243,7 @@ extension $BaseAnyOf1IntExtension on $BaseAnyOf1Int {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BaseAnyOf1Int> get serializer => const _$BaseAnyOf1IntSerializer();
-  static $BaseAnyOf1Int fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BaseAnyOf1Int fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -261,9 +258,9 @@ class _$BaseAnyOf1IntSerializer implements PrimitiveSerializer<$BaseAnyOf1Int> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BaseAnyOf1Int object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BaseAnyOf1Int object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.baseAnyOf1;
@@ -280,9 +277,9 @@ class _$BaseAnyOf1IntSerializer implements PrimitiveSerializer<$BaseAnyOf1Int> {
 
   @override
   $BaseAnyOf1Int deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BaseAnyOf1? baseAnyOf1;
     try {
@@ -311,7 +308,7 @@ extension $BaseAllOfBaseAnyOfBaseNestedOneOf3BaseOneOf1DoubleExtension
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BaseAllOfBaseAnyOfBaseNestedOneOf3BaseOneOf1Double> get serializer =>
       const _$BaseAllOfBaseAnyOfBaseNestedOneOf3BaseOneOf1DoubleSerializer();
-  static $BaseAllOfBaseAnyOfBaseNestedOneOf3BaseOneOf1Double fromJson(final Object? json) =>
+  static $BaseAllOfBaseAnyOfBaseNestedOneOf3BaseOneOf1Double fromJson(Object? json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
@@ -328,9 +325,9 @@ class _$BaseAllOfBaseAnyOfBaseNestedOneOf3BaseOneOf1DoubleSerializer
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BaseAllOfBaseAnyOfBaseNestedOneOf3BaseOneOf1Double object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BaseAllOfBaseAnyOfBaseNestedOneOf3BaseOneOf1Double object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.baseAllOf;
@@ -359,9 +356,9 @@ class _$BaseAllOfBaseAnyOfBaseNestedOneOf3BaseOneOf1DoubleSerializer
 
   @override
   $BaseAllOfBaseAnyOfBaseNestedOneOf3BaseOneOf1Double deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BaseAllOf? baseAllOf;
     try {
@@ -410,7 +407,7 @@ extension $BaseAllOfBaseAnyOf1BaseNestedAnyOf3BaseOneOfIntExtension
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BaseAllOfBaseAnyOf1BaseNestedAnyOf3BaseOneOfInt> get serializer =>
       const _$BaseAllOfBaseAnyOf1BaseNestedAnyOf3BaseOneOfIntSerializer();
-  static $BaseAllOfBaseAnyOf1BaseNestedAnyOf3BaseOneOfInt fromJson(final Object? json) =>
+  static $BaseAllOfBaseAnyOf1BaseNestedAnyOf3BaseOneOfInt fromJson(Object? json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
@@ -427,9 +424,9 @@ class _$BaseAllOfBaseAnyOf1BaseNestedAnyOf3BaseOneOfIntSerializer
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BaseAllOfBaseAnyOf1BaseNestedAnyOf3BaseOneOfInt object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BaseAllOfBaseAnyOf1BaseNestedAnyOf3BaseOneOfInt object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.baseAllOf;
@@ -458,9 +455,9 @@ class _$BaseAllOfBaseAnyOf1BaseNestedAnyOf3BaseOneOfIntSerializer
 
   @override
   $BaseAllOfBaseAnyOf1BaseNestedAnyOf3BaseOneOfInt deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BaseAllOf? baseAllOf;
     try {
@@ -501,7 +498,7 @@ extension $BaseOneOf1NumExtension on $BaseOneOf1Num {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BaseOneOf1Num> get serializer => const _$BaseOneOf1NumSerializer();
-  static $BaseOneOf1Num fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BaseOneOf1Num fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -516,9 +513,9 @@ class _$BaseOneOf1NumSerializer implements PrimitiveSerializer<$BaseOneOf1Num> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BaseOneOf1Num object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BaseOneOf1Num object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.baseOneOf1;
@@ -535,9 +532,9 @@ class _$BaseOneOf1NumSerializer implements PrimitiveSerializer<$BaseOneOf1Num> {
 
   @override
   $BaseOneOf1Num deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BaseOneOf1? baseOneOf1;
     try {

--- a/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.dart
@@ -23,7 +23,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -48,11 +48,11 @@ abstract interface class $ObjectOneOf0Interface {
 }
 
 abstract class ObjectOneOf0 implements $ObjectOneOf0Interface, Built<ObjectOneOf0, ObjectOneOf0Builder> {
-  factory ObjectOneOf0([final void Function(ObjectOneOf0Builder)? b]) = _$ObjectOneOf0;
+  factory ObjectOneOf0([void Function(ObjectOneOf0Builder)? b]) = _$ObjectOneOf0;
 
   const ObjectOneOf0._();
 
-  factory ObjectOneOf0.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ObjectOneOf0.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -66,11 +66,11 @@ abstract interface class $ObjectOneOf1Interface {
 }
 
 abstract class ObjectOneOf1 implements $ObjectOneOf1Interface, Built<ObjectOneOf1, ObjectOneOf1Builder> {
-  factory ObjectOneOf1([final void Function(ObjectOneOf1Builder)? b]) = _$ObjectOneOf1;
+  factory ObjectOneOf1([void Function(ObjectOneOf1Builder)? b]) = _$ObjectOneOf1;
 
   const ObjectOneOf1._();
 
-  factory ObjectOneOf1.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ObjectOneOf1.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -84,11 +84,11 @@ abstract interface class $MixedOneOf1Interface {
 }
 
 abstract class MixedOneOf1 implements $MixedOneOf1Interface, Built<MixedOneOf1, MixedOneOf1Builder> {
-  factory MixedOneOf1([final void Function(MixedOneOf1Builder)? b]) = _$MixedOneOf1;
+  factory MixedOneOf1([void Function(MixedOneOf1Builder)? b]) = _$MixedOneOf1;
 
   const MixedOneOf1._();
 
-  factory MixedOneOf1.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory MixedOneOf1.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -102,12 +102,11 @@ abstract interface class $OneObjectOneOf0Interface {
 }
 
 abstract class OneObjectOneOf0 implements $OneObjectOneOf0Interface, Built<OneObjectOneOf0, OneObjectOneOf0Builder> {
-  factory OneObjectOneOf0([final void Function(OneObjectOneOf0Builder)? b]) = _$OneObjectOneOf0;
+  factory OneObjectOneOf0([void Function(OneObjectOneOf0Builder)? b]) = _$OneObjectOneOf0;
 
   const OneObjectOneOf0._();
 
-  factory OneObjectOneOf0.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory OneObjectOneOf0.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -127,7 +126,7 @@ extension $ObjectOneOf0ObjectOneOf1Extension on $ObjectOneOf0ObjectOneOf1 {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$ObjectOneOf0ObjectOneOf1> get serializer => const _$ObjectOneOf0ObjectOneOf1Serializer();
-  static $ObjectOneOf0ObjectOneOf1 fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $ObjectOneOf0ObjectOneOf1 fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -142,9 +141,9 @@ class _$ObjectOneOf0ObjectOneOf1Serializer implements PrimitiveSerializer<$Objec
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $ObjectOneOf0ObjectOneOf1 object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $ObjectOneOf0ObjectOneOf1 object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.objectOneOf0;
@@ -161,9 +160,9 @@ class _$ObjectOneOf0ObjectOneOf1Serializer implements PrimitiveSerializer<$Objec
 
   @override
   $ObjectOneOf0ObjectOneOf1 deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     ObjectOneOf0? objectOneOf0;
     try {
@@ -184,7 +183,7 @@ extension $MixedOneOf1StringExtension on $MixedOneOf1String {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$MixedOneOf1String> get serializer => const _$MixedOneOf1StringSerializer();
-  static $MixedOneOf1String fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $MixedOneOf1String fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -199,9 +198,9 @@ class _$MixedOneOf1StringSerializer implements PrimitiveSerializer<$MixedOneOf1S
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $MixedOneOf1String object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $MixedOneOf1String object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.mixedOneOf1;
@@ -218,9 +217,9 @@ class _$MixedOneOf1StringSerializer implements PrimitiveSerializer<$MixedOneOf1S
 
   @override
   $MixedOneOf1String deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     MixedOneOf1? mixedOneOf1;
     try {
@@ -241,7 +240,7 @@ extension $NumStringExtension on $NumString {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$NumString> get serializer => const _$NumStringSerializer();
-  static $NumString fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $NumString fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -256,9 +255,9 @@ class _$NumStringSerializer implements PrimitiveSerializer<$NumString> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $NumString object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $NumString object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.$num;
@@ -275,9 +274,9 @@ class _$NumStringSerializer implements PrimitiveSerializer<$NumString> {
 
   @override
   $NumString deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     num? $num;
     try {

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
@@ -29,7 +29,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -62,19 +62,19 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [$getRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<JsonObject, void>> $get({
-    final ContentString<BuiltMap<String, JsonObject>>? contentString,
-    final ContentString<BuiltMap<String, JsonObject>>? contentParameter,
-    final BuiltList<String>? array,
-    final bool? $bool,
-    final String? string,
-    final Uint8List? stringBinary,
-    final int? $int,
-    final double? $double,
-    final num? $num,
-    final JsonObject? object,
-    final GetOneOf? oneOf,
-    final GetAnyOf? anyOf,
-    final GetEnumPattern? enumPattern,
+    ContentString<BuiltMap<String, JsonObject>>? contentString,
+    ContentString<BuiltMap<String, JsonObject>>? contentParameter,
+    BuiltList<String>? array,
+    bool? $bool,
+    String? string,
+    Uint8List? stringBinary,
+    int? $int,
+    double? $double,
+    num? $num,
+    JsonObject? object,
+    GetOneOf? oneOf,
+    GetAnyOf? anyOf,
+    GetEnumPattern? enumPattern,
   }) async {
     final rawResponse = $getRaw(
       contentString: contentString,
@@ -122,19 +122,19 @@ class Client extends DynamiteClient {
   ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<JsonObject, void> $getRaw({
-    final ContentString<BuiltMap<String, JsonObject>>? contentString,
-    final ContentString<BuiltMap<String, JsonObject>>? contentParameter,
-    final BuiltList<String>? array,
-    final bool? $bool,
-    final String? string,
-    final Uint8List? stringBinary,
-    final int? $int,
-    final double? $double,
-    final num? $num,
-    final JsonObject? object,
-    final GetOneOf? oneOf,
-    final GetAnyOf? anyOf,
-    final GetEnumPattern? enumPattern,
+    ContentString<BuiltMap<String, JsonObject>>? contentString,
+    ContentString<BuiltMap<String, JsonObject>>? contentParameter,
+    BuiltList<String>? array,
+    bool? $bool,
+    String? string,
+    Uint8List? stringBinary,
+    int? $int,
+    double? $double,
+    num? $num,
+    JsonObject? object,
+    GetOneOf? oneOf,
+    GetAnyOf? anyOf,
+    GetEnumPattern? enumPattern,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -228,12 +228,12 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [getHeadersRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<JsonObject, void>> getHeaders({
-    final BuiltList<String>? array,
-    final bool? $bool,
-    final String? string,
-    final int? $int,
-    final double? $double,
-    final num? $num,
+    BuiltList<String>? array,
+    bool? $bool,
+    String? string,
+    int? $int,
+    double? $double,
+    num? $num,
   }) async {
     final rawResponse = getHeadersRaw(
       array: array,
@@ -267,12 +267,12 @@ class Client extends DynamiteClient {
   ///  * [getHeaders] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<JsonObject, void> getHeadersRaw({
-    final BuiltList<String>? array,
-    final bool? $bool,
-    final String? string,
-    final int? $int,
-    final double? $double,
-    final num? $num,
+    BuiltList<String>? array,
+    bool? $bool,
+    String? string,
+    int? $int,
+    double? $double,
+    num? $num,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -282,7 +282,7 @@ class Client extends DynamiteClient {
 
     final $array = jsonSerializers.serialize(array, specifiedType: const FullType(BuiltList, [FullType(String)]));
     if ($array != null) {
-      headers['array'] = ($array as List).map<String>((final e) => e as String).join();
+      headers['array'] = ($array as List).map<String>((e) => e as String).join();
     }
 
     final $$bool = jsonSerializers.serialize($bool, specifiedType: const FullType(bool));
@@ -333,7 +333,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [getPathParameterRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<JsonObject, void>> getPathParameter({required final String pathParameter}) async {
+  Future<DynamiteResponse<JsonObject, void>> getPathParameter({required String pathParameter}) async {
     final rawResponse = getPathParameterRaw(
       pathParameter: pathParameter,
     );
@@ -352,7 +352,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [getPathParameter] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<JsonObject, void> getPathParameterRaw({required final String pathParameter}) {
+  DynamiteRawResponse<JsonObject, void> getPathParameterRaw({required String pathParameter}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -388,7 +388,7 @@ class GetEnumPattern extends EnumClass {
 
   static BuiltSet<GetEnumPattern> get values => _$getEnumPatternValues;
 
-  static GetEnumPattern valueOf(final String name) => _$valueOfGetEnumPattern(name);
+  static GetEnumPattern valueOf(String name) => _$valueOfGetEnumPattern(name);
 
   static Serializer<GetEnumPattern> get serializer => _$getEnumPatternSerializer;
 }
@@ -404,7 +404,7 @@ extension $BoolStringExtension on $BoolString {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BoolString> get serializer => const _$BoolStringSerializer();
-  static $BoolString fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BoolString fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -419,9 +419,9 @@ class _$BoolStringSerializer implements PrimitiveSerializer<$BoolString> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BoolString object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BoolString object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.$bool;
@@ -438,9 +438,9 @@ class _$BoolStringSerializer implements PrimitiveSerializer<$BoolString> {
 
   @override
   $BoolString deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     bool? $bool;
     try {

--- a/packages/dynamite/dynamite_end_to_end_test/lib/pattern_check.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/pattern_check.openapi.dart
@@ -23,7 +23,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -46,18 +46,18 @@ abstract interface class $TestObjectInterface {
 }
 
 abstract class TestObject implements $TestObjectInterface, Built<TestObject, TestObjectBuilder> {
-  factory TestObject([final void Function(TestObjectBuilder)? b]) = _$TestObject;
+  factory TestObject([void Function(TestObjectBuilder)? b]) = _$TestObject;
 
   const TestObject._();
 
-  factory TestObject.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory TestObject.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
   static Serializer<TestObject> get serializer => _$testObjectSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final TestObjectBuilder b) {
+  static void _validate(TestObjectBuilder b) {
     dynamite_utils.checkPattern(b.onlyNumbers, RegExp(r'^[0-9]*$'), 'onlyNumbers');
     dynamite_utils.checkMinLength(b.minLength, 3, 'minLength');
     dynamite_utils.checkMaxLength(b.maxLength, 20, 'maxLength');

--- a/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
@@ -23,7 +23,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -40,7 +40,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [$getRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<void, void>> $get({final Uint8List? uint8List}) async {
+  Future<DynamiteResponse<void, void>> $get({Uint8List? uint8List}) async {
     final rawResponse = $getRaw(
       uint8List: uint8List,
     );
@@ -59,7 +59,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<void, void> $getRaw({final Uint8List? uint8List}) {
+  DynamiteRawResponse<void, void> $getRaw({Uint8List? uint8List}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
@@ -91,7 +91,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [postRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<void, void>> post({final String? string}) async {
+  Future<DynamiteResponse<void, void>> post({String? string}) async {
     final rawResponse = postRaw(
       string: string,
     );
@@ -110,7 +110,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [post] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<void, void> postRaw({final String? string}) {
+  DynamiteRawResponse<void, void> postRaw({String? string}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;

--- a/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.dart
@@ -22,7 +22,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,

--- a/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.dart
@@ -23,7 +23,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -45,11 +45,11 @@ abstract interface class $OneValueSomeOfInObjectInterface {
 
 abstract class OneValueSomeOfInObject
     implements $OneValueSomeOfInObjectInterface, Built<OneValueSomeOfInObject, OneValueSomeOfInObjectBuilder> {
-  factory OneValueSomeOfInObject([final void Function(OneValueSomeOfInObjectBuilder)? b]) = _$OneValueSomeOfInObject;
+  factory OneValueSomeOfInObject([void Function(OneValueSomeOfInObjectBuilder)? b]) = _$OneValueSomeOfInObject;
 
   const OneValueSomeOfInObject._();
 
-  factory OneValueSomeOfInObject.fromJson(final Map<String, dynamic> json) =>
+  factory OneValueSomeOfInObject.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
@@ -57,7 +57,7 @@ abstract class OneValueSomeOfInObject
   static Serializer<OneValueSomeOfInObject> get serializer => _$oneValueSomeOfInObjectSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final OneValueSomeOfInObjectBuilder b) {
+  static void _validate(OneValueSomeOfInObjectBuilder b) {
     b.intDoubleString?.validateOneOf();
   }
 }
@@ -75,7 +75,7 @@ extension $NumStringExtension on $NumString {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$NumString> get serializer => const _$NumStringSerializer();
-  static $NumString fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $NumString fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -90,9 +90,9 @@ class _$NumStringSerializer implements PrimitiveSerializer<$NumString> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $NumString object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $NumString object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.$num;
@@ -109,9 +109,9 @@ class _$NumStringSerializer implements PrimitiveSerializer<$NumString> {
 
   @override
   $NumString deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     num? $num;
     try {

--- a/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.dart
@@ -24,7 +24,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -50,11 +50,11 @@ abstract interface class $BaseInterface {
 }
 
 abstract class Base implements $BaseInterface, Built<Base, BaseBuilder> {
-  factory Base([final void Function(BaseBuilder)? b]) = _$Base;
+  factory Base([void Function(BaseBuilder)? b]) = _$Base;
 
   const Base._();
 
-  factory Base.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Base.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -69,12 +69,11 @@ abstract interface class $NestedRedirectInterface {
 }
 
 abstract class NestedRedirect implements $NestedRedirectInterface, Built<NestedRedirect, NestedRedirectBuilder> {
-  factory NestedRedirect([final void Function(NestedRedirectBuilder)? b]) = _$NestedRedirect;
+  factory NestedRedirect([void Function(NestedRedirectBuilder)? b]) = _$NestedRedirect;
 
   const NestedRedirect._();
 
-  factory NestedRedirect.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory NestedRedirect.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
@@ -90,7 +89,7 @@ extension $BaseIntJsonObjectExtension on $BaseIntJsonObject {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BaseIntJsonObject> get serializer => const _$BaseIntJsonObjectSerializer();
-  static $BaseIntJsonObject fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BaseIntJsonObject fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -105,9 +104,9 @@ class _$BaseIntJsonObjectSerializer implements PrimitiveSerializer<$BaseIntJsonO
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BaseIntJsonObject object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BaseIntJsonObject object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.base;
@@ -128,9 +127,9 @@ class _$BaseIntJsonObjectSerializer implements PrimitiveSerializer<$BaseIntJsonO
 
   @override
   $BaseIntJsonObject deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     Base? base;
     try {

--- a/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.dart
@@ -26,7 +26,7 @@ class Client extends DynamiteClient {
     super.cookieJar,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -70,11 +70,11 @@ abstract interface class $BaseInterface {
 }
 
 abstract class Base implements $BaseInterface, Built<Base, BaseBuilder> {
-  factory Base([final void Function(BaseBuilder)? b]) = _$Base;
+  factory Base([void Function(BaseBuilder)? b]) = _$Base;
 
   const Base._();
 
-  factory Base.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Base.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
 
   Map<String, dynamic> toJson() => jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 

--- a/packages/dynamite/dynamite_end_to_end_test/test/all_of_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/all_of_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   test('ObjectAllOf', () {
     final object = ObjectAllOf(
-      (final b) => b
+      (b) => b
         ..attribute1AllOf = 'attribute1AllOfValue'
         ..attribute2AllOf = 'attribute2AllOfValue',
     );
@@ -20,7 +20,7 @@ void main() {
 
   test('OneObjectAllOf', () {
     final object = OneObjectAllOf(
-      (final b) => b..attributeAllOf = 'attributeAllOfValue',
+      (b) => b..attributeAllOf = 'attributeAllOfValue',
     );
 
     final json = {
@@ -33,7 +33,7 @@ void main() {
 
   test('PrimitiveAllOf', () {
     final object = PrimitiveAllOf(
-      (final b) => b
+      (b) => b
         ..string = 'stringValue'
         ..$int = 62,
     );
@@ -49,7 +49,7 @@ void main() {
 
   test('MixedAllOf', () {
     final object = MixedAllOf(
-      (final b) => b
+      (b) => b
         ..string = 'stringValue'
         ..attributeAllOf = 'attributeAllOfValue',
     );
@@ -65,7 +65,7 @@ void main() {
 
   test('OneValueAllOf', () {
     final object = OneValueAllOf(
-      (final b) => b..string = 'stringValue',
+      (b) => b..string = 'stringValue',
     );
 
     final json = {

--- a/packages/dynamite/dynamite_end_to_end_test/test/any_of_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/any_of_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   test('ObjectAnyOf', () {
     ObjectAnyOf object = (
-      objectAnyOf0: ObjectAnyOf0((final b) => b..attribute1AnyOf = 'attribute1AnyOf'),
+      objectAnyOf0: ObjectAnyOf0((b) => b..attribute1AnyOf = 'attribute1AnyOf'),
       objectAnyOf1: null,
     );
 
@@ -15,7 +15,7 @@ void main() {
 
     object = (
       objectAnyOf0: null,
-      objectAnyOf1: ObjectAnyOf1((final b) => b..attribute2AnyOf = 'attribute2AnyOf'),
+      objectAnyOf1: ObjectAnyOf1((b) => b..attribute2AnyOf = 'attribute2AnyOf'),
     );
 
     json = {'attribute2-anyOf': 'attribute2AnyOf'};
@@ -26,7 +26,7 @@ void main() {
 
   test('MixedAnyOf', () {
     MixedAnyOf object = (
-      mixedAnyOf1: MixedAnyOf1((final b) => b..attributeAnyOf = 'attributeAnyOf'),
+      mixedAnyOf1: MixedAnyOf1((b) => b..attributeAnyOf = 'attributeAnyOf'),
       string: null,
     );
 
@@ -47,7 +47,7 @@ void main() {
   });
 
   test('OneObjectAnyOf', () {
-    final object = OneObjectAnyOf((final b) => b..attributeAnyOf = 'attributeAnyOf');
+    final object = OneObjectAnyOf((b) => b..attributeAnyOf = 'attributeAnyOf');
 
     final json = {'attribute-anyOf': 'attributeAnyOf'};
 

--- a/packages/dynamite/dynamite_end_to_end_test/test/nested_ofs_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/nested_ofs_test.dart
@@ -4,17 +4,17 @@ import 'package:test/test.dart';
 void main() {
   test('BaseNestedAllOf', () {
     final object = BaseNestedAllOf(
-      (final b) => b
+      (b) => b
         ..string = 'attributeValue'
         ..attributeAllOf = 'attributeAllOfValue'
         ..attributeNestedAllOf = 'attributeNestedAllOf'
         ..baseAnyOf = (
           $int: null,
-          baseAnyOf1: BaseAnyOf1((final b) => b..attributeAnyOf = 'baseAnyOfAttributeAnyOfValue'),
+          baseAnyOf1: BaseAnyOf1((b) => b..attributeAnyOf = 'baseAnyOfAttributeAnyOfValue'),
         )
         ..baseOneOf = (
           $double: null,
-          baseOneOf1: BaseOneOf1((final b) => b..attributeOneOf = 'baseAnyOfAttributeOneOfValue'),
+          baseOneOf1: BaseOneOf1((b) => b..attributeOneOf = 'baseAnyOfAttributeOneOfValue'),
         ),
     );
 
@@ -33,7 +33,7 @@ void main() {
   test('BaseNestedOneOf', () {
     BaseNestedOneOf object = (
       baseAllOf: BaseAllOf(
-        (final b) => b
+        (b) => b
           ..string = 'BaseAllOfAttributeValue'
           ..attributeAllOf = 'BaseAllOfAttributeAllOfValue',
       ),
@@ -54,7 +54,7 @@ void main() {
     object = (
       baseAllOf: null,
       $double: null,
-      baseOneOf1: BaseOneOf1((final b) => b..attributeOneOf = 'baseOneOfAttributeOneOfValue'),
+      baseOneOf1: BaseOneOf1((b) => b..attributeOneOf = 'baseOneOfAttributeOneOfValue'),
       baseAnyOf: null,
       baseNestedOneOf3: null,
     );
@@ -85,7 +85,7 @@ void main() {
       baseOneOf1: null,
       baseAnyOf: (
         $int: null,
-        baseAnyOf1: BaseAnyOf1((final b) => b..attributeAnyOf = 'baseOneOfAttributeAnyOfValue'),
+        baseAnyOf1: BaseAnyOf1((b) => b..attributeAnyOf = 'baseOneOfAttributeAnyOfValue'),
       ),
       baseNestedOneOf3: null,
     );
@@ -119,7 +119,7 @@ void main() {
       baseOneOf1: null,
       baseAnyOf: null,
       baseNestedOneOf3: BaseNestedOneOf3(
-        (final b) => b..attributeNestedOneOf = 'BaseNestedOneOf3AttributeNestedOneOfValue',
+        (b) => b..attributeNestedOneOf = 'BaseNestedOneOf3AttributeNestedOneOfValue',
       ),
     );
 
@@ -134,7 +134,7 @@ void main() {
   test('BaseNestedAnyOf', () {
     BaseNestedAnyOf object = (
       baseAllOf: BaseAllOf(
-        (final b) => b
+        (b) => b
           ..string = 'BaseAllOfAttributeValue'
           ..attributeAllOf = 'BaseAllOfAttributeAllOfValue',
       ),
@@ -156,7 +156,7 @@ void main() {
       baseAllOf: null,
       baseOneOf: (
         $double: null,
-        baseOneOf1: BaseOneOf1((final b) => b..attributeOneOf = 'baseOneOfAttributeOneOfValue'),
+        baseOneOf1: BaseOneOf1((b) => b..attributeOneOf = 'baseOneOfAttributeOneOfValue'),
       ),
       $int: null,
       baseAnyOf1: null,
@@ -190,7 +190,7 @@ void main() {
       baseAllOf: null,
       baseOneOf: null,
       $int: null,
-      baseAnyOf1: BaseAnyOf1((final b) => b..attributeAnyOf = 'baseOneOfAttributeAnyOfValue'),
+      baseAnyOf1: BaseAnyOf1((b) => b..attributeAnyOf = 'baseOneOfAttributeAnyOfValue'),
       baseNestedAnyOf3: null,
     );
 
@@ -220,7 +220,7 @@ void main() {
       $int: null,
       baseAnyOf1: null,
       baseNestedAnyOf3: BaseNestedAnyOf3(
-        (final b) => b..attributeNestedAnyOf = 'BaseNestedOneOf3AttributeNestedAnyOfValue',
+        (b) => b..attributeNestedAnyOf = 'BaseNestedOneOf3AttributeNestedAnyOfValue',
       ),
     );
 
@@ -256,7 +256,7 @@ void main() {
     object = (
       $num: null,
       baseOneOf1: BaseOneOf1(
-        (final b) => b..attributeOneOf = 'NestedOptimizedOneOfBaseOneOf1AttributeOneOfValue',
+        (b) => b..attributeOneOf = 'NestedOptimizedOneOfBaseOneOf1AttributeOneOfValue',
       ),
     );
 

--- a/packages/dynamite/dynamite_end_to_end_test/test/one_of_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/one_of_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   test('ObjectOneOf', () {
     ObjectOneOf object = (
-      objectOneOf0: ObjectOneOf0((final b) => b..attribute1OneOf = 'attribute1OneOf'),
+      objectOneOf0: ObjectOneOf0((b) => b..attribute1OneOf = 'attribute1OneOf'),
       objectOneOf1: null,
     );
 
@@ -15,7 +15,7 @@ void main() {
 
     object = (
       objectOneOf0: null,
-      objectOneOf1: ObjectOneOf1((final b) => b..attribute2OneOf = 'attribute2OneOf'),
+      objectOneOf1: ObjectOneOf1((b) => b..attribute2OneOf = 'attribute2OneOf'),
     );
 
     json = {'attribute2-oneOf': 'attribute2OneOf'};
@@ -26,7 +26,7 @@ void main() {
 
   test('MixedOneOf', () {
     MixedOneOf object = (
-      mixedOneOf1: MixedOneOf1((final b) => b..attributeOneOf = 'attributeOneOf'),
+      mixedOneOf1: MixedOneOf1((b) => b..attributeOneOf = 'attributeOneOf'),
       string: null,
     );
 
@@ -47,7 +47,7 @@ void main() {
   });
 
   test('OneObjectOneOf', () {
-    final object = OneObjectOneOf0((final b) => b..attributeOneOf = 'attributeOneOf');
+    final object = OneObjectOneOf0((b) => b..attributeOneOf = 'attributeOneOf');
 
     final json = {'attribute-oneOf': 'attributeOneOf'};
 

--- a/packages/dynamite/dynamite_end_to_end_test/test/parameters_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/parameters_test.dart
@@ -16,7 +16,7 @@ late MockHttpClient mockHttpClient;
 
 class MockHttpOverrides extends HttpOverrides {
   @override
-  HttpClient createHttpClient(final SecurityContext? context) => mockHttpClient;
+  HttpClient createHttpClient(SecurityContext? context) => mockHttpClient;
 }
 
 void main() {
@@ -29,17 +29,17 @@ void main() {
     mockHttpClient = MockHttpClient();
     HttpOverrides.global = MockHttpOverrides();
 
-    when(mockHttpClient.openUrl(any, any)).thenAnswer((final invocation) {
+    when(mockHttpClient.openUrl(any, any)).thenAnswer((invocation) {
       headers = MockHttpHeaders();
 
       response = MockHttpClientResponse();
       when(response.headers).thenReturn(headers);
-      when(response.transform<dynamic>(any)).thenAnswer((final _) => Stream.value('{}'));
+      when(response.transform<dynamic>(any)).thenAnswer((_) => Stream.value('{}'));
       when(response.statusCode).thenReturn(200);
 
       request = MockHttpClientRequest();
       when(request.headers).thenReturn(headers);
-      when(request.close()).thenAnswer((final _) async => response);
+      when(request.close()).thenAnswer((_) async => response);
       return Future.value(request);
     });
 
@@ -55,7 +55,7 @@ void main() {
 
     test('with contentString', () async {
       final contentString = ContentString<BuiltMap<String, JsonObject>>(
-        (final b) => b..content = BuiltMap<String, JsonObject>({'key': JsonObject('value')}),
+        (b) => b..content = BuiltMap<String, JsonObject>({'key': JsonObject('value')}),
       );
 
       final queryComponent = Uri.encodeQueryComponent(json.encode({'key': 'value'}));
@@ -73,7 +73,7 @@ void main() {
 
     test('with contentParameter', () async {
       final contentParameter = ContentString<BuiltMap<String, JsonObject>>(
-        (final b) => b..content = BuiltMap<String, JsonObject>({'key': JsonObject('value')}),
+        (b) => b..content = BuiltMap<String, JsonObject>({'key': JsonObject('value')}),
       );
 
       final queryComponent = Uri.encodeQueryComponent(json.encode({'key': 'value'}));
@@ -103,7 +103,7 @@ void main() {
 
     test('with multiple query parameters', () async {
       final contentString = ContentString<BuiltMap<String, JsonObject>>(
-        (final b) => b..content = BuiltMap<String, JsonObject>({'key': JsonObject('value')}),
+        (b) => b..content = BuiltMap<String, JsonObject>({'key': JsonObject('value')}),
       );
 
       final queryComponent = Uri.encodeQueryComponent(json.encode({'key': 'value'}));

--- a/packages/dynamite/dynamite_end_to_end_test/test/pattern_check_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/pattern_check_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   const validString = '01234';
   final object = TestObject(
-    (final b) => b
+    (b) => b
       ..onlyNumbers = validString
       ..minLength = validString
       ..maxLength = validString
@@ -13,36 +13,36 @@ void main() {
 
   group('Pattern check', () {
     test('onlyNumbers', () {
-      object.rebuild((final b) => b..onlyNumbers = null);
-      expect(() => object.rebuild((final b) => b..onlyNumbers = 'Text'), throwsA(isA<FormatException>()));
+      object.rebuild((b) => b..onlyNumbers = null);
+      expect(() => object.rebuild((b) => b..onlyNumbers = 'Text'), throwsA(isA<FormatException>()));
     });
 
     test('minLength', () {
-      object.rebuild((final b) => b..minLength = null);
-      expect(() => object.rebuild((final b) => b..minLength = ''), throwsA(isA<FormatException>()));
-      expect(() => object.rebuild((final b) => b..minLength = 'Te'), throwsA(isA<FormatException>()));
-      expect(() => object.rebuild((final b) => b..minLength = '12'), throwsA(isA<FormatException>()));
+      object.rebuild((b) => b..minLength = null);
+      expect(() => object.rebuild((b) => b..minLength = ''), throwsA(isA<FormatException>()));
+      expect(() => object.rebuild((b) => b..minLength = 'Te'), throwsA(isA<FormatException>()));
+      expect(() => object.rebuild((b) => b..minLength = '12'), throwsA(isA<FormatException>()));
     });
 
     test('maxLength', () {
-      object.rebuild((final b) => b..maxLength = null);
+      object.rebuild((b) => b..maxLength = null);
       expect(
-        () => object.rebuild((final b) => b..maxLength = 'Super long text should throw'),
+        () => object.rebuild((b) => b..maxLength = 'Super long text should throw'),
         throwsA(isA<FormatException>()),
       );
       expect(
-        () => object.rebuild((final b) => b..maxLength = '419712642879393808962'),
+        () => object.rebuild((b) => b..maxLength = '419712642879393808962'),
         throwsA(isA<FormatException>()),
       );
     });
 
     test('multipleChecks', () {
-      object.rebuild((final b) => b..multipleChecks = null);
-      expect(() => object.rebuild((final b) => b..multipleChecks = 'Text'), throwsA(isA<FormatException>()));
-      expect(() => object.rebuild((final b) => b..minLength = ''), throwsA(isA<FormatException>()));
-      expect(() => object.rebuild((final b) => b..minLength = '12'), throwsA(isA<FormatException>()));
+      object.rebuild((b) => b..multipleChecks = null);
+      expect(() => object.rebuild((b) => b..multipleChecks = 'Text'), throwsA(isA<FormatException>()));
+      expect(() => object.rebuild((b) => b..minLength = ''), throwsA(isA<FormatException>()));
+      expect(() => object.rebuild((b) => b..minLength = '12'), throwsA(isA<FormatException>()));
       expect(
-        () => object.rebuild((final b) => b..maxLength = '419712642879393808962'),
+        () => object.rebuild((b) => b..maxLength = '419712642879393808962'),
         throwsA(isA<FormatException>()),
       );
     });

--- a/packages/dynamite/dynamite_end_to_end_test/test/types_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/types_test.dart
@@ -9,16 +9,16 @@ import 'package:test/test.dart';
 void main() {
   test(Base, () {
     final object = Base(
-      (final b) => b
+      (b) => b
         ..$bool = true
         ..integer = 350
         ..$double = 0.7617818016335848
         ..$num = 0.6538342555284606
         ..string = 'StringValue'
-        ..contentString.update((final b) => b..content = 98)
+        ..contentString.update((b) => b..content = 98)
         ..stringBinary = utf8.encode('StringValue')
         ..list.update(
-          (final b) => b
+          (b) => b
             ..addAll([
               JsonObject('value'),
               JsonObject(188),
@@ -28,7 +28,7 @@ void main() {
         )
         ..listNever = ListBuilder<Never>()
         ..listString.update(
-          (final b) => b
+          (b) => b
             ..addAll([
               'value1',
               'value2',
@@ -69,7 +69,7 @@ void main() {
 
   test(BuiltList<Never>, () {
     final object = Base(
-      (final b) => b..listNever = ListBuilder<Never>(),
+      (b) => b..listNever = ListBuilder<Never>(),
     );
 
     var json = <String, dynamic>{

--- a/packages/dynamite/dynamite_runtime/analysis_options.yaml
+++ b/packages/dynamite/dynamite_runtime/analysis_options.yaml
@@ -3,3 +3,9 @@ include: package:neon_lints/dart.yaml
 analyzer:
   exclude:
     - '**.g.dart'
+
+linter:
+  rules:
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false

--- a/packages/file_icons/analysis_options.yaml
+++ b/packages/file_icons/analysis_options.yaml
@@ -1,1 +1,7 @@
 include: package:neon_lints/dart.yaml
+
+linter:
+  rules:
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false

--- a/packages/neon/neon_dashboard/analysis_options.yaml
+++ b/packages/neon/neon_dashboard/analysis_options.yaml
@@ -3,3 +3,9 @@ include: package:neon_lints/flutter.yaml
 analyzer:
   exclude:
     - lib/l10n/**
+
+linter:
+  rules:
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false

--- a/packages/neon/neon_files/analysis_options.yaml
+++ b/packages/neon/neon_files/analysis_options.yaml
@@ -3,6 +3,9 @@ include: package:neon_lints/flutter.yaml
 linter:
   rules:
     public_member_api_docs: false
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false
 
 analyzer:
   exclude:

--- a/packages/neon/neon_news/analysis_options.yaml
+++ b/packages/neon/neon_news/analysis_options.yaml
@@ -3,6 +3,9 @@ include: package:neon_lints/flutter.yaml
 linter:
   rules:
     public_member_api_docs: false
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false
 
 analyzer:
   exclude:

--- a/packages/neon/neon_notes/analysis_options.yaml
+++ b/packages/neon/neon_notes/analysis_options.yaml
@@ -3,6 +3,9 @@ include: package:neon_lints/flutter.yaml
 linter:
   rules:
     public_member_api_docs: false
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false
 
 analyzer:
   exclude:

--- a/packages/neon/neon_notifications/analysis_options.yaml
+++ b/packages/neon/neon_notifications/analysis_options.yaml
@@ -3,6 +3,9 @@ include: package:neon_lints/flutter.yaml
 linter:
   rules:
     public_member_api_docs: false
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false
 
 analyzer:
   exclude:

--- a/packages/neon_framework/analysis_options.yaml
+++ b/packages/neon_framework/analysis_options.yaml
@@ -4,6 +4,9 @@ linter:
   rules:
     # should be enabled for release. https://github.com/nextcloud/neon/issues/692
     public_member_api_docs: false
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false
 
 analyzer:
   exclude:

--- a/packages/neon_lints/lib/src/base.yaml
+++ b/packages/neon_lints/lib/src/base.yaml
@@ -28,7 +28,7 @@ linter:
     avoid_equals_and_hash_code_on_mutable_classes: true
     avoid_escaping_inner_quotes: true
     avoid_field_initializers_in_const_classes: true
-    avoid_final_parameters: false
+    avoid_final_parameters: true
     avoid_function_literals_in_foreach_calls: true
     avoid_implementing_value_types: true
     avoid_init_to_null: true
@@ -137,7 +137,7 @@ linter:
     prefer_final_fields: true
     prefer_final_in_for_each: true
     prefer_final_locals: true
-    prefer_final_parameters: true
+    prefer_final_parameters: false
     prefer_for_elements_to_map_fromIterable: true
     prefer_foreach: true
     prefer_function_declarations_over_variables: true

--- a/packages/neon_lints/lint_maker.yaml
+++ b/packages/neon_lints/lint_maker.yaml
@@ -17,7 +17,6 @@ base:
         avoid_annotating_with_dynamic: false
         avoid_as: false
         avoid_catches_without_on_clauses: false
-        avoid_final_parameters: false
         avoid_print: false
         diagnostic_describe_all_properties: false
         lines_longer_than_80_chars: false
@@ -26,3 +25,4 @@ base:
         prefer_double_quotes: false
         prefer_relative_imports: false
         unnecessary_final: false
+        prefer_final_parameters: false

--- a/packages/nextcloud/analysis_options.yaml
+++ b/packages/nextcloud/analysis_options.yaml
@@ -1,1 +1,7 @@
 include: package:neon_lints/dart.yaml
+
+linter:
+  rules:
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false

--- a/packages/nextcloud/analysis_options.yaml
+++ b/packages/nextcloud/analysis_options.yaml
@@ -1,7 +1,1 @@
 include: package:neon_lints/dart.yaml
-
-linter:
-  rules:
-    # TODO: migrate package to new lint rules
-    prefer_final_parameters: true
-    avoid_final_parameters: false

--- a/packages/nextcloud/bin/generate_exports.dart
+++ b/packages/nextcloud/bin/generate_exports.dart
@@ -8,9 +8,9 @@ void main() {
   final files = Directory('lib/src/api')
       .listSync()
       .cast<File>()
-      .where((final file) => file.path.endsWith('.openapi.dart'))
+      .where((file) => file.path.endsWith('.openapi.dart'))
       .toList()
-    ..sort((final a, final b) => a.path.compareTo(b.path));
+    ..sort((a, b) => a.path.compareTo(b.path));
 
   final idStatements = StringBuffer();
 

--- a/packages/nextcloud/bin/generate_props.dart
+++ b/packages/nextcloud/bin/generate_props.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 void main() {
-  final props = File('lib/src/webdav/props.csv').readAsLinesSync().map((final line) => line.split(','));
+  final props = File('lib/src/webdav/props.csv').readAsLinesSync().map((line) => line.split(','));
   final valueProps = <String>[];
   final findProps = <String>[];
   final variables = <String>[];
@@ -58,33 +58,33 @@ void main() {
 }
 
 List<String> generateClass(
-  final String name,
-  final String elementName,
-  final String namespace,
-  final List<String> props,
-  final List<String> variables, {
-  required final bool isPropfind,
+  String name,
+  String elementName,
+  String namespace,
+  List<String> props,
+  List<String> variables, {
+  required bool isPropfind,
 }) =>
     [
       '@annotation.XmlSerializable(createMixin: true)',
       "@annotation.XmlRootElement(name: '$elementName', namespace: $namespace)",
       'class $name with _\$${name}XmlSerializableMixin {',
       '  $name({',
-      ...variables.map((final variable) => '    this.$variable,'),
+      ...variables.map((variable) => '    this.$variable,'),
       '  });',
       '',
       if (isPropfind) ...[
         '  $name.fromBools({',
-        ...variables.map((final variable) => '    final bool $variable = false,'),
-        '  }) : ${variables.map((final variable) => '$variable = $variable ? [null] : null').join(', ')};',
+        ...variables.map((variable) => '    bool $variable = false,'),
+        '  }) : ${variables.map((variable) => '$variable = $variable ? [null] : null').join(', ')};',
         '',
       ],
-      '  factory $name.fromXmlElement(final XmlElement element) => _\$${name}FromXmlElement(element);',
-      ...props.map((final prop) => '\n  $prop'),
+      '  factory $name.fromXmlElement(XmlElement element) => _\$${name}FromXmlElement(element);',
+      ...props.map((prop) => '\n  $prop'),
       '}',
     ];
 
-String convertNamespace(final String namespacePrefix) {
+String convertNamespace(String namespacePrefix) {
   switch (namespacePrefix) {
     case 'dav':
       return 'namespaceDav';

--- a/packages/nextcloud/lib/src/api/comments.openapi.dart
+++ b/packages/nextcloud/lib/src/api/comments.openapi.dart
@@ -23,7 +23,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -40,15 +40,14 @@ abstract interface class $Capabilities_FilesInterface {
 
 abstract class Capabilities_Files
     implements $Capabilities_FilesInterface, Built<Capabilities_Files, Capabilities_FilesBuilder> {
-  factory Capabilities_Files([final void Function(Capabilities_FilesBuilder)? b]) = _$Capabilities_Files;
+  factory Capabilities_Files([void Function(Capabilities_FilesBuilder)? b]) = _$Capabilities_Files;
 
   // coverage:ignore-start
   const Capabilities_Files._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_Files.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities_Files.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -64,14 +63,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -31,7 +31,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -148,7 +148,7 @@ class AppPasswordClient {
   /// See:
   ///  * [getAppPasswordRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppPasswordGetAppPasswordResponseApplicationJson, void>> getAppPassword({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getAppPasswordRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -174,9 +174,7 @@ class AppPasswordClient {
   /// See:
   ///  * [getAppPassword] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<AppPasswordGetAppPasswordResponseApplicationJson, void> getAppPasswordRaw({
-    final bool? oCSAPIRequest,
-  }) {
+  DynamiteRawResponse<AppPasswordGetAppPasswordResponseApplicationJson, void> getAppPasswordRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -185,7 +183,7 @@ class AppPasswordClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -234,7 +232,7 @@ class AppPasswordClient {
   /// See:
   ///  * [rotateAppPasswordRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppPasswordRotateAppPasswordResponseApplicationJson, void>> rotateAppPassword({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = rotateAppPasswordRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -261,7 +259,7 @@ class AppPasswordClient {
   ///  * [rotateAppPassword] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppPasswordRotateAppPasswordResponseApplicationJson, void> rotateAppPasswordRaw({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -271,7 +269,7 @@ class AppPasswordClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -320,7 +318,7 @@ class AppPasswordClient {
   /// See:
   ///  * [deleteAppPasswordRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppPasswordDeleteAppPasswordResponseApplicationJson, void>> deleteAppPassword({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteAppPasswordRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -347,7 +345,7 @@ class AppPasswordClient {
   ///  * [deleteAppPassword] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppPasswordDeleteAppPasswordResponseApplicationJson, void> deleteAppPasswordRaw({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -357,7 +355,7 @@ class AppPasswordClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -417,13 +415,13 @@ class AutoCompleteClient {
   /// See:
   ///  * [$getRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AutoCompleteGetResponseApplicationJson, void>> $get({
-    required final String search,
-    final String? itemType,
-    final String? itemId,
-    final String? sorter,
-    final BuiltList<int>? shareTypes,
-    final int? limit,
-    final bool? oCSAPIRequest,
+    required String search,
+    String? itemType,
+    String? itemId,
+    String? sorter,
+    BuiltList<int>? shareTypes,
+    int? limit,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = $getRaw(
       search: search,
@@ -461,13 +459,13 @@ class AutoCompleteClient {
   ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AutoCompleteGetResponseApplicationJson, void> $getRaw({
-    required final String search,
-    final String? itemType,
-    final String? itemId,
-    final String? sorter,
-    final BuiltList<int>? shareTypes,
-    final int? limit,
-    final bool? oCSAPIRequest,
+    required String search,
+    String? itemType,
+    String? itemId,
+    String? sorter,
+    BuiltList<int>? shareTypes,
+    int? limit,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -477,7 +475,7 @@ class AutoCompleteClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -557,8 +555,8 @@ class AvatarClient {
   /// See:
   ///  * [getAvatarDarkRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, AvatarAvatarGetAvatarDarkHeaders>> getAvatarDark({
-    required final String userId,
-    required final int size,
+    required String userId,
+    required int size,
   }) async {
     final rawResponse = getAvatarDarkRaw(
       userId: userId,
@@ -587,8 +585,8 @@ class AvatarClient {
   ///  * [getAvatarDark] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, AvatarAvatarGetAvatarDarkHeaders> getAvatarDarkRaw({
-    required final String userId,
-    required final int size,
+    required String userId,
+    required int size,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -598,7 +596,7 @@ class AvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -648,8 +646,8 @@ class AvatarClient {
   /// See:
   ///  * [getAvatarRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, AvatarAvatarGetAvatarHeaders>> getAvatar({
-    required final String userId,
-    required final int size,
+    required String userId,
+    required int size,
   }) async {
     final rawResponse = getAvatarRaw(
       userId: userId,
@@ -678,8 +676,8 @@ class AvatarClient {
   ///  * [getAvatar] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, AvatarAvatarGetAvatarHeaders> getAvatarRaw({
-    required final String userId,
-    required final int size,
+    required String userId,
+    required int size,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -689,7 +687,7 @@ class AvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -743,7 +741,7 @@ class ClientFlowLoginV2Client {
   ///
   /// See:
   ///  * [pollRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<LoginFlowV2Credentials, void>> poll({required final String token}) async {
+  Future<DynamiteResponse<LoginFlowV2Credentials, void>> poll({required String token}) async {
     final rawResponse = pollRaw(
       token: token,
     );
@@ -768,7 +766,7 @@ class ClientFlowLoginV2Client {
   /// See:
   ///  * [poll] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<LoginFlowV2Credentials, void> pollRaw({required final String token}) {
+  DynamiteRawResponse<LoginFlowV2Credentials, void> pollRaw({required String token}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -777,7 +775,7 @@ class ClientFlowLoginV2Client {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -846,7 +844,7 @@ class ClientFlowLoginV2Client {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -896,8 +894,8 @@ class CollaborationResourcesClient {
   /// See:
   ///  * [searchCollectionsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CollaborationResourcesSearchCollectionsResponseApplicationJson, void>> searchCollections({
-    required final String filter,
-    final bool? oCSAPIRequest,
+    required String filter,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = searchCollectionsRaw(
       filter: filter,
@@ -926,8 +924,8 @@ class CollaborationResourcesClient {
   ///  * [searchCollections] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CollaborationResourcesSearchCollectionsResponseApplicationJson, void> searchCollectionsRaw({
-    required final String filter,
-    final bool? oCSAPIRequest,
+    required String filter,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -937,7 +935,7 @@ class CollaborationResourcesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -992,8 +990,8 @@ class CollaborationResourcesClient {
   /// See:
   ///  * [listCollectionRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CollaborationResourcesListCollectionResponseApplicationJson, void>> listCollection({
-    required final int collectionId,
-    final bool? oCSAPIRequest,
+    required int collectionId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = listCollectionRaw(
       collectionId: collectionId,
@@ -1023,8 +1021,8 @@ class CollaborationResourcesClient {
   ///  * [listCollection] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CollaborationResourcesListCollectionResponseApplicationJson, void> listCollectionRaw({
-    required final int collectionId,
-    final bool? oCSAPIRequest,
+    required int collectionId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1034,7 +1032,7 @@ class CollaborationResourcesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1090,9 +1088,9 @@ class CollaborationResourcesClient {
   /// See:
   ///  * [renameCollectionRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CollaborationResourcesRenameCollectionResponseApplicationJson, void>> renameCollection({
-    required final String collectionName,
-    required final int collectionId,
-    final bool? oCSAPIRequest,
+    required String collectionName,
+    required int collectionId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = renameCollectionRaw(
       collectionName: collectionName,
@@ -1124,9 +1122,9 @@ class CollaborationResourcesClient {
   ///  * [renameCollection] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CollaborationResourcesRenameCollectionResponseApplicationJson, void> renameCollectionRaw({
-    required final String collectionName,
-    required final int collectionId,
-    final bool? oCSAPIRequest,
+    required String collectionName,
+    required int collectionId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1136,7 +1134,7 @@ class CollaborationResourcesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1198,10 +1196,10 @@ class CollaborationResourcesClient {
   /// See:
   ///  * [addResourceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CollaborationResourcesAddResourceResponseApplicationJson, void>> addResource({
-    required final String resourceType,
-    required final String resourceId,
-    required final int collectionId,
-    final bool? oCSAPIRequest,
+    required String resourceType,
+    required String resourceId,
+    required int collectionId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = addResourceRaw(
       resourceType: resourceType,
@@ -1235,10 +1233,10 @@ class CollaborationResourcesClient {
   ///  * [addResource] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CollaborationResourcesAddResourceResponseApplicationJson, void> addResourceRaw({
-    required final String resourceType,
-    required final String resourceId,
-    required final int collectionId,
-    final bool? oCSAPIRequest,
+    required String resourceType,
+    required String resourceId,
+    required int collectionId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1248,7 +1246,7 @@ class CollaborationResourcesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1313,10 +1311,10 @@ class CollaborationResourcesClient {
   /// See:
   ///  * [removeResourceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CollaborationResourcesRemoveResourceResponseApplicationJson, void>> removeResource({
-    required final String resourceType,
-    required final String resourceId,
-    required final int collectionId,
-    final bool? oCSAPIRequest,
+    required String resourceType,
+    required String resourceId,
+    required int collectionId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = removeResourceRaw(
       resourceType: resourceType,
@@ -1350,10 +1348,10 @@ class CollaborationResourcesClient {
   ///  * [removeResource] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CollaborationResourcesRemoveResourceResponseApplicationJson, void> removeResourceRaw({
-    required final String resourceType,
-    required final String resourceId,
-    required final int collectionId,
-    final bool? oCSAPIRequest,
+    required String resourceType,
+    required String resourceId,
+    required int collectionId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1363,7 +1361,7 @@ class CollaborationResourcesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1427,9 +1425,9 @@ class CollaborationResourcesClient {
   ///  * [getCollectionsByResourceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson, void>>
       getCollectionsByResource({
-    required final String resourceType,
-    required final String resourceId,
-    final bool? oCSAPIRequest,
+    required String resourceType,
+    required String resourceId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getCollectionsByResourceRaw(
       resourceType: resourceType,
@@ -1461,9 +1459,9 @@ class CollaborationResourcesClient {
   @experimental
   DynamiteRawResponse<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson, void>
       getCollectionsByResourceRaw({
-    required final String resourceType,
-    required final String resourceId,
-    final bool? oCSAPIRequest,
+    required String resourceType,
+    required String resourceId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1473,7 +1471,7 @@ class CollaborationResourcesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1535,10 +1533,10 @@ class CollaborationResourcesClient {
   ///  * [createCollectionOnResourceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson, void>>
       createCollectionOnResource({
-    required final String name,
-    required final String baseResourceType,
-    required final String baseResourceId,
-    final bool? oCSAPIRequest,
+    required String name,
+    required String baseResourceType,
+    required String baseResourceId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = createCollectionOnResourceRaw(
       name: name,
@@ -1574,10 +1572,10 @@ class CollaborationResourcesClient {
   @experimental
   DynamiteRawResponse<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson, void>
       createCollectionOnResourceRaw({
-    required final String name,
-    required final String baseResourceType,
-    required final String baseResourceId,
-    final bool? oCSAPIRequest,
+    required String name,
+    required String baseResourceType,
+    required String baseResourceId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1587,7 +1585,7 @@ class CollaborationResourcesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1656,8 +1654,8 @@ class GuestAvatarClient {
   /// See:
   ///  * [getAvatarDarkRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getAvatarDark({
-    required final String guestName,
-    required final String size,
+    required String guestName,
+    required String size,
   }) async {
     final rawResponse = getAvatarDarkRaw(
       guestName: guestName,
@@ -1687,8 +1685,8 @@ class GuestAvatarClient {
   ///  * [getAvatarDark] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getAvatarDarkRaw({
-    required final String guestName,
-    required final String size,
+    required String guestName,
+    required String size,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1698,7 +1696,7 @@ class GuestAvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1750,9 +1748,9 @@ class GuestAvatarClient {
   /// See:
   ///  * [getAvatarRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getAvatar({
-    required final String guestName,
-    required final String size,
-    final int? darkTheme,
+    required String guestName,
+    required String size,
+    int? darkTheme,
   }) async {
     final rawResponse = getAvatarRaw(
       guestName: guestName,
@@ -1784,9 +1782,9 @@ class GuestAvatarClient {
   ///  * [getAvatar] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getAvatarRaw({
-    required final String guestName,
-    required final String size,
-    final int? darkTheme,
+    required String guestName,
+    required String size,
+    int? darkTheme,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1796,7 +1794,7 @@ class GuestAvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1856,8 +1854,8 @@ class HoverCardClient {
   /// See:
   ///  * [getUserRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<HoverCardGetUserResponseApplicationJson, void>> getUser({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getUserRaw(
       userId: userId,
@@ -1886,8 +1884,8 @@ class HoverCardClient {
   ///  * [getUser] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<HoverCardGetUserResponseApplicationJson, void> getUserRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1897,7 +1895,7 @@ class HoverCardClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1956,8 +1954,8 @@ class NavigationClient {
   /// See:
   ///  * [getAppsNavigationRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<NavigationGetAppsNavigationResponseApplicationJson, void>> getAppsNavigation({
-    final int? absolute,
-    final bool? oCSAPIRequest,
+    int? absolute,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getAppsNavigationRaw(
       absolute: absolute,
@@ -1986,8 +1984,8 @@ class NavigationClient {
   ///  * [getAppsNavigation] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<NavigationGetAppsNavigationResponseApplicationJson, void> getAppsNavigationRaw({
-    final int? absolute,
-    final bool? oCSAPIRequest,
+    int? absolute,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1997,7 +1995,7 @@ class NavigationClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2051,8 +2049,8 @@ class NavigationClient {
   /// See:
   ///  * [getSettingsNavigationRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<NavigationGetSettingsNavigationResponseApplicationJson, void>> getSettingsNavigation({
-    final int? absolute,
-    final bool? oCSAPIRequest,
+    int? absolute,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getSettingsNavigationRaw(
       absolute: absolute,
@@ -2081,8 +2079,8 @@ class NavigationClient {
   ///  * [getSettingsNavigation] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<NavigationGetSettingsNavigationResponseApplicationJson, void> getSettingsNavigationRaw({
-    final int? absolute,
-    final bool? oCSAPIRequest,
+    int? absolute,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2092,7 +2090,7 @@ class NavigationClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2177,7 +2175,7 @@ class OcmClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2225,7 +2223,7 @@ class OcsClient {
   /// See:
   ///  * [getCapabilitiesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<OcsGetCapabilitiesResponseApplicationJson, void>> getCapabilities({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getCapabilitiesRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -2250,7 +2248,7 @@ class OcsClient {
   /// See:
   ///  * [getCapabilities] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<OcsGetCapabilitiesResponseApplicationJson, void> getCapabilitiesRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<OcsGetCapabilitiesResponseApplicationJson, void> getCapabilitiesRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -2259,7 +2257,7 @@ class OcsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2321,13 +2319,13 @@ class PreviewClient {
   /// See:
   ///  * [getPreviewByFileIdRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getPreviewByFileId({
-    final int? fileId,
-    final int? x,
-    final int? y,
-    final int? a,
-    final int? forceIcon,
-    final String? mode,
-    final int? mimeFallback,
+    int? fileId,
+    int? x,
+    int? y,
+    int? a,
+    int? forceIcon,
+    String? mode,
+    int? mimeFallback,
   }) async {
     final rawResponse = getPreviewByFileIdRaw(
       fileId: fileId,
@@ -2369,13 +2367,13 @@ class PreviewClient {
   ///  * [getPreviewByFileId] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getPreviewByFileIdRaw({
-    final int? fileId,
-    final int? x,
-    final int? y,
-    final int? a,
-    final int? forceIcon,
-    final String? mode,
-    final int? mimeFallback,
+    int? fileId,
+    int? x,
+    int? y,
+    int? a,
+    int? forceIcon,
+    String? mode,
+    int? mimeFallback,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2385,7 +2383,7 @@ class PreviewClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2469,13 +2467,13 @@ class PreviewClient {
   /// See:
   ///  * [getPreviewRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getPreview({
-    final String? file,
-    final int? x,
-    final int? y,
-    final int? a,
-    final int? forceIcon,
-    final String? mode,
-    final int? mimeFallback,
+    String? file,
+    int? x,
+    int? y,
+    int? a,
+    int? forceIcon,
+    String? mode,
+    int? mimeFallback,
   }) async {
     final rawResponse = getPreviewRaw(
       file: file,
@@ -2517,13 +2515,13 @@ class PreviewClient {
   ///  * [getPreview] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getPreviewRaw({
-    final String? file,
-    final int? x,
-    final int? y,
-    final int? a,
-    final int? forceIcon,
-    final String? mode,
-    final int? mimeFallback,
+    String? file,
+    int? x,
+    int? y,
+    int? a,
+    int? forceIcon,
+    String? mode,
+    int? mimeFallback,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2533,7 +2531,7 @@ class PreviewClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2619,10 +2617,10 @@ class ProfileApiClient {
   /// See:
   ///  * [setVisibilityRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ProfileApiSetVisibilityResponseApplicationJson, void>> setVisibility({
-    required final String paramId,
-    required final String visibility,
-    required final String targetUserId,
-    final bool? oCSAPIRequest,
+    required String paramId,
+    required String visibility,
+    required String targetUserId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setVisibilityRaw(
       paramId: paramId,
@@ -2657,10 +2655,10 @@ class ProfileApiClient {
   ///  * [setVisibility] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ProfileApiSetVisibilityResponseApplicationJson, void> setVisibilityRaw({
-    required final String paramId,
-    required final String visibility,
-    required final String targetUserId,
-    final bool? oCSAPIRequest,
+    required String paramId,
+    required String visibility,
+    required String targetUserId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2670,7 +2668,7 @@ class ProfileApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2733,7 +2731,7 @@ class ReferenceClient {
   ///
   /// See:
   ///  * [previewRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<Uint8List, void>> preview({required final String referenceId}) async {
+  Future<DynamiteResponse<Uint8List, void>> preview({required String referenceId}) async {
     final rawResponse = previewRaw(
       referenceId: referenceId,
     );
@@ -2758,7 +2756,7 @@ class ReferenceClient {
   /// See:
   ///  * [preview] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<Uint8List, void> previewRaw({required final String referenceId}) {
+  DynamiteRawResponse<Uint8List, void> previewRaw({required String referenceId}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -2767,7 +2765,7 @@ class ReferenceClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2819,8 +2817,8 @@ class ReferenceApiClient {
   /// See:
   ///  * [resolveOneRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ReferenceApiResolveOneResponseApplicationJson, void>> resolveOne({
-    required final String reference,
-    final bool? oCSAPIRequest,
+    required String reference,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = resolveOneRaw(
       reference: reference,
@@ -2848,8 +2846,8 @@ class ReferenceApiClient {
   ///  * [resolveOne] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ReferenceApiResolveOneResponseApplicationJson, void> resolveOneRaw({
-    required final String reference,
-    final bool? oCSAPIRequest,
+    required String reference,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2859,7 +2857,7 @@ class ReferenceApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2912,9 +2910,9 @@ class ReferenceApiClient {
   /// See:
   ///  * [resolveRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ReferenceApiResolveResponseApplicationJson, void>> resolve({
-    required final BuiltList<String> references,
-    final int? limit,
-    final bool? oCSAPIRequest,
+    required BuiltList<String> references,
+    int? limit,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = resolveRaw(
       references: references,
@@ -2944,9 +2942,9 @@ class ReferenceApiClient {
   ///  * [resolve] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ReferenceApiResolveResponseApplicationJson, void> resolveRaw({
-    required final BuiltList<String> references,
-    final int? limit,
-    final bool? oCSAPIRequest,
+    required BuiltList<String> references,
+    int? limit,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2956,7 +2954,7 @@ class ReferenceApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3015,10 +3013,10 @@ class ReferenceApiClient {
   /// See:
   ///  * [extractRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ReferenceApiExtractResponseApplicationJson, void>> extract({
-    required final String text,
-    final int? resolve,
-    final int? limit,
-    final bool? oCSAPIRequest,
+    required String text,
+    int? resolve,
+    int? limit,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = extractRaw(
       text: text,
@@ -3050,10 +3048,10 @@ class ReferenceApiClient {
   ///  * [extract] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ReferenceApiExtractResponseApplicationJson, void> extractRaw({
-    required final String text,
-    final int? resolve,
-    final int? limit,
-    final bool? oCSAPIRequest,
+    required String text,
+    int? resolve,
+    int? limit,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3063,7 +3061,7 @@ class ReferenceApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3122,7 +3120,7 @@ class ReferenceApiClient {
   /// See:
   ///  * [getProvidersInfoRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ReferenceApiGetProvidersInfoResponseApplicationJson, void>> getProvidersInfo({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getProvidersInfoRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -3148,7 +3146,7 @@ class ReferenceApiClient {
   ///  * [getProvidersInfo] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ReferenceApiGetProvidersInfoResponseApplicationJson, void> getProvidersInfoRaw({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3158,7 +3156,7 @@ class ReferenceApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3208,9 +3206,9 @@ class ReferenceApiClient {
   /// See:
   ///  * [touchProviderRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ReferenceApiTouchProviderResponseApplicationJson, void>> touchProvider({
-    required final String providerId,
-    final int? timestamp,
-    final bool? oCSAPIRequest,
+    required String providerId,
+    int? timestamp,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = touchProviderRaw(
       providerId: providerId,
@@ -3240,9 +3238,9 @@ class ReferenceApiClient {
   ///  * [touchProvider] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ReferenceApiTouchProviderResponseApplicationJson, void> touchProviderRaw({
-    required final String providerId,
-    final int? timestamp,
-    final bool? oCSAPIRequest,
+    required String providerId,
+    int? timestamp,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3252,7 +3250,7 @@ class ReferenceApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3312,7 +3310,7 @@ class TextProcessingApiClient {
   /// See:
   ///  * [taskTypesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TextProcessingApiTaskTypesResponseApplicationJson, void>> taskTypes({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = taskTypesRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -3337,9 +3335,7 @@ class TextProcessingApiClient {
   /// See:
   ///  * [taskTypes] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<TextProcessingApiTaskTypesResponseApplicationJson, void> taskTypesRaw({
-    final bool? oCSAPIRequest,
-  }) {
+  DynamiteRawResponse<TextProcessingApiTaskTypesResponseApplicationJson, void> taskTypesRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3348,7 +3344,7 @@ class TextProcessingApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3400,11 +3396,11 @@ class TextProcessingApiClient {
   /// See:
   ///  * [scheduleRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TextProcessingApiScheduleResponseApplicationJson, void>> schedule({
-    required final String input,
-    required final String type,
-    required final String appId,
-    final String? identifier,
-    final bool? oCSAPIRequest,
+    required String input,
+    required String type,
+    required String appId,
+    String? identifier,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = scheduleRaw(
       input: input,
@@ -3440,11 +3436,11 @@ class TextProcessingApiClient {
   ///  * [schedule] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TextProcessingApiScheduleResponseApplicationJson, void> scheduleRaw({
-    required final String input,
-    required final String type,
-    required final String appId,
-    final String? identifier,
-    final bool? oCSAPIRequest,
+    required String input,
+    required String type,
+    required String appId,
+    String? identifier,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3454,7 +3450,7 @@ class TextProcessingApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3518,8 +3514,8 @@ class TextProcessingApiClient {
   /// See:
   ///  * [getTaskRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TextProcessingApiGetTaskResponseApplicationJson, void>> getTask({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getTaskRaw(
       id: id,
@@ -3549,8 +3545,8 @@ class TextProcessingApiClient {
   ///  * [getTask] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TextProcessingApiGetTaskResponseApplicationJson, void> getTaskRaw({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3560,7 +3556,7 @@ class TextProcessingApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3612,8 +3608,8 @@ class TextProcessingApiClient {
   /// See:
   ///  * [deleteTaskRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TextProcessingApiDeleteTaskResponseApplicationJson, void>> deleteTask({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteTaskRaw(
       id: id,
@@ -3643,8 +3639,8 @@ class TextProcessingApiClient {
   ///  * [deleteTask] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TextProcessingApiDeleteTaskResponseApplicationJson, void> deleteTaskRaw({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3654,7 +3650,7 @@ class TextProcessingApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3708,9 +3704,9 @@ class TextProcessingApiClient {
   /// See:
   ///  * [listTasksByAppRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TextProcessingApiListTasksByAppResponseApplicationJson, void>> listTasksByApp({
-    required final String appId,
-    final String? identifier,
-    final bool? oCSAPIRequest,
+    required String appId,
+    String? identifier,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = listTasksByAppRaw(
       appId: appId,
@@ -3741,9 +3737,9 @@ class TextProcessingApiClient {
   ///  * [listTasksByApp] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TextProcessingApiListTasksByAppResponseApplicationJson, void> listTasksByAppRaw({
-    required final String appId,
-    final String? identifier,
-    final bool? oCSAPIRequest,
+    required String appId,
+    String? identifier,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3753,7 +3749,7 @@ class TextProcessingApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3813,7 +3809,7 @@ class TextToImageApiClient {
   /// See:
   ///  * [isAvailableRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TextToImageApiIsAvailableResponseApplicationJson, void>> isAvailable({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = isAvailableRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -3838,9 +3834,7 @@ class TextToImageApiClient {
   /// See:
   ///  * [isAvailable] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<TextToImageApiIsAvailableResponseApplicationJson, void> isAvailableRaw({
-    final bool? oCSAPIRequest,
-  }) {
+  DynamiteRawResponse<TextToImageApiIsAvailableResponseApplicationJson, void> isAvailableRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3849,7 +3843,7 @@ class TextToImageApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3901,11 +3895,11 @@ class TextToImageApiClient {
   /// See:
   ///  * [scheduleRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TextToImageApiScheduleResponseApplicationJson, void>> schedule({
-    required final String input,
-    required final String appId,
-    final String? identifier,
-    final int? numberOfImages,
-    final bool? oCSAPIRequest,
+    required String input,
+    required String appId,
+    String? identifier,
+    int? numberOfImages,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = scheduleRaw(
       input: input,
@@ -3941,11 +3935,11 @@ class TextToImageApiClient {
   ///  * [schedule] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TextToImageApiScheduleResponseApplicationJson, void> scheduleRaw({
-    required final String input,
-    required final String appId,
-    final String? identifier,
-    final int? numberOfImages,
-    final bool? oCSAPIRequest,
+    required String input,
+    required String appId,
+    String? identifier,
+    int? numberOfImages,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3955,7 +3949,7 @@ class TextToImageApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4020,8 +4014,8 @@ class TextToImageApiClient {
   /// See:
   ///  * [getTaskRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TextToImageApiGetTaskResponseApplicationJson, void>> getTask({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getTaskRaw(
       id: id,
@@ -4051,8 +4045,8 @@ class TextToImageApiClient {
   ///  * [getTask] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TextToImageApiGetTaskResponseApplicationJson, void> getTaskRaw({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4062,7 +4056,7 @@ class TextToImageApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4114,8 +4108,8 @@ class TextToImageApiClient {
   /// See:
   ///  * [deleteTaskRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TextToImageApiDeleteTaskResponseApplicationJson, void>> deleteTask({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteTaskRaw(
       id: id,
@@ -4145,8 +4139,8 @@ class TextToImageApiClient {
   ///  * [deleteTask] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TextToImageApiDeleteTaskResponseApplicationJson, void> deleteTaskRaw({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4156,7 +4150,7 @@ class TextToImageApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4211,9 +4205,9 @@ class TextToImageApiClient {
   /// See:
   ///  * [getImageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getImage({
-    required final int id,
-    required final int index,
-    final bool? oCSAPIRequest,
+    required int id,
+    required int index,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getImageRaw(
       id: id,
@@ -4245,9 +4239,9 @@ class TextToImageApiClient {
   ///  * [getImage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getImageRaw({
-    required final int id,
-    required final int index,
-    final bool? oCSAPIRequest,
+    required int id,
+    required int index,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4257,7 +4251,7 @@ class TextToImageApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4312,9 +4306,9 @@ class TextToImageApiClient {
   /// See:
   ///  * [listTasksByAppRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TextToImageApiListTasksByAppResponseApplicationJson, void>> listTasksByApp({
-    required final String appId,
-    final String? identifier,
-    final bool? oCSAPIRequest,
+    required String appId,
+    String? identifier,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = listTasksByAppRaw(
       appId: appId,
@@ -4345,9 +4339,9 @@ class TextToImageApiClient {
   ///  * [listTasksByApp] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TextToImageApiListTasksByAppResponseApplicationJson, void> listTasksByAppRaw({
-    required final String appId,
-    final String? identifier,
-    final bool? oCSAPIRequest,
+    required String appId,
+    String? identifier,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4357,7 +4351,7 @@ class TextToImageApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4417,7 +4411,7 @@ class TranslationApiClient {
   /// See:
   ///  * [languagesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TranslationApiLanguagesResponseApplicationJson, void>> languages({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = languagesRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -4442,7 +4436,7 @@ class TranslationApiClient {
   /// See:
   ///  * [languages] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<TranslationApiLanguagesResponseApplicationJson, void> languagesRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<TranslationApiLanguagesResponseApplicationJson, void> languagesRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4451,7 +4445,7 @@ class TranslationApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4503,10 +4497,10 @@ class TranslationApiClient {
   /// See:
   ///  * [translateRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TranslationApiTranslateResponseApplicationJson, void>> translate({
-    required final String text,
-    required final String toLanguage,
-    final String? fromLanguage,
-    final bool? oCSAPIRequest,
+    required String text,
+    required String toLanguage,
+    String? fromLanguage,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = translateRaw(
       text: text,
@@ -4541,10 +4535,10 @@ class TranslationApiClient {
   ///  * [translate] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TranslationApiTranslateResponseApplicationJson, void> translateRaw({
-    required final String text,
-    required final String toLanguage,
-    final String? fromLanguage,
-    final bool? oCSAPIRequest,
+    required String text,
+    required String toLanguage,
+    String? fromLanguage,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4554,7 +4548,7 @@ class TranslationApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4618,8 +4612,8 @@ class UnifiedSearchClient {
   /// See:
   ///  * [getProvidersRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UnifiedSearchGetProvidersResponseApplicationJson, void>> getProviders({
-    final String? from,
-    final bool? oCSAPIRequest,
+    String? from,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getProvidersRaw(
       from: from,
@@ -4647,8 +4641,8 @@ class UnifiedSearchClient {
   ///  * [getProviders] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UnifiedSearchGetProvidersResponseApplicationJson, void> getProvidersRaw({
-    final String? from,
-    final bool? oCSAPIRequest,
+    String? from,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4658,7 +4652,7 @@ class UnifiedSearchClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4717,13 +4711,13 @@ class UnifiedSearchClient {
   /// See:
   ///  * [searchRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UnifiedSearchSearchResponseApplicationJson, void>> search({
-    required final String providerId,
-    final String? term,
-    final int? sortOrder,
-    final int? limit,
-    final ContentString<UnifiedSearchSearchCursor>? cursor,
-    final String? from,
-    final bool? oCSAPIRequest,
+    required String providerId,
+    String? term,
+    int? sortOrder,
+    int? limit,
+    ContentString<UnifiedSearchSearchCursor>? cursor,
+    String? from,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = searchRaw(
       providerId: providerId,
@@ -4762,13 +4756,13 @@ class UnifiedSearchClient {
   ///  * [search] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UnifiedSearchSearchResponseApplicationJson, void> searchRaw({
-    required final String providerId,
-    final String? term,
-    final int? sortOrder,
-    final int? limit,
-    final ContentString<UnifiedSearchSearchCursor>? cursor,
-    final String? from,
-    final bool? oCSAPIRequest,
+    required String providerId,
+    String? term,
+    int? sortOrder,
+    int? limit,
+    ContentString<UnifiedSearchSearchCursor>? cursor,
+    String? from,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4778,7 +4772,7 @@ class UnifiedSearchClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4858,7 +4852,7 @@ class WhatsNewClient {
   ///
   /// See:
   ///  * [$getRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<WhatsNewGetResponseApplicationJson, void>> $get({final bool? oCSAPIRequest}) async {
+  Future<DynamiteResponse<WhatsNewGetResponseApplicationJson, void>> $get({bool? oCSAPIRequest}) async {
     final rawResponse = $getRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -4883,7 +4877,7 @@ class WhatsNewClient {
   /// See:
   ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<WhatsNewGetResponseApplicationJson, void> $getRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<WhatsNewGetResponseApplicationJson, void> $getRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -4892,7 +4886,7 @@ class WhatsNewClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4942,8 +4936,8 @@ class WhatsNewClient {
   /// See:
   ///  * [dismissRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<WhatsNewDismissResponseApplicationJson, void>> dismiss({
-    required final String version,
-    final bool? oCSAPIRequest,
+    required String version,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = dismissRaw(
       version: version,
@@ -4972,8 +4966,8 @@ class WhatsNewClient {
   ///  * [dismiss] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<WhatsNewDismissResponseApplicationJson, void> dismissRaw({
-    required final String version,
-    final bool? oCSAPIRequest,
+    required String version,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4983,7 +4977,7 @@ class WhatsNewClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5040,7 +5034,7 @@ class WipeClient {
   ///
   /// See:
   ///  * [checkWipeRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<WipeCheckWipeResponseApplicationJson, void>> checkWipe({required final String token}) async {
+  Future<DynamiteResponse<WipeCheckWipeResponseApplicationJson, void>> checkWipe({required String token}) async {
     final rawResponse = checkWipeRaw(
       token: token,
     );
@@ -5065,7 +5059,7 @@ class WipeClient {
   /// See:
   ///  * [checkWipe] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<WipeCheckWipeResponseApplicationJson, void> checkWipeRaw({required final String token}) {
+  DynamiteRawResponse<WipeCheckWipeResponseApplicationJson, void> checkWipeRaw({required String token}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5074,7 +5068,7 @@ class WipeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5119,7 +5113,7 @@ class WipeClient {
   ///
   /// See:
   ///  * [wipeDoneRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<JsonObject, void>> wipeDone({required final String token}) async {
+  Future<DynamiteResponse<JsonObject, void>> wipeDone({required String token}) async {
     final rawResponse = wipeDoneRaw(
       token: token,
     );
@@ -5144,7 +5138,7 @@ class WipeClient {
   /// See:
   ///  * [wipeDone] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<JsonObject, void> wipeDoneRaw({required final String token}) {
+  DynamiteRawResponse<JsonObject, void> wipeDoneRaw({required String token}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -5153,7 +5147,7 @@ class WipeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5198,14 +5192,14 @@ abstract interface class $StatusInterface {
 }
 
 abstract class Status implements $StatusInterface, Built<Status, StatusBuilder> {
-  factory Status([final void Function(StatusBuilder)? b]) = _$Status;
+  factory Status([void Function(StatusBuilder)? b]) = _$Status;
 
   // coverage:ignore-start
   const Status._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Status.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Status.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5225,14 +5219,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5253,7 +5247,7 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data
         Built<AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data,
             AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder> {
   factory AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data([
-    final void Function(AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -5261,7 +5255,7 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5285,7 +5279,7 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson_Ocs
         Built<AppPasswordGetAppPasswordResponseApplicationJson_Ocs,
             AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder> {
   factory AppPasswordGetAppPasswordResponseApplicationJson_Ocs([
-    final void Function(AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder)? b,
+    void Function(AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AppPasswordGetAppPasswordResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5293,7 +5287,7 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppPasswordGetAppPasswordResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppPasswordGetAppPasswordResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5316,7 +5310,7 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson
         Built<AppPasswordGetAppPasswordResponseApplicationJson,
             AppPasswordGetAppPasswordResponseApplicationJsonBuilder> {
   factory AppPasswordGetAppPasswordResponseApplicationJson([
-    final void Function(AppPasswordGetAppPasswordResponseApplicationJsonBuilder)? b,
+    void Function(AppPasswordGetAppPasswordResponseApplicationJsonBuilder)? b,
   ]) = _$AppPasswordGetAppPasswordResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5324,7 +5318,7 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppPasswordGetAppPasswordResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppPasswordGetAppPasswordResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5347,7 +5341,7 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data
         Built<AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data,
             AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder> {
   factory AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data([
-    final void Function(AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -5355,7 +5349,7 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5379,7 +5373,7 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs
         Built<AppPasswordRotateAppPasswordResponseApplicationJson_Ocs,
             AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder> {
   factory AppPasswordRotateAppPasswordResponseApplicationJson_Ocs([
-    final void Function(AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder)? b,
+    void Function(AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AppPasswordRotateAppPasswordResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5387,7 +5381,7 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppPasswordRotateAppPasswordResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppPasswordRotateAppPasswordResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5410,7 +5404,7 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson
         Built<AppPasswordRotateAppPasswordResponseApplicationJson,
             AppPasswordRotateAppPasswordResponseApplicationJsonBuilder> {
   factory AppPasswordRotateAppPasswordResponseApplicationJson([
-    final void Function(AppPasswordRotateAppPasswordResponseApplicationJsonBuilder)? b,
+    void Function(AppPasswordRotateAppPasswordResponseApplicationJsonBuilder)? b,
   ]) = _$AppPasswordRotateAppPasswordResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5418,7 +5412,7 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppPasswordRotateAppPasswordResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppPasswordRotateAppPasswordResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5442,7 +5436,7 @@ abstract class AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs
         Built<AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs,
             AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder> {
   factory AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs([
-    final void Function(AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder)? b,
+    void Function(AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5450,7 +5444,7 @@ abstract class AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5473,7 +5467,7 @@ abstract class AppPasswordDeleteAppPasswordResponseApplicationJson
         Built<AppPasswordDeleteAppPasswordResponseApplicationJson,
             AppPasswordDeleteAppPasswordResponseApplicationJsonBuilder> {
   factory AppPasswordDeleteAppPasswordResponseApplicationJson([
-    final void Function(AppPasswordDeleteAppPasswordResponseApplicationJsonBuilder)? b,
+    void Function(AppPasswordDeleteAppPasswordResponseApplicationJsonBuilder)? b,
   ]) = _$AppPasswordDeleteAppPasswordResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5481,7 +5475,7 @@ abstract class AppPasswordDeleteAppPasswordResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppPasswordDeleteAppPasswordResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppPasswordDeleteAppPasswordResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5505,7 +5499,7 @@ abstract class AutocompleteResult_Status0
     implements
         $AutocompleteResult_Status0Interface,
         Built<AutocompleteResult_Status0, AutocompleteResult_Status0Builder> {
-  factory AutocompleteResult_Status0([final void Function(AutocompleteResult_Status0Builder)? b]) =
+  factory AutocompleteResult_Status0([void Function(AutocompleteResult_Status0Builder)? b]) =
       _$AutocompleteResult_Status0;
 
   // coverage:ignore-start
@@ -5513,7 +5507,7 @@ abstract class AutocompleteResult_Status0
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AutocompleteResult_Status0.fromJson(final Map<String, dynamic> json) =>
+  factory AutocompleteResult_Status0.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5537,15 +5531,14 @@ abstract interface class $AutocompleteResultInterface {
 
 abstract class AutocompleteResult
     implements $AutocompleteResultInterface, Built<AutocompleteResult, AutocompleteResultBuilder> {
-  factory AutocompleteResult([final void Function(AutocompleteResultBuilder)? b]) = _$AutocompleteResult;
+  factory AutocompleteResult([void Function(AutocompleteResultBuilder)? b]) = _$AutocompleteResult;
 
   // coverage:ignore-start
   const AutocompleteResult._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AutocompleteResult.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory AutocompleteResult.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5555,7 +5548,7 @@ abstract class AutocompleteResult
   static Serializer<AutocompleteResult> get serializer => _$autocompleteResultSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final AutocompleteResultBuilder b) {
+  static void _validate(AutocompleteResultBuilder b) {
     b.status?.validateOneOf();
   }
 }
@@ -5571,7 +5564,7 @@ abstract class AutoCompleteGetResponseApplicationJson_Ocs
         $AutoCompleteGetResponseApplicationJson_OcsInterface,
         Built<AutoCompleteGetResponseApplicationJson_Ocs, AutoCompleteGetResponseApplicationJson_OcsBuilder> {
   factory AutoCompleteGetResponseApplicationJson_Ocs([
-    final void Function(AutoCompleteGetResponseApplicationJson_OcsBuilder)? b,
+    void Function(AutoCompleteGetResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AutoCompleteGetResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5579,7 +5572,7 @@ abstract class AutoCompleteGetResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AutoCompleteGetResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AutoCompleteGetResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5600,16 +5593,15 @@ abstract class AutoCompleteGetResponseApplicationJson
     implements
         $AutoCompleteGetResponseApplicationJsonInterface,
         Built<AutoCompleteGetResponseApplicationJson, AutoCompleteGetResponseApplicationJsonBuilder> {
-  factory AutoCompleteGetResponseApplicationJson([
-    final void Function(AutoCompleteGetResponseApplicationJsonBuilder)? b,
-  ]) = _$AutoCompleteGetResponseApplicationJson;
+  factory AutoCompleteGetResponseApplicationJson([void Function(AutoCompleteGetResponseApplicationJsonBuilder)? b]) =
+      _$AutoCompleteGetResponseApplicationJson;
 
   // coverage:ignore-start
   const AutoCompleteGetResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AutoCompleteGetResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AutoCompleteGetResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5631,7 +5623,7 @@ abstract class AvatarAvatarGetAvatarDarkHeaders
     implements
         $AvatarAvatarGetAvatarDarkHeadersInterface,
         Built<AvatarAvatarGetAvatarDarkHeaders, AvatarAvatarGetAvatarDarkHeadersBuilder> {
-  factory AvatarAvatarGetAvatarDarkHeaders([final void Function(AvatarAvatarGetAvatarDarkHeadersBuilder)? b]) =
+  factory AvatarAvatarGetAvatarDarkHeaders([void Function(AvatarAvatarGetAvatarDarkHeadersBuilder)? b]) =
       _$AvatarAvatarGetAvatarDarkHeaders;
 
   // coverage:ignore-start
@@ -5639,7 +5631,7 @@ abstract class AvatarAvatarGetAvatarDarkHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AvatarAvatarGetAvatarDarkHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory AvatarAvatarGetAvatarDarkHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5660,7 +5652,7 @@ abstract class AvatarAvatarGetAvatarHeaders
     implements
         $AvatarAvatarGetAvatarHeadersInterface,
         Built<AvatarAvatarGetAvatarHeaders, AvatarAvatarGetAvatarHeadersBuilder> {
-  factory AvatarAvatarGetAvatarHeaders([final void Function(AvatarAvatarGetAvatarHeadersBuilder)? b]) =
+  factory AvatarAvatarGetAvatarHeaders([void Function(AvatarAvatarGetAvatarHeadersBuilder)? b]) =
       _$AvatarAvatarGetAvatarHeaders;
 
   // coverage:ignore-start
@@ -5668,7 +5660,7 @@ abstract class AvatarAvatarGetAvatarHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AvatarAvatarGetAvatarHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory AvatarAvatarGetAvatarHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5688,14 +5680,14 @@ abstract interface class $LoginFlowV2CredentialsInterface {
 
 abstract class LoginFlowV2Credentials
     implements $LoginFlowV2CredentialsInterface, Built<LoginFlowV2Credentials, LoginFlowV2CredentialsBuilder> {
-  factory LoginFlowV2Credentials([final void Function(LoginFlowV2CredentialsBuilder)? b]) = _$LoginFlowV2Credentials;
+  factory LoginFlowV2Credentials([void Function(LoginFlowV2CredentialsBuilder)? b]) = _$LoginFlowV2Credentials;
 
   // coverage:ignore-start
   const LoginFlowV2Credentials._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory LoginFlowV2Credentials.fromJson(final Map<String, dynamic> json) =>
+  factory LoginFlowV2Credentials.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5714,15 +5706,14 @@ abstract interface class $LoginFlowV2_PollInterface {
 
 abstract class LoginFlowV2_Poll
     implements $LoginFlowV2_PollInterface, Built<LoginFlowV2_Poll, LoginFlowV2_PollBuilder> {
-  factory LoginFlowV2_Poll([final void Function(LoginFlowV2_PollBuilder)? b]) = _$LoginFlowV2_Poll;
+  factory LoginFlowV2_Poll([void Function(LoginFlowV2_PollBuilder)? b]) = _$LoginFlowV2_Poll;
 
   // coverage:ignore-start
   const LoginFlowV2_Poll._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory LoginFlowV2_Poll.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory LoginFlowV2_Poll.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5739,14 +5730,14 @@ abstract interface class $LoginFlowV2Interface {
 }
 
 abstract class LoginFlowV2 implements $LoginFlowV2Interface, Built<LoginFlowV2, LoginFlowV2Builder> {
-  factory LoginFlowV2([final void Function(LoginFlowV2Builder)? b]) = _$LoginFlowV2;
+  factory LoginFlowV2([void Function(LoginFlowV2Builder)? b]) = _$LoginFlowV2;
 
   // coverage:ignore-start
   const LoginFlowV2._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory LoginFlowV2.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory LoginFlowV2.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5766,15 +5757,14 @@ abstract interface class $OpenGraphObjectInterface {
 }
 
 abstract class OpenGraphObject implements $OpenGraphObjectInterface, Built<OpenGraphObject, OpenGraphObjectBuilder> {
-  factory OpenGraphObject([final void Function(OpenGraphObjectBuilder)? b]) = _$OpenGraphObject;
+  factory OpenGraphObject([void Function(OpenGraphObjectBuilder)? b]) = _$OpenGraphObject;
 
   // coverage:ignore-start
   const OpenGraphObject._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OpenGraphObject.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory OpenGraphObject.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5793,14 +5783,14 @@ abstract interface class $ResourceInterface {
 }
 
 abstract class Resource implements $ResourceInterface, Built<Resource, ResourceBuilder> {
-  factory Resource([final void Function(ResourceBuilder)? b]) = _$Resource;
+  factory Resource([void Function(ResourceBuilder)? b]) = _$Resource;
 
   // coverage:ignore-start
   const Resource._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Resource.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Resource.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5818,14 +5808,14 @@ abstract interface class $CollectionInterface {
 }
 
 abstract class Collection implements $CollectionInterface, Built<Collection, CollectionBuilder> {
-  factory Collection([final void Function(CollectionBuilder)? b]) = _$Collection;
+  factory Collection([void Function(CollectionBuilder)? b]) = _$Collection;
 
   // coverage:ignore-start
   const Collection._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Collection.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Collection.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5847,7 +5837,7 @@ abstract class CollaborationResourcesSearchCollectionsResponseApplicationJson_Oc
         Built<CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs,
             CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder> {
   factory CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs([
-    final void Function(CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder)? b,
+    void Function(CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5855,9 +5845,7 @@ abstract class CollaborationResourcesSearchCollectionsResponseApplicationJson_Oc
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs.fromJson(
-    final Map<String, dynamic> json,
-  ) =>
+  factory CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5880,7 +5868,7 @@ abstract class CollaborationResourcesSearchCollectionsResponseApplicationJson
         Built<CollaborationResourcesSearchCollectionsResponseApplicationJson,
             CollaborationResourcesSearchCollectionsResponseApplicationJsonBuilder> {
   factory CollaborationResourcesSearchCollectionsResponseApplicationJson([
-    final void Function(CollaborationResourcesSearchCollectionsResponseApplicationJsonBuilder)? b,
+    void Function(CollaborationResourcesSearchCollectionsResponseApplicationJsonBuilder)? b,
   ]) = _$CollaborationResourcesSearchCollectionsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5888,7 +5876,7 @@ abstract class CollaborationResourcesSearchCollectionsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesSearchCollectionsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CollaborationResourcesSearchCollectionsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5912,7 +5900,7 @@ abstract class CollaborationResourcesListCollectionResponseApplicationJson_Ocs
         Built<CollaborationResourcesListCollectionResponseApplicationJson_Ocs,
             CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder> {
   factory CollaborationResourcesListCollectionResponseApplicationJson_Ocs([
-    final void Function(CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder)? b,
+    void Function(CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CollaborationResourcesListCollectionResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5920,7 +5908,7 @@ abstract class CollaborationResourcesListCollectionResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesListCollectionResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CollaborationResourcesListCollectionResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5943,7 +5931,7 @@ abstract class CollaborationResourcesListCollectionResponseApplicationJson
         Built<CollaborationResourcesListCollectionResponseApplicationJson,
             CollaborationResourcesListCollectionResponseApplicationJsonBuilder> {
   factory CollaborationResourcesListCollectionResponseApplicationJson([
-    final void Function(CollaborationResourcesListCollectionResponseApplicationJsonBuilder)? b,
+    void Function(CollaborationResourcesListCollectionResponseApplicationJsonBuilder)? b,
   ]) = _$CollaborationResourcesListCollectionResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5951,7 +5939,7 @@ abstract class CollaborationResourcesListCollectionResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesListCollectionResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CollaborationResourcesListCollectionResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5975,7 +5963,7 @@ abstract class CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs
         Built<CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs,
             CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder> {
   factory CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs([
-    final void Function(CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder)? b,
+    void Function(CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5983,7 +5971,7 @@ abstract class CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6006,7 +5994,7 @@ abstract class CollaborationResourcesRenameCollectionResponseApplicationJson
         Built<CollaborationResourcesRenameCollectionResponseApplicationJson,
             CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder> {
   factory CollaborationResourcesRenameCollectionResponseApplicationJson([
-    final void Function(CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder)? b,
+    void Function(CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder)? b,
   ]) = _$CollaborationResourcesRenameCollectionResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6014,7 +6002,7 @@ abstract class CollaborationResourcesRenameCollectionResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesRenameCollectionResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CollaborationResourcesRenameCollectionResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6038,7 +6026,7 @@ abstract class CollaborationResourcesAddResourceResponseApplicationJson_Ocs
         Built<CollaborationResourcesAddResourceResponseApplicationJson_Ocs,
             CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder> {
   factory CollaborationResourcesAddResourceResponseApplicationJson_Ocs([
-    final void Function(CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder)? b,
+    void Function(CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CollaborationResourcesAddResourceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6046,7 +6034,7 @@ abstract class CollaborationResourcesAddResourceResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesAddResourceResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CollaborationResourcesAddResourceResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6069,7 +6057,7 @@ abstract class CollaborationResourcesAddResourceResponseApplicationJson
         Built<CollaborationResourcesAddResourceResponseApplicationJson,
             CollaborationResourcesAddResourceResponseApplicationJsonBuilder> {
   factory CollaborationResourcesAddResourceResponseApplicationJson([
-    final void Function(CollaborationResourcesAddResourceResponseApplicationJsonBuilder)? b,
+    void Function(CollaborationResourcesAddResourceResponseApplicationJsonBuilder)? b,
   ]) = _$CollaborationResourcesAddResourceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6077,7 +6065,7 @@ abstract class CollaborationResourcesAddResourceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesAddResourceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CollaborationResourcesAddResourceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6101,7 +6089,7 @@ abstract class CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs
         Built<CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs,
             CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder> {
   factory CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs([
-    final void Function(CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder)? b,
+    void Function(CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6109,7 +6097,7 @@ abstract class CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6132,7 +6120,7 @@ abstract class CollaborationResourcesRemoveResourceResponseApplicationJson
         Built<CollaborationResourcesRemoveResourceResponseApplicationJson,
             CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder> {
   factory CollaborationResourcesRemoveResourceResponseApplicationJson([
-    final void Function(CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder)? b,
+    void Function(CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder)? b,
   ]) = _$CollaborationResourcesRemoveResourceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6140,7 +6128,7 @@ abstract class CollaborationResourcesRemoveResourceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesRemoveResourceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CollaborationResourcesRemoveResourceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6164,7 +6152,7 @@ abstract class CollaborationResourcesGetCollectionsByResourceResponseApplication
         Built<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs,
             CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsBuilder> {
   factory CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs([
-    final void Function(CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsBuilder)? b,
+    void Function(CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6173,7 +6161,7 @@ abstract class CollaborationResourcesGetCollectionsByResourceResponseApplication
 
   // coverage:ignore-start
   factory CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs.fromJson(
-    final Map<String, dynamic> json,
+    Map<String, dynamic> json,
   ) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
@@ -6197,7 +6185,7 @@ abstract class CollaborationResourcesGetCollectionsByResourceResponseApplication
         Built<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson,
             CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuilder> {
   factory CollaborationResourcesGetCollectionsByResourceResponseApplicationJson([
-    final void Function(CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuilder)? b,
+    void Function(CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuilder)? b,
   ]) = _$CollaborationResourcesGetCollectionsByResourceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6205,9 +6193,7 @@ abstract class CollaborationResourcesGetCollectionsByResourceResponseApplication
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesGetCollectionsByResourceResponseApplicationJson.fromJson(
-    final Map<String, dynamic> json,
-  ) =>
+  factory CollaborationResourcesGetCollectionsByResourceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6231,7 +6217,7 @@ abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicati
         Built<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs,
             CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder> {
   factory CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs([
-    final void Function(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder)? b,
+    void Function(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6240,7 +6226,7 @@ abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicati
 
   // coverage:ignore-start
   factory CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs.fromJson(
-    final Map<String, dynamic> json,
+    Map<String, dynamic> json,
   ) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
@@ -6264,7 +6250,7 @@ abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicati
         Built<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson,
             CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBuilder> {
   factory CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson([
-    final void Function(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBuilder)? b,
+    void Function(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBuilder)? b,
   ]) = _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6272,9 +6258,7 @@ abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicati
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson.fromJson(
-    final Map<String, dynamic> json,
-  ) =>
+  factory CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6295,15 +6279,14 @@ abstract interface class $ContactsActionInterface {
 }
 
 abstract class ContactsAction implements $ContactsActionInterface, Built<ContactsAction, ContactsActionBuilder> {
-  factory ContactsAction([final void Function(ContactsActionBuilder)? b]) = _$ContactsAction;
+  factory ContactsAction([void Function(ContactsActionBuilder)? b]) = _$ContactsAction;
 
   // coverage:ignore-start
   const ContactsAction._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ContactsAction.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory ContactsAction.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -6326,7 +6309,7 @@ abstract class HoverCardGetUserResponseApplicationJson_Ocs_Data
         Built<HoverCardGetUserResponseApplicationJson_Ocs_Data,
             HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder> {
   factory HoverCardGetUserResponseApplicationJson_Ocs_Data([
-    final void Function(HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$HoverCardGetUserResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -6334,7 +6317,7 @@ abstract class HoverCardGetUserResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory HoverCardGetUserResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory HoverCardGetUserResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6357,7 +6340,7 @@ abstract class HoverCardGetUserResponseApplicationJson_Ocs
         $HoverCardGetUserResponseApplicationJson_OcsInterface,
         Built<HoverCardGetUserResponseApplicationJson_Ocs, HoverCardGetUserResponseApplicationJson_OcsBuilder> {
   factory HoverCardGetUserResponseApplicationJson_Ocs([
-    final void Function(HoverCardGetUserResponseApplicationJson_OcsBuilder)? b,
+    void Function(HoverCardGetUserResponseApplicationJson_OcsBuilder)? b,
   ]) = _$HoverCardGetUserResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6365,7 +6348,7 @@ abstract class HoverCardGetUserResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory HoverCardGetUserResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory HoverCardGetUserResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6386,16 +6369,15 @@ abstract class HoverCardGetUserResponseApplicationJson
     implements
         $HoverCardGetUserResponseApplicationJsonInterface,
         Built<HoverCardGetUserResponseApplicationJson, HoverCardGetUserResponseApplicationJsonBuilder> {
-  factory HoverCardGetUserResponseApplicationJson([
-    final void Function(HoverCardGetUserResponseApplicationJsonBuilder)? b,
-  ]) = _$HoverCardGetUserResponseApplicationJson;
+  factory HoverCardGetUserResponseApplicationJson([void Function(HoverCardGetUserResponseApplicationJsonBuilder)? b]) =
+      _$HoverCardGetUserResponseApplicationJson;
 
   // coverage:ignore-start
   const HoverCardGetUserResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory HoverCardGetUserResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory HoverCardGetUserResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6421,15 +6403,14 @@ abstract interface class $NavigationEntryInterface {
 }
 
 abstract class NavigationEntry implements $NavigationEntryInterface, Built<NavigationEntry, NavigationEntryBuilder> {
-  factory NavigationEntry([final void Function(NavigationEntryBuilder)? b]) = _$NavigationEntry;
+  factory NavigationEntry([void Function(NavigationEntryBuilder)? b]) = _$NavigationEntry;
 
   // coverage:ignore-start
   const NavigationEntry._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NavigationEntry.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory NavigationEntry.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -6439,7 +6420,7 @@ abstract class NavigationEntry implements $NavigationEntryInterface, Built<Navig
   static Serializer<NavigationEntry> get serializer => _$navigationEntrySerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final NavigationEntryBuilder b) {
+  static void _validate(NavigationEntryBuilder b) {
     b.order?.validateOneOf();
   }
 }
@@ -6456,7 +6437,7 @@ abstract class NavigationGetAppsNavigationResponseApplicationJson_Ocs
         Built<NavigationGetAppsNavigationResponseApplicationJson_Ocs,
             NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder> {
   factory NavigationGetAppsNavigationResponseApplicationJson_Ocs([
-    final void Function(NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder)? b,
+    void Function(NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder)? b,
   ]) = _$NavigationGetAppsNavigationResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6464,7 +6445,7 @@ abstract class NavigationGetAppsNavigationResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NavigationGetAppsNavigationResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory NavigationGetAppsNavigationResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6487,7 +6468,7 @@ abstract class NavigationGetAppsNavigationResponseApplicationJson
         Built<NavigationGetAppsNavigationResponseApplicationJson,
             NavigationGetAppsNavigationResponseApplicationJsonBuilder> {
   factory NavigationGetAppsNavigationResponseApplicationJson([
-    final void Function(NavigationGetAppsNavigationResponseApplicationJsonBuilder)? b,
+    void Function(NavigationGetAppsNavigationResponseApplicationJsonBuilder)? b,
   ]) = _$NavigationGetAppsNavigationResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6495,7 +6476,7 @@ abstract class NavigationGetAppsNavigationResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NavigationGetAppsNavigationResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory NavigationGetAppsNavigationResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6519,7 +6500,7 @@ abstract class NavigationGetSettingsNavigationResponseApplicationJson_Ocs
         Built<NavigationGetSettingsNavigationResponseApplicationJson_Ocs,
             NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder> {
   factory NavigationGetSettingsNavigationResponseApplicationJson_Ocs([
-    final void Function(NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder)? b,
+    void Function(NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder)? b,
   ]) = _$NavigationGetSettingsNavigationResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6527,7 +6508,7 @@ abstract class NavigationGetSettingsNavigationResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NavigationGetSettingsNavigationResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory NavigationGetSettingsNavigationResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6550,7 +6531,7 @@ abstract class NavigationGetSettingsNavigationResponseApplicationJson
         Built<NavigationGetSettingsNavigationResponseApplicationJson,
             NavigationGetSettingsNavigationResponseApplicationJsonBuilder> {
   factory NavigationGetSettingsNavigationResponseApplicationJson([
-    final void Function(NavigationGetSettingsNavigationResponseApplicationJsonBuilder)? b,
+    void Function(NavigationGetSettingsNavigationResponseApplicationJsonBuilder)? b,
   ]) = _$NavigationGetSettingsNavigationResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6558,7 +6539,7 @@ abstract class NavigationGetSettingsNavigationResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NavigationGetSettingsNavigationResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory NavigationGetSettingsNavigationResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6578,14 +6559,14 @@ abstract interface class $OcmOcmDiscoveryHeadersInterface {
 
 abstract class OcmOcmDiscoveryHeaders
     implements $OcmOcmDiscoveryHeadersInterface, Built<OcmOcmDiscoveryHeaders, OcmOcmDiscoveryHeadersBuilder> {
-  factory OcmOcmDiscoveryHeaders([final void Function(OcmOcmDiscoveryHeadersBuilder)? b]) = _$OcmOcmDiscoveryHeaders;
+  factory OcmOcmDiscoveryHeaders([void Function(OcmOcmDiscoveryHeadersBuilder)? b]) = _$OcmOcmDiscoveryHeaders;
 
   // coverage:ignore-start
   const OcmOcmDiscoveryHeaders._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OcmOcmDiscoveryHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory OcmOcmDiscoveryHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6607,7 +6588,7 @@ abstract class OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols
         Built<OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols,
             OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder> {
   factory OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols([
-    final void Function(OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder)? b,
+    void Function(OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder)? b,
   ]) = _$OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols;
 
   // coverage:ignore-start
@@ -6615,7 +6596,7 @@ abstract class OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols.fromJson(final Map<String, dynamic> json) =>
+  factory OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6640,7 +6621,7 @@ abstract class OcmDiscoveryResponseApplicationJson_ResourceTypes
         Built<OcmDiscoveryResponseApplicationJson_ResourceTypes,
             OcmDiscoveryResponseApplicationJson_ResourceTypesBuilder> {
   factory OcmDiscoveryResponseApplicationJson_ResourceTypes([
-    final void Function(OcmDiscoveryResponseApplicationJson_ResourceTypesBuilder)? b,
+    void Function(OcmDiscoveryResponseApplicationJson_ResourceTypesBuilder)? b,
   ]) = _$OcmDiscoveryResponseApplicationJson_ResourceTypes;
 
   // coverage:ignore-start
@@ -6648,7 +6629,7 @@ abstract class OcmDiscoveryResponseApplicationJson_ResourceTypes
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OcmDiscoveryResponseApplicationJson_ResourceTypes.fromJson(final Map<String, dynamic> json) =>
+  factory OcmDiscoveryResponseApplicationJson_ResourceTypes.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6672,7 +6653,7 @@ abstract class OcmDiscoveryResponseApplicationJson
     implements
         $OcmDiscoveryResponseApplicationJsonInterface,
         Built<OcmDiscoveryResponseApplicationJson, OcmDiscoveryResponseApplicationJsonBuilder> {
-  factory OcmDiscoveryResponseApplicationJson([final void Function(OcmDiscoveryResponseApplicationJsonBuilder)? b]) =
+  factory OcmDiscoveryResponseApplicationJson([void Function(OcmDiscoveryResponseApplicationJsonBuilder)? b]) =
       _$OcmDiscoveryResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6680,7 +6661,7 @@ abstract class OcmDiscoveryResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OcmDiscoveryResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory OcmDiscoveryResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6708,7 +6689,7 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version
         Built<OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version,
             OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionBuilder> {
   factory OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version([
-    final void Function(OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionBuilder)? b,
+    void Function(OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionBuilder)? b,
   ]) = _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version;
 
   // coverage:ignore-start
@@ -6716,7 +6697,7 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version.fromJson(final Map<String, dynamic> json) =>
+  factory OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6737,7 +6718,7 @@ abstract class CommentsCapabilities_Files
     implements
         $CommentsCapabilities_FilesInterface,
         Built<CommentsCapabilities_Files, CommentsCapabilities_FilesBuilder> {
-  factory CommentsCapabilities_Files([final void Function(CommentsCapabilities_FilesBuilder)? b]) =
+  factory CommentsCapabilities_Files([void Function(CommentsCapabilities_FilesBuilder)? b]) =
       _$CommentsCapabilities_Files;
 
   // coverage:ignore-start
@@ -6745,7 +6726,7 @@ abstract class CommentsCapabilities_Files
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CommentsCapabilities_Files.fromJson(final Map<String, dynamic> json) =>
+  factory CommentsCapabilities_Files.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6763,14 +6744,14 @@ abstract interface class $CommentsCapabilitiesInterface {
 
 abstract class CommentsCapabilities
     implements $CommentsCapabilitiesInterface, Built<CommentsCapabilities, CommentsCapabilitiesBuilder> {
-  factory CommentsCapabilities([final void Function(CommentsCapabilitiesBuilder)? b]) = _$CommentsCapabilities;
+  factory CommentsCapabilities([void Function(CommentsCapabilitiesBuilder)? b]) = _$CommentsCapabilities;
 
   // coverage:ignore-start
   const CommentsCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CommentsCapabilities.fromJson(final Map<String, dynamic> json) =>
+  factory CommentsCapabilities.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6789,15 +6770,14 @@ abstract interface class $DavCapabilities_DavInterface {
 
 abstract class DavCapabilities_Dav
     implements $DavCapabilities_DavInterface, Built<DavCapabilities_Dav, DavCapabilities_DavBuilder> {
-  factory DavCapabilities_Dav([final void Function(DavCapabilities_DavBuilder)? b]) = _$DavCapabilities_Dav;
+  factory DavCapabilities_Dav([void Function(DavCapabilities_DavBuilder)? b]) = _$DavCapabilities_Dav;
 
   // coverage:ignore-start
   const DavCapabilities_Dav._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DavCapabilities_Dav.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory DavCapabilities_Dav.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -6813,15 +6793,14 @@ abstract interface class $DavCapabilitiesInterface {
 }
 
 abstract class DavCapabilities implements $DavCapabilitiesInterface, Built<DavCapabilities, DavCapabilitiesBuilder> {
-  factory DavCapabilities([final void Function(DavCapabilitiesBuilder)? b]) = _$DavCapabilities;
+  factory DavCapabilities([void Function(DavCapabilitiesBuilder)? b]) = _$DavCapabilities;
 
   // coverage:ignore-start
   const DavCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DavCapabilities.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory DavCapabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -6842,16 +6821,15 @@ abstract class FilesCapabilities_Files_DirectEditing
     implements
         $FilesCapabilities_Files_DirectEditingInterface,
         Built<FilesCapabilities_Files_DirectEditing, FilesCapabilities_Files_DirectEditingBuilder> {
-  factory FilesCapabilities_Files_DirectEditing([
-    final void Function(FilesCapabilities_Files_DirectEditingBuilder)? b,
-  ]) = _$FilesCapabilities_Files_DirectEditing;
+  factory FilesCapabilities_Files_DirectEditing([void Function(FilesCapabilities_Files_DirectEditingBuilder)? b]) =
+      _$FilesCapabilities_Files_DirectEditing;
 
   // coverage:ignore-start
   const FilesCapabilities_Files_DirectEditing._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesCapabilities_Files_DirectEditing.fromJson(final Map<String, dynamic> json) =>
+  factory FilesCapabilities_Files_DirectEditing.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6873,14 +6851,14 @@ abstract interface class $FilesCapabilities_FilesInterface {
 
 abstract class FilesCapabilities_Files
     implements $FilesCapabilities_FilesInterface, Built<FilesCapabilities_Files, FilesCapabilities_FilesBuilder> {
-  factory FilesCapabilities_Files([final void Function(FilesCapabilities_FilesBuilder)? b]) = _$FilesCapabilities_Files;
+  factory FilesCapabilities_Files([void Function(FilesCapabilities_FilesBuilder)? b]) = _$FilesCapabilities_Files;
 
   // coverage:ignore-start
   const FilesCapabilities_Files._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesCapabilities_Files.fromJson(final Map<String, dynamic> json) =>
+  factory FilesCapabilities_Files.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6898,15 +6876,14 @@ abstract interface class $FilesCapabilitiesInterface {
 
 abstract class FilesCapabilities
     implements $FilesCapabilitiesInterface, Built<FilesCapabilities, FilesCapabilitiesBuilder> {
-  factory FilesCapabilities([final void Function(FilesCapabilitiesBuilder)? b]) = _$FilesCapabilities;
+  factory FilesCapabilities([void Function(FilesCapabilitiesBuilder)? b]) = _$FilesCapabilities;
 
   // coverage:ignore-start
   const FilesCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesCapabilities.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory FilesCapabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -6928,7 +6905,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_Password
         Built<FilesSharingCapabilities_FilesSharing_Public_Password,
             FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Public_Password([
-    final void Function(FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Public_Password;
 
   // coverage:ignore-start
@@ -6936,7 +6913,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_Password
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Public_Password.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_Public_Password.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6961,7 +6938,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDate
         Built<FilesSharingCapabilities_FilesSharing_Public_ExpireDate,
             FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Public_ExpireDate([
-    final void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Public_ExpireDate;
 
   // coverage:ignore-start
@@ -6969,7 +6946,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDate
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Public_ExpireDate.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_Public_ExpireDate.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6994,7 +6971,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
         Built<FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal,
             FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal([
-    final void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal;
 
   // coverage:ignore-start
@@ -7002,7 +6979,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7027,7 +7004,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
         Built<FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote,
             FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote([
-    final void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote;
 
   // coverage:ignore-start
@@ -7035,7 +7012,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7071,7 +7048,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Public
         $FilesSharingCapabilities_FilesSharing_PublicInterface,
         Built<FilesSharingCapabilities_FilesSharing_Public, FilesSharingCapabilities_FilesSharing_PublicBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Public([
-    final void Function(FilesSharingCapabilities_FilesSharing_PublicBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_PublicBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Public;
 
   // coverage:ignore-start
@@ -7079,7 +7056,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Public
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Public.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_Public.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7102,7 +7079,7 @@ abstract class FilesSharingCapabilities_FilesSharing_User_ExpireDate
         Built<FilesSharingCapabilities_FilesSharing_User_ExpireDate,
             FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder> {
   factory FilesSharingCapabilities_FilesSharing_User_ExpireDate([
-    final void Function(FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_User_ExpireDate;
 
   // coverage:ignore-start
@@ -7110,7 +7087,7 @@ abstract class FilesSharingCapabilities_FilesSharing_User_ExpireDate
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_User_ExpireDate.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_User_ExpireDate.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7135,7 +7112,7 @@ abstract class FilesSharingCapabilities_FilesSharing_User
         $FilesSharingCapabilities_FilesSharing_UserInterface,
         Built<FilesSharingCapabilities_FilesSharing_User, FilesSharingCapabilities_FilesSharing_UserBuilder> {
   factory FilesSharingCapabilities_FilesSharing_User([
-    final void Function(FilesSharingCapabilities_FilesSharing_UserBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_UserBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_User;
 
   // coverage:ignore-start
@@ -7143,7 +7120,7 @@ abstract class FilesSharingCapabilities_FilesSharing_User
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_User.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_User.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7166,7 +7143,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Group_ExpireDate
         Built<FilesSharingCapabilities_FilesSharing_Group_ExpireDate,
             FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Group_ExpireDate([
-    final void Function(FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Group_ExpireDate;
 
   // coverage:ignore-start
@@ -7174,7 +7151,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Group_ExpireDate
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Group_ExpireDate.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_Group_ExpireDate.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7198,7 +7175,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Group
         $FilesSharingCapabilities_FilesSharing_GroupInterface,
         Built<FilesSharingCapabilities_FilesSharing_Group, FilesSharingCapabilities_FilesSharing_GroupBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Group([
-    final void Function(FilesSharingCapabilities_FilesSharing_GroupBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_GroupBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Group;
 
   // coverage:ignore-start
@@ -7206,7 +7183,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Group
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Group.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_Group.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7229,7 +7206,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDate
         Built<FilesSharingCapabilities_FilesSharing_Federation_ExpireDate,
             FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Federation_ExpireDate([
-    final void Function(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDate;
 
   // coverage:ignore-start
@@ -7237,7 +7214,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDate
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Federation_ExpireDate.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_Federation_ExpireDate.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7260,7 +7237,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSuppor
         Built<FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported,
             FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported([
-    final void Function(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported;
 
   // coverage:ignore-start
@@ -7268,9 +7245,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSuppor
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported.fromJson(
-    final Map<String, dynamic> json,
-  ) =>
+  factory FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7298,7 +7273,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation
         Built<FilesSharingCapabilities_FilesSharing_Federation,
             FilesSharingCapabilities_FilesSharing_FederationBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Federation([
-    final void Function(FilesSharingCapabilities_FilesSharing_FederationBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_FederationBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Federation;
 
   // coverage:ignore-start
@@ -7306,7 +7281,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Federation.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_Federation.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7331,7 +7306,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Sharee
         $FilesSharingCapabilities_FilesSharing_ShareeInterface,
         Built<FilesSharingCapabilities_FilesSharing_Sharee, FilesSharingCapabilities_FilesSharing_ShareeBuilder> {
   factory FilesSharingCapabilities_FilesSharing_Sharee([
-    final void Function(FilesSharingCapabilities_FilesSharing_ShareeBuilder)? b,
+    void Function(FilesSharingCapabilities_FilesSharing_ShareeBuilder)? b,
   ]) = _$FilesSharingCapabilities_FilesSharing_Sharee;
 
   // coverage:ignore-start
@@ -7339,7 +7314,7 @@ abstract class FilesSharingCapabilities_FilesSharing_Sharee
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing_Sharee.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing_Sharee.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7371,16 +7346,15 @@ abstract class FilesSharingCapabilities_FilesSharing
     implements
         $FilesSharingCapabilities_FilesSharingInterface,
         Built<FilesSharingCapabilities_FilesSharing, FilesSharingCapabilities_FilesSharingBuilder> {
-  factory FilesSharingCapabilities_FilesSharing([
-    final void Function(FilesSharingCapabilities_FilesSharingBuilder)? b,
-  ]) = _$FilesSharingCapabilities_FilesSharing;
+  factory FilesSharingCapabilities_FilesSharing([void Function(FilesSharingCapabilities_FilesSharingBuilder)? b]) =
+      _$FilesSharingCapabilities_FilesSharing;
 
   // coverage:ignore-start
   const FilesSharingCapabilities_FilesSharing._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities_FilesSharing.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities_FilesSharing.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7400,15 +7374,14 @@ abstract interface class $FilesSharingCapabilitiesInterface {
 
 abstract class FilesSharingCapabilities
     implements $FilesSharingCapabilitiesInterface, Built<FilesSharingCapabilities, FilesSharingCapabilitiesBuilder> {
-  factory FilesSharingCapabilities([final void Function(FilesSharingCapabilitiesBuilder)? b]) =
-      _$FilesSharingCapabilities;
+  factory FilesSharingCapabilities([void Function(FilesSharingCapabilitiesBuilder)? b]) = _$FilesSharingCapabilities;
 
   // coverage:ignore-start
   const FilesSharingCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesSharingCapabilities.fromJson(final Map<String, dynamic> json) =>
+  factory FilesSharingCapabilities.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7428,7 +7401,7 @@ abstract class FilesTrashbinCapabilities_Files
     implements
         $FilesTrashbinCapabilities_FilesInterface,
         Built<FilesTrashbinCapabilities_Files, FilesTrashbinCapabilities_FilesBuilder> {
-  factory FilesTrashbinCapabilities_Files([final void Function(FilesTrashbinCapabilities_FilesBuilder)? b]) =
+  factory FilesTrashbinCapabilities_Files([void Function(FilesTrashbinCapabilities_FilesBuilder)? b]) =
       _$FilesTrashbinCapabilities_Files;
 
   // coverage:ignore-start
@@ -7436,7 +7409,7 @@ abstract class FilesTrashbinCapabilities_Files
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesTrashbinCapabilities_Files.fromJson(final Map<String, dynamic> json) =>
+  factory FilesTrashbinCapabilities_Files.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7454,15 +7427,14 @@ abstract interface class $FilesTrashbinCapabilitiesInterface {
 
 abstract class FilesTrashbinCapabilities
     implements $FilesTrashbinCapabilitiesInterface, Built<FilesTrashbinCapabilities, FilesTrashbinCapabilitiesBuilder> {
-  factory FilesTrashbinCapabilities([final void Function(FilesTrashbinCapabilitiesBuilder)? b]) =
-      _$FilesTrashbinCapabilities;
+  factory FilesTrashbinCapabilities([void Function(FilesTrashbinCapabilitiesBuilder)? b]) = _$FilesTrashbinCapabilities;
 
   // coverage:ignore-start
   const FilesTrashbinCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesTrashbinCapabilities.fromJson(final Map<String, dynamic> json) =>
+  factory FilesTrashbinCapabilities.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7486,7 +7458,7 @@ abstract class FilesVersionsCapabilities_Files
     implements
         $FilesVersionsCapabilities_FilesInterface,
         Built<FilesVersionsCapabilities_Files, FilesVersionsCapabilities_FilesBuilder> {
-  factory FilesVersionsCapabilities_Files([final void Function(FilesVersionsCapabilities_FilesBuilder)? b]) =
+  factory FilesVersionsCapabilities_Files([void Function(FilesVersionsCapabilities_FilesBuilder)? b]) =
       _$FilesVersionsCapabilities_Files;
 
   // coverage:ignore-start
@@ -7494,7 +7466,7 @@ abstract class FilesVersionsCapabilities_Files
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesVersionsCapabilities_Files.fromJson(final Map<String, dynamic> json) =>
+  factory FilesVersionsCapabilities_Files.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7512,15 +7484,14 @@ abstract interface class $FilesVersionsCapabilitiesInterface {
 
 abstract class FilesVersionsCapabilities
     implements $FilesVersionsCapabilitiesInterface, Built<FilesVersionsCapabilities, FilesVersionsCapabilitiesBuilder> {
-  factory FilesVersionsCapabilities([final void Function(FilesVersionsCapabilitiesBuilder)? b]) =
-      _$FilesVersionsCapabilities;
+  factory FilesVersionsCapabilities([void Function(FilesVersionsCapabilitiesBuilder)? b]) = _$FilesVersionsCapabilities;
 
   // coverage:ignore-start
   const FilesVersionsCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesVersionsCapabilities.fromJson(final Map<String, dynamic> json) =>
+  factory FilesVersionsCapabilities.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7540,14 +7511,14 @@ abstract interface class $NotesCapabilities_NotesInterface {
 
 abstract class NotesCapabilities_Notes
     implements $NotesCapabilities_NotesInterface, Built<NotesCapabilities_Notes, NotesCapabilities_NotesBuilder> {
-  factory NotesCapabilities_Notes([final void Function(NotesCapabilities_NotesBuilder)? b]) = _$NotesCapabilities_Notes;
+  factory NotesCapabilities_Notes([void Function(NotesCapabilities_NotesBuilder)? b]) = _$NotesCapabilities_Notes;
 
   // coverage:ignore-start
   const NotesCapabilities_Notes._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NotesCapabilities_Notes.fromJson(final Map<String, dynamic> json) =>
+  factory NotesCapabilities_Notes.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7565,15 +7536,14 @@ abstract interface class $NotesCapabilitiesInterface {
 
 abstract class NotesCapabilities
     implements $NotesCapabilitiesInterface, Built<NotesCapabilities, NotesCapabilitiesBuilder> {
-  factory NotesCapabilities([final void Function(NotesCapabilitiesBuilder)? b]) = _$NotesCapabilities;
+  factory NotesCapabilities([void Function(NotesCapabilitiesBuilder)? b]) = _$NotesCapabilities;
 
   // coverage:ignore-start
   const NotesCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NotesCapabilities.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory NotesCapabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -7596,16 +7566,15 @@ abstract class NotificationsCapabilities_Notifications
     implements
         $NotificationsCapabilities_NotificationsInterface,
         Built<NotificationsCapabilities_Notifications, NotificationsCapabilities_NotificationsBuilder> {
-  factory NotificationsCapabilities_Notifications([
-    final void Function(NotificationsCapabilities_NotificationsBuilder)? b,
-  ]) = _$NotificationsCapabilities_Notifications;
+  factory NotificationsCapabilities_Notifications([void Function(NotificationsCapabilities_NotificationsBuilder)? b]) =
+      _$NotificationsCapabilities_Notifications;
 
   // coverage:ignore-start
   const NotificationsCapabilities_Notifications._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NotificationsCapabilities_Notifications.fromJson(final Map<String, dynamic> json) =>
+  factory NotificationsCapabilities_Notifications.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7624,15 +7593,14 @@ abstract interface class $NotificationsCapabilitiesInterface {
 
 abstract class NotificationsCapabilities
     implements $NotificationsCapabilitiesInterface, Built<NotificationsCapabilities, NotificationsCapabilitiesBuilder> {
-  factory NotificationsCapabilities([final void Function(NotificationsCapabilitiesBuilder)? b]) =
-      _$NotificationsCapabilities;
+  factory NotificationsCapabilities([void Function(NotificationsCapabilitiesBuilder)? b]) = _$NotificationsCapabilities;
 
   // coverage:ignore-start
   const NotificationsCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NotificationsCapabilities.fromJson(final Map<String, dynamic> json) =>
+  factory NotificationsCapabilities.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7659,7 +7627,7 @@ abstract class ProvisioningApiCapabilities_ProvisioningApi
         $ProvisioningApiCapabilities_ProvisioningApiInterface,
         Built<ProvisioningApiCapabilities_ProvisioningApi, ProvisioningApiCapabilities_ProvisioningApiBuilder> {
   factory ProvisioningApiCapabilities_ProvisioningApi([
-    final void Function(ProvisioningApiCapabilities_ProvisioningApiBuilder)? b,
+    void Function(ProvisioningApiCapabilities_ProvisioningApiBuilder)? b,
   ]) = _$ProvisioningApiCapabilities_ProvisioningApi;
 
   // coverage:ignore-start
@@ -7667,7 +7635,7 @@ abstract class ProvisioningApiCapabilities_ProvisioningApi
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ProvisioningApiCapabilities_ProvisioningApi.fromJson(final Map<String, dynamic> json) =>
+  factory ProvisioningApiCapabilities_ProvisioningApi.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7689,7 +7657,7 @@ abstract class ProvisioningApiCapabilities
     implements
         $ProvisioningApiCapabilitiesInterface,
         Built<ProvisioningApiCapabilities, ProvisioningApiCapabilitiesBuilder> {
-  factory ProvisioningApiCapabilities([final void Function(ProvisioningApiCapabilitiesBuilder)? b]) =
+  factory ProvisioningApiCapabilities([void Function(ProvisioningApiCapabilitiesBuilder)? b]) =
       _$ProvisioningApiCapabilities;
 
   // coverage:ignore-start
@@ -7697,7 +7665,7 @@ abstract class ProvisioningApiCapabilities
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ProvisioningApiCapabilities.fromJson(final Map<String, dynamic> json) =>
+  factory ProvisioningApiCapabilities.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7719,7 +7687,7 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop
         Built<SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop,
             SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder> {
   factory SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop([
-    final void Function(SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder)? b,
+    void Function(SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder)? b,
   ]) = _$SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop;
 
   // coverage:ignore-start
@@ -7727,7 +7695,7 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop.fromJson(final Map<String, dynamic> json) =>
+  factory SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7751,7 +7719,7 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_Password
         Built<SharebymailCapabilities0_FilesSharing_Sharebymail_Password,
             SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordBuilder> {
   factory SharebymailCapabilities0_FilesSharing_Sharebymail_Password([
-    final void Function(SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordBuilder)? b,
+    void Function(SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordBuilder)? b,
   ]) = _$SharebymailCapabilities0_FilesSharing_Sharebymail_Password;
 
   // coverage:ignore-start
@@ -7759,7 +7727,7 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_Password
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SharebymailCapabilities0_FilesSharing_Sharebymail_Password.fromJson(final Map<String, dynamic> json) =>
+  factory SharebymailCapabilities0_FilesSharing_Sharebymail_Password.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7783,7 +7751,7 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate
         Built<SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate,
             SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder> {
   factory SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate([
-    final void Function(SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder)? b,
+    void Function(SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder)? b,
   ]) = _$SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate;
 
   // coverage:ignore-start
@@ -7791,7 +7759,7 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate.fromJson(final Map<String, dynamic> json) =>
+  factory SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7821,7 +7789,7 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail
         Built<SharebymailCapabilities0_FilesSharing_Sharebymail,
             SharebymailCapabilities0_FilesSharing_SharebymailBuilder> {
   factory SharebymailCapabilities0_FilesSharing_Sharebymail([
-    final void Function(SharebymailCapabilities0_FilesSharing_SharebymailBuilder)? b,
+    void Function(SharebymailCapabilities0_FilesSharing_SharebymailBuilder)? b,
   ]) = _$SharebymailCapabilities0_FilesSharing_Sharebymail;
 
   // coverage:ignore-start
@@ -7829,7 +7797,7 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SharebymailCapabilities0_FilesSharing_Sharebymail.fromJson(final Map<String, dynamic> json) =>
+  factory SharebymailCapabilities0_FilesSharing_Sharebymail.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7850,16 +7818,15 @@ abstract class SharebymailCapabilities0_FilesSharing
     implements
         $SharebymailCapabilities0_FilesSharingInterface,
         Built<SharebymailCapabilities0_FilesSharing, SharebymailCapabilities0_FilesSharingBuilder> {
-  factory SharebymailCapabilities0_FilesSharing([
-    final void Function(SharebymailCapabilities0_FilesSharingBuilder)? b,
-  ]) = _$SharebymailCapabilities0_FilesSharing;
+  factory SharebymailCapabilities0_FilesSharing([void Function(SharebymailCapabilities0_FilesSharingBuilder)? b]) =
+      _$SharebymailCapabilities0_FilesSharing;
 
   // coverage:ignore-start
   const SharebymailCapabilities0_FilesSharing._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SharebymailCapabilities0_FilesSharing.fromJson(final Map<String, dynamic> json) =>
+  factory SharebymailCapabilities0_FilesSharing.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7879,15 +7846,14 @@ abstract interface class $SharebymailCapabilities0Interface {
 
 abstract class SharebymailCapabilities0
     implements $SharebymailCapabilities0Interface, Built<SharebymailCapabilities0, SharebymailCapabilities0Builder> {
-  factory SharebymailCapabilities0([final void Function(SharebymailCapabilities0Builder)? b]) =
-      _$SharebymailCapabilities0;
+  factory SharebymailCapabilities0([void Function(SharebymailCapabilities0Builder)? b]) = _$SharebymailCapabilities0;
 
   // coverage:ignore-start
   const SharebymailCapabilities0._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SharebymailCapabilities0.fromJson(final Map<String, dynamic> json) =>
+  factory SharebymailCapabilities0.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7910,7 +7876,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Attachments
         Built<SpreedPublicCapabilities0_Spreed_Config_Attachments,
             SpreedPublicCapabilities0_Spreed_Config_AttachmentsBuilder> {
   factory SpreedPublicCapabilities0_Spreed_Config_Attachments([
-    final void Function(SpreedPublicCapabilities0_Spreed_Config_AttachmentsBuilder)? b,
+    void Function(SpreedPublicCapabilities0_Spreed_Config_AttachmentsBuilder)? b,
   ]) = _$SpreedPublicCapabilities0_Spreed_Config_Attachments;
 
   // coverage:ignore-start
@@ -7918,7 +7884,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Attachments
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SpreedPublicCapabilities0_Spreed_Config_Attachments.fromJson(final Map<String, dynamic> json) =>
+  factory SpreedPublicCapabilities0_Spreed_Config_Attachments.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7957,7 +7923,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Call
         $SpreedPublicCapabilities0_Spreed_Config_CallInterface,
         Built<SpreedPublicCapabilities0_Spreed_Config_Call, SpreedPublicCapabilities0_Spreed_Config_CallBuilder> {
   factory SpreedPublicCapabilities0_Spreed_Config_Call([
-    final void Function(SpreedPublicCapabilities0_Spreed_Config_CallBuilder)? b,
+    void Function(SpreedPublicCapabilities0_Spreed_Config_CallBuilder)? b,
   ]) = _$SpreedPublicCapabilities0_Spreed_Config_Call;
 
   // coverage:ignore-start
@@ -7965,7 +7931,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Call
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SpreedPublicCapabilities0_Spreed_Config_Call.fromJson(final Map<String, dynamic> json) =>
+  factory SpreedPublicCapabilities0_Spreed_Config_Call.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7995,7 +7961,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Chat
         $SpreedPublicCapabilities0_Spreed_Config_ChatInterface,
         Built<SpreedPublicCapabilities0_Spreed_Config_Chat, SpreedPublicCapabilities0_Spreed_Config_ChatBuilder> {
   factory SpreedPublicCapabilities0_Spreed_Config_Chat([
-    final void Function(SpreedPublicCapabilities0_Spreed_Config_ChatBuilder)? b,
+    void Function(SpreedPublicCapabilities0_Spreed_Config_ChatBuilder)? b,
   ]) = _$SpreedPublicCapabilities0_Spreed_Config_Chat;
 
   // coverage:ignore-start
@@ -8003,7 +7969,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Chat
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SpreedPublicCapabilities0_Spreed_Config_Chat.fromJson(final Map<String, dynamic> json) =>
+  factory SpreedPublicCapabilities0_Spreed_Config_Chat.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8027,7 +7993,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Conversations
         Built<SpreedPublicCapabilities0_Spreed_Config_Conversations,
             SpreedPublicCapabilities0_Spreed_Config_ConversationsBuilder> {
   factory SpreedPublicCapabilities0_Spreed_Config_Conversations([
-    final void Function(SpreedPublicCapabilities0_Spreed_Config_ConversationsBuilder)? b,
+    void Function(SpreedPublicCapabilities0_Spreed_Config_ConversationsBuilder)? b,
   ]) = _$SpreedPublicCapabilities0_Spreed_Config_Conversations;
 
   // coverage:ignore-start
@@ -8035,7 +8001,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Conversations
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SpreedPublicCapabilities0_Spreed_Config_Conversations.fromJson(final Map<String, dynamic> json) =>
+  factory SpreedPublicCapabilities0_Spreed_Config_Conversations.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8059,7 +8025,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Previews
         Built<SpreedPublicCapabilities0_Spreed_Config_Previews,
             SpreedPublicCapabilities0_Spreed_Config_PreviewsBuilder> {
   factory SpreedPublicCapabilities0_Spreed_Config_Previews([
-    final void Function(SpreedPublicCapabilities0_Spreed_Config_PreviewsBuilder)? b,
+    void Function(SpreedPublicCapabilities0_Spreed_Config_PreviewsBuilder)? b,
   ]) = _$SpreedPublicCapabilities0_Spreed_Config_Previews;
 
   // coverage:ignore-start
@@ -8067,7 +8033,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Previews
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SpreedPublicCapabilities0_Spreed_Config_Previews.fromJson(final Map<String, dynamic> json) =>
+  factory SpreedPublicCapabilities0_Spreed_Config_Previews.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8093,7 +8059,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Signaling
         Built<SpreedPublicCapabilities0_Spreed_Config_Signaling,
             SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder> {
   factory SpreedPublicCapabilities0_Spreed_Config_Signaling([
-    final void Function(SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder)? b,
+    void Function(SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder)? b,
   ]) = _$SpreedPublicCapabilities0_Spreed_Config_Signaling;
 
   // coverage:ignore-start
@@ -8101,7 +8067,7 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Signaling
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SpreedPublicCapabilities0_Spreed_Config_Signaling.fromJson(final Map<String, dynamic> json) =>
+  factory SpreedPublicCapabilities0_Spreed_Config_Signaling.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8127,16 +8093,15 @@ abstract class SpreedPublicCapabilities0_Spreed_Config
     implements
         $SpreedPublicCapabilities0_Spreed_ConfigInterface,
         Built<SpreedPublicCapabilities0_Spreed_Config, SpreedPublicCapabilities0_Spreed_ConfigBuilder> {
-  factory SpreedPublicCapabilities0_Spreed_Config([
-    final void Function(SpreedPublicCapabilities0_Spreed_ConfigBuilder)? b,
-  ]) = _$SpreedPublicCapabilities0_Spreed_Config;
+  factory SpreedPublicCapabilities0_Spreed_Config([void Function(SpreedPublicCapabilities0_Spreed_ConfigBuilder)? b]) =
+      _$SpreedPublicCapabilities0_Spreed_Config;
 
   // coverage:ignore-start
   const SpreedPublicCapabilities0_Spreed_Config._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SpreedPublicCapabilities0_Spreed_Config.fromJson(final Map<String, dynamic> json) =>
+  factory SpreedPublicCapabilities0_Spreed_Config.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8159,7 +8124,7 @@ abstract class SpreedPublicCapabilities0_Spreed
     implements
         $SpreedPublicCapabilities0_SpreedInterface,
         Built<SpreedPublicCapabilities0_Spreed, SpreedPublicCapabilities0_SpreedBuilder> {
-  factory SpreedPublicCapabilities0_Spreed([final void Function(SpreedPublicCapabilities0_SpreedBuilder)? b]) =
+  factory SpreedPublicCapabilities0_Spreed([void Function(SpreedPublicCapabilities0_SpreedBuilder)? b]) =
       _$SpreedPublicCapabilities0_Spreed;
 
   // coverage:ignore-start
@@ -8167,7 +8132,7 @@ abstract class SpreedPublicCapabilities0_Spreed
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SpreedPublicCapabilities0_Spreed.fromJson(final Map<String, dynamic> json) =>
+  factory SpreedPublicCapabilities0_Spreed.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8185,15 +8150,14 @@ abstract interface class $SpreedPublicCapabilities0Interface {
 
 abstract class SpreedPublicCapabilities0
     implements $SpreedPublicCapabilities0Interface, Built<SpreedPublicCapabilities0, SpreedPublicCapabilities0Builder> {
-  factory SpreedPublicCapabilities0([final void Function(SpreedPublicCapabilities0Builder)? b]) =
-      _$SpreedPublicCapabilities0;
+  factory SpreedPublicCapabilities0([void Function(SpreedPublicCapabilities0Builder)? b]) = _$SpreedPublicCapabilities0;
 
   // coverage:ignore-start
   const SpreedPublicCapabilities0._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SpreedPublicCapabilities0.fromJson(final Map<String, dynamic> json) =>
+  factory SpreedPublicCapabilities0.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8232,7 +8196,7 @@ abstract class ThemingPublicCapabilities_Theming
     implements
         $ThemingPublicCapabilities_ThemingInterface,
         Built<ThemingPublicCapabilities_Theming, ThemingPublicCapabilities_ThemingBuilder> {
-  factory ThemingPublicCapabilities_Theming([final void Function(ThemingPublicCapabilities_ThemingBuilder)? b]) =
+  factory ThemingPublicCapabilities_Theming([void Function(ThemingPublicCapabilities_ThemingBuilder)? b]) =
       _$ThemingPublicCapabilities_Theming;
 
   // coverage:ignore-start
@@ -8240,7 +8204,7 @@ abstract class ThemingPublicCapabilities_Theming
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ThemingPublicCapabilities_Theming.fromJson(final Map<String, dynamic> json) =>
+  factory ThemingPublicCapabilities_Theming.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8258,15 +8222,14 @@ abstract interface class $ThemingPublicCapabilitiesInterface {
 
 abstract class ThemingPublicCapabilities
     implements $ThemingPublicCapabilitiesInterface, Built<ThemingPublicCapabilities, ThemingPublicCapabilitiesBuilder> {
-  factory ThemingPublicCapabilities([final void Function(ThemingPublicCapabilitiesBuilder)? b]) =
-      _$ThemingPublicCapabilities;
+  factory ThemingPublicCapabilities([void Function(ThemingPublicCapabilitiesBuilder)? b]) = _$ThemingPublicCapabilities;
 
   // coverage:ignore-start
   const ThemingPublicCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ThemingPublicCapabilities.fromJson(final Map<String, dynamic> json) =>
+  factory ThemingPublicCapabilities.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8289,7 +8252,7 @@ abstract class UserStatusCapabilities_UserStatus
     implements
         $UserStatusCapabilities_UserStatusInterface,
         Built<UserStatusCapabilities_UserStatus, UserStatusCapabilities_UserStatusBuilder> {
-  factory UserStatusCapabilities_UserStatus([final void Function(UserStatusCapabilities_UserStatusBuilder)? b]) =
+  factory UserStatusCapabilities_UserStatus([void Function(UserStatusCapabilities_UserStatusBuilder)? b]) =
       _$UserStatusCapabilities_UserStatus;
 
   // coverage:ignore-start
@@ -8297,7 +8260,7 @@ abstract class UserStatusCapabilities_UserStatus
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusCapabilities_UserStatus.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusCapabilities_UserStatus.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8316,14 +8279,14 @@ abstract interface class $UserStatusCapabilitiesInterface {
 
 abstract class UserStatusCapabilities
     implements $UserStatusCapabilitiesInterface, Built<UserStatusCapabilities, UserStatusCapabilitiesBuilder> {
-  factory UserStatusCapabilities([final void Function(UserStatusCapabilitiesBuilder)? b]) = _$UserStatusCapabilities;
+  factory UserStatusCapabilities([void Function(UserStatusCapabilitiesBuilder)? b]) = _$UserStatusCapabilities;
 
   // coverage:ignore-start
   const UserStatusCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusCapabilities.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusCapabilities.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8343,16 +8306,15 @@ abstract class WeatherStatusCapabilities_WeatherStatus
     implements
         $WeatherStatusCapabilities_WeatherStatusInterface,
         Built<WeatherStatusCapabilities_WeatherStatus, WeatherStatusCapabilities_WeatherStatusBuilder> {
-  factory WeatherStatusCapabilities_WeatherStatus([
-    final void Function(WeatherStatusCapabilities_WeatherStatusBuilder)? b,
-  ]) = _$WeatherStatusCapabilities_WeatherStatus;
+  factory WeatherStatusCapabilities_WeatherStatus([void Function(WeatherStatusCapabilities_WeatherStatusBuilder)? b]) =
+      _$WeatherStatusCapabilities_WeatherStatus;
 
   // coverage:ignore-start
   const WeatherStatusCapabilities_WeatherStatus._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusCapabilities_WeatherStatus.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusCapabilities_WeatherStatus.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8372,15 +8334,14 @@ abstract interface class $WeatherStatusCapabilitiesInterface {
 
 abstract class WeatherStatusCapabilities
     implements $WeatherStatusCapabilitiesInterface, Built<WeatherStatusCapabilities, WeatherStatusCapabilitiesBuilder> {
-  factory WeatherStatusCapabilities([final void Function(WeatherStatusCapabilitiesBuilder)? b]) =
-      _$WeatherStatusCapabilities;
+  factory WeatherStatusCapabilities([void Function(WeatherStatusCapabilitiesBuilder)? b]) = _$WeatherStatusCapabilities;
 
   // coverage:ignore-start
   const WeatherStatusCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusCapabilities.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusCapabilities.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8403,7 +8364,7 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data
         Built<OcsGetCapabilitiesResponseApplicationJson_Ocs_Data,
             OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder> {
   factory OcsGetCapabilitiesResponseApplicationJson_Ocs_Data([
-    final void Function(OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -8411,7 +8372,7 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OcsGetCapabilitiesResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory OcsGetCapabilitiesResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8423,7 +8384,7 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data
       _$ocsGetCapabilitiesResponseApplicationJsonOcsDataSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder b) {
+  static void _validate(OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder b) {
     b.capabilities?.validateAnyOf();
   }
 }
@@ -8439,7 +8400,7 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs
         $OcsGetCapabilitiesResponseApplicationJson_OcsInterface,
         Built<OcsGetCapabilitiesResponseApplicationJson_Ocs, OcsGetCapabilitiesResponseApplicationJson_OcsBuilder> {
   factory OcsGetCapabilitiesResponseApplicationJson_Ocs([
-    final void Function(OcsGetCapabilitiesResponseApplicationJson_OcsBuilder)? b,
+    void Function(OcsGetCapabilitiesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$OcsGetCapabilitiesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -8447,7 +8408,7 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OcsGetCapabilitiesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory OcsGetCapabilitiesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8469,7 +8430,7 @@ abstract class OcsGetCapabilitiesResponseApplicationJson
         $OcsGetCapabilitiesResponseApplicationJsonInterface,
         Built<OcsGetCapabilitiesResponseApplicationJson, OcsGetCapabilitiesResponseApplicationJsonBuilder> {
   factory OcsGetCapabilitiesResponseApplicationJson([
-    final void Function(OcsGetCapabilitiesResponseApplicationJsonBuilder)? b,
+    void Function(OcsGetCapabilitiesResponseApplicationJsonBuilder)? b,
   ]) = _$OcsGetCapabilitiesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -8477,7 +8438,7 @@ abstract class OcsGetCapabilitiesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OcsGetCapabilitiesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory OcsGetCapabilitiesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8501,7 +8462,7 @@ abstract class ProfileApiSetVisibilityResponseApplicationJson_Ocs
         Built<ProfileApiSetVisibilityResponseApplicationJson_Ocs,
             ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder> {
   factory ProfileApiSetVisibilityResponseApplicationJson_Ocs([
-    final void Function(ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder)? b,
+    void Function(ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ProfileApiSetVisibilityResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -8509,7 +8470,7 @@ abstract class ProfileApiSetVisibilityResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ProfileApiSetVisibilityResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ProfileApiSetVisibilityResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8531,7 +8492,7 @@ abstract class ProfileApiSetVisibilityResponseApplicationJson
         $ProfileApiSetVisibilityResponseApplicationJsonInterface,
         Built<ProfileApiSetVisibilityResponseApplicationJson, ProfileApiSetVisibilityResponseApplicationJsonBuilder> {
   factory ProfileApiSetVisibilityResponseApplicationJson([
-    final void Function(ProfileApiSetVisibilityResponseApplicationJsonBuilder)? b,
+    void Function(ProfileApiSetVisibilityResponseApplicationJsonBuilder)? b,
   ]) = _$ProfileApiSetVisibilityResponseApplicationJson;
 
   // coverage:ignore-start
@@ -8539,7 +8500,7 @@ abstract class ProfileApiSetVisibilityResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ProfileApiSetVisibilityResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ProfileApiSetVisibilityResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8560,14 +8521,14 @@ abstract interface class $ReferenceInterface {
 }
 
 abstract class Reference implements $ReferenceInterface, Built<Reference, ReferenceBuilder> {
-  factory Reference([final void Function(ReferenceBuilder)? b]) = _$Reference;
+  factory Reference([void Function(ReferenceBuilder)? b]) = _$Reference;
 
   // coverage:ignore-start
   const Reference._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Reference.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Reference.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -8588,7 +8549,7 @@ abstract class ReferenceApiResolveOneResponseApplicationJson_Ocs_Data
         Built<ReferenceApiResolveOneResponseApplicationJson_Ocs_Data,
             ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder> {
   factory ReferenceApiResolveOneResponseApplicationJson_Ocs_Data([
-    final void Function(ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$ReferenceApiResolveOneResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -8596,7 +8557,7 @@ abstract class ReferenceApiResolveOneResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiResolveOneResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiResolveOneResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8620,7 +8581,7 @@ abstract class ReferenceApiResolveOneResponseApplicationJson_Ocs
         Built<ReferenceApiResolveOneResponseApplicationJson_Ocs,
             ReferenceApiResolveOneResponseApplicationJson_OcsBuilder> {
   factory ReferenceApiResolveOneResponseApplicationJson_Ocs([
-    final void Function(ReferenceApiResolveOneResponseApplicationJson_OcsBuilder)? b,
+    void Function(ReferenceApiResolveOneResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ReferenceApiResolveOneResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -8628,7 +8589,7 @@ abstract class ReferenceApiResolveOneResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiResolveOneResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiResolveOneResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8650,7 +8611,7 @@ abstract class ReferenceApiResolveOneResponseApplicationJson
         $ReferenceApiResolveOneResponseApplicationJsonInterface,
         Built<ReferenceApiResolveOneResponseApplicationJson, ReferenceApiResolveOneResponseApplicationJsonBuilder> {
   factory ReferenceApiResolveOneResponseApplicationJson([
-    final void Function(ReferenceApiResolveOneResponseApplicationJsonBuilder)? b,
+    void Function(ReferenceApiResolveOneResponseApplicationJsonBuilder)? b,
   ]) = _$ReferenceApiResolveOneResponseApplicationJson;
 
   // coverage:ignore-start
@@ -8658,7 +8619,7 @@ abstract class ReferenceApiResolveOneResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiResolveOneResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiResolveOneResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8681,7 +8642,7 @@ abstract class ReferenceApiResolveResponseApplicationJson_Ocs_Data
         Built<ReferenceApiResolveResponseApplicationJson_Ocs_Data,
             ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder> {
   factory ReferenceApiResolveResponseApplicationJson_Ocs_Data([
-    final void Function(ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$ReferenceApiResolveResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -8689,7 +8650,7 @@ abstract class ReferenceApiResolveResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiResolveResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiResolveResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8712,7 +8673,7 @@ abstract class ReferenceApiResolveResponseApplicationJson_Ocs
         $ReferenceApiResolveResponseApplicationJson_OcsInterface,
         Built<ReferenceApiResolveResponseApplicationJson_Ocs, ReferenceApiResolveResponseApplicationJson_OcsBuilder> {
   factory ReferenceApiResolveResponseApplicationJson_Ocs([
-    final void Function(ReferenceApiResolveResponseApplicationJson_OcsBuilder)? b,
+    void Function(ReferenceApiResolveResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ReferenceApiResolveResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -8720,7 +8681,7 @@ abstract class ReferenceApiResolveResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiResolveResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiResolveResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8742,7 +8703,7 @@ abstract class ReferenceApiResolveResponseApplicationJson
         $ReferenceApiResolveResponseApplicationJsonInterface,
         Built<ReferenceApiResolveResponseApplicationJson, ReferenceApiResolveResponseApplicationJsonBuilder> {
   factory ReferenceApiResolveResponseApplicationJson([
-    final void Function(ReferenceApiResolveResponseApplicationJsonBuilder)? b,
+    void Function(ReferenceApiResolveResponseApplicationJsonBuilder)? b,
   ]) = _$ReferenceApiResolveResponseApplicationJson;
 
   // coverage:ignore-start
@@ -8750,7 +8711,7 @@ abstract class ReferenceApiResolveResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiResolveResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiResolveResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8773,7 +8734,7 @@ abstract class ReferenceApiExtractResponseApplicationJson_Ocs_Data
         Built<ReferenceApiExtractResponseApplicationJson_Ocs_Data,
             ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder> {
   factory ReferenceApiExtractResponseApplicationJson_Ocs_Data([
-    final void Function(ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$ReferenceApiExtractResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -8781,7 +8742,7 @@ abstract class ReferenceApiExtractResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiExtractResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiExtractResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8804,7 +8765,7 @@ abstract class ReferenceApiExtractResponseApplicationJson_Ocs
         $ReferenceApiExtractResponseApplicationJson_OcsInterface,
         Built<ReferenceApiExtractResponseApplicationJson_Ocs, ReferenceApiExtractResponseApplicationJson_OcsBuilder> {
   factory ReferenceApiExtractResponseApplicationJson_Ocs([
-    final void Function(ReferenceApiExtractResponseApplicationJson_OcsBuilder)? b,
+    void Function(ReferenceApiExtractResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ReferenceApiExtractResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -8812,7 +8773,7 @@ abstract class ReferenceApiExtractResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiExtractResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiExtractResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8834,7 +8795,7 @@ abstract class ReferenceApiExtractResponseApplicationJson
         $ReferenceApiExtractResponseApplicationJsonInterface,
         Built<ReferenceApiExtractResponseApplicationJson, ReferenceApiExtractResponseApplicationJsonBuilder> {
   factory ReferenceApiExtractResponseApplicationJson([
-    final void Function(ReferenceApiExtractResponseApplicationJsonBuilder)? b,
+    void Function(ReferenceApiExtractResponseApplicationJsonBuilder)? b,
   ]) = _$ReferenceApiExtractResponseApplicationJson;
 
   // coverage:ignore-start
@@ -8842,7 +8803,7 @@ abstract class ReferenceApiExtractResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiExtractResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiExtractResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8867,15 +8828,14 @@ abstract interface class $ReferenceProviderInterface {
 
 abstract class ReferenceProvider
     implements $ReferenceProviderInterface, Built<ReferenceProvider, ReferenceProviderBuilder> {
-  factory ReferenceProvider([final void Function(ReferenceProviderBuilder)? b]) = _$ReferenceProvider;
+  factory ReferenceProvider([void Function(ReferenceProviderBuilder)? b]) = _$ReferenceProvider;
 
   // coverage:ignore-start
   const ReferenceProvider._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceProvider.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory ReferenceProvider.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -8897,7 +8857,7 @@ abstract class ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs
         Built<ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs,
             ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder> {
   factory ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs([
-    final void Function(ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder)? b,
+    void Function(ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -8905,7 +8865,7 @@ abstract class ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8928,7 +8888,7 @@ abstract class ReferenceApiGetProvidersInfoResponseApplicationJson
         Built<ReferenceApiGetProvidersInfoResponseApplicationJson,
             ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder> {
   factory ReferenceApiGetProvidersInfoResponseApplicationJson([
-    final void Function(ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder)? b,
+    void Function(ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder)? b,
   ]) = _$ReferenceApiGetProvidersInfoResponseApplicationJson;
 
   // coverage:ignore-start
@@ -8936,7 +8896,7 @@ abstract class ReferenceApiGetProvidersInfoResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiGetProvidersInfoResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiGetProvidersInfoResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8959,7 +8919,7 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data
         Built<ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data,
             ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder> {
   factory ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data([
-    final void Function(ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -8967,7 +8927,7 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8991,7 +8951,7 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson_Ocs
         Built<ReferenceApiTouchProviderResponseApplicationJson_Ocs,
             ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder> {
   factory ReferenceApiTouchProviderResponseApplicationJson_Ocs([
-    final void Function(ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder)? b,
+    void Function(ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ReferenceApiTouchProviderResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -8999,7 +8959,7 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiTouchProviderResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiTouchProviderResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9022,7 +8982,7 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson
         Built<ReferenceApiTouchProviderResponseApplicationJson,
             ReferenceApiTouchProviderResponseApplicationJsonBuilder> {
   factory ReferenceApiTouchProviderResponseApplicationJson([
-    final void Function(ReferenceApiTouchProviderResponseApplicationJsonBuilder)? b,
+    void Function(ReferenceApiTouchProviderResponseApplicationJsonBuilder)? b,
   ]) = _$ReferenceApiTouchProviderResponseApplicationJson;
 
   // coverage:ignore-start
@@ -9030,7 +8990,7 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReferenceApiTouchProviderResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ReferenceApiTouchProviderResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9055,7 +9015,7 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types
         Built<TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types,
             TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesBuilder> {
   factory TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types([
-    final void Function(TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesBuilder)? b,
+    void Function(TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesBuilder)? b,
   ]) = _$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types;
 
   // coverage:ignore-start
@@ -9063,7 +9023,7 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9086,7 +9046,7 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data
         Built<TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data,
             TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder> {
   factory TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data([
-    final void Function(TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -9094,7 +9054,7 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9118,7 +9078,7 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs
         Built<TextProcessingApiTaskTypesResponseApplicationJson_Ocs,
             TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder> {
   factory TextProcessingApiTaskTypesResponseApplicationJson_Ocs([
-    final void Function(TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder)? b,
+    void Function(TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TextProcessingApiTaskTypesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -9126,7 +9086,7 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiTaskTypesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiTaskTypesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9149,7 +9109,7 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson
         Built<TextProcessingApiTaskTypesResponseApplicationJson,
             TextProcessingApiTaskTypesResponseApplicationJsonBuilder> {
   factory TextProcessingApiTaskTypesResponseApplicationJson([
-    final void Function(TextProcessingApiTaskTypesResponseApplicationJsonBuilder)? b,
+    void Function(TextProcessingApiTaskTypesResponseApplicationJsonBuilder)? b,
   ]) = _$TextProcessingApiTaskTypesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -9157,7 +9117,7 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiTaskTypesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiTaskTypesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9183,15 +9143,14 @@ abstract interface class $TextProcessingTaskInterface {
 
 abstract class TextProcessingTask
     implements $TextProcessingTaskInterface, Built<TextProcessingTask, TextProcessingTaskBuilder> {
-  factory TextProcessingTask([final void Function(TextProcessingTaskBuilder)? b]) = _$TextProcessingTask;
+  factory TextProcessingTask([void Function(TextProcessingTaskBuilder)? b]) = _$TextProcessingTask;
 
   // coverage:ignore-start
   const TextProcessingTask._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingTask.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory TextProcessingTask.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -9212,7 +9171,7 @@ abstract class TextProcessingApiScheduleResponseApplicationJson_Ocs_Data
         Built<TextProcessingApiScheduleResponseApplicationJson_Ocs_Data,
             TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder> {
   factory TextProcessingApiScheduleResponseApplicationJson_Ocs_Data([
-    final void Function(TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TextProcessingApiScheduleResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -9220,7 +9179,7 @@ abstract class TextProcessingApiScheduleResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiScheduleResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiScheduleResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9244,7 +9203,7 @@ abstract class TextProcessingApiScheduleResponseApplicationJson_Ocs
         Built<TextProcessingApiScheduleResponseApplicationJson_Ocs,
             TextProcessingApiScheduleResponseApplicationJson_OcsBuilder> {
   factory TextProcessingApiScheduleResponseApplicationJson_Ocs([
-    final void Function(TextProcessingApiScheduleResponseApplicationJson_OcsBuilder)? b,
+    void Function(TextProcessingApiScheduleResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TextProcessingApiScheduleResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -9252,7 +9211,7 @@ abstract class TextProcessingApiScheduleResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiScheduleResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiScheduleResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9275,7 +9234,7 @@ abstract class TextProcessingApiScheduleResponseApplicationJson
         Built<TextProcessingApiScheduleResponseApplicationJson,
             TextProcessingApiScheduleResponseApplicationJsonBuilder> {
   factory TextProcessingApiScheduleResponseApplicationJson([
-    final void Function(TextProcessingApiScheduleResponseApplicationJsonBuilder)? b,
+    void Function(TextProcessingApiScheduleResponseApplicationJsonBuilder)? b,
   ]) = _$TextProcessingApiScheduleResponseApplicationJson;
 
   // coverage:ignore-start
@@ -9283,7 +9242,7 @@ abstract class TextProcessingApiScheduleResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiScheduleResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiScheduleResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9306,7 +9265,7 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data
         Built<TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data,
             TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder> {
   factory TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data([
-    final void Function(TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -9314,7 +9273,7 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9338,7 +9297,7 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson_Ocs
         Built<TextProcessingApiGetTaskResponseApplicationJson_Ocs,
             TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder> {
   factory TextProcessingApiGetTaskResponseApplicationJson_Ocs([
-    final void Function(TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder)? b,
+    void Function(TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TextProcessingApiGetTaskResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -9346,7 +9305,7 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiGetTaskResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiGetTaskResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9368,7 +9327,7 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson
         $TextProcessingApiGetTaskResponseApplicationJsonInterface,
         Built<TextProcessingApiGetTaskResponseApplicationJson, TextProcessingApiGetTaskResponseApplicationJsonBuilder> {
   factory TextProcessingApiGetTaskResponseApplicationJson([
-    final void Function(TextProcessingApiGetTaskResponseApplicationJsonBuilder)? b,
+    void Function(TextProcessingApiGetTaskResponseApplicationJsonBuilder)? b,
   ]) = _$TextProcessingApiGetTaskResponseApplicationJson;
 
   // coverage:ignore-start
@@ -9376,7 +9335,7 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiGetTaskResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiGetTaskResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9399,7 +9358,7 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data
         Built<TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data,
             TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder> {
   factory TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data([
-    final void Function(TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -9407,7 +9366,7 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9431,7 +9390,7 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs
         Built<TextProcessingApiDeleteTaskResponseApplicationJson_Ocs,
             TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder> {
   factory TextProcessingApiDeleteTaskResponseApplicationJson_Ocs([
-    final void Function(TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder)? b,
+    void Function(TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TextProcessingApiDeleteTaskResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -9439,7 +9398,7 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiDeleteTaskResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiDeleteTaskResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9462,7 +9421,7 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson
         Built<TextProcessingApiDeleteTaskResponseApplicationJson,
             TextProcessingApiDeleteTaskResponseApplicationJsonBuilder> {
   factory TextProcessingApiDeleteTaskResponseApplicationJson([
-    final void Function(TextProcessingApiDeleteTaskResponseApplicationJsonBuilder)? b,
+    void Function(TextProcessingApiDeleteTaskResponseApplicationJsonBuilder)? b,
   ]) = _$TextProcessingApiDeleteTaskResponseApplicationJson;
 
   // coverage:ignore-start
@@ -9470,7 +9429,7 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiDeleteTaskResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiDeleteTaskResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9493,7 +9452,7 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data
         Built<TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data,
             TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder> {
   factory TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data([
-    final void Function(TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -9501,7 +9460,7 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9525,7 +9484,7 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs
         Built<TextProcessingApiListTasksByAppResponseApplicationJson_Ocs,
             TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder> {
   factory TextProcessingApiListTasksByAppResponseApplicationJson_Ocs([
-    final void Function(TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder)? b,
+    void Function(TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -9533,7 +9492,7 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiListTasksByAppResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiListTasksByAppResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9556,7 +9515,7 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson
         Built<TextProcessingApiListTasksByAppResponseApplicationJson,
             TextProcessingApiListTasksByAppResponseApplicationJsonBuilder> {
   factory TextProcessingApiListTasksByAppResponseApplicationJson([
-    final void Function(TextProcessingApiListTasksByAppResponseApplicationJsonBuilder)? b,
+    void Function(TextProcessingApiListTasksByAppResponseApplicationJsonBuilder)? b,
   ]) = _$TextProcessingApiListTasksByAppResponseApplicationJson;
 
   // coverage:ignore-start
@@ -9564,7 +9523,7 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextProcessingApiListTasksByAppResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TextProcessingApiListTasksByAppResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9587,7 +9546,7 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data
         Built<TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data,
             TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder> {
   factory TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data([
-    final void Function(TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -9595,7 +9554,7 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9619,7 +9578,7 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson_Ocs
         Built<TextToImageApiIsAvailableResponseApplicationJson_Ocs,
             TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder> {
   factory TextToImageApiIsAvailableResponseApplicationJson_Ocs([
-    final void Function(TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder)? b,
+    void Function(TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TextToImageApiIsAvailableResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -9627,7 +9586,7 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiIsAvailableResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiIsAvailableResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9650,7 +9609,7 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson
         Built<TextToImageApiIsAvailableResponseApplicationJson,
             TextToImageApiIsAvailableResponseApplicationJsonBuilder> {
   factory TextToImageApiIsAvailableResponseApplicationJson([
-    final void Function(TextToImageApiIsAvailableResponseApplicationJsonBuilder)? b,
+    void Function(TextToImageApiIsAvailableResponseApplicationJsonBuilder)? b,
   ]) = _$TextToImageApiIsAvailableResponseApplicationJson;
 
   // coverage:ignore-start
@@ -9658,7 +9617,7 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiIsAvailableResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiIsAvailableResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9683,15 +9642,14 @@ abstract interface class $TextToImageTaskInterface {
 }
 
 abstract class TextToImageTask implements $TextToImageTaskInterface, Built<TextToImageTask, TextToImageTaskBuilder> {
-  factory TextToImageTask([final void Function(TextToImageTaskBuilder)? b]) = _$TextToImageTask;
+  factory TextToImageTask([void Function(TextToImageTaskBuilder)? b]) = _$TextToImageTask;
 
   // coverage:ignore-start
   const TextToImageTask._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageTask.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory TextToImageTask.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -9712,7 +9670,7 @@ abstract class TextToImageApiScheduleResponseApplicationJson_Ocs_Data
         Built<TextToImageApiScheduleResponseApplicationJson_Ocs_Data,
             TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder> {
   factory TextToImageApiScheduleResponseApplicationJson_Ocs_Data([
-    final void Function(TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TextToImageApiScheduleResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -9720,7 +9678,7 @@ abstract class TextToImageApiScheduleResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiScheduleResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiScheduleResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9744,7 +9702,7 @@ abstract class TextToImageApiScheduleResponseApplicationJson_Ocs
         Built<TextToImageApiScheduleResponseApplicationJson_Ocs,
             TextToImageApiScheduleResponseApplicationJson_OcsBuilder> {
   factory TextToImageApiScheduleResponseApplicationJson_Ocs([
-    final void Function(TextToImageApiScheduleResponseApplicationJson_OcsBuilder)? b,
+    void Function(TextToImageApiScheduleResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TextToImageApiScheduleResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -9752,7 +9710,7 @@ abstract class TextToImageApiScheduleResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiScheduleResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiScheduleResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9774,7 +9732,7 @@ abstract class TextToImageApiScheduleResponseApplicationJson
         $TextToImageApiScheduleResponseApplicationJsonInterface,
         Built<TextToImageApiScheduleResponseApplicationJson, TextToImageApiScheduleResponseApplicationJsonBuilder> {
   factory TextToImageApiScheduleResponseApplicationJson([
-    final void Function(TextToImageApiScheduleResponseApplicationJsonBuilder)? b,
+    void Function(TextToImageApiScheduleResponseApplicationJsonBuilder)? b,
   ]) = _$TextToImageApiScheduleResponseApplicationJson;
 
   // coverage:ignore-start
@@ -9782,7 +9740,7 @@ abstract class TextToImageApiScheduleResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiScheduleResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiScheduleResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9805,7 +9763,7 @@ abstract class TextToImageApiGetTaskResponseApplicationJson_Ocs_Data
         Built<TextToImageApiGetTaskResponseApplicationJson_Ocs_Data,
             TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder> {
   factory TextToImageApiGetTaskResponseApplicationJson_Ocs_Data([
-    final void Function(TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TextToImageApiGetTaskResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -9813,7 +9771,7 @@ abstract class TextToImageApiGetTaskResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiGetTaskResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiGetTaskResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9837,7 +9795,7 @@ abstract class TextToImageApiGetTaskResponseApplicationJson_Ocs
         Built<TextToImageApiGetTaskResponseApplicationJson_Ocs,
             TextToImageApiGetTaskResponseApplicationJson_OcsBuilder> {
   factory TextToImageApiGetTaskResponseApplicationJson_Ocs([
-    final void Function(TextToImageApiGetTaskResponseApplicationJson_OcsBuilder)? b,
+    void Function(TextToImageApiGetTaskResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TextToImageApiGetTaskResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -9845,7 +9803,7 @@ abstract class TextToImageApiGetTaskResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiGetTaskResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiGetTaskResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9867,7 +9825,7 @@ abstract class TextToImageApiGetTaskResponseApplicationJson
         $TextToImageApiGetTaskResponseApplicationJsonInterface,
         Built<TextToImageApiGetTaskResponseApplicationJson, TextToImageApiGetTaskResponseApplicationJsonBuilder> {
   factory TextToImageApiGetTaskResponseApplicationJson([
-    final void Function(TextToImageApiGetTaskResponseApplicationJsonBuilder)? b,
+    void Function(TextToImageApiGetTaskResponseApplicationJsonBuilder)? b,
   ]) = _$TextToImageApiGetTaskResponseApplicationJson;
 
   // coverage:ignore-start
@@ -9875,7 +9833,7 @@ abstract class TextToImageApiGetTaskResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiGetTaskResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiGetTaskResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9898,7 +9856,7 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data
         Built<TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data,
             TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder> {
   factory TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data([
-    final void Function(TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -9906,7 +9864,7 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9930,7 +9888,7 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson_Ocs
         Built<TextToImageApiDeleteTaskResponseApplicationJson_Ocs,
             TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder> {
   factory TextToImageApiDeleteTaskResponseApplicationJson_Ocs([
-    final void Function(TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder)? b,
+    void Function(TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TextToImageApiDeleteTaskResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -9938,7 +9896,7 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiDeleteTaskResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiDeleteTaskResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9960,7 +9918,7 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson
         $TextToImageApiDeleteTaskResponseApplicationJsonInterface,
         Built<TextToImageApiDeleteTaskResponseApplicationJson, TextToImageApiDeleteTaskResponseApplicationJsonBuilder> {
   factory TextToImageApiDeleteTaskResponseApplicationJson([
-    final void Function(TextToImageApiDeleteTaskResponseApplicationJsonBuilder)? b,
+    void Function(TextToImageApiDeleteTaskResponseApplicationJsonBuilder)? b,
   ]) = _$TextToImageApiDeleteTaskResponseApplicationJson;
 
   // coverage:ignore-start
@@ -9968,7 +9926,7 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiDeleteTaskResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiDeleteTaskResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -9991,7 +9949,7 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data
         Built<TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data,
             TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder> {
   factory TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data([
-    final void Function(TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -9999,7 +9957,7 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10023,7 +9981,7 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson_Ocs
         Built<TextToImageApiListTasksByAppResponseApplicationJson_Ocs,
             TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder> {
   factory TextToImageApiListTasksByAppResponseApplicationJson_Ocs([
-    final void Function(TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder)? b,
+    void Function(TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TextToImageApiListTasksByAppResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -10031,7 +9989,7 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiListTasksByAppResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiListTasksByAppResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10054,7 +10012,7 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson
         Built<TextToImageApiListTasksByAppResponseApplicationJson,
             TextToImageApiListTasksByAppResponseApplicationJsonBuilder> {
   factory TextToImageApiListTasksByAppResponseApplicationJson([
-    final void Function(TextToImageApiListTasksByAppResponseApplicationJsonBuilder)? b,
+    void Function(TextToImageApiListTasksByAppResponseApplicationJsonBuilder)? b,
   ]) = _$TextToImageApiListTasksByAppResponseApplicationJson;
 
   // coverage:ignore-start
@@ -10062,7 +10020,7 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TextToImageApiListTasksByAppResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TextToImageApiListTasksByAppResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10088,7 +10046,7 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages
         Built<TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages,
             TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesBuilder> {
   factory TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages([
-    final void Function(TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesBuilder)? b,
+    void Function(TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesBuilder)? b,
   ]) = _$TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages;
 
   // coverage:ignore-start
@@ -10096,7 +10054,7 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages.fromJson(final Map<String, dynamic> json) =>
+  factory TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10120,7 +10078,7 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs_Data
         Built<TranslationApiLanguagesResponseApplicationJson_Ocs_Data,
             TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder> {
   factory TranslationApiLanguagesResponseApplicationJson_Ocs_Data([
-    final void Function(TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TranslationApiLanguagesResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -10128,7 +10086,7 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TranslationApiLanguagesResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TranslationApiLanguagesResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10152,7 +10110,7 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs
         Built<TranslationApiLanguagesResponseApplicationJson_Ocs,
             TranslationApiLanguagesResponseApplicationJson_OcsBuilder> {
   factory TranslationApiLanguagesResponseApplicationJson_Ocs([
-    final void Function(TranslationApiLanguagesResponseApplicationJson_OcsBuilder)? b,
+    void Function(TranslationApiLanguagesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TranslationApiLanguagesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -10160,7 +10118,7 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TranslationApiLanguagesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TranslationApiLanguagesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10182,7 +10140,7 @@ abstract class TranslationApiLanguagesResponseApplicationJson
         $TranslationApiLanguagesResponseApplicationJsonInterface,
         Built<TranslationApiLanguagesResponseApplicationJson, TranslationApiLanguagesResponseApplicationJsonBuilder> {
   factory TranslationApiLanguagesResponseApplicationJson([
-    final void Function(TranslationApiLanguagesResponseApplicationJsonBuilder)? b,
+    void Function(TranslationApiLanguagesResponseApplicationJsonBuilder)? b,
   ]) = _$TranslationApiLanguagesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -10190,7 +10148,7 @@ abstract class TranslationApiLanguagesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TranslationApiLanguagesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TranslationApiLanguagesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10214,7 +10172,7 @@ abstract class TranslationApiTranslateResponseApplicationJson_Ocs_Data
         Built<TranslationApiTranslateResponseApplicationJson_Ocs_Data,
             TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder> {
   factory TranslationApiTranslateResponseApplicationJson_Ocs_Data([
-    final void Function(TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TranslationApiTranslateResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -10222,7 +10180,7 @@ abstract class TranslationApiTranslateResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TranslationApiTranslateResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TranslationApiTranslateResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10246,7 +10204,7 @@ abstract class TranslationApiTranslateResponseApplicationJson_Ocs
         Built<TranslationApiTranslateResponseApplicationJson_Ocs,
             TranslationApiTranslateResponseApplicationJson_OcsBuilder> {
   factory TranslationApiTranslateResponseApplicationJson_Ocs([
-    final void Function(TranslationApiTranslateResponseApplicationJson_OcsBuilder)? b,
+    void Function(TranslationApiTranslateResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TranslationApiTranslateResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -10254,7 +10212,7 @@ abstract class TranslationApiTranslateResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TranslationApiTranslateResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TranslationApiTranslateResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10276,7 +10234,7 @@ abstract class TranslationApiTranslateResponseApplicationJson
         $TranslationApiTranslateResponseApplicationJsonInterface,
         Built<TranslationApiTranslateResponseApplicationJson, TranslationApiTranslateResponseApplicationJsonBuilder> {
   factory TranslationApiTranslateResponseApplicationJson([
-    final void Function(TranslationApiTranslateResponseApplicationJsonBuilder)? b,
+    void Function(TranslationApiTranslateResponseApplicationJsonBuilder)? b,
   ]) = _$TranslationApiTranslateResponseApplicationJson;
 
   // coverage:ignore-start
@@ -10284,7 +10242,7 @@ abstract class TranslationApiTranslateResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TranslationApiTranslateResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TranslationApiTranslateResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10305,14 +10263,14 @@ abstract interface class $UnifiedSearchProviderInterface {
 
 abstract class UnifiedSearchProvider
     implements $UnifiedSearchProviderInterface, Built<UnifiedSearchProvider, UnifiedSearchProviderBuilder> {
-  factory UnifiedSearchProvider([final void Function(UnifiedSearchProviderBuilder)? b]) = _$UnifiedSearchProvider;
+  factory UnifiedSearchProvider([void Function(UnifiedSearchProviderBuilder)? b]) = _$UnifiedSearchProvider;
 
   // coverage:ignore-start
   const UnifiedSearchProvider._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UnifiedSearchProvider.fromJson(final Map<String, dynamic> json) =>
+  factory UnifiedSearchProvider.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10335,7 +10293,7 @@ abstract class UnifiedSearchGetProvidersResponseApplicationJson_Ocs
         Built<UnifiedSearchGetProvidersResponseApplicationJson_Ocs,
             UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder> {
   factory UnifiedSearchGetProvidersResponseApplicationJson_Ocs([
-    final void Function(UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder)? b,
+    void Function(UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UnifiedSearchGetProvidersResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -10343,7 +10301,7 @@ abstract class UnifiedSearchGetProvidersResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UnifiedSearchGetProvidersResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UnifiedSearchGetProvidersResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10366,7 +10324,7 @@ abstract class UnifiedSearchGetProvidersResponseApplicationJson
         Built<UnifiedSearchGetProvidersResponseApplicationJson,
             UnifiedSearchGetProvidersResponseApplicationJsonBuilder> {
   factory UnifiedSearchGetProvidersResponseApplicationJson([
-    final void Function(UnifiedSearchGetProvidersResponseApplicationJsonBuilder)? b,
+    void Function(UnifiedSearchGetProvidersResponseApplicationJsonBuilder)? b,
   ]) = _$UnifiedSearchGetProvidersResponseApplicationJson;
 
   // coverage:ignore-start
@@ -10374,7 +10332,7 @@ abstract class UnifiedSearchGetProvidersResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UnifiedSearchGetProvidersResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UnifiedSearchGetProvidersResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10399,15 +10357,14 @@ abstract interface class $UnifiedSearchResultEntryInterface {
 
 abstract class UnifiedSearchResultEntry
     implements $UnifiedSearchResultEntryInterface, Built<UnifiedSearchResultEntry, UnifiedSearchResultEntryBuilder> {
-  factory UnifiedSearchResultEntry([final void Function(UnifiedSearchResultEntryBuilder)? b]) =
-      _$UnifiedSearchResultEntry;
+  factory UnifiedSearchResultEntry([void Function(UnifiedSearchResultEntryBuilder)? b]) = _$UnifiedSearchResultEntry;
 
   // coverage:ignore-start
   const UnifiedSearchResultEntry._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UnifiedSearchResultEntry.fromJson(final Map<String, dynamic> json) =>
+  factory UnifiedSearchResultEntry.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10428,15 +10385,14 @@ abstract interface class $UnifiedSearchResultInterface {
 
 abstract class UnifiedSearchResult
     implements $UnifiedSearchResultInterface, Built<UnifiedSearchResult, UnifiedSearchResultBuilder> {
-  factory UnifiedSearchResult([final void Function(UnifiedSearchResultBuilder)? b]) = _$UnifiedSearchResult;
+  factory UnifiedSearchResult([void Function(UnifiedSearchResultBuilder)? b]) = _$UnifiedSearchResult;
 
   // coverage:ignore-start
   const UnifiedSearchResult._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UnifiedSearchResult.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory UnifiedSearchResult.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -10446,7 +10402,7 @@ abstract class UnifiedSearchResult
   static Serializer<UnifiedSearchResult> get serializer => _$unifiedSearchResultSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final UnifiedSearchResultBuilder b) {
+  static void _validate(UnifiedSearchResultBuilder b) {
     b.cursor?.validateOneOf();
   }
 }
@@ -10462,7 +10418,7 @@ abstract class UnifiedSearchSearchResponseApplicationJson_Ocs
         $UnifiedSearchSearchResponseApplicationJson_OcsInterface,
         Built<UnifiedSearchSearchResponseApplicationJson_Ocs, UnifiedSearchSearchResponseApplicationJson_OcsBuilder> {
   factory UnifiedSearchSearchResponseApplicationJson_Ocs([
-    final void Function(UnifiedSearchSearchResponseApplicationJson_OcsBuilder)? b,
+    void Function(UnifiedSearchSearchResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UnifiedSearchSearchResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -10470,7 +10426,7 @@ abstract class UnifiedSearchSearchResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UnifiedSearchSearchResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UnifiedSearchSearchResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10492,7 +10448,7 @@ abstract class UnifiedSearchSearchResponseApplicationJson
         $UnifiedSearchSearchResponseApplicationJsonInterface,
         Built<UnifiedSearchSearchResponseApplicationJson, UnifiedSearchSearchResponseApplicationJsonBuilder> {
   factory UnifiedSearchSearchResponseApplicationJson([
-    final void Function(UnifiedSearchSearchResponseApplicationJsonBuilder)? b,
+    void Function(UnifiedSearchSearchResponseApplicationJsonBuilder)? b,
   ]) = _$UnifiedSearchSearchResponseApplicationJson;
 
   // coverage:ignore-start
@@ -10500,7 +10456,7 @@ abstract class UnifiedSearchSearchResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UnifiedSearchSearchResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UnifiedSearchSearchResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10524,7 +10480,7 @@ abstract class WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew
         Built<WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew,
             WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder> {
   factory WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew([
-    final void Function(WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder)? b,
+    void Function(WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder)? b,
   ]) = _$WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew;
 
   // coverage:ignore-start
@@ -10532,7 +10488,7 @@ abstract class WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew.fromJson(final Map<String, dynamic> json) =>
+  factory WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10557,7 +10513,7 @@ abstract class WhatsNewGetResponseApplicationJson_Ocs_Data
         $WhatsNewGetResponseApplicationJson_Ocs_DataInterface,
         Built<WhatsNewGetResponseApplicationJson_Ocs_Data, WhatsNewGetResponseApplicationJson_Ocs_DataBuilder> {
   factory WhatsNewGetResponseApplicationJson_Ocs_Data([
-    final void Function(WhatsNewGetResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(WhatsNewGetResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$WhatsNewGetResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -10565,7 +10521,7 @@ abstract class WhatsNewGetResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WhatsNewGetResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory WhatsNewGetResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10587,16 +10543,15 @@ abstract class WhatsNewGetResponseApplicationJson_Ocs
     implements
         $WhatsNewGetResponseApplicationJson_OcsInterface,
         Built<WhatsNewGetResponseApplicationJson_Ocs, WhatsNewGetResponseApplicationJson_OcsBuilder> {
-  factory WhatsNewGetResponseApplicationJson_Ocs([
-    final void Function(WhatsNewGetResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$WhatsNewGetResponseApplicationJson_Ocs;
+  factory WhatsNewGetResponseApplicationJson_Ocs([void Function(WhatsNewGetResponseApplicationJson_OcsBuilder)? b]) =
+      _$WhatsNewGetResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const WhatsNewGetResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WhatsNewGetResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory WhatsNewGetResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10617,7 +10572,7 @@ abstract class WhatsNewGetResponseApplicationJson
     implements
         $WhatsNewGetResponseApplicationJsonInterface,
         Built<WhatsNewGetResponseApplicationJson, WhatsNewGetResponseApplicationJsonBuilder> {
-  factory WhatsNewGetResponseApplicationJson([final void Function(WhatsNewGetResponseApplicationJsonBuilder)? b]) =
+  factory WhatsNewGetResponseApplicationJson([void Function(WhatsNewGetResponseApplicationJsonBuilder)? b]) =
       _$WhatsNewGetResponseApplicationJson;
 
   // coverage:ignore-start
@@ -10625,7 +10580,7 @@ abstract class WhatsNewGetResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WhatsNewGetResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory WhatsNewGetResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10648,7 +10603,7 @@ abstract class WhatsNewDismissResponseApplicationJson_Ocs
         $WhatsNewDismissResponseApplicationJson_OcsInterface,
         Built<WhatsNewDismissResponseApplicationJson_Ocs, WhatsNewDismissResponseApplicationJson_OcsBuilder> {
   factory WhatsNewDismissResponseApplicationJson_Ocs([
-    final void Function(WhatsNewDismissResponseApplicationJson_OcsBuilder)? b,
+    void Function(WhatsNewDismissResponseApplicationJson_OcsBuilder)? b,
   ]) = _$WhatsNewDismissResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -10656,7 +10611,7 @@ abstract class WhatsNewDismissResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WhatsNewDismissResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory WhatsNewDismissResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10677,16 +10632,15 @@ abstract class WhatsNewDismissResponseApplicationJson
     implements
         $WhatsNewDismissResponseApplicationJsonInterface,
         Built<WhatsNewDismissResponseApplicationJson, WhatsNewDismissResponseApplicationJsonBuilder> {
-  factory WhatsNewDismissResponseApplicationJson([
-    final void Function(WhatsNewDismissResponseApplicationJsonBuilder)? b,
-  ]) = _$WhatsNewDismissResponseApplicationJson;
+  factory WhatsNewDismissResponseApplicationJson([void Function(WhatsNewDismissResponseApplicationJsonBuilder)? b]) =
+      _$WhatsNewDismissResponseApplicationJson;
 
   // coverage:ignore-start
   const WhatsNewDismissResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WhatsNewDismissResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory WhatsNewDismissResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10707,7 +10661,7 @@ abstract class WipeCheckWipeResponseApplicationJson
     implements
         $WipeCheckWipeResponseApplicationJsonInterface,
         Built<WipeCheckWipeResponseApplicationJson, WipeCheckWipeResponseApplicationJsonBuilder> {
-  factory WipeCheckWipeResponseApplicationJson([final void Function(WipeCheckWipeResponseApplicationJsonBuilder)? b]) =
+  factory WipeCheckWipeResponseApplicationJson([void Function(WipeCheckWipeResponseApplicationJsonBuilder)? b]) =
       _$WipeCheckWipeResponseApplicationJson;
 
   // coverage:ignore-start
@@ -10715,7 +10669,7 @@ abstract class WipeCheckWipeResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WipeCheckWipeResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory WipeCheckWipeResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -10770,8 +10724,7 @@ extension $AutocompleteResultStatus0StringExtension on $AutocompleteResultStatus
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$AutocompleteResultStatus0String> get serializer =>
       const _$AutocompleteResultStatus0StringSerializer();
-  static $AutocompleteResultStatus0String fromJson(final Object? json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  static $AutocompleteResultStatus0String fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -10786,9 +10739,9 @@ class _$AutocompleteResultStatus0StringSerializer implements PrimitiveSerializer
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $AutocompleteResultStatus0String object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $AutocompleteResultStatus0String object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.autocompleteResultStatus0;
@@ -10805,9 +10758,9 @@ class _$AutocompleteResultStatus0StringSerializer implements PrimitiveSerializer
 
   @override
   $AutocompleteResultStatus0String deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     AutocompleteResult_Status0? autocompleteResultStatus0;
     try {
@@ -10831,7 +10784,7 @@ extension $IntStringExtension on $IntString {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$IntString> get serializer => const _$IntStringSerializer();
-  static $IntString fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $IntString fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -10846,9 +10799,9 @@ class _$IntStringSerializer implements PrimitiveSerializer<$IntString> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $IntString object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $IntString object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.$int;
@@ -10865,9 +10818,9 @@ class _$IntStringSerializer implements PrimitiveSerializer<$IntString> {
 
   @override
   $IntString deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     int? $int;
     try {
@@ -10892,7 +10845,7 @@ extension $BuiltListSharebymailCapabilities0Extension on $BuiltListSharebymailCa
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BuiltListSharebymailCapabilities0> get serializer =>
       const _$BuiltListSharebymailCapabilities0Serializer();
-  static $BuiltListSharebymailCapabilities0 fromJson(final Object? json) =>
+  static $BuiltListSharebymailCapabilities0 fromJson(Object? json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
@@ -10908,9 +10861,9 @@ class _$BuiltListSharebymailCapabilities0Serializer implements PrimitiveSerializ
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BuiltListSharebymailCapabilities0 object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BuiltListSharebymailCapabilities0 object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.builtListNever;
@@ -10927,9 +10880,9 @@ class _$BuiltListSharebymailCapabilities0Serializer implements PrimitiveSerializ
 
   @override
   $BuiltListSharebymailCapabilities0 deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BuiltList<Never>? builtListNever;
     try {
@@ -10956,7 +10909,7 @@ extension $BuiltListSpreedPublicCapabilities0Extension on $BuiltListSpreedPublic
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BuiltListSpreedPublicCapabilities0> get serializer =>
       const _$BuiltListSpreedPublicCapabilities0Serializer();
-  static $BuiltListSpreedPublicCapabilities0 fromJson(final Object? json) =>
+  static $BuiltListSpreedPublicCapabilities0 fromJson(Object? json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
@@ -10973,9 +10926,9 @@ class _$BuiltListSpreedPublicCapabilities0Serializer
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BuiltListSpreedPublicCapabilities0 object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BuiltListSpreedPublicCapabilities0 object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.builtListNever;
@@ -10992,9 +10945,9 @@ class _$BuiltListSpreedPublicCapabilities0Serializer
 
   @override
   $BuiltListSpreedPublicCapabilities0 deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BuiltList<Never>? builtListNever;
     try {
@@ -11055,7 +11008,7 @@ extension $CommentsCapabilitiesDavCapabilitiesFilesCapabilitiesFilesSharingCapab
       get serializer =>
           const _$CommentsCapabilitiesDavCapabilitiesFilesCapabilitiesFilesSharingCapabilitiesFilesTrashbinCapabilitiesFilesVersionsCapabilitiesNotesCapabilitiesNotificationsCapabilitiesProvisioningApiCapabilitiesSharebymailCapabilitiesSpreedPublicCapabilitiesThemingPublicCapabilitiesUserStatusCapabilitiesWeatherStatusCapabilitiesSerializer();
   static $CommentsCapabilitiesDavCapabilitiesFilesCapabilitiesFilesSharingCapabilitiesFilesTrashbinCapabilitiesFilesVersionsCapabilitiesNotesCapabilitiesNotificationsCapabilitiesProvisioningApiCapabilitiesSharebymailCapabilitiesSpreedPublicCapabilitiesThemingPublicCapabilitiesUserStatusCapabilitiesWeatherStatusCapabilities
-      fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+      fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -11076,10 +11029,10 @@ class _$CommentsCapabilitiesDavCapabilitiesFilesCapabilitiesFilesSharingCapabili
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $CommentsCapabilitiesDavCapabilitiesFilesCapabilitiesFilesSharingCapabilitiesFilesTrashbinCapabilitiesFilesVersionsCapabilitiesNotesCapabilitiesNotificationsCapabilitiesProvisioningApiCapabilitiesSharebymailCapabilitiesSpreedPublicCapabilitiesThemingPublicCapabilitiesUserStatusCapabilitiesWeatherStatusCapabilities
+    Serializers serializers,
+    $CommentsCapabilitiesDavCapabilitiesFilesCapabilitiesFilesSharingCapabilitiesFilesTrashbinCapabilitiesFilesVersionsCapabilitiesNotesCapabilitiesNotificationsCapabilitiesProvisioningApiCapabilitiesSharebymailCapabilitiesSpreedPublicCapabilitiesThemingPublicCapabilitiesUserStatusCapabilitiesWeatherStatusCapabilities
         object, {
-    final FullType specifiedType = FullType.unspecified,
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.commentsCapabilities;
@@ -11145,9 +11098,9 @@ class _$CommentsCapabilitiesDavCapabilitiesFilesCapabilitiesFilesSharingCapabili
   @override
   $CommentsCapabilitiesDavCapabilitiesFilesCapabilitiesFilesSharingCapabilitiesFilesTrashbinCapabilitiesFilesVersionsCapabilitiesNotesCapabilitiesNotificationsCapabilitiesProvisioningApiCapabilitiesSharebymailCapabilitiesSpreedPublicCapabilitiesThemingPublicCapabilitiesUserStatusCapabilitiesWeatherStatusCapabilities
       deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     CommentsCapabilities? commentsCapabilities;
     try {

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.dart
@@ -29,7 +29,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -60,7 +60,7 @@ class DashboardApiClient {
   /// See:
   ///  * [getWidgetsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<DashboardApiGetWidgetsResponseApplicationJson, void>> getWidgets({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getWidgetsRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -85,7 +85,7 @@ class DashboardApiClient {
   /// See:
   ///  * [getWidgets] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<DashboardApiGetWidgetsResponseApplicationJson, void> getWidgetsRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<DashboardApiGetWidgetsResponseApplicationJson, void> getWidgetsRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -94,7 +94,7 @@ class DashboardApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -145,10 +145,10 @@ class DashboardApiClient {
   /// See:
   ///  * [getWidgetItemsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<DashboardApiGetWidgetItemsResponseApplicationJson, void>> getWidgetItems({
-    final ContentString<BuiltMap<String, String>>? sinceIds,
-    final int? limit,
-    final BuiltList<String>? widgets,
-    final bool? oCSAPIRequest,
+    ContentString<BuiltMap<String, String>>? sinceIds,
+    int? limit,
+    BuiltList<String>? widgets,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getWidgetItemsRaw(
       sinceIds: sinceIds,
@@ -180,10 +180,10 @@ class DashboardApiClient {
   ///  * [getWidgetItems] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DashboardApiGetWidgetItemsResponseApplicationJson, void> getWidgetItemsRaw({
-    final ContentString<BuiltMap<String, String>>? sinceIds,
-    final int? limit,
-    final BuiltList<String>? widgets,
-    final bool? oCSAPIRequest,
+    ContentString<BuiltMap<String, String>>? sinceIds,
+    int? limit,
+    BuiltList<String>? widgets,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -193,7 +193,7 @@ class DashboardApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -265,10 +265,10 @@ class DashboardApiClient {
   /// See:
   ///  * [getWidgetItemsV2Raw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<DashboardApiGetWidgetItemsV2ResponseApplicationJson, void>> getWidgetItemsV2({
-    final ContentString<BuiltMap<String, String>>? sinceIds,
-    final int? limit,
-    final BuiltList<String>? widgets,
-    final bool? oCSAPIRequest,
+    ContentString<BuiltMap<String, String>>? sinceIds,
+    int? limit,
+    BuiltList<String>? widgets,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getWidgetItemsV2Raw(
       sinceIds: sinceIds,
@@ -302,10 +302,10 @@ class DashboardApiClient {
   ///  * [getWidgetItemsV2] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DashboardApiGetWidgetItemsV2ResponseApplicationJson, void> getWidgetItemsV2Raw({
-    final ContentString<BuiltMap<String, String>>? sinceIds,
-    final int? limit,
-    final BuiltList<String>? widgets,
-    final bool? oCSAPIRequest,
+    ContentString<BuiltMap<String, String>>? sinceIds,
+    int? limit,
+    BuiltList<String>? widgets,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -315,7 +315,7 @@ class DashboardApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -379,14 +379,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -404,15 +404,14 @@ abstract interface class $Widget_ButtonsInterface {
 }
 
 abstract class Widget_Buttons implements $Widget_ButtonsInterface, Built<Widget_Buttons, Widget_ButtonsBuilder> {
-  factory Widget_Buttons([final void Function(Widget_ButtonsBuilder)? b]) = _$Widget_Buttons;
+  factory Widget_Buttons([void Function(Widget_ButtonsBuilder)? b]) = _$Widget_Buttons;
 
   // coverage:ignore-start
   const Widget_Buttons._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Widget_Buttons.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory Widget_Buttons.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -443,14 +442,14 @@ abstract interface class $WidgetInterface {
 }
 
 abstract class Widget implements $WidgetInterface, Built<Widget, WidgetBuilder> {
-  factory Widget([final void Function(WidgetBuilder)? b]) = _$Widget;
+  factory Widget([void Function(WidgetBuilder)? b]) = _$Widget;
 
   // coverage:ignore-start
   const Widget._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Widget.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Widget.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -472,7 +471,7 @@ abstract class DashboardApiGetWidgetsResponseApplicationJson_Ocs
         Built<DashboardApiGetWidgetsResponseApplicationJson_Ocs,
             DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder> {
   factory DashboardApiGetWidgetsResponseApplicationJson_Ocs([
-    final void Function(DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder)? b,
+    void Function(DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$DashboardApiGetWidgetsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -480,7 +479,7 @@ abstract class DashboardApiGetWidgetsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DashboardApiGetWidgetsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory DashboardApiGetWidgetsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -502,7 +501,7 @@ abstract class DashboardApiGetWidgetsResponseApplicationJson
         $DashboardApiGetWidgetsResponseApplicationJsonInterface,
         Built<DashboardApiGetWidgetsResponseApplicationJson, DashboardApiGetWidgetsResponseApplicationJsonBuilder> {
   factory DashboardApiGetWidgetsResponseApplicationJson([
-    final void Function(DashboardApiGetWidgetsResponseApplicationJsonBuilder)? b,
+    void Function(DashboardApiGetWidgetsResponseApplicationJsonBuilder)? b,
   ]) = _$DashboardApiGetWidgetsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -510,7 +509,7 @@ abstract class DashboardApiGetWidgetsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DashboardApiGetWidgetsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DashboardApiGetWidgetsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -533,14 +532,14 @@ abstract interface class $WidgetItemInterface {
 }
 
 abstract class WidgetItem implements $WidgetItemInterface, Built<WidgetItem, WidgetItemBuilder> {
-  factory WidgetItem([final void Function(WidgetItemBuilder)? b]) = _$WidgetItem;
+  factory WidgetItem([void Function(WidgetItemBuilder)? b]) = _$WidgetItem;
 
   // coverage:ignore-start
   const WidgetItem._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WidgetItem.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory WidgetItem.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -562,7 +561,7 @@ abstract class DashboardApiGetWidgetItemsResponseApplicationJson_Ocs
         Built<DashboardApiGetWidgetItemsResponseApplicationJson_Ocs,
             DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder> {
   factory DashboardApiGetWidgetItemsResponseApplicationJson_Ocs([
-    final void Function(DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder)? b,
+    void Function(DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$DashboardApiGetWidgetItemsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -570,7 +569,7 @@ abstract class DashboardApiGetWidgetItemsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DashboardApiGetWidgetItemsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory DashboardApiGetWidgetItemsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -593,7 +592,7 @@ abstract class DashboardApiGetWidgetItemsResponseApplicationJson
         Built<DashboardApiGetWidgetItemsResponseApplicationJson,
             DashboardApiGetWidgetItemsResponseApplicationJsonBuilder> {
   factory DashboardApiGetWidgetItemsResponseApplicationJson([
-    final void Function(DashboardApiGetWidgetItemsResponseApplicationJsonBuilder)? b,
+    void Function(DashboardApiGetWidgetItemsResponseApplicationJsonBuilder)? b,
   ]) = _$DashboardApiGetWidgetItemsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -601,7 +600,7 @@ abstract class DashboardApiGetWidgetItemsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DashboardApiGetWidgetItemsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DashboardApiGetWidgetItemsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -621,14 +620,14 @@ abstract interface class $WidgetItemsInterface {
 }
 
 abstract class WidgetItems implements $WidgetItemsInterface, Built<WidgetItems, WidgetItemsBuilder> {
-  factory WidgetItems([final void Function(WidgetItemsBuilder)? b]) = _$WidgetItems;
+  factory WidgetItems([void Function(WidgetItemsBuilder)? b]) = _$WidgetItems;
 
   // coverage:ignore-start
   const WidgetItems._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WidgetItems.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory WidgetItems.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -650,7 +649,7 @@ abstract class DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs
         Built<DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs,
             DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder> {
   factory DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs([
-    final void Function(DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder)? b,
+    void Function(DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder)? b,
   ]) = _$DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -658,7 +657,7 @@ abstract class DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -681,7 +680,7 @@ abstract class DashboardApiGetWidgetItemsV2ResponseApplicationJson
         Built<DashboardApiGetWidgetItemsV2ResponseApplicationJson,
             DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder> {
   factory DashboardApiGetWidgetItemsV2ResponseApplicationJson([
-    final void Function(DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder)? b,
+    void Function(DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder)? b,
   ]) = _$DashboardApiGetWidgetItemsV2ResponseApplicationJson;
 
   // coverage:ignore-start
@@ -689,7 +688,7 @@ abstract class DashboardApiGetWidgetItemsV2ResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DashboardApiGetWidgetItemsV2ResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DashboardApiGetWidgetItemsV2ResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -27,7 +27,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -63,9 +63,9 @@ class DirectClient {
   /// See:
   ///  * [getUrlRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<DirectGetUrlResponseApplicationJson, void>> getUrl({
-    required final int fileId,
-    final int? expirationTime,
-    final bool? oCSAPIRequest,
+    required int fileId,
+    int? expirationTime,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getUrlRaw(
       fileId: fileId,
@@ -98,9 +98,9 @@ class DirectClient {
   ///  * [getUrl] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DirectGetUrlResponseApplicationJson, void> getUrlRaw({
-    required final int fileId,
-    final int? expirationTime,
-    final bool? oCSAPIRequest,
+    required int fileId,
+    int? expirationTime,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -110,7 +110,7 @@ class DirectClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -162,14 +162,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -189,7 +189,7 @@ abstract class DirectGetUrlResponseApplicationJson_Ocs_Data
         $DirectGetUrlResponseApplicationJson_Ocs_DataInterface,
         Built<DirectGetUrlResponseApplicationJson_Ocs_Data, DirectGetUrlResponseApplicationJson_Ocs_DataBuilder> {
   factory DirectGetUrlResponseApplicationJson_Ocs_Data([
-    final void Function(DirectGetUrlResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(DirectGetUrlResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$DirectGetUrlResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -197,7 +197,7 @@ abstract class DirectGetUrlResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectGetUrlResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory DirectGetUrlResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -219,16 +219,15 @@ abstract class DirectGetUrlResponseApplicationJson_Ocs
     implements
         $DirectGetUrlResponseApplicationJson_OcsInterface,
         Built<DirectGetUrlResponseApplicationJson_Ocs, DirectGetUrlResponseApplicationJson_OcsBuilder> {
-  factory DirectGetUrlResponseApplicationJson_Ocs([
-    final void Function(DirectGetUrlResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$DirectGetUrlResponseApplicationJson_Ocs;
+  factory DirectGetUrlResponseApplicationJson_Ocs([void Function(DirectGetUrlResponseApplicationJson_OcsBuilder)? b]) =
+      _$DirectGetUrlResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const DirectGetUrlResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectGetUrlResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory DirectGetUrlResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -249,7 +248,7 @@ abstract class DirectGetUrlResponseApplicationJson
     implements
         $DirectGetUrlResponseApplicationJsonInterface,
         Built<DirectGetUrlResponseApplicationJson, DirectGetUrlResponseApplicationJsonBuilder> {
-  factory DirectGetUrlResponseApplicationJson([final void Function(DirectGetUrlResponseApplicationJsonBuilder)? b]) =
+  factory DirectGetUrlResponseApplicationJson([void Function(DirectGetUrlResponseApplicationJsonBuilder)? b]) =
       _$DirectGetUrlResponseApplicationJson;
 
   // coverage:ignore-start
@@ -257,7 +256,7 @@ abstract class DirectGetUrlResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectGetUrlResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DirectGetUrlResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -277,15 +276,14 @@ abstract interface class $Capabilities_DavInterface {
 
 abstract class Capabilities_Dav
     implements $Capabilities_DavInterface, Built<Capabilities_Dav, Capabilities_DavBuilder> {
-  factory Capabilities_Dav([final void Function(Capabilities_DavBuilder)? b]) = _$Capabilities_Dav;
+  factory Capabilities_Dav([void Function(Capabilities_DavBuilder)? b]) = _$Capabilities_Dav;
 
   // coverage:ignore-start
   const Capabilities_Dav._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_Dav.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities_Dav.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -301,14 +299,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -30,7 +30,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -73,9 +73,9 @@ class ApiClient {
   /// See:
   ///  * [getThumbnailRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getThumbnail({
-    required final int x,
-    required final int y,
-    required final String file,
+    required int x,
+    required int y,
+    required String file,
   }) async {
     final rawResponse = getThumbnailRaw(
       x: x,
@@ -107,9 +107,9 @@ class ApiClient {
   ///  * [getThumbnail] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getThumbnailRaw({
-    required final int x,
-    required final int y,
-    required final String file,
+    required int x,
+    required int y,
+    required String file,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -119,7 +119,7 @@ class ApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -178,7 +178,7 @@ class DirectEditingClient {
   ///
   /// See:
   ///  * [infoRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<DirectEditingInfoResponseApplicationJson, void>> info({final bool? oCSAPIRequest}) async {
+  Future<DynamiteResponse<DirectEditingInfoResponseApplicationJson, void>> info({bool? oCSAPIRequest}) async {
     final rawResponse = infoRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -202,7 +202,7 @@ class DirectEditingClient {
   /// See:
   ///  * [info] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<DirectEditingInfoResponseApplicationJson, void> infoRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<DirectEditingInfoResponseApplicationJson, void> infoRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -211,7 +211,7 @@ class DirectEditingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -262,9 +262,9 @@ class DirectEditingClient {
   /// See:
   ///  * [templatesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<DirectEditingTemplatesResponseApplicationJson, void>> templates({
-    required final String editorId,
-    required final String creatorId,
-    final bool? oCSAPIRequest,
+    required String editorId,
+    required String creatorId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = templatesRaw(
       editorId: editorId,
@@ -295,9 +295,9 @@ class DirectEditingClient {
   ///  * [templates] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DirectEditingTemplatesResponseApplicationJson, void> templatesRaw({
-    required final String editorId,
-    required final String creatorId,
-    final bool? oCSAPIRequest,
+    required String editorId,
+    required String creatorId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -307,7 +307,7 @@ class DirectEditingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -368,10 +368,10 @@ class DirectEditingClient {
   /// See:
   ///  * [openRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<DirectEditingOpenResponseApplicationJson, void>> open({
-    required final String path,
-    final String? editorId,
-    final int? fileId,
-    final bool? oCSAPIRequest,
+    required String path,
+    String? editorId,
+    int? fileId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = openRaw(
       path: path,
@@ -405,10 +405,10 @@ class DirectEditingClient {
   ///  * [open] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DirectEditingOpenResponseApplicationJson, void> openRaw({
-    required final String path,
-    final String? editorId,
-    final int? fileId,
-    final bool? oCSAPIRequest,
+    required String path,
+    String? editorId,
+    int? fileId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -418,7 +418,7 @@ class DirectEditingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -483,11 +483,11 @@ class DirectEditingClient {
   /// See:
   ///  * [createRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<DirectEditingCreateResponseApplicationJson, void>> create({
-    required final String path,
-    required final String editorId,
-    required final String creatorId,
-    final String? templateId,
-    final bool? oCSAPIRequest,
+    required String path,
+    required String editorId,
+    required String creatorId,
+    String? templateId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = createRaw(
       path: path,
@@ -523,11 +523,11 @@ class DirectEditingClient {
   ///  * [create] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DirectEditingCreateResponseApplicationJson, void> createRaw({
-    required final String path,
-    required final String editorId,
-    required final String creatorId,
-    final String? templateId,
-    final bool? oCSAPIRequest,
+    required String path,
+    required String editorId,
+    required String creatorId,
+    String? templateId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -537,7 +537,7 @@ class DirectEditingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -608,8 +608,8 @@ class OpenLocalEditorClient {
   /// See:
   ///  * [createRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<OpenLocalEditorCreateResponseApplicationJson, void>> create({
-    required final String path,
-    final bool? oCSAPIRequest,
+    required String path,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = createRaw(
       path: path,
@@ -638,8 +638,8 @@ class OpenLocalEditorClient {
   ///  * [create] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<OpenLocalEditorCreateResponseApplicationJson, void> createRaw({
-    required final String path,
-    final bool? oCSAPIRequest,
+    required String path,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -649,7 +649,7 @@ class OpenLocalEditorClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -703,9 +703,9 @@ class OpenLocalEditorClient {
   /// See:
   ///  * [validateRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<OpenLocalEditorValidateResponseApplicationJson, void>> validate({
-    required final String path,
-    required final String token,
-    final bool? oCSAPIRequest,
+    required String path,
+    required String token,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = validateRaw(
       path: path,
@@ -736,9 +736,9 @@ class OpenLocalEditorClient {
   ///  * [validate] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<OpenLocalEditorValidateResponseApplicationJson, void> validateRaw({
-    required final String path,
-    required final String token,
-    final bool? oCSAPIRequest,
+    required String path,
+    required String token,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -748,7 +748,7 @@ class OpenLocalEditorClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -808,7 +808,7 @@ class TemplateClient {
   ///
   /// See:
   ///  * [listRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<TemplateListResponseApplicationJson, void>> list({final bool? oCSAPIRequest}) async {
+  Future<DynamiteResponse<TemplateListResponseApplicationJson, void>> list({bool? oCSAPIRequest}) async {
     final rawResponse = listRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -832,7 +832,7 @@ class TemplateClient {
   /// See:
   ///  * [list] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<TemplateListResponseApplicationJson, void> listRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<TemplateListResponseApplicationJson, void> listRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -841,7 +841,7 @@ class TemplateClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -893,10 +893,10 @@ class TemplateClient {
   /// See:
   ///  * [createRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TemplateCreateResponseApplicationJson, void>> create({
-    required final String filePath,
-    final String? templatePath,
-    final String? templateType,
-    final bool? oCSAPIRequest,
+    required String filePath,
+    String? templatePath,
+    String? templateType,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = createRaw(
       filePath: filePath,
@@ -929,10 +929,10 @@ class TemplateClient {
   ///  * [create] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TemplateCreateResponseApplicationJson, void> createRaw({
-    required final String filePath,
-    final String? templatePath,
-    final String? templateType,
-    final bool? oCSAPIRequest,
+    required String filePath,
+    String? templatePath,
+    String? templateType,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -942,7 +942,7 @@ class TemplateClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1007,9 +1007,9 @@ class TemplateClient {
   /// See:
   ///  * [pathRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TemplatePathResponseApplicationJson, void>> path({
-    final String? templatePath,
-    final int? copySystemTemplates,
-    final bool? oCSAPIRequest,
+    String? templatePath,
+    int? copySystemTemplates,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = pathRaw(
       templatePath: templatePath,
@@ -1040,9 +1040,9 @@ class TemplateClient {
   ///  * [path] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TemplatePathResponseApplicationJson, void> pathRaw({
-    final String? templatePath,
-    final int? copySystemTemplates,
-    final bool? oCSAPIRequest,
+    String? templatePath,
+    int? copySystemTemplates,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1052,7 +1052,7 @@ class TemplateClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1121,9 +1121,9 @@ class TransferOwnershipClient {
   /// See:
   ///  * [transferRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TransferOwnershipTransferResponseApplicationJson, void>> transfer({
-    required final String recipient,
-    required final String path,
-    final bool? oCSAPIRequest,
+    required String recipient,
+    required String path,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = transferRaw(
       recipient: recipient,
@@ -1155,9 +1155,9 @@ class TransferOwnershipClient {
   ///  * [transfer] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TransferOwnershipTransferResponseApplicationJson, void> transferRaw({
-    required final String recipient,
-    required final String path,
-    final bool? oCSAPIRequest,
+    required String recipient,
+    required String path,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1167,7 +1167,7 @@ class TransferOwnershipClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1226,8 +1226,8 @@ class TransferOwnershipClient {
   /// See:
   ///  * [acceptRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TransferOwnershipAcceptResponseApplicationJson, void>> accept({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = acceptRaw(
       id: id,
@@ -1257,8 +1257,8 @@ class TransferOwnershipClient {
   ///  * [accept] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TransferOwnershipAcceptResponseApplicationJson, void> acceptRaw({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1268,7 +1268,7 @@ class TransferOwnershipClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1322,8 +1322,8 @@ class TransferOwnershipClient {
   /// See:
   ///  * [rejectRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TransferOwnershipRejectResponseApplicationJson, void>> reject({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = rejectRaw(
       id: id,
@@ -1353,8 +1353,8 @@ class TransferOwnershipClient {
   ///  * [reject] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<TransferOwnershipRejectResponseApplicationJson, void> rejectRaw({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1364,7 +1364,7 @@ class TransferOwnershipClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1412,14 +1412,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1444,7 +1444,7 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors
         Built<DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors,
             DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsBuilder> {
   factory DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors([
-    final void Function(DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsBuilder)? b,
+    void Function(DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsBuilder)? b,
   ]) = _$DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors;
 
   // coverage:ignore-start
@@ -1452,7 +1452,7 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1481,7 +1481,7 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators
         Built<DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators,
             DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsBuilder> {
   factory DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators([
-    final void Function(DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsBuilder)? b,
+    void Function(DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsBuilder)? b,
   ]) = _$DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators;
 
   // coverage:ignore-start
@@ -1489,7 +1489,7 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1513,7 +1513,7 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data
         Built<DirectEditingInfoResponseApplicationJson_Ocs_Data,
             DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder> {
   factory DirectEditingInfoResponseApplicationJson_Ocs_Data([
-    final void Function(DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$DirectEditingInfoResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -1521,7 +1521,7 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingInfoResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingInfoResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1544,7 +1544,7 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs
         $DirectEditingInfoResponseApplicationJson_OcsInterface,
         Built<DirectEditingInfoResponseApplicationJson_Ocs, DirectEditingInfoResponseApplicationJson_OcsBuilder> {
   factory DirectEditingInfoResponseApplicationJson_Ocs([
-    final void Function(DirectEditingInfoResponseApplicationJson_OcsBuilder)? b,
+    void Function(DirectEditingInfoResponseApplicationJson_OcsBuilder)? b,
   ]) = _$DirectEditingInfoResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1552,7 +1552,7 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingInfoResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingInfoResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1574,7 +1574,7 @@ abstract class DirectEditingInfoResponseApplicationJson
         $DirectEditingInfoResponseApplicationJsonInterface,
         Built<DirectEditingInfoResponseApplicationJson, DirectEditingInfoResponseApplicationJsonBuilder> {
   factory DirectEditingInfoResponseApplicationJson([
-    final void Function(DirectEditingInfoResponseApplicationJsonBuilder)? b,
+    void Function(DirectEditingInfoResponseApplicationJsonBuilder)? b,
   ]) = _$DirectEditingInfoResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1582,7 +1582,7 @@ abstract class DirectEditingInfoResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingInfoResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingInfoResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1610,7 +1610,7 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates
         Built<DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates,
             DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesBuilder> {
   factory DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates([
-    final void Function(DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesBuilder)? b,
+    void Function(DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesBuilder)? b,
   ]) = _$DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates;
 
   // coverage:ignore-start
@@ -1618,7 +1618,7 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1641,7 +1641,7 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs_Data
         Built<DirectEditingTemplatesResponseApplicationJson_Ocs_Data,
             DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder> {
   factory DirectEditingTemplatesResponseApplicationJson_Ocs_Data([
-    final void Function(DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$DirectEditingTemplatesResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -1649,7 +1649,7 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingTemplatesResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingTemplatesResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1673,7 +1673,7 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs
         Built<DirectEditingTemplatesResponseApplicationJson_Ocs,
             DirectEditingTemplatesResponseApplicationJson_OcsBuilder> {
   factory DirectEditingTemplatesResponseApplicationJson_Ocs([
-    final void Function(DirectEditingTemplatesResponseApplicationJson_OcsBuilder)? b,
+    void Function(DirectEditingTemplatesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$DirectEditingTemplatesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1681,7 +1681,7 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingTemplatesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingTemplatesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1703,7 +1703,7 @@ abstract class DirectEditingTemplatesResponseApplicationJson
         $DirectEditingTemplatesResponseApplicationJsonInterface,
         Built<DirectEditingTemplatesResponseApplicationJson, DirectEditingTemplatesResponseApplicationJsonBuilder> {
   factory DirectEditingTemplatesResponseApplicationJson([
-    final void Function(DirectEditingTemplatesResponseApplicationJsonBuilder)? b,
+    void Function(DirectEditingTemplatesResponseApplicationJsonBuilder)? b,
   ]) = _$DirectEditingTemplatesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1711,7 +1711,7 @@ abstract class DirectEditingTemplatesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingTemplatesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingTemplatesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1734,7 +1734,7 @@ abstract class DirectEditingOpenResponseApplicationJson_Ocs_Data
         Built<DirectEditingOpenResponseApplicationJson_Ocs_Data,
             DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder> {
   factory DirectEditingOpenResponseApplicationJson_Ocs_Data([
-    final void Function(DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$DirectEditingOpenResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -1742,7 +1742,7 @@ abstract class DirectEditingOpenResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingOpenResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingOpenResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1765,7 +1765,7 @@ abstract class DirectEditingOpenResponseApplicationJson_Ocs
         $DirectEditingOpenResponseApplicationJson_OcsInterface,
         Built<DirectEditingOpenResponseApplicationJson_Ocs, DirectEditingOpenResponseApplicationJson_OcsBuilder> {
   factory DirectEditingOpenResponseApplicationJson_Ocs([
-    final void Function(DirectEditingOpenResponseApplicationJson_OcsBuilder)? b,
+    void Function(DirectEditingOpenResponseApplicationJson_OcsBuilder)? b,
   ]) = _$DirectEditingOpenResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1773,7 +1773,7 @@ abstract class DirectEditingOpenResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingOpenResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingOpenResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1795,7 +1795,7 @@ abstract class DirectEditingOpenResponseApplicationJson
         $DirectEditingOpenResponseApplicationJsonInterface,
         Built<DirectEditingOpenResponseApplicationJson, DirectEditingOpenResponseApplicationJsonBuilder> {
   factory DirectEditingOpenResponseApplicationJson([
-    final void Function(DirectEditingOpenResponseApplicationJsonBuilder)? b,
+    void Function(DirectEditingOpenResponseApplicationJsonBuilder)? b,
   ]) = _$DirectEditingOpenResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1803,7 +1803,7 @@ abstract class DirectEditingOpenResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingOpenResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingOpenResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1826,7 +1826,7 @@ abstract class DirectEditingCreateResponseApplicationJson_Ocs_Data
         Built<DirectEditingCreateResponseApplicationJson_Ocs_Data,
             DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder> {
   factory DirectEditingCreateResponseApplicationJson_Ocs_Data([
-    final void Function(DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$DirectEditingCreateResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -1834,7 +1834,7 @@ abstract class DirectEditingCreateResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingCreateResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingCreateResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1857,7 +1857,7 @@ abstract class DirectEditingCreateResponseApplicationJson_Ocs
         $DirectEditingCreateResponseApplicationJson_OcsInterface,
         Built<DirectEditingCreateResponseApplicationJson_Ocs, DirectEditingCreateResponseApplicationJson_OcsBuilder> {
   factory DirectEditingCreateResponseApplicationJson_Ocs([
-    final void Function(DirectEditingCreateResponseApplicationJson_OcsBuilder)? b,
+    void Function(DirectEditingCreateResponseApplicationJson_OcsBuilder)? b,
   ]) = _$DirectEditingCreateResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1865,7 +1865,7 @@ abstract class DirectEditingCreateResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingCreateResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingCreateResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1887,7 +1887,7 @@ abstract class DirectEditingCreateResponseApplicationJson
         $DirectEditingCreateResponseApplicationJsonInterface,
         Built<DirectEditingCreateResponseApplicationJson, DirectEditingCreateResponseApplicationJsonBuilder> {
   factory DirectEditingCreateResponseApplicationJson([
-    final void Function(DirectEditingCreateResponseApplicationJsonBuilder)? b,
+    void Function(DirectEditingCreateResponseApplicationJsonBuilder)? b,
   ]) = _$DirectEditingCreateResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1895,7 +1895,7 @@ abstract class DirectEditingCreateResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DirectEditingCreateResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DirectEditingCreateResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1921,7 +1921,7 @@ abstract class OpenLocalEditorCreateResponseApplicationJson_Ocs_Data
         Built<OpenLocalEditorCreateResponseApplicationJson_Ocs_Data,
             OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder> {
   factory OpenLocalEditorCreateResponseApplicationJson_Ocs_Data([
-    final void Function(OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$OpenLocalEditorCreateResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -1929,7 +1929,7 @@ abstract class OpenLocalEditorCreateResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OpenLocalEditorCreateResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory OpenLocalEditorCreateResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1953,7 +1953,7 @@ abstract class OpenLocalEditorCreateResponseApplicationJson_Ocs
         Built<OpenLocalEditorCreateResponseApplicationJson_Ocs,
             OpenLocalEditorCreateResponseApplicationJson_OcsBuilder> {
   factory OpenLocalEditorCreateResponseApplicationJson_Ocs([
-    final void Function(OpenLocalEditorCreateResponseApplicationJson_OcsBuilder)? b,
+    void Function(OpenLocalEditorCreateResponseApplicationJson_OcsBuilder)? b,
   ]) = _$OpenLocalEditorCreateResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1961,7 +1961,7 @@ abstract class OpenLocalEditorCreateResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OpenLocalEditorCreateResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory OpenLocalEditorCreateResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1983,7 +1983,7 @@ abstract class OpenLocalEditorCreateResponseApplicationJson
         $OpenLocalEditorCreateResponseApplicationJsonInterface,
         Built<OpenLocalEditorCreateResponseApplicationJson, OpenLocalEditorCreateResponseApplicationJsonBuilder> {
   factory OpenLocalEditorCreateResponseApplicationJson([
-    final void Function(OpenLocalEditorCreateResponseApplicationJsonBuilder)? b,
+    void Function(OpenLocalEditorCreateResponseApplicationJsonBuilder)? b,
   ]) = _$OpenLocalEditorCreateResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1991,7 +1991,7 @@ abstract class OpenLocalEditorCreateResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OpenLocalEditorCreateResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory OpenLocalEditorCreateResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2017,7 +2017,7 @@ abstract class OpenLocalEditorValidateResponseApplicationJson_Ocs_Data
         Built<OpenLocalEditorValidateResponseApplicationJson_Ocs_Data,
             OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder> {
   factory OpenLocalEditorValidateResponseApplicationJson_Ocs_Data([
-    final void Function(OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$OpenLocalEditorValidateResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -2025,7 +2025,7 @@ abstract class OpenLocalEditorValidateResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OpenLocalEditorValidateResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory OpenLocalEditorValidateResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2049,7 +2049,7 @@ abstract class OpenLocalEditorValidateResponseApplicationJson_Ocs
         Built<OpenLocalEditorValidateResponseApplicationJson_Ocs,
             OpenLocalEditorValidateResponseApplicationJson_OcsBuilder> {
   factory OpenLocalEditorValidateResponseApplicationJson_Ocs([
-    final void Function(OpenLocalEditorValidateResponseApplicationJson_OcsBuilder)? b,
+    void Function(OpenLocalEditorValidateResponseApplicationJson_OcsBuilder)? b,
   ]) = _$OpenLocalEditorValidateResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2057,7 +2057,7 @@ abstract class OpenLocalEditorValidateResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OpenLocalEditorValidateResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory OpenLocalEditorValidateResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2079,7 +2079,7 @@ abstract class OpenLocalEditorValidateResponseApplicationJson
         $OpenLocalEditorValidateResponseApplicationJsonInterface,
         Built<OpenLocalEditorValidateResponseApplicationJson, OpenLocalEditorValidateResponseApplicationJsonBuilder> {
   factory OpenLocalEditorValidateResponseApplicationJson([
-    final void Function(OpenLocalEditorValidateResponseApplicationJsonBuilder)? b,
+    void Function(OpenLocalEditorValidateResponseApplicationJsonBuilder)? b,
   ]) = _$OpenLocalEditorValidateResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2087,7 +2087,7 @@ abstract class OpenLocalEditorValidateResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OpenLocalEditorValidateResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory OpenLocalEditorValidateResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2113,15 +2113,14 @@ abstract interface class $TemplateFileCreatorInterface {
 
 abstract class TemplateFileCreator
     implements $TemplateFileCreatorInterface, Built<TemplateFileCreator, TemplateFileCreatorBuilder> {
-  factory TemplateFileCreator([final void Function(TemplateFileCreatorBuilder)? b]) = _$TemplateFileCreator;
+  factory TemplateFileCreator([void Function(TemplateFileCreatorBuilder)? b]) = _$TemplateFileCreator;
 
   // coverage:ignore-start
   const TemplateFileCreator._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TemplateFileCreator.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory TemplateFileCreator.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -2141,16 +2140,15 @@ abstract class TemplateListResponseApplicationJson_Ocs
     implements
         $TemplateListResponseApplicationJson_OcsInterface,
         Built<TemplateListResponseApplicationJson_Ocs, TemplateListResponseApplicationJson_OcsBuilder> {
-  factory TemplateListResponseApplicationJson_Ocs([
-    final void Function(TemplateListResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$TemplateListResponseApplicationJson_Ocs;
+  factory TemplateListResponseApplicationJson_Ocs([void Function(TemplateListResponseApplicationJson_OcsBuilder)? b]) =
+      _$TemplateListResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const TemplateListResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TemplateListResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TemplateListResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2171,7 +2169,7 @@ abstract class TemplateListResponseApplicationJson
     implements
         $TemplateListResponseApplicationJsonInterface,
         Built<TemplateListResponseApplicationJson, TemplateListResponseApplicationJsonBuilder> {
-  factory TemplateListResponseApplicationJson([final void Function(TemplateListResponseApplicationJsonBuilder)? b]) =
+  factory TemplateListResponseApplicationJson([void Function(TemplateListResponseApplicationJsonBuilder)? b]) =
       _$TemplateListResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2179,7 +2177,7 @@ abstract class TemplateListResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TemplateListResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TemplateListResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2205,14 +2203,14 @@ abstract interface class $TemplateFileInterface {
 }
 
 abstract class TemplateFile implements $TemplateFileInterface, Built<TemplateFile, TemplateFileBuilder> {
-  factory TemplateFile([final void Function(TemplateFileBuilder)? b]) = _$TemplateFile;
+  factory TemplateFile([void Function(TemplateFileBuilder)? b]) = _$TemplateFile;
 
   // coverage:ignore-start
   const TemplateFile._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TemplateFile.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory TemplateFile.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -2233,7 +2231,7 @@ abstract class TemplateCreateResponseApplicationJson_Ocs
         $TemplateCreateResponseApplicationJson_OcsInterface,
         Built<TemplateCreateResponseApplicationJson_Ocs, TemplateCreateResponseApplicationJson_OcsBuilder> {
   factory TemplateCreateResponseApplicationJson_Ocs([
-    final void Function(TemplateCreateResponseApplicationJson_OcsBuilder)? b,
+    void Function(TemplateCreateResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TemplateCreateResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2241,7 +2239,7 @@ abstract class TemplateCreateResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TemplateCreateResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TemplateCreateResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2262,16 +2260,15 @@ abstract class TemplateCreateResponseApplicationJson
     implements
         $TemplateCreateResponseApplicationJsonInterface,
         Built<TemplateCreateResponseApplicationJson, TemplateCreateResponseApplicationJsonBuilder> {
-  factory TemplateCreateResponseApplicationJson([
-    final void Function(TemplateCreateResponseApplicationJsonBuilder)? b,
-  ]) = _$TemplateCreateResponseApplicationJson;
+  factory TemplateCreateResponseApplicationJson([void Function(TemplateCreateResponseApplicationJsonBuilder)? b]) =
+      _$TemplateCreateResponseApplicationJson;
 
   // coverage:ignore-start
   const TemplateCreateResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TemplateCreateResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TemplateCreateResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2295,7 +2292,7 @@ abstract class TemplatePathResponseApplicationJson_Ocs_Data
         $TemplatePathResponseApplicationJson_Ocs_DataInterface,
         Built<TemplatePathResponseApplicationJson_Ocs_Data, TemplatePathResponseApplicationJson_Ocs_DataBuilder> {
   factory TemplatePathResponseApplicationJson_Ocs_Data([
-    final void Function(TemplatePathResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(TemplatePathResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$TemplatePathResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -2303,7 +2300,7 @@ abstract class TemplatePathResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TemplatePathResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory TemplatePathResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2325,16 +2322,15 @@ abstract class TemplatePathResponseApplicationJson_Ocs
     implements
         $TemplatePathResponseApplicationJson_OcsInterface,
         Built<TemplatePathResponseApplicationJson_Ocs, TemplatePathResponseApplicationJson_OcsBuilder> {
-  factory TemplatePathResponseApplicationJson_Ocs([
-    final void Function(TemplatePathResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$TemplatePathResponseApplicationJson_Ocs;
+  factory TemplatePathResponseApplicationJson_Ocs([void Function(TemplatePathResponseApplicationJson_OcsBuilder)? b]) =
+      _$TemplatePathResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const TemplatePathResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TemplatePathResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TemplatePathResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2355,7 +2351,7 @@ abstract class TemplatePathResponseApplicationJson
     implements
         $TemplatePathResponseApplicationJsonInterface,
         Built<TemplatePathResponseApplicationJson, TemplatePathResponseApplicationJsonBuilder> {
-  factory TemplatePathResponseApplicationJson([final void Function(TemplatePathResponseApplicationJsonBuilder)? b]) =
+  factory TemplatePathResponseApplicationJson([void Function(TemplatePathResponseApplicationJsonBuilder)? b]) =
       _$TemplatePathResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2363,7 +2359,7 @@ abstract class TemplatePathResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TemplatePathResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TemplatePathResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2387,7 +2383,7 @@ abstract class TransferOwnershipTransferResponseApplicationJson_Ocs
         Built<TransferOwnershipTransferResponseApplicationJson_Ocs,
             TransferOwnershipTransferResponseApplicationJson_OcsBuilder> {
   factory TransferOwnershipTransferResponseApplicationJson_Ocs([
-    final void Function(TransferOwnershipTransferResponseApplicationJson_OcsBuilder)? b,
+    void Function(TransferOwnershipTransferResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TransferOwnershipTransferResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2395,7 +2391,7 @@ abstract class TransferOwnershipTransferResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TransferOwnershipTransferResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TransferOwnershipTransferResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2418,7 +2414,7 @@ abstract class TransferOwnershipTransferResponseApplicationJson
         Built<TransferOwnershipTransferResponseApplicationJson,
             TransferOwnershipTransferResponseApplicationJsonBuilder> {
   factory TransferOwnershipTransferResponseApplicationJson([
-    final void Function(TransferOwnershipTransferResponseApplicationJsonBuilder)? b,
+    void Function(TransferOwnershipTransferResponseApplicationJsonBuilder)? b,
   ]) = _$TransferOwnershipTransferResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2426,7 +2422,7 @@ abstract class TransferOwnershipTransferResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TransferOwnershipTransferResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TransferOwnershipTransferResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2450,7 +2446,7 @@ abstract class TransferOwnershipAcceptResponseApplicationJson_Ocs
         Built<TransferOwnershipAcceptResponseApplicationJson_Ocs,
             TransferOwnershipAcceptResponseApplicationJson_OcsBuilder> {
   factory TransferOwnershipAcceptResponseApplicationJson_Ocs([
-    final void Function(TransferOwnershipAcceptResponseApplicationJson_OcsBuilder)? b,
+    void Function(TransferOwnershipAcceptResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TransferOwnershipAcceptResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2458,7 +2454,7 @@ abstract class TransferOwnershipAcceptResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TransferOwnershipAcceptResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TransferOwnershipAcceptResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2480,7 +2476,7 @@ abstract class TransferOwnershipAcceptResponseApplicationJson
         $TransferOwnershipAcceptResponseApplicationJsonInterface,
         Built<TransferOwnershipAcceptResponseApplicationJson, TransferOwnershipAcceptResponseApplicationJsonBuilder> {
   factory TransferOwnershipAcceptResponseApplicationJson([
-    final void Function(TransferOwnershipAcceptResponseApplicationJsonBuilder)? b,
+    void Function(TransferOwnershipAcceptResponseApplicationJsonBuilder)? b,
   ]) = _$TransferOwnershipAcceptResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2488,7 +2484,7 @@ abstract class TransferOwnershipAcceptResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TransferOwnershipAcceptResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TransferOwnershipAcceptResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2512,7 +2508,7 @@ abstract class TransferOwnershipRejectResponseApplicationJson_Ocs
         Built<TransferOwnershipRejectResponseApplicationJson_Ocs,
             TransferOwnershipRejectResponseApplicationJson_OcsBuilder> {
   factory TransferOwnershipRejectResponseApplicationJson_Ocs([
-    final void Function(TransferOwnershipRejectResponseApplicationJson_OcsBuilder)? b,
+    void Function(TransferOwnershipRejectResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TransferOwnershipRejectResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2520,7 +2516,7 @@ abstract class TransferOwnershipRejectResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TransferOwnershipRejectResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TransferOwnershipRejectResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2542,7 +2538,7 @@ abstract class TransferOwnershipRejectResponseApplicationJson
         $TransferOwnershipRejectResponseApplicationJsonInterface,
         Built<TransferOwnershipRejectResponseApplicationJson, TransferOwnershipRejectResponseApplicationJsonBuilder> {
   factory TransferOwnershipRejectResponseApplicationJson([
-    final void Function(TransferOwnershipRejectResponseApplicationJsonBuilder)? b,
+    void Function(TransferOwnershipRejectResponseApplicationJsonBuilder)? b,
   ]) = _$TransferOwnershipRejectResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2550,7 +2546,7 @@ abstract class TransferOwnershipRejectResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TransferOwnershipRejectResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TransferOwnershipRejectResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2573,7 +2569,7 @@ abstract class Capabilities_Files_DirectEditing
     implements
         $Capabilities_Files_DirectEditingInterface,
         Built<Capabilities_Files_DirectEditing, Capabilities_Files_DirectEditingBuilder> {
-  factory Capabilities_Files_DirectEditing([final void Function(Capabilities_Files_DirectEditingBuilder)? b]) =
+  factory Capabilities_Files_DirectEditing([void Function(Capabilities_Files_DirectEditingBuilder)? b]) =
       _$Capabilities_Files_DirectEditing;
 
   // coverage:ignore-start
@@ -2581,7 +2577,7 @@ abstract class Capabilities_Files_DirectEditing
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_Files_DirectEditing.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_Files_DirectEditing.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2602,15 +2598,14 @@ abstract interface class $Capabilities_FilesInterface {
 
 abstract class Capabilities_Files
     implements $Capabilities_FilesInterface, Built<Capabilities_Files, Capabilities_FilesBuilder> {
-  factory Capabilities_Files([final void Function(Capabilities_FilesBuilder)? b]) = _$Capabilities_Files;
+  factory Capabilities_Files([void Function(Capabilities_FilesBuilder)? b]) = _$Capabilities_Files;
 
   // coverage:ignore-start
   const Capabilities_Files._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_Files.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities_Files.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -2626,14 +2621,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -2660,14 +2655,14 @@ abstract interface class $TemplateInterface {
 }
 
 abstract class Template implements $TemplateInterface, Built<Template, TemplateBuilder> {
-  factory Template([final void Function(TemplateBuilder)? b]) = _$Template;
+  factory Template([void Function(TemplateBuilder)? b]) = _$Template;
 
   // coverage:ignore-start
   const Template._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Template.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Template.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/files_external.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.dart
@@ -29,7 +29,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -59,9 +59,7 @@ class ApiClient {
   ///
   /// See:
   ///  * [getUserMountsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<ApiGetUserMountsResponseApplicationJson, void>> getUserMounts({
-    final bool? oCSAPIRequest,
-  }) async {
+  Future<DynamiteResponse<ApiGetUserMountsResponseApplicationJson, void>> getUserMounts({bool? oCSAPIRequest}) async {
     final rawResponse = getUserMountsRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -85,7 +83,7 @@ class ApiClient {
   /// See:
   ///  * [getUserMounts] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<ApiGetUserMountsResponseApplicationJson, void> getUserMountsRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<ApiGetUserMountsResponseApplicationJson, void> getUserMountsRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -94,7 +92,7 @@ class ApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -139,14 +137,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -165,7 +163,7 @@ class Mount_Type extends EnumClass {
   static BuiltSet<Mount_Type> get values => _$mountTypeValues;
   // coverage:ignore-end
 
-  static Mount_Type valueOf(final String name) => _$valueOfMount_Type(name);
+  static Mount_Type valueOf(String name) => _$valueOfMount_Type(name);
 
   static Serializer<Mount_Type> get serializer => _$mountTypeSerializer;
 }
@@ -181,7 +179,7 @@ class Mount_Scope extends EnumClass {
   static BuiltSet<Mount_Scope> get values => _$mountScopeValues;
   // coverage:ignore-end
 
-  static Mount_Scope valueOf(final String name) => _$valueOfMount_Scope(name);
+  static Mount_Scope valueOf(String name) => _$valueOfMount_Scope(name);
 
   static Serializer<Mount_Scope> get serializer => _$mountScopeSerializer;
 }
@@ -197,7 +195,7 @@ class StorageConfig_Type extends EnumClass {
   static BuiltSet<StorageConfig_Type> get values => _$storageConfigTypeValues;
   // coverage:ignore-end
 
-  static StorageConfig_Type valueOf(final String name) => _$valueOfStorageConfig_Type(name);
+  static StorageConfig_Type valueOf(String name) => _$valueOfStorageConfig_Type(name);
 
   static Serializer<StorageConfig_Type> get serializer => _$storageConfigTypeSerializer;
 }
@@ -220,14 +218,14 @@ abstract interface class $StorageConfigInterface {
 }
 
 abstract class StorageConfig implements $StorageConfigInterface, Built<StorageConfig, StorageConfigBuilder> {
-  factory StorageConfig([final void Function(StorageConfigBuilder)? b]) = _$StorageConfig;
+  factory StorageConfig([void Function(StorageConfigBuilder)? b]) = _$StorageConfig;
 
   // coverage:ignore-start
   const StorageConfig._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory StorageConfig.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory StorageConfig.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -252,14 +250,14 @@ abstract interface class $MountInterface {
 }
 
 abstract class Mount implements $MountInterface, Built<Mount, MountBuilder> {
-  factory Mount([final void Function(MountBuilder)? b]) = _$Mount;
+  factory Mount([void Function(MountBuilder)? b]) = _$Mount;
 
   // coverage:ignore-start
   const Mount._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Mount.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Mount.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -280,7 +278,7 @@ abstract class ApiGetUserMountsResponseApplicationJson_Ocs
         $ApiGetUserMountsResponseApplicationJson_OcsInterface,
         Built<ApiGetUserMountsResponseApplicationJson_Ocs, ApiGetUserMountsResponseApplicationJson_OcsBuilder> {
   factory ApiGetUserMountsResponseApplicationJson_Ocs([
-    final void Function(ApiGetUserMountsResponseApplicationJson_OcsBuilder)? b,
+    void Function(ApiGetUserMountsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ApiGetUserMountsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -288,7 +286,7 @@ abstract class ApiGetUserMountsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiGetUserMountsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ApiGetUserMountsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -309,16 +307,15 @@ abstract class ApiGetUserMountsResponseApplicationJson
     implements
         $ApiGetUserMountsResponseApplicationJsonInterface,
         Built<ApiGetUserMountsResponseApplicationJson, ApiGetUserMountsResponseApplicationJsonBuilder> {
-  factory ApiGetUserMountsResponseApplicationJson([
-    final void Function(ApiGetUserMountsResponseApplicationJsonBuilder)? b,
-  ]) = _$ApiGetUserMountsResponseApplicationJson;
+  factory ApiGetUserMountsResponseApplicationJson([void Function(ApiGetUserMountsResponseApplicationJsonBuilder)? b]) =
+      _$ApiGetUserMountsResponseApplicationJson;
 
   // coverage:ignore-start
   const ApiGetUserMountsResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiGetUserMountsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ApiGetUserMountsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
@@ -29,7 +29,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -63,9 +63,9 @@ class ApiClient {
   /// See:
   ///  * [$getRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ApiGetResponseApplicationJson, void>> $get({
-    required final String version,
-    required final int fileId,
-    final bool? oCSAPIRequest,
+    required String version,
+    required int fileId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = $getRaw(
       version: version,
@@ -96,9 +96,9 @@ class ApiClient {
   ///  * [$get] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ApiGetResponseApplicationJson, void> $getRaw({
-    required final String version,
-    required final int fileId,
-    final bool? oCSAPIRequest,
+    required String version,
+    required int fileId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -108,7 +108,7 @@ class ApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -170,10 +170,10 @@ class ApiClient {
   /// See:
   ///  * [$setRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ApiSetResponseApplicationJson, void>> $set({
-    required final String dueDate,
-    required final String version,
-    required final int fileId,
-    final bool? oCSAPIRequest,
+    required String dueDate,
+    required String version,
+    required int fileId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = $setRaw(
       dueDate: dueDate,
@@ -209,10 +209,10 @@ class ApiClient {
   ///  * [$set] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ApiSetResponseApplicationJson, void> $setRaw({
-    required final String dueDate,
-    required final String version,
-    required final int fileId,
-    final bool? oCSAPIRequest,
+    required String dueDate,
+    required String version,
+    required int fileId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -222,7 +222,7 @@ class ApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -286,9 +286,9 @@ class ApiClient {
   /// See:
   ///  * [removeRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ApiRemoveResponseApplicationJson, void>> remove({
-    required final String version,
-    required final int fileId,
-    final bool? oCSAPIRequest,
+    required String version,
+    required int fileId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = removeRaw(
       version: version,
@@ -320,9 +320,9 @@ class ApiClient {
   ///  * [remove] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ApiRemoveResponseApplicationJson, void> removeRaw({
-    required final String version,
-    required final int fileId,
-    final bool? oCSAPIRequest,
+    required String version,
+    required int fileId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -332,7 +332,7 @@ class ApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -384,14 +384,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -410,16 +410,15 @@ abstract class ApiGetResponseApplicationJson_Ocs_Data
     implements
         $ApiGetResponseApplicationJson_Ocs_DataInterface,
         Built<ApiGetResponseApplicationJson_Ocs_Data, ApiGetResponseApplicationJson_Ocs_DataBuilder> {
-  factory ApiGetResponseApplicationJson_Ocs_Data([
-    final void Function(ApiGetResponseApplicationJson_Ocs_DataBuilder)? b,
-  ]) = _$ApiGetResponseApplicationJson_Ocs_Data;
+  factory ApiGetResponseApplicationJson_Ocs_Data([void Function(ApiGetResponseApplicationJson_Ocs_DataBuilder)? b]) =
+      _$ApiGetResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
   const ApiGetResponseApplicationJson_Ocs_Data._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiGetResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory ApiGetResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -441,7 +440,7 @@ abstract class ApiGetResponseApplicationJson_Ocs
     implements
         $ApiGetResponseApplicationJson_OcsInterface,
         Built<ApiGetResponseApplicationJson_Ocs, ApiGetResponseApplicationJson_OcsBuilder> {
-  factory ApiGetResponseApplicationJson_Ocs([final void Function(ApiGetResponseApplicationJson_OcsBuilder)? b]) =
+  factory ApiGetResponseApplicationJson_Ocs([void Function(ApiGetResponseApplicationJson_OcsBuilder)? b]) =
       _$ApiGetResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -449,7 +448,7 @@ abstract class ApiGetResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiGetResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ApiGetResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -469,7 +468,7 @@ abstract class ApiGetResponseApplicationJson
     implements
         $ApiGetResponseApplicationJsonInterface,
         Built<ApiGetResponseApplicationJson, ApiGetResponseApplicationJsonBuilder> {
-  factory ApiGetResponseApplicationJson([final void Function(ApiGetResponseApplicationJsonBuilder)? b]) =
+  factory ApiGetResponseApplicationJson([void Function(ApiGetResponseApplicationJsonBuilder)? b]) =
       _$ApiGetResponseApplicationJson;
 
   // coverage:ignore-start
@@ -477,7 +476,7 @@ abstract class ApiGetResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiGetResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ApiGetResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -498,7 +497,7 @@ abstract class ApiSetResponseApplicationJson_Ocs
     implements
         $ApiSetResponseApplicationJson_OcsInterface,
         Built<ApiSetResponseApplicationJson_Ocs, ApiSetResponseApplicationJson_OcsBuilder> {
-  factory ApiSetResponseApplicationJson_Ocs([final void Function(ApiSetResponseApplicationJson_OcsBuilder)? b]) =
+  factory ApiSetResponseApplicationJson_Ocs([void Function(ApiSetResponseApplicationJson_OcsBuilder)? b]) =
       _$ApiSetResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -506,7 +505,7 @@ abstract class ApiSetResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiSetResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ApiSetResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -526,7 +525,7 @@ abstract class ApiSetResponseApplicationJson
     implements
         $ApiSetResponseApplicationJsonInterface,
         Built<ApiSetResponseApplicationJson, ApiSetResponseApplicationJsonBuilder> {
-  factory ApiSetResponseApplicationJson([final void Function(ApiSetResponseApplicationJsonBuilder)? b]) =
+  factory ApiSetResponseApplicationJson([void Function(ApiSetResponseApplicationJsonBuilder)? b]) =
       _$ApiSetResponseApplicationJson;
 
   // coverage:ignore-start
@@ -534,7 +533,7 @@ abstract class ApiSetResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiSetResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ApiSetResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -555,7 +554,7 @@ abstract class ApiRemoveResponseApplicationJson_Ocs
     implements
         $ApiRemoveResponseApplicationJson_OcsInterface,
         Built<ApiRemoveResponseApplicationJson_Ocs, ApiRemoveResponseApplicationJson_OcsBuilder> {
-  factory ApiRemoveResponseApplicationJson_Ocs([final void Function(ApiRemoveResponseApplicationJson_OcsBuilder)? b]) =
+  factory ApiRemoveResponseApplicationJson_Ocs([void Function(ApiRemoveResponseApplicationJson_OcsBuilder)? b]) =
       _$ApiRemoveResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -563,7 +562,7 @@ abstract class ApiRemoveResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiRemoveResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ApiRemoveResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -584,7 +583,7 @@ abstract class ApiRemoveResponseApplicationJson
     implements
         $ApiRemoveResponseApplicationJsonInterface,
         Built<ApiRemoveResponseApplicationJson, ApiRemoveResponseApplicationJsonBuilder> {
-  factory ApiRemoveResponseApplicationJson([final void Function(ApiRemoveResponseApplicationJsonBuilder)? b]) =
+  factory ApiRemoveResponseApplicationJson([void Function(ApiRemoveResponseApplicationJsonBuilder)? b]) =
       _$ApiRemoveResponseApplicationJson;
 
   // coverage:ignore-start
@@ -592,7 +591,7 @@ abstract class ApiRemoveResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiRemoveResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ApiRemoveResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -31,7 +31,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -71,7 +71,7 @@ class DeletedShareapiClient {
   ///
   /// See:
   ///  * [listRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<DeletedShareapiListResponseApplicationJson, void>> list({final bool? oCSAPIRequest}) async {
+  Future<DynamiteResponse<DeletedShareapiListResponseApplicationJson, void>> list({bool? oCSAPIRequest}) async {
     final rawResponse = listRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -95,7 +95,7 @@ class DeletedShareapiClient {
   /// See:
   ///  * [list] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<DeletedShareapiListResponseApplicationJson, void> listRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<DeletedShareapiListResponseApplicationJson, void> listRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -104,7 +104,7 @@ class DeletedShareapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -154,8 +154,8 @@ class DeletedShareapiClient {
   /// See:
   ///  * [undeleteRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<DeletedShareapiUndeleteResponseApplicationJson, void>> undelete({
-    required final String id,
-    final bool? oCSAPIRequest,
+    required String id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = undeleteRaw(
       id: id,
@@ -184,8 +184,8 @@ class DeletedShareapiClient {
   ///  * [undelete] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<DeletedShareapiUndeleteResponseApplicationJson, void> undeleteRaw({
-    required final String id,
-    final bool? oCSAPIRequest,
+    required String id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -195,7 +195,7 @@ class DeletedShareapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -256,8 +256,8 @@ class PublicPreviewClient {
   /// See:
   ///  * [directLinkRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> directLink({
-    required final String token,
-    final bool? oCSAPIRequest,
+    required String token,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = directLinkRaw(
       token: token,
@@ -288,8 +288,8 @@ class PublicPreviewClient {
   ///  * [directLink] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> directLinkRaw({
-    required final String token,
-    final bool? oCSAPIRequest,
+    required String token,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -299,7 +299,7 @@ class PublicPreviewClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -356,12 +356,12 @@ class PublicPreviewClient {
   /// See:
   ///  * [getPreviewRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getPreview({
-    required final String token,
-    final String? file,
-    final int? x,
-    final int? y,
-    final int? a,
-    final bool? oCSAPIRequest,
+    required String token,
+    String? file,
+    int? x,
+    int? y,
+    int? a,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getPreviewRaw(
       token: token,
@@ -400,12 +400,12 @@ class PublicPreviewClient {
   ///  * [getPreview] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getPreviewRaw({
-    required final String token,
-    final String? file,
-    final int? x,
-    final int? y,
-    final int? a,
-    final bool? oCSAPIRequest,
+    required String token,
+    String? file,
+    int? x,
+    int? y,
+    int? a,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -415,7 +415,7 @@ class PublicPreviewClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -487,7 +487,7 @@ class RemoteClient {
   ///
   /// See:
   ///  * [getSharesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<RemoteGetSharesResponseApplicationJson, void>> getShares({final bool? oCSAPIRequest}) async {
+  Future<DynamiteResponse<RemoteGetSharesResponseApplicationJson, void>> getShares({bool? oCSAPIRequest}) async {
     final rawResponse = getSharesRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -511,7 +511,7 @@ class RemoteClient {
   /// See:
   ///  * [getShares] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<RemoteGetSharesResponseApplicationJson, void> getSharesRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<RemoteGetSharesResponseApplicationJson, void> getSharesRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -520,7 +520,7 @@ class RemoteClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -568,7 +568,7 @@ class RemoteClient {
   /// See:
   ///  * [getOpenSharesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RemoteGetOpenSharesResponseApplicationJson, void>> getOpenShares({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getOpenSharesRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -593,7 +593,7 @@ class RemoteClient {
   /// See:
   ///  * [getOpenShares] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<RemoteGetOpenSharesResponseApplicationJson, void> getOpenSharesRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<RemoteGetOpenSharesResponseApplicationJson, void> getOpenSharesRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -602,7 +602,7 @@ class RemoteClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -653,8 +653,8 @@ class RemoteClient {
   /// See:
   ///  * [acceptShareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RemoteAcceptShareResponseApplicationJson, void>> acceptShare({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = acceptShareRaw(
       id: id,
@@ -683,8 +683,8 @@ class RemoteClient {
   ///  * [acceptShare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RemoteAcceptShareResponseApplicationJson, void> acceptShareRaw({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -694,7 +694,7 @@ class RemoteClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -748,8 +748,8 @@ class RemoteClient {
   /// See:
   ///  * [declineShareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RemoteDeclineShareResponseApplicationJson, void>> declineShare({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = declineShareRaw(
       id: id,
@@ -778,8 +778,8 @@ class RemoteClient {
   ///  * [declineShare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RemoteDeclineShareResponseApplicationJson, void> declineShareRaw({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -789,7 +789,7 @@ class RemoteClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -843,8 +843,8 @@ class RemoteClient {
   /// See:
   ///  * [getShareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RemoteGetShareResponseApplicationJson, void>> getShare({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getShareRaw(
       id: id,
@@ -873,8 +873,8 @@ class RemoteClient {
   ///  * [getShare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RemoteGetShareResponseApplicationJson, void> getShareRaw({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -884,7 +884,7 @@ class RemoteClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -938,8 +938,8 @@ class RemoteClient {
   /// See:
   ///  * [unshareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RemoteUnshareResponseApplicationJson, void>> unshare({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = unshareRaw(
       id: id,
@@ -969,8 +969,8 @@ class RemoteClient {
   ///  * [unshare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RemoteUnshareResponseApplicationJson, void> unshareRaw({
-    required final int id,
-    final bool? oCSAPIRequest,
+    required int id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -980,7 +980,7 @@ class RemoteClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1042,10 +1042,10 @@ class ShareInfoClient {
   /// See:
   ///  * [infoRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareInfo, void>> info({
-    required final String t,
-    final String? password,
-    final String? dir,
-    final int? depth,
+    required String t,
+    String? password,
+    String? dir,
+    int? depth,
   }) async {
     final rawResponse = infoRaw(
       t: t,
@@ -1079,10 +1079,10 @@ class ShareInfoClient {
   ///  * [info] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ShareInfo, void> infoRaw({
-    required final String t,
-    final String? password,
-    final String? dir,
-    final int? depth,
+    required String t,
+    String? password,
+    String? dir,
+    int? depth,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1092,7 +1092,7 @@ class ShareInfoClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1161,12 +1161,12 @@ class ShareapiClient {
   /// See:
   ///  * [getSharesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareapiGetSharesResponseApplicationJson, void>> getShares({
-    final String? sharedWithMe,
-    final String? reshares,
-    final String? subfiles,
-    final String? path,
-    final String? includeTags,
-    final bool? oCSAPIRequest,
+    String? sharedWithMe,
+    String? reshares,
+    String? subfiles,
+    String? path,
+    String? includeTags,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getSharesRaw(
       sharedWithMe: sharedWithMe,
@@ -1203,12 +1203,12 @@ class ShareapiClient {
   ///  * [getShares] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ShareapiGetSharesResponseApplicationJson, void> getSharesRaw({
-    final String? sharedWithMe,
-    final String? reshares,
-    final String? subfiles,
-    final String? path,
-    final String? includeTags,
-    final bool? oCSAPIRequest,
+    String? sharedWithMe,
+    String? reshares,
+    String? subfiles,
+    String? path,
+    String? includeTags,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1218,7 +1218,7 @@ class ShareapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1304,18 +1304,18 @@ class ShareapiClient {
   /// See:
   ///  * [createShareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareapiCreateShareResponseApplicationJson, void>> createShare({
-    final String? path,
-    final int? permissions,
-    final int? shareType,
-    final String? shareWith,
-    final String? publicUpload,
-    final String? password,
-    final String? sendPasswordByTalk,
-    final String? expireDate,
-    final String? note,
-    final String? label,
-    final String? attributes,
-    final bool? oCSAPIRequest,
+    String? path,
+    int? permissions,
+    int? shareType,
+    String? shareWith,
+    String? publicUpload,
+    String? password,
+    String? sendPasswordByTalk,
+    String? expireDate,
+    String? note,
+    String? label,
+    String? attributes,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = createShareRaw(
       path: path,
@@ -1366,18 +1366,18 @@ class ShareapiClient {
   ///  * [createShare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ShareapiCreateShareResponseApplicationJson, void> createShareRaw({
-    final String? path,
-    final int? permissions,
-    final int? shareType,
-    final String? shareWith,
-    final String? publicUpload,
-    final String? password,
-    final String? sendPasswordByTalk,
-    final String? expireDate,
-    final String? note,
-    final String? label,
-    final String? attributes,
-    final bool? oCSAPIRequest,
+    String? path,
+    int? permissions,
+    int? shareType,
+    String? shareWith,
+    String? publicUpload,
+    String? password,
+    String? sendPasswordByTalk,
+    String? expireDate,
+    String? note,
+    String? label,
+    String? attributes,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1387,7 +1387,7 @@ class ShareapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1481,8 +1481,8 @@ class ShareapiClient {
   /// See:
   ///  * [getInheritedSharesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareapiGetInheritedSharesResponseApplicationJson, void>> getInheritedShares({
-    required final String path,
-    final bool? oCSAPIRequest,
+    required String path,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getInheritedSharesRaw(
       path: path,
@@ -1512,8 +1512,8 @@ class ShareapiClient {
   ///  * [getInheritedShares] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ShareapiGetInheritedSharesResponseApplicationJson, void> getInheritedSharesRaw({
-    required final String path,
-    final bool? oCSAPIRequest,
+    required String path,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1523,7 +1523,7 @@ class ShareapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1575,7 +1575,7 @@ class ShareapiClient {
   /// See:
   ///  * [pendingSharesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareapiPendingSharesResponseApplicationJson, void>> pendingShares({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = pendingSharesRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -1600,9 +1600,7 @@ class ShareapiClient {
   /// See:
   ///  * [pendingShares] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<ShareapiPendingSharesResponseApplicationJson, void> pendingSharesRaw({
-    final bool? oCSAPIRequest,
-  }) {
+  DynamiteRawResponse<ShareapiPendingSharesResponseApplicationJson, void> pendingSharesRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -1611,7 +1609,7 @@ class ShareapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1662,9 +1660,9 @@ class ShareapiClient {
   /// See:
   ///  * [getShareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareapiGetShareResponseApplicationJson, void>> getShare({
-    required final String id,
-    final int? includeTags,
-    final bool? oCSAPIRequest,
+    required String id,
+    int? includeTags,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getShareRaw(
       id: id,
@@ -1695,9 +1693,9 @@ class ShareapiClient {
   ///  * [getShare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ShareapiGetShareResponseApplicationJson, void> getShareRaw({
-    required final String id,
-    final int? includeTags,
-    final bool? oCSAPIRequest,
+    required String id,
+    int? includeTags,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1707,7 +1705,7 @@ class ShareapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1776,17 +1774,17 @@ class ShareapiClient {
   /// See:
   ///  * [updateShareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareapiUpdateShareResponseApplicationJson, void>> updateShare({
-    required final String id,
-    final int? permissions,
-    final String? password,
-    final String? sendPasswordByTalk,
-    final String? publicUpload,
-    final String? expireDate,
-    final String? note,
-    final String? label,
-    final String? hideDownload,
-    final String? attributes,
-    final bool? oCSAPIRequest,
+    required String id,
+    int? permissions,
+    String? password,
+    String? sendPasswordByTalk,
+    String? publicUpload,
+    String? expireDate,
+    String? note,
+    String? label,
+    String? hideDownload,
+    String? attributes,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = updateShareRaw(
       id: id,
@@ -1835,17 +1833,17 @@ class ShareapiClient {
   ///  * [updateShare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ShareapiUpdateShareResponseApplicationJson, void> updateShareRaw({
-    required final String id,
-    final int? permissions,
-    final String? password,
-    final String? sendPasswordByTalk,
-    final String? publicUpload,
-    final String? expireDate,
-    final String? note,
-    final String? label,
-    final String? hideDownload,
-    final String? attributes,
-    final bool? oCSAPIRequest,
+    required String id,
+    int? permissions,
+    String? password,
+    String? sendPasswordByTalk,
+    String? publicUpload,
+    String? expireDate,
+    String? note,
+    String? label,
+    String? hideDownload,
+    String? attributes,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1855,7 +1853,7 @@ class ShareapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1940,8 +1938,8 @@ class ShareapiClient {
   /// See:
   ///  * [deleteShareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareapiDeleteShareResponseApplicationJson, void>> deleteShare({
-    required final String id,
-    final bool? oCSAPIRequest,
+    required String id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteShareRaw(
       id: id,
@@ -1971,8 +1969,8 @@ class ShareapiClient {
   ///  * [deleteShare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ShareapiDeleteShareResponseApplicationJson, void> deleteShareRaw({
-    required final String id,
-    final bool? oCSAPIRequest,
+    required String id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1982,7 +1980,7 @@ class ShareapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2036,8 +2034,8 @@ class ShareapiClient {
   /// See:
   ///  * [acceptShareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareapiAcceptShareResponseApplicationJson, void>> acceptShare({
-    required final String id,
-    final bool? oCSAPIRequest,
+    required String id,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = acceptShareRaw(
       id: id,
@@ -2067,8 +2065,8 @@ class ShareapiClient {
   ///  * [acceptShare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ShareapiAcceptShareResponseApplicationJson, void> acceptShareRaw({
-    required final String id,
-    final bool? oCSAPIRequest,
+    required String id,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2078,7 +2076,7 @@ class ShareapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2142,13 +2140,13 @@ class ShareesapiClient {
   /// See:
   ///  * [searchRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareesapiSearchResponseApplicationJson, ShareesapiShareesapiSearchHeaders>> search({
-    final String? search,
-    final String? itemType,
-    final int? page,
-    final int? perPage,
-    final ContentString<ShareesapiSearchShareType>? shareType,
-    final int? lookup,
-    final bool? oCSAPIRequest,
+    String? search,
+    String? itemType,
+    int? page,
+    int? perPage,
+    ContentString<ShareesapiSearchShareType>? shareType,
+    int? lookup,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = searchRaw(
       search: search,
@@ -2187,13 +2185,13 @@ class ShareesapiClient {
   ///  * [search] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ShareesapiSearchResponseApplicationJson, ShareesapiShareesapiSearchHeaders> searchRaw({
-    final String? search,
-    final String? itemType,
-    final int? page,
-    final int? perPage,
-    final ContentString<ShareesapiSearchShareType>? shareType,
-    final int? lookup,
-    final bool? oCSAPIRequest,
+    String? search,
+    String? itemType,
+    int? page,
+    int? perPage,
+    ContentString<ShareesapiSearchShareType>? shareType,
+    int? lookup,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2203,7 +2201,7 @@ class ShareesapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2282,9 +2280,9 @@ class ShareesapiClient {
   /// See:
   ///  * [findRecommendedRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ShareesapiFindRecommendedResponseApplicationJson, void>> findRecommended({
-    required final String itemType,
-    final ContentString<ShareesapiFindRecommendedShareType>? shareType,
-    final bool? oCSAPIRequest,
+    required String itemType,
+    ContentString<ShareesapiFindRecommendedShareType>? shareType,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = findRecommendedRaw(
       itemType: itemType,
@@ -2314,9 +2312,9 @@ class ShareesapiClient {
   ///  * [findRecommended] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ShareesapiFindRecommendedResponseApplicationJson, void> findRecommendedRaw({
-    required final String itemType,
-    final ContentString<ShareesapiFindRecommendedShareType>? shareType,
-    final bool? oCSAPIRequest,
+    required String itemType,
+    ContentString<ShareesapiFindRecommendedShareType>? shareType,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2326,7 +2324,7 @@ class ShareesapiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2383,14 +2381,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -2438,14 +2436,14 @@ abstract interface class $DeletedShareInterface {
 }
 
 abstract class DeletedShare implements $DeletedShareInterface, Built<DeletedShare, DeletedShareBuilder> {
-  factory DeletedShare([final void Function(DeletedShareBuilder)? b]) = _$DeletedShare;
+  factory DeletedShare([void Function(DeletedShareBuilder)? b]) = _$DeletedShare;
 
   // coverage:ignore-start
   const DeletedShare._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DeletedShare.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory DeletedShare.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -2466,7 +2464,7 @@ abstract class DeletedShareapiListResponseApplicationJson_Ocs
         $DeletedShareapiListResponseApplicationJson_OcsInterface,
         Built<DeletedShareapiListResponseApplicationJson_Ocs, DeletedShareapiListResponseApplicationJson_OcsBuilder> {
   factory DeletedShareapiListResponseApplicationJson_Ocs([
-    final void Function(DeletedShareapiListResponseApplicationJson_OcsBuilder)? b,
+    void Function(DeletedShareapiListResponseApplicationJson_OcsBuilder)? b,
   ]) = _$DeletedShareapiListResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2474,7 +2472,7 @@ abstract class DeletedShareapiListResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DeletedShareapiListResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory DeletedShareapiListResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2496,7 +2494,7 @@ abstract class DeletedShareapiListResponseApplicationJson
         $DeletedShareapiListResponseApplicationJsonInterface,
         Built<DeletedShareapiListResponseApplicationJson, DeletedShareapiListResponseApplicationJsonBuilder> {
   factory DeletedShareapiListResponseApplicationJson([
-    final void Function(DeletedShareapiListResponseApplicationJsonBuilder)? b,
+    void Function(DeletedShareapiListResponseApplicationJsonBuilder)? b,
   ]) = _$DeletedShareapiListResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2504,7 +2502,7 @@ abstract class DeletedShareapiListResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DeletedShareapiListResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DeletedShareapiListResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2528,7 +2526,7 @@ abstract class DeletedShareapiUndeleteResponseApplicationJson_Ocs
         Built<DeletedShareapiUndeleteResponseApplicationJson_Ocs,
             DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder> {
   factory DeletedShareapiUndeleteResponseApplicationJson_Ocs([
-    final void Function(DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder)? b,
+    void Function(DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder)? b,
   ]) = _$DeletedShareapiUndeleteResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2536,7 +2534,7 @@ abstract class DeletedShareapiUndeleteResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DeletedShareapiUndeleteResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory DeletedShareapiUndeleteResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2558,7 +2556,7 @@ abstract class DeletedShareapiUndeleteResponseApplicationJson
         $DeletedShareapiUndeleteResponseApplicationJsonInterface,
         Built<DeletedShareapiUndeleteResponseApplicationJson, DeletedShareapiUndeleteResponseApplicationJsonBuilder> {
   factory DeletedShareapiUndeleteResponseApplicationJson([
-    final void Function(DeletedShareapiUndeleteResponseApplicationJsonBuilder)? b,
+    void Function(DeletedShareapiUndeleteResponseApplicationJsonBuilder)? b,
   ]) = _$DeletedShareapiUndeleteResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2566,7 +2564,7 @@ abstract class DeletedShareapiUndeleteResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DeletedShareapiUndeleteResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DeletedShareapiUndeleteResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2603,14 +2601,14 @@ abstract interface class $RemoteShareInterface {
 }
 
 abstract class RemoteShare implements $RemoteShareInterface, Built<RemoteShare, RemoteShareBuilder> {
-  factory RemoteShare([final void Function(RemoteShareBuilder)? b]) = _$RemoteShare;
+  factory RemoteShare([void Function(RemoteShareBuilder)? b]) = _$RemoteShare;
 
   // coverage:ignore-start
   const RemoteShare._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteShare.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory RemoteShare.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -2631,7 +2629,7 @@ abstract class RemoteGetSharesResponseApplicationJson_Ocs
         $RemoteGetSharesResponseApplicationJson_OcsInterface,
         Built<RemoteGetSharesResponseApplicationJson_Ocs, RemoteGetSharesResponseApplicationJson_OcsBuilder> {
   factory RemoteGetSharesResponseApplicationJson_Ocs([
-    final void Function(RemoteGetSharesResponseApplicationJson_OcsBuilder)? b,
+    void Function(RemoteGetSharesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RemoteGetSharesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2639,7 +2637,7 @@ abstract class RemoteGetSharesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteGetSharesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteGetSharesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2660,16 +2658,15 @@ abstract class RemoteGetSharesResponseApplicationJson
     implements
         $RemoteGetSharesResponseApplicationJsonInterface,
         Built<RemoteGetSharesResponseApplicationJson, RemoteGetSharesResponseApplicationJsonBuilder> {
-  factory RemoteGetSharesResponseApplicationJson([
-    final void Function(RemoteGetSharesResponseApplicationJsonBuilder)? b,
-  ]) = _$RemoteGetSharesResponseApplicationJson;
+  factory RemoteGetSharesResponseApplicationJson([void Function(RemoteGetSharesResponseApplicationJsonBuilder)? b]) =
+      _$RemoteGetSharesResponseApplicationJson;
 
   // coverage:ignore-start
   const RemoteGetSharesResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteGetSharesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteGetSharesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2692,7 +2689,7 @@ abstract class RemoteGetOpenSharesResponseApplicationJson_Ocs
         $RemoteGetOpenSharesResponseApplicationJson_OcsInterface,
         Built<RemoteGetOpenSharesResponseApplicationJson_Ocs, RemoteGetOpenSharesResponseApplicationJson_OcsBuilder> {
   factory RemoteGetOpenSharesResponseApplicationJson_Ocs([
-    final void Function(RemoteGetOpenSharesResponseApplicationJson_OcsBuilder)? b,
+    void Function(RemoteGetOpenSharesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RemoteGetOpenSharesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2700,7 +2697,7 @@ abstract class RemoteGetOpenSharesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteGetOpenSharesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteGetOpenSharesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2722,7 +2719,7 @@ abstract class RemoteGetOpenSharesResponseApplicationJson
         $RemoteGetOpenSharesResponseApplicationJsonInterface,
         Built<RemoteGetOpenSharesResponseApplicationJson, RemoteGetOpenSharesResponseApplicationJsonBuilder> {
   factory RemoteGetOpenSharesResponseApplicationJson([
-    final void Function(RemoteGetOpenSharesResponseApplicationJsonBuilder)? b,
+    void Function(RemoteGetOpenSharesResponseApplicationJsonBuilder)? b,
   ]) = _$RemoteGetOpenSharesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2730,7 +2727,7 @@ abstract class RemoteGetOpenSharesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteGetOpenSharesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteGetOpenSharesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2753,7 +2750,7 @@ abstract class RemoteAcceptShareResponseApplicationJson_Ocs
         $RemoteAcceptShareResponseApplicationJson_OcsInterface,
         Built<RemoteAcceptShareResponseApplicationJson_Ocs, RemoteAcceptShareResponseApplicationJson_OcsBuilder> {
   factory RemoteAcceptShareResponseApplicationJson_Ocs([
-    final void Function(RemoteAcceptShareResponseApplicationJson_OcsBuilder)? b,
+    void Function(RemoteAcceptShareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RemoteAcceptShareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2761,7 +2758,7 @@ abstract class RemoteAcceptShareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteAcceptShareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteAcceptShareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2783,7 +2780,7 @@ abstract class RemoteAcceptShareResponseApplicationJson
         $RemoteAcceptShareResponseApplicationJsonInterface,
         Built<RemoteAcceptShareResponseApplicationJson, RemoteAcceptShareResponseApplicationJsonBuilder> {
   factory RemoteAcceptShareResponseApplicationJson([
-    final void Function(RemoteAcceptShareResponseApplicationJsonBuilder)? b,
+    void Function(RemoteAcceptShareResponseApplicationJsonBuilder)? b,
   ]) = _$RemoteAcceptShareResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2791,7 +2788,7 @@ abstract class RemoteAcceptShareResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteAcceptShareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteAcceptShareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2814,7 +2811,7 @@ abstract class RemoteDeclineShareResponseApplicationJson_Ocs
         $RemoteDeclineShareResponseApplicationJson_OcsInterface,
         Built<RemoteDeclineShareResponseApplicationJson_Ocs, RemoteDeclineShareResponseApplicationJson_OcsBuilder> {
   factory RemoteDeclineShareResponseApplicationJson_Ocs([
-    final void Function(RemoteDeclineShareResponseApplicationJson_OcsBuilder)? b,
+    void Function(RemoteDeclineShareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RemoteDeclineShareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2822,7 +2819,7 @@ abstract class RemoteDeclineShareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteDeclineShareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteDeclineShareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2844,7 +2841,7 @@ abstract class RemoteDeclineShareResponseApplicationJson
         $RemoteDeclineShareResponseApplicationJsonInterface,
         Built<RemoteDeclineShareResponseApplicationJson, RemoteDeclineShareResponseApplicationJsonBuilder> {
   factory RemoteDeclineShareResponseApplicationJson([
-    final void Function(RemoteDeclineShareResponseApplicationJsonBuilder)? b,
+    void Function(RemoteDeclineShareResponseApplicationJsonBuilder)? b,
   ]) = _$RemoteDeclineShareResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2852,7 +2849,7 @@ abstract class RemoteDeclineShareResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteDeclineShareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteDeclineShareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2875,7 +2872,7 @@ abstract class RemoteGetShareResponseApplicationJson_Ocs
         $RemoteGetShareResponseApplicationJson_OcsInterface,
         Built<RemoteGetShareResponseApplicationJson_Ocs, RemoteGetShareResponseApplicationJson_OcsBuilder> {
   factory RemoteGetShareResponseApplicationJson_Ocs([
-    final void Function(RemoteGetShareResponseApplicationJson_OcsBuilder)? b,
+    void Function(RemoteGetShareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RemoteGetShareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2883,7 +2880,7 @@ abstract class RemoteGetShareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteGetShareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteGetShareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2904,16 +2901,15 @@ abstract class RemoteGetShareResponseApplicationJson
     implements
         $RemoteGetShareResponseApplicationJsonInterface,
         Built<RemoteGetShareResponseApplicationJson, RemoteGetShareResponseApplicationJsonBuilder> {
-  factory RemoteGetShareResponseApplicationJson([
-    final void Function(RemoteGetShareResponseApplicationJsonBuilder)? b,
-  ]) = _$RemoteGetShareResponseApplicationJson;
+  factory RemoteGetShareResponseApplicationJson([void Function(RemoteGetShareResponseApplicationJsonBuilder)? b]) =
+      _$RemoteGetShareResponseApplicationJson;
 
   // coverage:ignore-start
   const RemoteGetShareResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteGetShareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteGetShareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2936,7 +2932,7 @@ abstract class RemoteUnshareResponseApplicationJson_Ocs
         $RemoteUnshareResponseApplicationJson_OcsInterface,
         Built<RemoteUnshareResponseApplicationJson_Ocs, RemoteUnshareResponseApplicationJson_OcsBuilder> {
   factory RemoteUnshareResponseApplicationJson_Ocs([
-    final void Function(RemoteUnshareResponseApplicationJson_OcsBuilder)? b,
+    void Function(RemoteUnshareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RemoteUnshareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2944,7 +2940,7 @@ abstract class RemoteUnshareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteUnshareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteUnshareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2965,7 +2961,7 @@ abstract class RemoteUnshareResponseApplicationJson
     implements
         $RemoteUnshareResponseApplicationJsonInterface,
         Built<RemoteUnshareResponseApplicationJson, RemoteUnshareResponseApplicationJsonBuilder> {
-  factory RemoteUnshareResponseApplicationJson([final void Function(RemoteUnshareResponseApplicationJsonBuilder)? b]) =
+  factory RemoteUnshareResponseApplicationJson([void Function(RemoteUnshareResponseApplicationJsonBuilder)? b]) =
       _$RemoteUnshareResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2973,7 +2969,7 @@ abstract class RemoteUnshareResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RemoteUnshareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RemoteUnshareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3000,14 +2996,14 @@ abstract interface class $ShareInfoInterface {
 }
 
 abstract class ShareInfo implements $ShareInfoInterface, Built<ShareInfo, ShareInfoBuilder> {
-  factory ShareInfo([final void Function(ShareInfoBuilder)? b]) = _$ShareInfo;
+  factory ShareInfo([void Function(ShareInfoBuilder)? b]) = _$ShareInfo;
 
   // coverage:ignore-start
   const ShareInfo._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareInfo.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareInfo.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3028,7 +3024,7 @@ class Share_ItemType extends EnumClass {
   static BuiltSet<Share_ItemType> get values => _$shareItemTypeValues;
   // coverage:ignore-end
 
-  static Share_ItemType valueOf(final String name) => _$valueOfShare_ItemType(name);
+  static Share_ItemType valueOf(String name) => _$valueOfShare_ItemType(name);
 
   static Serializer<Share_ItemType> get serializer => _$shareItemTypeSerializer;
 }
@@ -3042,14 +3038,14 @@ abstract interface class $Share_StatusInterface {
 }
 
 abstract class Share_Status implements $Share_StatusInterface, Built<Share_Status, Share_StatusBuilder> {
-  factory Share_Status([final void Function(Share_StatusBuilder)? b]) = _$Share_Status;
+  factory Share_Status([void Function(Share_StatusBuilder)? b]) = _$Share_Status;
 
   // coverage:ignore-start
   const Share_Status._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Share_Status.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Share_Status.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3131,14 +3127,14 @@ abstract interface class $ShareInterface {
 }
 
 abstract class Share implements $ShareInterface, Built<Share, ShareBuilder> {
-  factory Share([final void Function(ShareBuilder)? b]) = _$Share;
+  factory Share([void Function(ShareBuilder)? b]) = _$Share;
 
   // coverage:ignore-start
   const Share._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Share.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Share.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3159,7 +3155,7 @@ abstract class ShareapiGetSharesResponseApplicationJson_Ocs
         $ShareapiGetSharesResponseApplicationJson_OcsInterface,
         Built<ShareapiGetSharesResponseApplicationJson_Ocs, ShareapiGetSharesResponseApplicationJson_OcsBuilder> {
   factory ShareapiGetSharesResponseApplicationJson_Ocs([
-    final void Function(ShareapiGetSharesResponseApplicationJson_OcsBuilder)? b,
+    void Function(ShareapiGetSharesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ShareapiGetSharesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -3167,7 +3163,7 @@ abstract class ShareapiGetSharesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiGetSharesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiGetSharesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3189,7 +3185,7 @@ abstract class ShareapiGetSharesResponseApplicationJson
         $ShareapiGetSharesResponseApplicationJsonInterface,
         Built<ShareapiGetSharesResponseApplicationJson, ShareapiGetSharesResponseApplicationJsonBuilder> {
   factory ShareapiGetSharesResponseApplicationJson([
-    final void Function(ShareapiGetSharesResponseApplicationJsonBuilder)? b,
+    void Function(ShareapiGetSharesResponseApplicationJsonBuilder)? b,
   ]) = _$ShareapiGetSharesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -3197,7 +3193,7 @@ abstract class ShareapiGetSharesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiGetSharesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiGetSharesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3220,7 +3216,7 @@ abstract class ShareapiCreateShareResponseApplicationJson_Ocs
         $ShareapiCreateShareResponseApplicationJson_OcsInterface,
         Built<ShareapiCreateShareResponseApplicationJson_Ocs, ShareapiCreateShareResponseApplicationJson_OcsBuilder> {
   factory ShareapiCreateShareResponseApplicationJson_Ocs([
-    final void Function(ShareapiCreateShareResponseApplicationJson_OcsBuilder)? b,
+    void Function(ShareapiCreateShareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ShareapiCreateShareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -3228,7 +3224,7 @@ abstract class ShareapiCreateShareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiCreateShareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiCreateShareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3250,7 +3246,7 @@ abstract class ShareapiCreateShareResponseApplicationJson
         $ShareapiCreateShareResponseApplicationJsonInterface,
         Built<ShareapiCreateShareResponseApplicationJson, ShareapiCreateShareResponseApplicationJsonBuilder> {
   factory ShareapiCreateShareResponseApplicationJson([
-    final void Function(ShareapiCreateShareResponseApplicationJsonBuilder)? b,
+    void Function(ShareapiCreateShareResponseApplicationJsonBuilder)? b,
   ]) = _$ShareapiCreateShareResponseApplicationJson;
 
   // coverage:ignore-start
@@ -3258,7 +3254,7 @@ abstract class ShareapiCreateShareResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiCreateShareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiCreateShareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3282,7 +3278,7 @@ abstract class ShareapiGetInheritedSharesResponseApplicationJson_Ocs
         Built<ShareapiGetInheritedSharesResponseApplicationJson_Ocs,
             ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder> {
   factory ShareapiGetInheritedSharesResponseApplicationJson_Ocs([
-    final void Function(ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder)? b,
+    void Function(ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ShareapiGetInheritedSharesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -3290,7 +3286,7 @@ abstract class ShareapiGetInheritedSharesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiGetInheritedSharesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiGetInheritedSharesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3313,7 +3309,7 @@ abstract class ShareapiGetInheritedSharesResponseApplicationJson
         Built<ShareapiGetInheritedSharesResponseApplicationJson,
             ShareapiGetInheritedSharesResponseApplicationJsonBuilder> {
   factory ShareapiGetInheritedSharesResponseApplicationJson([
-    final void Function(ShareapiGetInheritedSharesResponseApplicationJsonBuilder)? b,
+    void Function(ShareapiGetInheritedSharesResponseApplicationJsonBuilder)? b,
   ]) = _$ShareapiGetInheritedSharesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -3321,7 +3317,7 @@ abstract class ShareapiGetInheritedSharesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiGetInheritedSharesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiGetInheritedSharesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3345,7 +3341,7 @@ abstract class ShareapiPendingSharesResponseApplicationJson_Ocs
         Built<ShareapiPendingSharesResponseApplicationJson_Ocs,
             ShareapiPendingSharesResponseApplicationJson_OcsBuilder> {
   factory ShareapiPendingSharesResponseApplicationJson_Ocs([
-    final void Function(ShareapiPendingSharesResponseApplicationJson_OcsBuilder)? b,
+    void Function(ShareapiPendingSharesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ShareapiPendingSharesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -3353,7 +3349,7 @@ abstract class ShareapiPendingSharesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiPendingSharesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiPendingSharesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3375,7 +3371,7 @@ abstract class ShareapiPendingSharesResponseApplicationJson
         $ShareapiPendingSharesResponseApplicationJsonInterface,
         Built<ShareapiPendingSharesResponseApplicationJson, ShareapiPendingSharesResponseApplicationJsonBuilder> {
   factory ShareapiPendingSharesResponseApplicationJson([
-    final void Function(ShareapiPendingSharesResponseApplicationJsonBuilder)? b,
+    void Function(ShareapiPendingSharesResponseApplicationJsonBuilder)? b,
   ]) = _$ShareapiPendingSharesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -3383,7 +3379,7 @@ abstract class ShareapiPendingSharesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiPendingSharesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiPendingSharesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3406,7 +3402,7 @@ abstract class ShareapiGetShareResponseApplicationJson_Ocs
         $ShareapiGetShareResponseApplicationJson_OcsInterface,
         Built<ShareapiGetShareResponseApplicationJson_Ocs, ShareapiGetShareResponseApplicationJson_OcsBuilder> {
   factory ShareapiGetShareResponseApplicationJson_Ocs([
-    final void Function(ShareapiGetShareResponseApplicationJson_OcsBuilder)? b,
+    void Function(ShareapiGetShareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ShareapiGetShareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -3414,7 +3410,7 @@ abstract class ShareapiGetShareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiGetShareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiGetShareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3435,16 +3431,15 @@ abstract class ShareapiGetShareResponseApplicationJson
     implements
         $ShareapiGetShareResponseApplicationJsonInterface,
         Built<ShareapiGetShareResponseApplicationJson, ShareapiGetShareResponseApplicationJsonBuilder> {
-  factory ShareapiGetShareResponseApplicationJson([
-    final void Function(ShareapiGetShareResponseApplicationJsonBuilder)? b,
-  ]) = _$ShareapiGetShareResponseApplicationJson;
+  factory ShareapiGetShareResponseApplicationJson([void Function(ShareapiGetShareResponseApplicationJsonBuilder)? b]) =
+      _$ShareapiGetShareResponseApplicationJson;
 
   // coverage:ignore-start
   const ShareapiGetShareResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiGetShareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiGetShareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3467,7 +3462,7 @@ abstract class ShareapiUpdateShareResponseApplicationJson_Ocs
         $ShareapiUpdateShareResponseApplicationJson_OcsInterface,
         Built<ShareapiUpdateShareResponseApplicationJson_Ocs, ShareapiUpdateShareResponseApplicationJson_OcsBuilder> {
   factory ShareapiUpdateShareResponseApplicationJson_Ocs([
-    final void Function(ShareapiUpdateShareResponseApplicationJson_OcsBuilder)? b,
+    void Function(ShareapiUpdateShareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ShareapiUpdateShareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -3475,7 +3470,7 @@ abstract class ShareapiUpdateShareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiUpdateShareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiUpdateShareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3497,7 +3492,7 @@ abstract class ShareapiUpdateShareResponseApplicationJson
         $ShareapiUpdateShareResponseApplicationJsonInterface,
         Built<ShareapiUpdateShareResponseApplicationJson, ShareapiUpdateShareResponseApplicationJsonBuilder> {
   factory ShareapiUpdateShareResponseApplicationJson([
-    final void Function(ShareapiUpdateShareResponseApplicationJsonBuilder)? b,
+    void Function(ShareapiUpdateShareResponseApplicationJsonBuilder)? b,
   ]) = _$ShareapiUpdateShareResponseApplicationJson;
 
   // coverage:ignore-start
@@ -3505,7 +3500,7 @@ abstract class ShareapiUpdateShareResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiUpdateShareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiUpdateShareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3528,7 +3523,7 @@ abstract class ShareapiDeleteShareResponseApplicationJson_Ocs
         $ShareapiDeleteShareResponseApplicationJson_OcsInterface,
         Built<ShareapiDeleteShareResponseApplicationJson_Ocs, ShareapiDeleteShareResponseApplicationJson_OcsBuilder> {
   factory ShareapiDeleteShareResponseApplicationJson_Ocs([
-    final void Function(ShareapiDeleteShareResponseApplicationJson_OcsBuilder)? b,
+    void Function(ShareapiDeleteShareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ShareapiDeleteShareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -3536,7 +3531,7 @@ abstract class ShareapiDeleteShareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiDeleteShareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiDeleteShareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3558,7 +3553,7 @@ abstract class ShareapiDeleteShareResponseApplicationJson
         $ShareapiDeleteShareResponseApplicationJsonInterface,
         Built<ShareapiDeleteShareResponseApplicationJson, ShareapiDeleteShareResponseApplicationJsonBuilder> {
   factory ShareapiDeleteShareResponseApplicationJson([
-    final void Function(ShareapiDeleteShareResponseApplicationJsonBuilder)? b,
+    void Function(ShareapiDeleteShareResponseApplicationJsonBuilder)? b,
   ]) = _$ShareapiDeleteShareResponseApplicationJson;
 
   // coverage:ignore-start
@@ -3566,7 +3561,7 @@ abstract class ShareapiDeleteShareResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiDeleteShareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiDeleteShareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3589,7 +3584,7 @@ abstract class ShareapiAcceptShareResponseApplicationJson_Ocs
         $ShareapiAcceptShareResponseApplicationJson_OcsInterface,
         Built<ShareapiAcceptShareResponseApplicationJson_Ocs, ShareapiAcceptShareResponseApplicationJson_OcsBuilder> {
   factory ShareapiAcceptShareResponseApplicationJson_Ocs([
-    final void Function(ShareapiAcceptShareResponseApplicationJson_OcsBuilder)? b,
+    void Function(ShareapiAcceptShareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ShareapiAcceptShareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -3597,7 +3592,7 @@ abstract class ShareapiAcceptShareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiAcceptShareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiAcceptShareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3619,7 +3614,7 @@ abstract class ShareapiAcceptShareResponseApplicationJson
         $ShareapiAcceptShareResponseApplicationJsonInterface,
         Built<ShareapiAcceptShareResponseApplicationJson, ShareapiAcceptShareResponseApplicationJsonBuilder> {
   factory ShareapiAcceptShareResponseApplicationJson([
-    final void Function(ShareapiAcceptShareResponseApplicationJsonBuilder)? b,
+    void Function(ShareapiAcceptShareResponseApplicationJsonBuilder)? b,
   ]) = _$ShareapiAcceptShareResponseApplicationJson;
 
   // coverage:ignore-start
@@ -3627,7 +3622,7 @@ abstract class ShareapiAcceptShareResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareapiAcceptShareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ShareapiAcceptShareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3648,7 +3643,7 @@ abstract class ShareesapiShareesapiSearchHeaders
     implements
         $ShareesapiShareesapiSearchHeadersInterface,
         Built<ShareesapiShareesapiSearchHeaders, ShareesapiShareesapiSearchHeadersBuilder> {
-  factory ShareesapiShareesapiSearchHeaders([final void Function(ShareesapiShareesapiSearchHeadersBuilder)? b]) =
+  factory ShareesapiShareesapiSearchHeaders([void Function(ShareesapiShareesapiSearchHeadersBuilder)? b]) =
       _$ShareesapiShareesapiSearchHeaders;
 
   // coverage:ignore-start
@@ -3656,7 +3651,7 @@ abstract class ShareesapiShareesapiSearchHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareesapiShareesapiSearchHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory ShareesapiShareesapiSearchHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3674,14 +3669,14 @@ abstract interface class $ShareeInterface {
 }
 
 abstract class Sharee implements $ShareeInterface, Built<Sharee, ShareeBuilder> {
-  factory Sharee([final void Function(ShareeBuilder)? b]) = _$Sharee;
+  factory Sharee([void Function(ShareeBuilder)? b]) = _$Sharee;
 
   // coverage:ignore-start
   const Sharee._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Sharee.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Sharee.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3698,14 +3693,14 @@ abstract interface class $ShareeValueInterface {
 }
 
 abstract class ShareeValue implements $ShareeValueInterface, Built<ShareeValue, ShareeValueBuilder> {
-  factory ShareeValue([final void Function(ShareeValueBuilder)? b]) = _$ShareeValue;
+  factory ShareeValue([void Function(ShareeValueBuilder)? b]) = _$ShareeValue;
 
   // coverage:ignore-start
   const ShareeValue._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeValue.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareeValue.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3726,14 +3721,14 @@ abstract interface class $ShareeCircle_1_ValueInterface
 
 abstract class ShareeCircle_1_Value
     implements $ShareeCircle_1_ValueInterface, Built<ShareeCircle_1_Value, ShareeCircle_1_ValueBuilder> {
-  factory ShareeCircle_1_Value([final void Function(ShareeCircle_1_ValueBuilder)? b]) = _$ShareeCircle_1_Value;
+  factory ShareeCircle_1_Value([void Function(ShareeCircle_1_ValueBuilder)? b]) = _$ShareeCircle_1_Value;
 
   // coverage:ignore-start
   const ShareeCircle_1_Value._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeCircle_1_Value.fromJson(final Map<String, dynamic> json) =>
+  factory ShareeCircle_1_Value.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3754,14 +3749,14 @@ abstract interface class $ShareeCircle_1Interface {
 abstract interface class $ShareeCircleInterface implements $ShareeInterface, $ShareeCircle_1Interface {}
 
 abstract class ShareeCircle implements $ShareeCircleInterface, Built<ShareeCircle, ShareeCircleBuilder> {
-  factory ShareeCircle([final void Function(ShareeCircleBuilder)? b]) = _$ShareeCircle;
+  factory ShareeCircle([void Function(ShareeCircleBuilder)? b]) = _$ShareeCircle;
 
   // coverage:ignore-start
   const ShareeCircle._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeCircle.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareeCircle.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3784,14 +3779,14 @@ abstract interface class $ShareeEmail_1Interface {
 abstract interface class $ShareeEmailInterface implements $ShareeInterface, $ShareeEmail_1Interface {}
 
 abstract class ShareeEmail implements $ShareeEmailInterface, Built<ShareeEmail, ShareeEmailBuilder> {
-  factory ShareeEmail([final void Function(ShareeEmailBuilder)? b]) = _$ShareeEmail;
+  factory ShareeEmail([void Function(ShareeEmailBuilder)? b]) = _$ShareeEmail;
 
   // coverage:ignore-start
   const ShareeEmail._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeEmail.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareeEmail.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3812,15 +3807,14 @@ abstract interface class $ShareeRemoteGroup_1_ValueInterface
 
 abstract class ShareeRemoteGroup_1_Value
     implements $ShareeRemoteGroup_1_ValueInterface, Built<ShareeRemoteGroup_1_Value, ShareeRemoteGroup_1_ValueBuilder> {
-  factory ShareeRemoteGroup_1_Value([final void Function(ShareeRemoteGroup_1_ValueBuilder)? b]) =
-      _$ShareeRemoteGroup_1_Value;
+  factory ShareeRemoteGroup_1_Value([void Function(ShareeRemoteGroup_1_ValueBuilder)? b]) = _$ShareeRemoteGroup_1_Value;
 
   // coverage:ignore-start
   const ShareeRemoteGroup_1_Value._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeRemoteGroup_1_Value.fromJson(final Map<String, dynamic> json) =>
+  factory ShareeRemoteGroup_1_Value.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3843,15 +3837,14 @@ abstract interface class $ShareeRemoteGroupInterface implements $ShareeInterface
 
 abstract class ShareeRemoteGroup
     implements $ShareeRemoteGroupInterface, Built<ShareeRemoteGroup, ShareeRemoteGroupBuilder> {
-  factory ShareeRemoteGroup([final void Function(ShareeRemoteGroupBuilder)? b]) = _$ShareeRemoteGroup;
+  factory ShareeRemoteGroup([void Function(ShareeRemoteGroupBuilder)? b]) = _$ShareeRemoteGroup;
 
   // coverage:ignore-start
   const ShareeRemoteGroup._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeRemoteGroup.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareeRemoteGroup.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3872,14 +3865,14 @@ abstract interface class $ShareeRemote_1_ValueInterface
 
 abstract class ShareeRemote_1_Value
     implements $ShareeRemote_1_ValueInterface, Built<ShareeRemote_1_Value, ShareeRemote_1_ValueBuilder> {
-  factory ShareeRemote_1_Value([final void Function(ShareeRemote_1_ValueBuilder)? b]) = _$ShareeRemote_1_Value;
+  factory ShareeRemote_1_Value([void Function(ShareeRemote_1_ValueBuilder)? b]) = _$ShareeRemote_1_Value;
 
   // coverage:ignore-start
   const ShareeRemote_1_Value._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeRemote_1_Value.fromJson(final Map<String, dynamic> json) =>
+  factory ShareeRemote_1_Value.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -3902,14 +3895,14 @@ abstract interface class $ShareeRemote_1Interface {
 abstract interface class $ShareeRemoteInterface implements $ShareeInterface, $ShareeRemote_1Interface {}
 
 abstract class ShareeRemote implements $ShareeRemoteInterface, Built<ShareeRemote, ShareeRemoteBuilder> {
-  factory ShareeRemote([final void Function(ShareeRemoteBuilder)? b]) = _$ShareeRemote;
+  factory ShareeRemote([void Function(ShareeRemoteBuilder)? b]) = _$ShareeRemote;
 
   // coverage:ignore-start
   const ShareeRemote._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeRemote.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareeRemote.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3929,15 +3922,14 @@ abstract interface class $ShareeUser_1_StatusInterface {
 
 abstract class ShareeUser_1_Status
     implements $ShareeUser_1_StatusInterface, Built<ShareeUser_1_Status, ShareeUser_1_StatusBuilder> {
-  factory ShareeUser_1_Status([final void Function(ShareeUser_1_StatusBuilder)? b]) = _$ShareeUser_1_Status;
+  factory ShareeUser_1_Status([void Function(ShareeUser_1_StatusBuilder)? b]) = _$ShareeUser_1_Status;
 
   // coverage:ignore-start
   const ShareeUser_1_Status._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeUser_1_Status.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareeUser_1_Status.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3960,14 +3952,14 @@ abstract interface class $ShareeUser_1Interface {
 abstract interface class $ShareeUserInterface implements $ShareeInterface, $ShareeUser_1Interface {}
 
 abstract class ShareeUser implements $ShareeUserInterface, Built<ShareeUser, ShareeUserBuilder> {
-  factory ShareeUser([final void Function(ShareeUserBuilder)? b]) = _$ShareeUser;
+  factory ShareeUser([void Function(ShareeUserBuilder)? b]) = _$ShareeUser;
 
   // coverage:ignore-start
   const ShareeUser._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeUser.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareeUser.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -3991,15 +3983,14 @@ abstract interface class $ShareesSearchResult_ExactInterface {
 
 abstract class ShareesSearchResult_Exact
     implements $ShareesSearchResult_ExactInterface, Built<ShareesSearchResult_Exact, ShareesSearchResult_ExactBuilder> {
-  factory ShareesSearchResult_Exact([final void Function(ShareesSearchResult_ExactBuilder)? b]) =
-      _$ShareesSearchResult_Exact;
+  factory ShareesSearchResult_Exact([void Function(ShareesSearchResult_ExactBuilder)? b]) = _$ShareesSearchResult_Exact;
 
   // coverage:ignore-start
   const ShareesSearchResult_Exact._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareesSearchResult_Exact.fromJson(final Map<String, dynamic> json) =>
+  factory ShareesSearchResult_Exact.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4017,14 +4008,14 @@ abstract interface class $LookupInterface {
 }
 
 abstract class Lookup implements $LookupInterface, Built<Lookup, LookupBuilder> {
-  factory Lookup([final void Function(LookupBuilder)? b]) = _$Lookup;
+  factory Lookup([void Function(LookupBuilder)? b]) = _$Lookup;
 
   // coverage:ignore-start
   const Lookup._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Lookup.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Lookup.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -4052,14 +4043,14 @@ abstract interface class $ShareeLookup_1_ExtraInterface {
 
 abstract class ShareeLookup_1_Extra
     implements $ShareeLookup_1_ExtraInterface, Built<ShareeLookup_1_Extra, ShareeLookup_1_ExtraBuilder> {
-  factory ShareeLookup_1_Extra([final void Function(ShareeLookup_1_ExtraBuilder)? b]) = _$ShareeLookup_1_Extra;
+  factory ShareeLookup_1_Extra([void Function(ShareeLookup_1_ExtraBuilder)? b]) = _$ShareeLookup_1_Extra;
 
   // coverage:ignore-start
   const ShareeLookup_1_Extra._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeLookup_1_Extra.fromJson(final Map<String, dynamic> json) =>
+  factory ShareeLookup_1_Extra.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4081,14 +4072,14 @@ abstract interface class $ShareeLookup_1_ValueInterface
 
 abstract class ShareeLookup_1_Value
     implements $ShareeLookup_1_ValueInterface, Built<ShareeLookup_1_Value, ShareeLookup_1_ValueBuilder> {
-  factory ShareeLookup_1_Value([final void Function(ShareeLookup_1_ValueBuilder)? b]) = _$ShareeLookup_1_Value;
+  factory ShareeLookup_1_Value([void Function(ShareeLookup_1_ValueBuilder)? b]) = _$ShareeLookup_1_Value;
 
   // coverage:ignore-start
   const ShareeLookup_1_Value._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeLookup_1_Value.fromJson(final Map<String, dynamic> json) =>
+  factory ShareeLookup_1_Value.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4109,14 +4100,14 @@ abstract interface class $ShareeLookup_1Interface {
 abstract interface class $ShareeLookupInterface implements $ShareeInterface, $ShareeLookup_1Interface {}
 
 abstract class ShareeLookup implements $ShareeLookupInterface, Built<ShareeLookup, ShareeLookupBuilder> {
-  factory ShareeLookup([final void Function(ShareeLookupBuilder)? b]) = _$ShareeLookup;
+  factory ShareeLookup([void Function(ShareeLookupBuilder)? b]) = _$ShareeLookup;
 
   // coverage:ignore-start
   const ShareeLookup._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareeLookup.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareeLookup.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -4143,15 +4134,14 @@ abstract interface class $ShareesSearchResultInterface {
 
 abstract class ShareesSearchResult
     implements $ShareesSearchResultInterface, Built<ShareesSearchResult, ShareesSearchResultBuilder> {
-  factory ShareesSearchResult([final void Function(ShareesSearchResultBuilder)? b]) = _$ShareesSearchResult;
+  factory ShareesSearchResult([void Function(ShareesSearchResultBuilder)? b]) = _$ShareesSearchResult;
 
   // coverage:ignore-start
   const ShareesSearchResult._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareesSearchResult.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareesSearchResult.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -4172,7 +4162,7 @@ abstract class ShareesapiSearchResponseApplicationJson_Ocs
         $ShareesapiSearchResponseApplicationJson_OcsInterface,
         Built<ShareesapiSearchResponseApplicationJson_Ocs, ShareesapiSearchResponseApplicationJson_OcsBuilder> {
   factory ShareesapiSearchResponseApplicationJson_Ocs([
-    final void Function(ShareesapiSearchResponseApplicationJson_OcsBuilder)? b,
+    void Function(ShareesapiSearchResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ShareesapiSearchResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -4180,7 +4170,7 @@ abstract class ShareesapiSearchResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareesapiSearchResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ShareesapiSearchResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4201,16 +4191,15 @@ abstract class ShareesapiSearchResponseApplicationJson
     implements
         $ShareesapiSearchResponseApplicationJsonInterface,
         Built<ShareesapiSearchResponseApplicationJson, ShareesapiSearchResponseApplicationJsonBuilder> {
-  factory ShareesapiSearchResponseApplicationJson([
-    final void Function(ShareesapiSearchResponseApplicationJsonBuilder)? b,
-  ]) = _$ShareesapiSearchResponseApplicationJson;
+  factory ShareesapiSearchResponseApplicationJson([void Function(ShareesapiSearchResponseApplicationJsonBuilder)? b]) =
+      _$ShareesapiSearchResponseApplicationJson;
 
   // coverage:ignore-start
   const ShareesapiSearchResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareesapiSearchResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ShareesapiSearchResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4236,7 +4225,7 @@ abstract class ShareesRecommendedResult_Exact
     implements
         $ShareesRecommendedResult_ExactInterface,
         Built<ShareesRecommendedResult_Exact, ShareesRecommendedResult_ExactBuilder> {
-  factory ShareesRecommendedResult_Exact([final void Function(ShareesRecommendedResult_ExactBuilder)? b]) =
+  factory ShareesRecommendedResult_Exact([void Function(ShareesRecommendedResult_ExactBuilder)? b]) =
       _$ShareesRecommendedResult_Exact;
 
   // coverage:ignore-start
@@ -4244,7 +4233,7 @@ abstract class ShareesRecommendedResult_Exact
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareesRecommendedResult_Exact.fromJson(final Map<String, dynamic> json) =>
+  factory ShareesRecommendedResult_Exact.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4268,15 +4257,14 @@ abstract interface class $ShareesRecommendedResultInterface {
 
 abstract class ShareesRecommendedResult
     implements $ShareesRecommendedResultInterface, Built<ShareesRecommendedResult, ShareesRecommendedResultBuilder> {
-  factory ShareesRecommendedResult([final void Function(ShareesRecommendedResultBuilder)? b]) =
-      _$ShareesRecommendedResult;
+  factory ShareesRecommendedResult([void Function(ShareesRecommendedResultBuilder)? b]) = _$ShareesRecommendedResult;
 
   // coverage:ignore-start
   const ShareesRecommendedResult._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareesRecommendedResult.fromJson(final Map<String, dynamic> json) =>
+  factory ShareesRecommendedResult.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4299,7 +4287,7 @@ abstract class ShareesapiFindRecommendedResponseApplicationJson_Ocs
         Built<ShareesapiFindRecommendedResponseApplicationJson_Ocs,
             ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder> {
   factory ShareesapiFindRecommendedResponseApplicationJson_Ocs([
-    final void Function(ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder)? b,
+    void Function(ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ShareesapiFindRecommendedResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -4307,7 +4295,7 @@ abstract class ShareesapiFindRecommendedResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareesapiFindRecommendedResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ShareesapiFindRecommendedResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4330,7 +4318,7 @@ abstract class ShareesapiFindRecommendedResponseApplicationJson
         Built<ShareesapiFindRecommendedResponseApplicationJson,
             ShareesapiFindRecommendedResponseApplicationJsonBuilder> {
   factory ShareesapiFindRecommendedResponseApplicationJson([
-    final void Function(ShareesapiFindRecommendedResponseApplicationJsonBuilder)? b,
+    void Function(ShareesapiFindRecommendedResponseApplicationJsonBuilder)? b,
   ]) = _$ShareesapiFindRecommendedResponseApplicationJson;
 
   // coverage:ignore-start
@@ -4338,7 +4326,7 @@ abstract class ShareesapiFindRecommendedResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ShareesapiFindRecommendedResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ShareesapiFindRecommendedResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4361,7 +4349,7 @@ abstract class Capabilities_FilesSharing_Public_Password
         $Capabilities_FilesSharing_Public_PasswordInterface,
         Built<Capabilities_FilesSharing_Public_Password, Capabilities_FilesSharing_Public_PasswordBuilder> {
   factory Capabilities_FilesSharing_Public_Password([
-    final void Function(Capabilities_FilesSharing_Public_PasswordBuilder)? b,
+    void Function(Capabilities_FilesSharing_Public_PasswordBuilder)? b,
   ]) = _$Capabilities_FilesSharing_Public_Password;
 
   // coverage:ignore-start
@@ -4369,7 +4357,7 @@ abstract class Capabilities_FilesSharing_Public_Password
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Public_Password.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Public_Password.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4393,7 +4381,7 @@ abstract class Capabilities_FilesSharing_Public_ExpireDate
         $Capabilities_FilesSharing_Public_ExpireDateInterface,
         Built<Capabilities_FilesSharing_Public_ExpireDate, Capabilities_FilesSharing_Public_ExpireDateBuilder> {
   factory Capabilities_FilesSharing_Public_ExpireDate([
-    final void Function(Capabilities_FilesSharing_Public_ExpireDateBuilder)? b,
+    void Function(Capabilities_FilesSharing_Public_ExpireDateBuilder)? b,
   ]) = _$Capabilities_FilesSharing_Public_ExpireDate;
 
   // coverage:ignore-start
@@ -4401,7 +4389,7 @@ abstract class Capabilities_FilesSharing_Public_ExpireDate
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Public_ExpireDate.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Public_ExpireDate.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4426,7 +4414,7 @@ abstract class Capabilities_FilesSharing_Public_ExpireDateInternal
         Built<Capabilities_FilesSharing_Public_ExpireDateInternal,
             Capabilities_FilesSharing_Public_ExpireDateInternalBuilder> {
   factory Capabilities_FilesSharing_Public_ExpireDateInternal([
-    final void Function(Capabilities_FilesSharing_Public_ExpireDateInternalBuilder)? b,
+    void Function(Capabilities_FilesSharing_Public_ExpireDateInternalBuilder)? b,
   ]) = _$Capabilities_FilesSharing_Public_ExpireDateInternal;
 
   // coverage:ignore-start
@@ -4434,7 +4422,7 @@ abstract class Capabilities_FilesSharing_Public_ExpireDateInternal
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Public_ExpireDateInternal.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Public_ExpireDateInternal.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4459,7 +4447,7 @@ abstract class Capabilities_FilesSharing_Public_ExpireDateRemote
         Built<Capabilities_FilesSharing_Public_ExpireDateRemote,
             Capabilities_FilesSharing_Public_ExpireDateRemoteBuilder> {
   factory Capabilities_FilesSharing_Public_ExpireDateRemote([
-    final void Function(Capabilities_FilesSharing_Public_ExpireDateRemoteBuilder)? b,
+    void Function(Capabilities_FilesSharing_Public_ExpireDateRemoteBuilder)? b,
   ]) = _$Capabilities_FilesSharing_Public_ExpireDateRemote;
 
   // coverage:ignore-start
@@ -4467,7 +4455,7 @@ abstract class Capabilities_FilesSharing_Public_ExpireDateRemote
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Public_ExpireDateRemote.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Public_ExpireDateRemote.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4502,7 +4490,7 @@ abstract class Capabilities_FilesSharing_Public
     implements
         $Capabilities_FilesSharing_PublicInterface,
         Built<Capabilities_FilesSharing_Public, Capabilities_FilesSharing_PublicBuilder> {
-  factory Capabilities_FilesSharing_Public([final void Function(Capabilities_FilesSharing_PublicBuilder)? b]) =
+  factory Capabilities_FilesSharing_Public([void Function(Capabilities_FilesSharing_PublicBuilder)? b]) =
       _$Capabilities_FilesSharing_Public;
 
   // coverage:ignore-start
@@ -4510,7 +4498,7 @@ abstract class Capabilities_FilesSharing_Public
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Public.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Public.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4531,7 +4519,7 @@ abstract class Capabilities_FilesSharing_User_ExpireDate
         $Capabilities_FilesSharing_User_ExpireDateInterface,
         Built<Capabilities_FilesSharing_User_ExpireDate, Capabilities_FilesSharing_User_ExpireDateBuilder> {
   factory Capabilities_FilesSharing_User_ExpireDate([
-    final void Function(Capabilities_FilesSharing_User_ExpireDateBuilder)? b,
+    void Function(Capabilities_FilesSharing_User_ExpireDateBuilder)? b,
   ]) = _$Capabilities_FilesSharing_User_ExpireDate;
 
   // coverage:ignore-start
@@ -4539,7 +4527,7 @@ abstract class Capabilities_FilesSharing_User_ExpireDate
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_User_ExpireDate.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_User_ExpireDate.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4563,7 +4551,7 @@ abstract class Capabilities_FilesSharing_User
     implements
         $Capabilities_FilesSharing_UserInterface,
         Built<Capabilities_FilesSharing_User, Capabilities_FilesSharing_UserBuilder> {
-  factory Capabilities_FilesSharing_User([final void Function(Capabilities_FilesSharing_UserBuilder)? b]) =
+  factory Capabilities_FilesSharing_User([void Function(Capabilities_FilesSharing_UserBuilder)? b]) =
       _$Capabilities_FilesSharing_User;
 
   // coverage:ignore-start
@@ -4571,7 +4559,7 @@ abstract class Capabilities_FilesSharing_User
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_User.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_User.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4592,7 +4580,7 @@ abstract class Capabilities_FilesSharing_Group_ExpireDate
         $Capabilities_FilesSharing_Group_ExpireDateInterface,
         Built<Capabilities_FilesSharing_Group_ExpireDate, Capabilities_FilesSharing_Group_ExpireDateBuilder> {
   factory Capabilities_FilesSharing_Group_ExpireDate([
-    final void Function(Capabilities_FilesSharing_Group_ExpireDateBuilder)? b,
+    void Function(Capabilities_FilesSharing_Group_ExpireDateBuilder)? b,
   ]) = _$Capabilities_FilesSharing_Group_ExpireDate;
 
   // coverage:ignore-start
@@ -4600,7 +4588,7 @@ abstract class Capabilities_FilesSharing_Group_ExpireDate
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Group_ExpireDate.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Group_ExpireDate.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4623,7 +4611,7 @@ abstract class Capabilities_FilesSharing_Group
     implements
         $Capabilities_FilesSharing_GroupInterface,
         Built<Capabilities_FilesSharing_Group, Capabilities_FilesSharing_GroupBuilder> {
-  factory Capabilities_FilesSharing_Group([final void Function(Capabilities_FilesSharing_GroupBuilder)? b]) =
+  factory Capabilities_FilesSharing_Group([void Function(Capabilities_FilesSharing_GroupBuilder)? b]) =
       _$Capabilities_FilesSharing_Group;
 
   // coverage:ignore-start
@@ -4631,7 +4619,7 @@ abstract class Capabilities_FilesSharing_Group
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Group.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Group.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4652,7 +4640,7 @@ abstract class Capabilities_FilesSharing_Federation_ExpireDate
         $Capabilities_FilesSharing_Federation_ExpireDateInterface,
         Built<Capabilities_FilesSharing_Federation_ExpireDate, Capabilities_FilesSharing_Federation_ExpireDateBuilder> {
   factory Capabilities_FilesSharing_Federation_ExpireDate([
-    final void Function(Capabilities_FilesSharing_Federation_ExpireDateBuilder)? b,
+    void Function(Capabilities_FilesSharing_Federation_ExpireDateBuilder)? b,
   ]) = _$Capabilities_FilesSharing_Federation_ExpireDate;
 
   // coverage:ignore-start
@@ -4660,7 +4648,7 @@ abstract class Capabilities_FilesSharing_Federation_ExpireDate
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Federation_ExpireDate.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Federation_ExpireDate.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4683,7 +4671,7 @@ abstract class Capabilities_FilesSharing_Federation_ExpireDateSupported
         Built<Capabilities_FilesSharing_Federation_ExpireDateSupported,
             Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder> {
   factory Capabilities_FilesSharing_Federation_ExpireDateSupported([
-    final void Function(Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder)? b,
+    void Function(Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder)? b,
   ]) = _$Capabilities_FilesSharing_Federation_ExpireDateSupported;
 
   // coverage:ignore-start
@@ -4691,7 +4679,7 @@ abstract class Capabilities_FilesSharing_Federation_ExpireDateSupported
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Federation_ExpireDateSupported.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Federation_ExpireDateSupported.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4717,7 +4705,7 @@ abstract class Capabilities_FilesSharing_Federation
     implements
         $Capabilities_FilesSharing_FederationInterface,
         Built<Capabilities_FilesSharing_Federation, Capabilities_FilesSharing_FederationBuilder> {
-  factory Capabilities_FilesSharing_Federation([final void Function(Capabilities_FilesSharing_FederationBuilder)? b]) =
+  factory Capabilities_FilesSharing_Federation([void Function(Capabilities_FilesSharing_FederationBuilder)? b]) =
       _$Capabilities_FilesSharing_Federation;
 
   // coverage:ignore-start
@@ -4725,7 +4713,7 @@ abstract class Capabilities_FilesSharing_Federation
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Federation.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Federation.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4749,7 +4737,7 @@ abstract class Capabilities_FilesSharing_Sharee
     implements
         $Capabilities_FilesSharing_ShareeInterface,
         Built<Capabilities_FilesSharing_Sharee, Capabilities_FilesSharing_ShareeBuilder> {
-  factory Capabilities_FilesSharing_Sharee([final void Function(Capabilities_FilesSharing_ShareeBuilder)? b]) =
+  factory Capabilities_FilesSharing_Sharee([void Function(Capabilities_FilesSharing_ShareeBuilder)? b]) =
       _$Capabilities_FilesSharing_Sharee;
 
   // coverage:ignore-start
@@ -4757,7 +4745,7 @@ abstract class Capabilities_FilesSharing_Sharee
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing_Sharee.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing_Sharee.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4786,15 +4774,14 @@ abstract interface class $Capabilities_FilesSharingInterface {
 
 abstract class Capabilities_FilesSharing
     implements $Capabilities_FilesSharingInterface, Built<Capabilities_FilesSharing, Capabilities_FilesSharingBuilder> {
-  factory Capabilities_FilesSharing([final void Function(Capabilities_FilesSharingBuilder)? b]) =
-      _$Capabilities_FilesSharing;
+  factory Capabilities_FilesSharing([void Function(Capabilities_FilesSharingBuilder)? b]) = _$Capabilities_FilesSharing;
 
   // coverage:ignore-start
   const Capabilities_FilesSharing._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_FilesSharing.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_FilesSharing.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4812,14 +4799,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -4840,7 +4827,7 @@ extension $BuiltListIntExtension on $BuiltListInt {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BuiltListInt> get serializer => const _$BuiltListIntSerializer();
-  static $BuiltListInt fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BuiltListInt fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -4855,9 +4842,9 @@ class _$BuiltListIntSerializer implements PrimitiveSerializer<$BuiltListInt> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BuiltListInt object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BuiltListInt object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.builtListInt;
@@ -4874,9 +4861,9 @@ class _$BuiltListIntSerializer implements PrimitiveSerializer<$BuiltListInt> {
 
   @override
   $BuiltListInt deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BuiltList<int>? builtListInt;
     try {

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -27,7 +27,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -63,10 +63,10 @@ class PreviewClient {
   /// See:
   ///  * [getPreviewRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getPreview({
-    final int? fileId,
-    final int? x,
-    final int? y,
-    final int? a,
+    int? fileId,
+    int? x,
+    int? y,
+    int? a,
   }) async {
     final rawResponse = getPreviewRaw(
       fileId: fileId,
@@ -100,10 +100,10 @@ class PreviewClient {
   ///  * [getPreview] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getPreviewRaw({
-    final int? fileId,
-    final int? x,
-    final int? y,
-    final int? a,
+    int? fileId,
+    int? x,
+    int? y,
+    int? a,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -113,7 +113,7 @@ class PreviewClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -167,15 +167,14 @@ abstract interface class $Capabilities_FilesInterface {
 
 abstract class Capabilities_Files
     implements $Capabilities_FilesInterface, Built<Capabilities_Files, Capabilities_FilesBuilder> {
-  factory Capabilities_Files([final void Function(Capabilities_FilesBuilder)? b]) = _$Capabilities_Files;
+  factory Capabilities_Files([void Function(Capabilities_FilesBuilder)? b]) = _$Capabilities_Files;
 
   // coverage:ignore-start
   const Capabilities_Files._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_Files.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities_Files.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -191,14 +190,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.dart
@@ -27,7 +27,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -63,10 +63,10 @@ class PreviewClient {
   /// See:
   ///  * [getPreviewRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getPreview({
-    final String? file,
-    final int? x,
-    final int? y,
-    final String? version,
+    String? file,
+    int? x,
+    int? y,
+    String? version,
   }) async {
     final rawResponse = getPreviewRaw(
       file: file,
@@ -100,10 +100,10 @@ class PreviewClient {
   ///  * [getPreview] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getPreviewRaw({
-    final String? file,
-    final int? x,
-    final int? y,
-    final String? version,
+    String? file,
+    int? x,
+    int? y,
+    String? version,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -113,7 +113,7 @@ class PreviewClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -172,15 +172,14 @@ abstract interface class $Capabilities_FilesInterface {
 
 abstract class Capabilities_Files
     implements $Capabilities_FilesInterface, Built<Capabilities_Files, Capabilities_FilesBuilder> {
-  factory Capabilities_Files([final void Function(Capabilities_FilesBuilder)? b]) = _$Capabilities_Files;
+  factory Capabilities_Files([void Function(Capabilities_FilesBuilder)? b]) = _$Capabilities_Files;
 
   // coverage:ignore-start
   const Capabilities_Files._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_Files.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities_Files.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -196,14 +195,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/news.openapi.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.dart
@@ -29,7 +29,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -72,7 +72,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -136,7 +136,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -177,7 +177,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [createFolderRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<ListFolders, void>> createFolder({required final String name}) async {
+  Future<DynamiteResponse<ListFolders, void>> createFolder({required String name}) async {
     final rawResponse = createFolderRaw(
       name: name,
     );
@@ -199,7 +199,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [createFolder] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<ListFolders, void> createFolderRaw({required final String name}) {
+  DynamiteRawResponse<ListFolders, void> createFolderRaw({required String name}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -208,7 +208,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -253,8 +253,8 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [renameFolderRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<void, void>> renameFolder({
-    required final int folderId,
-    required final String name,
+    required int folderId,
+    required String name,
   }) async {
     final rawResponse = renameFolderRaw(
       folderId: folderId,
@@ -279,8 +279,8 @@ class Client extends DynamiteClient {
   ///  * [renameFolder] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> renameFolderRaw({
-    required final int folderId,
-    required final String name,
+    required int folderId,
+    required String name,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
@@ -288,7 +288,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -332,7 +332,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [deleteFolderRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<void, void>> deleteFolder({required final int folderId}) async {
+  Future<DynamiteResponse<void, void>> deleteFolder({required int folderId}) async {
     final rawResponse = deleteFolderRaw(
       folderId: folderId,
     );
@@ -351,14 +351,14 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [deleteFolder] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<void, void> deleteFolderRaw({required final int folderId}) {
+  DynamiteRawResponse<void, void> deleteFolderRaw({required int folderId}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -403,8 +403,8 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [markFolderAsReadRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<void, void>> markFolderAsRead({
-    required final int folderId,
-    required final int newestItemId,
+    required int folderId,
+    required int newestItemId,
   }) async {
     final rawResponse = markFolderAsReadRaw(
       folderId: folderId,
@@ -429,8 +429,8 @@ class Client extends DynamiteClient {
   ///  * [markFolderAsRead] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> markFolderAsReadRaw({
-    required final int folderId,
-    required final int newestItemId,
+    required int folderId,
+    required int newestItemId,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
@@ -438,7 +438,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -510,7 +510,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -553,8 +553,8 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [addFeedRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ListFeeds, void>> addFeed({
-    required final String url,
-    final int? folderId,
+    required String url,
+    int? folderId,
   }) async {
     final rawResponse = addFeedRaw(
       url: url,
@@ -580,8 +580,8 @@ class Client extends DynamiteClient {
   ///  * [addFeed] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ListFeeds, void> addFeedRaw({
-    required final String url,
-    final int? folderId,
+    required String url,
+    int? folderId,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -591,7 +591,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -635,7 +635,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [deleteFeedRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<void, void>> deleteFeed({required final int feedId}) async {
+  Future<DynamiteResponse<void, void>> deleteFeed({required int feedId}) async {
     final rawResponse = deleteFeedRaw(
       feedId: feedId,
     );
@@ -654,14 +654,14 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [deleteFeed] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<void, void> deleteFeedRaw({required final int feedId}) {
+  DynamiteRawResponse<void, void> deleteFeedRaw({required int feedId}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -706,8 +706,8 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [moveFeedRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<void, void>> moveFeed({
-    required final int feedId,
-    final int? folderId,
+    required int feedId,
+    int? folderId,
   }) async {
     final rawResponse = moveFeedRaw(
       feedId: feedId,
@@ -732,8 +732,8 @@ class Client extends DynamiteClient {
   ///  * [moveFeed] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> moveFeedRaw({
-    required final int feedId,
-    final int? folderId,
+    required int feedId,
+    int? folderId,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
@@ -741,7 +741,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -790,8 +790,8 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [renameFeedRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<void, void>> renameFeed({
-    required final int feedId,
-    required final String feedTitle,
+    required int feedId,
+    required String feedTitle,
   }) async {
     final rawResponse = renameFeedRaw(
       feedId: feedId,
@@ -816,8 +816,8 @@ class Client extends DynamiteClient {
   ///  * [renameFeed] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> renameFeedRaw({
-    required final int feedId,
-    required final String feedTitle,
+    required int feedId,
+    required String feedTitle,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
@@ -825,7 +825,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -874,8 +874,8 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [markFeedAsReadRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<void, void>> markFeedAsRead({
-    required final int feedId,
-    required final int newestItemId,
+    required int feedId,
+    required int newestItemId,
   }) async {
     final rawResponse = markFeedAsReadRaw(
       feedId: feedId,
@@ -900,8 +900,8 @@ class Client extends DynamiteClient {
   ///  * [markFeedAsRead] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<void, void> markFeedAsReadRaw({
-    required final int feedId,
-    required final int newestItemId,
+    required int feedId,
+    required int newestItemId,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
@@ -909,7 +909,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -963,12 +963,12 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [listArticlesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ListArticles, void>> listArticles({
-    final int? type,
-    final int? id,
-    final int? getRead,
-    final int? batchSize,
-    final int? offset,
-    final int? oldestFirst,
+    int? type,
+    int? id,
+    int? getRead,
+    int? batchSize,
+    int? offset,
+    int? oldestFirst,
   }) async {
     final rawResponse = listArticlesRaw(
       type: type,
@@ -1002,12 +1002,12 @@ class Client extends DynamiteClient {
   ///  * [listArticles] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ListArticles, void> listArticlesRaw({
-    final int? type,
-    final int? id,
-    final int? getRead,
-    final int? batchSize,
-    final int? offset,
-    final int? oldestFirst,
+    int? type,
+    int? id,
+    int? getRead,
+    int? batchSize,
+    int? offset,
+    int? oldestFirst,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1017,7 +1017,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1088,9 +1088,9 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [listUpdatedArticlesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ListArticles, void>> listUpdatedArticles({
-    final int? type,
-    final int? id,
-    final int? lastModified,
+    int? type,
+    int? id,
+    int? lastModified,
   }) async {
     final rawResponse = listUpdatedArticlesRaw(
       type: type,
@@ -1118,9 +1118,9 @@ class Client extends DynamiteClient {
   ///  * [listUpdatedArticles] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ListArticles, void> listUpdatedArticlesRaw({
-    final int? type,
-    final int? id,
-    final int? lastModified,
+    int? type,
+    int? id,
+    int? lastModified,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1130,7 +1130,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1182,7 +1182,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [markArticleAsReadRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<void, void>> markArticleAsRead({required final int itemId}) async {
+  Future<DynamiteResponse<void, void>> markArticleAsRead({required int itemId}) async {
     final rawResponse = markArticleAsReadRaw(
       itemId: itemId,
     );
@@ -1201,14 +1201,14 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [markArticleAsRead] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<void, void> markArticleAsReadRaw({required final int itemId}) {
+  DynamiteRawResponse<void, void> markArticleAsReadRaw({required int itemId}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1249,7 +1249,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [markArticleAsUnreadRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<void, void>> markArticleAsUnread({required final int itemId}) async {
+  Future<DynamiteResponse<void, void>> markArticleAsUnread({required int itemId}) async {
     final rawResponse = markArticleAsUnreadRaw(
       itemId: itemId,
     );
@@ -1268,14 +1268,14 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [markArticleAsUnread] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<void, void> markArticleAsUnreadRaw({required final int itemId}) {
+  DynamiteRawResponse<void, void> markArticleAsUnreadRaw({required int itemId}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1316,7 +1316,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [starArticleRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<void, void>> starArticle({required final int itemId}) async {
+  Future<DynamiteResponse<void, void>> starArticle({required int itemId}) async {
     final rawResponse = starArticleRaw(
       itemId: itemId,
     );
@@ -1335,14 +1335,14 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [starArticle] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<void, void> starArticleRaw({required final int itemId}) {
+  DynamiteRawResponse<void, void> starArticleRaw({required int itemId}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1383,7 +1383,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [unstarArticleRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<void, void>> unstarArticle({required final int itemId}) async {
+  Future<DynamiteResponse<void, void>> unstarArticle({required int itemId}) async {
     final rawResponse = unstarArticleRaw(
       itemId: itemId,
     );
@@ -1402,14 +1402,14 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [unstarArticle] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<void, void> unstarArticleRaw({required final int itemId}) {
+  DynamiteRawResponse<void, void> unstarArticleRaw({required int itemId}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{};
     Uint8List? body;
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1450,14 +1450,14 @@ abstract interface class $SupportedAPIVersionsInterface {
 
 abstract class SupportedAPIVersions
     implements $SupportedAPIVersionsInterface, Built<SupportedAPIVersions, SupportedAPIVersionsBuilder> {
-  factory SupportedAPIVersions([final void Function(SupportedAPIVersionsBuilder)? b]) = _$SupportedAPIVersions;
+  factory SupportedAPIVersions([void Function(SupportedAPIVersionsBuilder)? b]) = _$SupportedAPIVersions;
 
   // coverage:ignore-start
   const SupportedAPIVersions._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SupportedAPIVersions.fromJson(final Map<String, dynamic> json) =>
+  factory SupportedAPIVersions.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1493,14 +1493,14 @@ abstract interface class $ArticleInterface {
 }
 
 abstract class Article implements $ArticleInterface, Built<Article, ArticleBuilder> {
-  factory Article([final void Function(ArticleBuilder)? b]) = _$Article;
+  factory Article([void Function(ArticleBuilder)? b]) = _$Article;
 
   // coverage:ignore-start
   const Article._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Article.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Article.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1528,14 +1528,14 @@ abstract interface class $FeedInterface {
 }
 
 abstract class Feed implements $FeedInterface, Built<Feed, FeedBuilder> {
-  factory Feed([final void Function(FeedBuilder)? b]) = _$Feed;
+  factory Feed([void Function(FeedBuilder)? b]) = _$Feed;
 
   // coverage:ignore-start
   const Feed._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Feed.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Feed.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1556,14 +1556,14 @@ abstract interface class $FolderInterface {
 }
 
 abstract class Folder implements $FolderInterface, Built<Folder, FolderBuilder> {
-  factory Folder([final void Function(FolderBuilder)? b]) = _$Folder;
+  factory Folder([void Function(FolderBuilder)? b]) = _$Folder;
 
   // coverage:ignore-start
   const Folder._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Folder.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Folder.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1579,14 +1579,14 @@ abstract interface class $ListFoldersInterface {
 }
 
 abstract class ListFolders implements $ListFoldersInterface, Built<ListFolders, ListFoldersBuilder> {
-  factory ListFolders([final void Function(ListFoldersBuilder)? b]) = _$ListFolders;
+  factory ListFolders([void Function(ListFoldersBuilder)? b]) = _$ListFolders;
 
   // coverage:ignore-start
   const ListFolders._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ListFolders.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ListFolders.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1604,14 +1604,14 @@ abstract interface class $ListFeedsInterface {
 }
 
 abstract class ListFeeds implements $ListFeedsInterface, Built<ListFeeds, ListFeedsBuilder> {
-  factory ListFeeds([final void Function(ListFeedsBuilder)? b]) = _$ListFeeds;
+  factory ListFeeds([void Function(ListFeedsBuilder)? b]) = _$ListFeeds;
 
   // coverage:ignore-start
   const ListFeeds._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ListFeeds.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ListFeeds.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1627,14 +1627,14 @@ abstract interface class $ListArticlesInterface {
 }
 
 abstract class ListArticles implements $ListArticlesInterface, Built<ListArticles, ListArticlesBuilder> {
-  factory ListArticles([final void Function(ListArticlesBuilder)? b]) = _$ListArticles;
+  factory ListArticles([void Function(ListArticlesBuilder)? b]) = _$ListArticles;
 
   // coverage:ignore-start
   const ListArticles._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ListArticles.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ListArticles.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1654,14 +1654,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1678,14 +1678,14 @@ abstract interface class $EmptyOCS_OcsInterface {
 }
 
 abstract class EmptyOCS_Ocs implements $EmptyOCS_OcsInterface, Built<EmptyOCS_Ocs, EmptyOCS_OcsBuilder> {
-  factory EmptyOCS_Ocs([final void Function(EmptyOCS_OcsBuilder)? b]) = _$EmptyOCS_Ocs;
+  factory EmptyOCS_Ocs([void Function(EmptyOCS_OcsBuilder)? b]) = _$EmptyOCS_Ocs;
 
   // coverage:ignore-start
   const EmptyOCS_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EmptyOCS_Ocs.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory EmptyOCS_Ocs.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1701,14 +1701,14 @@ abstract interface class $EmptyOCSInterface {
 }
 
 abstract class EmptyOCS implements $EmptyOCSInterface, Built<EmptyOCS, EmptyOCSBuilder> {
-  factory EmptyOCS([final void Function(EmptyOCSBuilder)? b]) = _$EmptyOCS;
+  factory EmptyOCS([void Function(EmptyOCSBuilder)? b]) = _$EmptyOCS;
 
   // coverage:ignore-start
   const EmptyOCS._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EmptyOCS.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory EmptyOCS.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/notes.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.dart
@@ -30,7 +30,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -56,12 +56,12 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [getNotesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BuiltList<Note>, void>> getNotes({
-    final String? category,
-    final String? exclude,
-    final int? pruneBefore,
-    final int? chunkSize,
-    final String? chunkCursor,
-    final String? ifNoneMatch,
+    String? category,
+    String? exclude,
+    int? pruneBefore,
+    int? chunkSize,
+    String? chunkCursor,
+    String? ifNoneMatch,
   }) async {
     final rawResponse = getNotesRaw(
       category: category,
@@ -95,12 +95,12 @@ class Client extends DynamiteClient {
   ///  * [getNotes] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BuiltList<Note>, void> getNotesRaw({
-    final String? category,
-    final String? exclude,
-    final int? pruneBefore,
-    final int? chunkSize,
-    final String? chunkCursor,
-    final String? ifNoneMatch,
+    String? category,
+    String? exclude,
+    int? pruneBefore,
+    int? chunkSize,
+    String? chunkCursor,
+    String? ifNoneMatch,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -110,7 +110,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -182,11 +182,11 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [createNoteRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Note, void>> createNote({
-    final String? category,
-    final String? title,
-    final String? content,
-    final int? modified,
-    final int? favorite,
+    String? category,
+    String? title,
+    String? content,
+    int? modified,
+    int? favorite,
   }) async {
     final rawResponse = createNoteRaw(
       category: category,
@@ -218,11 +218,11 @@ class Client extends DynamiteClient {
   ///  * [createNote] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Note, void> createNoteRaw({
-    final String? category,
-    final String? title,
-    final String? content,
-    final int? modified,
-    final int? favorite,
+    String? category,
+    String? title,
+    String? content,
+    int? modified,
+    int? favorite,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -232,7 +232,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -298,9 +298,9 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [getNoteRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Note, void>> getNote({
-    required final int id,
-    final String? exclude,
-    final String? ifNoneMatch,
+    required int id,
+    String? exclude,
+    String? ifNoneMatch,
   }) async {
     final rawResponse = getNoteRaw(
       id: id,
@@ -327,9 +327,9 @@ class Client extends DynamiteClient {
   ///  * [getNote] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Note, void> getNoteRaw({
-    required final int id,
-    final String? exclude,
-    final String? ifNoneMatch,
+    required int id,
+    String? exclude,
+    String? ifNoneMatch,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -339,7 +339,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -398,13 +398,13 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [updateNoteRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Note, void>> updateNote({
-    required final int id,
-    final String? content,
-    final int? modified,
-    final String? title,
-    final String? category,
-    final int? favorite,
-    final String? ifMatch,
+    required int id,
+    String? content,
+    int? modified,
+    String? title,
+    String? category,
+    int? favorite,
+    String? ifMatch,
   }) async {
     final rawResponse = updateNoteRaw(
       id: id,
@@ -439,13 +439,13 @@ class Client extends DynamiteClient {
   ///  * [updateNote] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Note, void> updateNoteRaw({
-    required final int id,
-    final String? content,
-    final int? modified,
-    final String? title,
-    final String? category,
-    final int? favorite,
-    final String? ifMatch,
+    required int id,
+    String? content,
+    int? modified,
+    String? title,
+    String? category,
+    int? favorite,
+    String? ifMatch,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -455,7 +455,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -519,7 +519,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [deleteNoteRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<String, void>> deleteNote({required final int id}) async {
+  Future<DynamiteResponse<String, void>> deleteNote({required int id}) async {
     final rawResponse = deleteNoteRaw(
       id: id,
     );
@@ -538,7 +538,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [deleteNote] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<String, void> deleteNoteRaw({required final int id}) {
+  DynamiteRawResponse<String, void> deleteNoteRaw({required int id}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -547,7 +547,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -614,7 +614,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -652,7 +652,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [updateSettingsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<Settings, void>> updateSettings({required final Settings settings}) async {
+  Future<DynamiteResponse<Settings, void>> updateSettings({required Settings settings}) async {
     final rawResponse = updateSettingsRaw(
       settings: settings,
     );
@@ -671,7 +671,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [updateSettings] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<Settings, void> updateSettingsRaw({required final Settings settings}) {
+  DynamiteRawResponse<Settings, void> updateSettingsRaw({required Settings settings}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -680,7 +680,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -728,14 +728,14 @@ abstract interface class $NoteInterface {
 }
 
 abstract class Note implements $NoteInterface, Built<Note, NoteBuilder> {
-  factory Note([final void Function(NoteBuilder)? b]) = _$Note;
+  factory Note([void Function(NoteBuilder)? b]) = _$Note;
 
   // coverage:ignore-start
   const Note._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Note.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Note.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -758,7 +758,7 @@ class Settings_NoteMode extends EnumClass {
   static BuiltSet<Settings_NoteMode> get values => _$settingsNoteModeValues;
   // coverage:ignore-end
 
-  static Settings_NoteMode valueOf(final String name) => _$valueOfSettings_NoteMode(name);
+  static Settings_NoteMode valueOf(String name) => _$valueOfSettings_NoteMode(name);
 
   static Serializer<Settings_NoteMode> get serializer => _$settingsNoteModeSerializer;
 }
@@ -771,14 +771,14 @@ abstract interface class $SettingsInterface {
 }
 
 abstract class Settings implements $SettingsInterface, Built<Settings, SettingsBuilder> {
-  factory Settings([final void Function(SettingsBuilder)? b]) = _$Settings;
+  factory Settings([void Function(SettingsBuilder)? b]) = _$Settings;
 
   // coverage:ignore-start
   const Settings._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Settings.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Settings.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -797,15 +797,14 @@ abstract interface class $Capabilities_NotesInterface {
 
 abstract class Capabilities_Notes
     implements $Capabilities_NotesInterface, Built<Capabilities_Notes, Capabilities_NotesBuilder> {
-  factory Capabilities_Notes([final void Function(Capabilities_NotesBuilder)? b]) = _$Capabilities_Notes;
+  factory Capabilities_Notes([void Function(Capabilities_NotesBuilder)? b]) = _$Capabilities_Notes;
 
   // coverage:ignore-start
   const Capabilities_Notes._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_Notes.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities_Notes.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -821,14 +820,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -848,14 +847,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -872,14 +871,14 @@ abstract interface class $EmptyOCS_OcsInterface {
 }
 
 abstract class EmptyOCS_Ocs implements $EmptyOCS_OcsInterface, Built<EmptyOCS_Ocs, EmptyOCS_OcsBuilder> {
-  factory EmptyOCS_Ocs([final void Function(EmptyOCS_OcsBuilder)? b]) = _$EmptyOCS_Ocs;
+  factory EmptyOCS_Ocs([void Function(EmptyOCS_OcsBuilder)? b]) = _$EmptyOCS_Ocs;
 
   // coverage:ignore-start
   const EmptyOCS_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EmptyOCS_Ocs.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory EmptyOCS_Ocs.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -895,14 +894,14 @@ abstract interface class $EmptyOCSInterface {
 }
 
 abstract class EmptyOCS implements $EmptyOCSInterface, Built<EmptyOCS, EmptyOCSBuilder> {
-  factory EmptyOCS([final void Function(EmptyOCSBuilder)? b]) = _$EmptyOCS;
+  factory EmptyOCS([void Function(EmptyOCSBuilder)? b]) = _$EmptyOCS;
 
   // coverage:ignore-start
   const EmptyOCS._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EmptyOCS.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory EmptyOCS.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/notifications.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.dart
@@ -29,7 +29,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -75,11 +75,11 @@ class ApiClient {
   /// See:
   ///  * [generateNotificationRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ApiGenerateNotificationResponseApplicationJson, void>> generateNotification({
-    required final String shortMessage,
-    required final String userId,
-    final String? longMessage,
-    final ApiGenerateNotificationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String shortMessage,
+    required String userId,
+    String? longMessage,
+    ApiGenerateNotificationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = generateNotificationRaw(
       shortMessage: shortMessage,
@@ -118,11 +118,11 @@ class ApiClient {
   ///  * [generateNotification] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ApiGenerateNotificationResponseApplicationJson, void> generateNotificationRaw({
-    required final String shortMessage,
-    required final String userId,
-    final String? longMessage,
-    final ApiGenerateNotificationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String shortMessage,
+    required String userId,
+    String? longMessage,
+    ApiGenerateNotificationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -132,7 +132,7 @@ class ApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -208,8 +208,8 @@ class EndpointClient {
   ///  * [listNotificationsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<EndpointListNotificationsResponseApplicationJson, EndpointEndpointListNotificationsHeaders>>
       listNotifications({
-    final EndpointListNotificationsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    EndpointListNotificationsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = listNotificationsRaw(
       apiVersion: apiVersion,
@@ -239,8 +239,8 @@ class EndpointClient {
   @experimental
   DynamiteRawResponse<EndpointListNotificationsResponseApplicationJson, EndpointEndpointListNotificationsHeaders>
       listNotificationsRaw({
-    final EndpointListNotificationsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    EndpointListNotificationsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -250,7 +250,7 @@ class EndpointClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -307,8 +307,8 @@ class EndpointClient {
   /// See:
   ///  * [deleteAllNotificationsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<EndpointDeleteAllNotificationsResponseApplicationJson, void>> deleteAllNotifications({
-    final EndpointDeleteAllNotificationsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    EndpointDeleteAllNotificationsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteAllNotificationsRaw(
       apiVersion: apiVersion,
@@ -337,8 +337,8 @@ class EndpointClient {
   ///  * [deleteAllNotifications] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<EndpointDeleteAllNotificationsResponseApplicationJson, void> deleteAllNotificationsRaw({
-    final EndpointDeleteAllNotificationsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    EndpointDeleteAllNotificationsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -348,7 +348,7 @@ class EndpointClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -405,9 +405,9 @@ class EndpointClient {
   /// See:
   ///  * [getNotificationRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<EndpointGetNotificationResponseApplicationJson, void>> getNotification({
-    required final int id,
-    final EndpointGetNotificationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int id,
+    EndpointGetNotificationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getNotificationRaw(
       id: id,
@@ -438,9 +438,9 @@ class EndpointClient {
   ///  * [getNotification] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<EndpointGetNotificationResponseApplicationJson, void> getNotificationRaw({
-    required final int id,
-    final EndpointGetNotificationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int id,
+    EndpointGetNotificationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -450,7 +450,7 @@ class EndpointClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -512,9 +512,9 @@ class EndpointClient {
   /// See:
   ///  * [deleteNotificationRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<EndpointDeleteNotificationResponseApplicationJson, void>> deleteNotification({
-    required final int id,
-    final EndpointDeleteNotificationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int id,
+    EndpointDeleteNotificationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteNotificationRaw(
       id: id,
@@ -546,9 +546,9 @@ class EndpointClient {
   ///  * [deleteNotification] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<EndpointDeleteNotificationResponseApplicationJson, void> deleteNotificationRaw({
-    required final int id,
-    final EndpointDeleteNotificationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int id,
+    EndpointDeleteNotificationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -558,7 +558,7 @@ class EndpointClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -619,9 +619,9 @@ class EndpointClient {
   /// See:
   ///  * [confirmIdsForUserRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<EndpointConfirmIdsForUserResponseApplicationJson, void>> confirmIdsForUser({
-    required final BuiltList<int> ids,
-    final EndpointConfirmIdsForUserApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required BuiltList<int> ids,
+    EndpointConfirmIdsForUserApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = confirmIdsForUserRaw(
       ids: ids,
@@ -652,9 +652,9 @@ class EndpointClient {
   ///  * [confirmIdsForUser] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<EndpointConfirmIdsForUserResponseApplicationJson, void> confirmIdsForUserRaw({
-    required final BuiltList<int> ids,
-    final EndpointConfirmIdsForUserApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required BuiltList<int> ids,
+    EndpointConfirmIdsForUserApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -664,7 +664,7 @@ class EndpointClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -736,11 +736,11 @@ class PushClient {
   /// See:
   ///  * [registerDeviceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PushRegisterDeviceResponseApplicationJson, void>> registerDevice({
-    required final String pushTokenHash,
-    required final String devicePublicKey,
-    required final String proxyServer,
-    final PushRegisterDeviceApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String pushTokenHash,
+    required String devicePublicKey,
+    required String proxyServer,
+    PushRegisterDeviceApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = registerDeviceRaw(
       pushTokenHash: pushTokenHash,
@@ -777,11 +777,11 @@ class PushClient {
   ///  * [registerDevice] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PushRegisterDeviceResponseApplicationJson, void> registerDeviceRaw({
-    required final String pushTokenHash,
-    required final String devicePublicKey,
-    required final String proxyServer,
-    final PushRegisterDeviceApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String pushTokenHash,
+    required String devicePublicKey,
+    required String proxyServer,
+    PushRegisterDeviceApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -791,7 +791,7 @@ class PushClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -861,8 +861,8 @@ class PushClient {
   /// See:
   ///  * [removeDeviceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PushRemoveDeviceResponseApplicationJson, void>> removeDevice({
-    final PushRemoveDeviceApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    PushRemoveDeviceApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = removeDeviceRaw(
       apiVersion: apiVersion,
@@ -893,8 +893,8 @@ class PushClient {
   ///  * [removeDevice] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PushRemoveDeviceResponseApplicationJson, void> removeDeviceRaw({
-    final PushRemoveDeviceApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    PushRemoveDeviceApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -904,7 +904,7 @@ class PushClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -966,11 +966,11 @@ class SettingsClient {
   /// See:
   ///  * [personalRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<SettingsPersonalResponseApplicationJson, void>> personal({
-    required final int batchSetting,
-    required final String soundNotification,
-    required final String soundTalk,
-    final SettingsPersonalApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int batchSetting,
+    required String soundNotification,
+    required String soundTalk,
+    SettingsPersonalApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = personalRaw(
       batchSetting: batchSetting,
@@ -1004,11 +1004,11 @@ class SettingsClient {
   ///  * [personal] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SettingsPersonalResponseApplicationJson, void> personalRaw({
-    required final int batchSetting,
-    required final String soundNotification,
-    required final String soundTalk,
-    final SettingsPersonalApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int batchSetting,
+    required String soundNotification,
+    required String soundTalk,
+    SettingsPersonalApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1018,7 +1018,7 @@ class SettingsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1089,11 +1089,11 @@ class SettingsClient {
   /// See:
   ///  * [adminRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<SettingsAdminResponseApplicationJson, void>> admin({
-    required final int batchSetting,
-    required final String soundNotification,
-    required final String soundTalk,
-    final SettingsAdminApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int batchSetting,
+    required String soundNotification,
+    required String soundTalk,
+    SettingsAdminApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = adminRaw(
       batchSetting: batchSetting,
@@ -1129,11 +1129,11 @@ class SettingsClient {
   ///  * [admin] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SettingsAdminResponseApplicationJson, void> adminRaw({
-    required final int batchSetting,
-    required final String soundNotification,
-    required final String soundTalk,
-    final SettingsAdminApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int batchSetting,
+    required String soundNotification,
+    required String soundTalk,
+    SettingsAdminApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1143,7 +1143,7 @@ class SettingsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1206,8 +1206,7 @@ class ApiGenerateNotificationApiVersion extends EnumClass {
   static BuiltSet<ApiGenerateNotificationApiVersion> get values => _$apiGenerateNotificationApiVersionValues;
   // coverage:ignore-end
 
-  static ApiGenerateNotificationApiVersion valueOf(final String name) =>
-      _$valueOfApiGenerateNotificationApiVersion(name);
+  static ApiGenerateNotificationApiVersion valueOf(String name) => _$valueOfApiGenerateNotificationApiVersion(name);
 
   static Serializer<ApiGenerateNotificationApiVersion> get serializer => _$apiGenerateNotificationApiVersionSerializer;
 }
@@ -1222,14 +1221,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1251,7 +1250,7 @@ abstract class ApiGenerateNotificationResponseApplicationJson_Ocs
         Built<ApiGenerateNotificationResponseApplicationJson_Ocs,
             ApiGenerateNotificationResponseApplicationJson_OcsBuilder> {
   factory ApiGenerateNotificationResponseApplicationJson_Ocs([
-    final void Function(ApiGenerateNotificationResponseApplicationJson_OcsBuilder)? b,
+    void Function(ApiGenerateNotificationResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ApiGenerateNotificationResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1259,7 +1258,7 @@ abstract class ApiGenerateNotificationResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiGenerateNotificationResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ApiGenerateNotificationResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1281,7 +1280,7 @@ abstract class ApiGenerateNotificationResponseApplicationJson
         $ApiGenerateNotificationResponseApplicationJsonInterface,
         Built<ApiGenerateNotificationResponseApplicationJson, ApiGenerateNotificationResponseApplicationJsonBuilder> {
   factory ApiGenerateNotificationResponseApplicationJson([
-    final void Function(ApiGenerateNotificationResponseApplicationJsonBuilder)? b,
+    void Function(ApiGenerateNotificationResponseApplicationJsonBuilder)? b,
   ]) = _$ApiGenerateNotificationResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1289,7 +1288,7 @@ abstract class ApiGenerateNotificationResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiGenerateNotificationResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ApiGenerateNotificationResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1312,8 +1311,7 @@ class EndpointListNotificationsApiVersion extends EnumClass {
   static BuiltSet<EndpointListNotificationsApiVersion> get values => _$endpointListNotificationsApiVersionValues;
   // coverage:ignore-end
 
-  static EndpointListNotificationsApiVersion valueOf(final String name) =>
-      _$valueOfEndpointListNotificationsApiVersion(name);
+  static EndpointListNotificationsApiVersion valueOf(String name) => _$valueOfEndpointListNotificationsApiVersion(name);
 
   static Serializer<EndpointListNotificationsApiVersion> get serializer =>
       _$endpointListNotificationsApiVersionSerializer;
@@ -1330,7 +1328,7 @@ abstract class EndpointEndpointListNotificationsHeaders
         $EndpointEndpointListNotificationsHeadersInterface,
         Built<EndpointEndpointListNotificationsHeaders, EndpointEndpointListNotificationsHeadersBuilder> {
   factory EndpointEndpointListNotificationsHeaders([
-    final void Function(EndpointEndpointListNotificationsHeadersBuilder)? b,
+    void Function(EndpointEndpointListNotificationsHeadersBuilder)? b,
   ]) = _$EndpointEndpointListNotificationsHeaders;
 
   // coverage:ignore-start
@@ -1338,7 +1336,7 @@ abstract class EndpointEndpointListNotificationsHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointEndpointListNotificationsHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointEndpointListNotificationsHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1360,15 +1358,14 @@ abstract interface class $NotificationActionInterface {
 
 abstract class NotificationAction
     implements $NotificationActionInterface, Built<NotificationAction, NotificationActionBuilder> {
-  factory NotificationAction([final void Function(NotificationActionBuilder)? b]) = _$NotificationAction;
+  factory NotificationAction([void Function(NotificationActionBuilder)? b]) = _$NotificationAction;
 
   // coverage:ignore-start
   const NotificationAction._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory NotificationAction.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory NotificationAction.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1402,14 +1399,14 @@ abstract interface class $NotificationInterface {
 }
 
 abstract class Notification implements $NotificationInterface, Built<Notification, NotificationBuilder> {
-  factory Notification([final void Function(NotificationBuilder)? b]) = _$Notification;
+  factory Notification([void Function(NotificationBuilder)? b]) = _$Notification;
 
   // coverage:ignore-start
   const Notification._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Notification.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Notification.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1431,7 +1428,7 @@ abstract class EndpointListNotificationsResponseApplicationJson_Ocs
         Built<EndpointListNotificationsResponseApplicationJson_Ocs,
             EndpointListNotificationsResponseApplicationJson_OcsBuilder> {
   factory EndpointListNotificationsResponseApplicationJson_Ocs([
-    final void Function(EndpointListNotificationsResponseApplicationJson_OcsBuilder)? b,
+    void Function(EndpointListNotificationsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$EndpointListNotificationsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1439,7 +1436,7 @@ abstract class EndpointListNotificationsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointListNotificationsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointListNotificationsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1462,7 +1459,7 @@ abstract class EndpointListNotificationsResponseApplicationJson
         Built<EndpointListNotificationsResponseApplicationJson,
             EndpointListNotificationsResponseApplicationJsonBuilder> {
   factory EndpointListNotificationsResponseApplicationJson([
-    final void Function(EndpointListNotificationsResponseApplicationJsonBuilder)? b,
+    void Function(EndpointListNotificationsResponseApplicationJsonBuilder)? b,
   ]) = _$EndpointListNotificationsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1470,7 +1467,7 @@ abstract class EndpointListNotificationsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointListNotificationsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointListNotificationsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1494,7 +1491,7 @@ class EndpointDeleteAllNotificationsApiVersion extends EnumClass {
       _$endpointDeleteAllNotificationsApiVersionValues;
   // coverage:ignore-end
 
-  static EndpointDeleteAllNotificationsApiVersion valueOf(final String name) =>
+  static EndpointDeleteAllNotificationsApiVersion valueOf(String name) =>
       _$valueOfEndpointDeleteAllNotificationsApiVersion(name);
 
   static Serializer<EndpointDeleteAllNotificationsApiVersion> get serializer =>
@@ -1513,7 +1510,7 @@ abstract class EndpointDeleteAllNotificationsResponseApplicationJson_Ocs
         Built<EndpointDeleteAllNotificationsResponseApplicationJson_Ocs,
             EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder> {
   factory EndpointDeleteAllNotificationsResponseApplicationJson_Ocs([
-    final void Function(EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder)? b,
+    void Function(EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$EndpointDeleteAllNotificationsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1521,7 +1518,7 @@ abstract class EndpointDeleteAllNotificationsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointDeleteAllNotificationsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointDeleteAllNotificationsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1544,7 +1541,7 @@ abstract class EndpointDeleteAllNotificationsResponseApplicationJson
         Built<EndpointDeleteAllNotificationsResponseApplicationJson,
             EndpointDeleteAllNotificationsResponseApplicationJsonBuilder> {
   factory EndpointDeleteAllNotificationsResponseApplicationJson([
-    final void Function(EndpointDeleteAllNotificationsResponseApplicationJsonBuilder)? b,
+    void Function(EndpointDeleteAllNotificationsResponseApplicationJsonBuilder)? b,
   ]) = _$EndpointDeleteAllNotificationsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1552,7 +1549,7 @@ abstract class EndpointDeleteAllNotificationsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointDeleteAllNotificationsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointDeleteAllNotificationsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1575,8 +1572,7 @@ class EndpointGetNotificationApiVersion extends EnumClass {
   static BuiltSet<EndpointGetNotificationApiVersion> get values => _$endpointGetNotificationApiVersionValues;
   // coverage:ignore-end
 
-  static EndpointGetNotificationApiVersion valueOf(final String name) =>
-      _$valueOfEndpointGetNotificationApiVersion(name);
+  static EndpointGetNotificationApiVersion valueOf(String name) => _$valueOfEndpointGetNotificationApiVersion(name);
 
   static Serializer<EndpointGetNotificationApiVersion> get serializer => _$endpointGetNotificationApiVersionSerializer;
 }
@@ -1593,7 +1589,7 @@ abstract class EndpointGetNotificationResponseApplicationJson_Ocs
         Built<EndpointGetNotificationResponseApplicationJson_Ocs,
             EndpointGetNotificationResponseApplicationJson_OcsBuilder> {
   factory EndpointGetNotificationResponseApplicationJson_Ocs([
-    final void Function(EndpointGetNotificationResponseApplicationJson_OcsBuilder)? b,
+    void Function(EndpointGetNotificationResponseApplicationJson_OcsBuilder)? b,
   ]) = _$EndpointGetNotificationResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1601,7 +1597,7 @@ abstract class EndpointGetNotificationResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointGetNotificationResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointGetNotificationResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1623,7 +1619,7 @@ abstract class EndpointGetNotificationResponseApplicationJson
         $EndpointGetNotificationResponseApplicationJsonInterface,
         Built<EndpointGetNotificationResponseApplicationJson, EndpointGetNotificationResponseApplicationJsonBuilder> {
   factory EndpointGetNotificationResponseApplicationJson([
-    final void Function(EndpointGetNotificationResponseApplicationJsonBuilder)? b,
+    void Function(EndpointGetNotificationResponseApplicationJsonBuilder)? b,
   ]) = _$EndpointGetNotificationResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1631,7 +1627,7 @@ abstract class EndpointGetNotificationResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointGetNotificationResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointGetNotificationResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1654,7 +1650,7 @@ class EndpointDeleteNotificationApiVersion extends EnumClass {
   static BuiltSet<EndpointDeleteNotificationApiVersion> get values => _$endpointDeleteNotificationApiVersionValues;
   // coverage:ignore-end
 
-  static EndpointDeleteNotificationApiVersion valueOf(final String name) =>
+  static EndpointDeleteNotificationApiVersion valueOf(String name) =>
       _$valueOfEndpointDeleteNotificationApiVersion(name);
 
   static Serializer<EndpointDeleteNotificationApiVersion> get serializer =>
@@ -1673,7 +1669,7 @@ abstract class EndpointDeleteNotificationResponseApplicationJson_Ocs
         Built<EndpointDeleteNotificationResponseApplicationJson_Ocs,
             EndpointDeleteNotificationResponseApplicationJson_OcsBuilder> {
   factory EndpointDeleteNotificationResponseApplicationJson_Ocs([
-    final void Function(EndpointDeleteNotificationResponseApplicationJson_OcsBuilder)? b,
+    void Function(EndpointDeleteNotificationResponseApplicationJson_OcsBuilder)? b,
   ]) = _$EndpointDeleteNotificationResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1681,7 +1677,7 @@ abstract class EndpointDeleteNotificationResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointDeleteNotificationResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointDeleteNotificationResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1704,7 +1700,7 @@ abstract class EndpointDeleteNotificationResponseApplicationJson
         Built<EndpointDeleteNotificationResponseApplicationJson,
             EndpointDeleteNotificationResponseApplicationJsonBuilder> {
   factory EndpointDeleteNotificationResponseApplicationJson([
-    final void Function(EndpointDeleteNotificationResponseApplicationJsonBuilder)? b,
+    void Function(EndpointDeleteNotificationResponseApplicationJsonBuilder)? b,
   ]) = _$EndpointDeleteNotificationResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1712,7 +1708,7 @@ abstract class EndpointDeleteNotificationResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointDeleteNotificationResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointDeleteNotificationResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1735,8 +1731,7 @@ class EndpointConfirmIdsForUserApiVersion extends EnumClass {
   static BuiltSet<EndpointConfirmIdsForUserApiVersion> get values => _$endpointConfirmIdsForUserApiVersionValues;
   // coverage:ignore-end
 
-  static EndpointConfirmIdsForUserApiVersion valueOf(final String name) =>
-      _$valueOfEndpointConfirmIdsForUserApiVersion(name);
+  static EndpointConfirmIdsForUserApiVersion valueOf(String name) => _$valueOfEndpointConfirmIdsForUserApiVersion(name);
 
   static Serializer<EndpointConfirmIdsForUserApiVersion> get serializer =>
       _$endpointConfirmIdsForUserApiVersionSerializer;
@@ -1754,7 +1749,7 @@ abstract class EndpointConfirmIdsForUserResponseApplicationJson_Ocs
         Built<EndpointConfirmIdsForUserResponseApplicationJson_Ocs,
             EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder> {
   factory EndpointConfirmIdsForUserResponseApplicationJson_Ocs([
-    final void Function(EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder)? b,
+    void Function(EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder)? b,
   ]) = _$EndpointConfirmIdsForUserResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1762,7 +1757,7 @@ abstract class EndpointConfirmIdsForUserResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointConfirmIdsForUserResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointConfirmIdsForUserResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1785,7 +1780,7 @@ abstract class EndpointConfirmIdsForUserResponseApplicationJson
         Built<EndpointConfirmIdsForUserResponseApplicationJson,
             EndpointConfirmIdsForUserResponseApplicationJsonBuilder> {
   factory EndpointConfirmIdsForUserResponseApplicationJson([
-    final void Function(EndpointConfirmIdsForUserResponseApplicationJsonBuilder)? b,
+    void Function(EndpointConfirmIdsForUserResponseApplicationJsonBuilder)? b,
   ]) = _$EndpointConfirmIdsForUserResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1793,7 +1788,7 @@ abstract class EndpointConfirmIdsForUserResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory EndpointConfirmIdsForUserResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory EndpointConfirmIdsForUserResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1814,7 +1809,7 @@ class PushRegisterDeviceApiVersion extends EnumClass {
   static BuiltSet<PushRegisterDeviceApiVersion> get values => _$pushRegisterDeviceApiVersionValues;
   // coverage:ignore-end
 
-  static PushRegisterDeviceApiVersion valueOf(final String name) => _$valueOfPushRegisterDeviceApiVersion(name);
+  static PushRegisterDeviceApiVersion valueOf(String name) => _$valueOfPushRegisterDeviceApiVersion(name);
 
   static Serializer<PushRegisterDeviceApiVersion> get serializer => _$pushRegisterDeviceApiVersionSerializer;
 }
@@ -1827,14 +1822,14 @@ abstract interface class $PushDeviceInterface {
 }
 
 abstract class PushDevice implements $PushDeviceInterface, Built<PushDevice, PushDeviceBuilder> {
-  factory PushDevice([final void Function(PushDeviceBuilder)? b]) = _$PushDevice;
+  factory PushDevice([void Function(PushDeviceBuilder)? b]) = _$PushDevice;
 
   // coverage:ignore-start
   const PushDevice._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PushDevice.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory PushDevice.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1855,7 +1850,7 @@ abstract class PushRegisterDeviceResponseApplicationJson_Ocs
         $PushRegisterDeviceResponseApplicationJson_OcsInterface,
         Built<PushRegisterDeviceResponseApplicationJson_Ocs, PushRegisterDeviceResponseApplicationJson_OcsBuilder> {
   factory PushRegisterDeviceResponseApplicationJson_Ocs([
-    final void Function(PushRegisterDeviceResponseApplicationJson_OcsBuilder)? b,
+    void Function(PushRegisterDeviceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$PushRegisterDeviceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1863,7 +1858,7 @@ abstract class PushRegisterDeviceResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PushRegisterDeviceResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PushRegisterDeviceResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1885,7 +1880,7 @@ abstract class PushRegisterDeviceResponseApplicationJson
         $PushRegisterDeviceResponseApplicationJsonInterface,
         Built<PushRegisterDeviceResponseApplicationJson, PushRegisterDeviceResponseApplicationJsonBuilder> {
   factory PushRegisterDeviceResponseApplicationJson([
-    final void Function(PushRegisterDeviceResponseApplicationJsonBuilder)? b,
+    void Function(PushRegisterDeviceResponseApplicationJsonBuilder)? b,
   ]) = _$PushRegisterDeviceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1893,7 +1888,7 @@ abstract class PushRegisterDeviceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PushRegisterDeviceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PushRegisterDeviceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1914,7 +1909,7 @@ class PushRemoveDeviceApiVersion extends EnumClass {
   static BuiltSet<PushRemoveDeviceApiVersion> get values => _$pushRemoveDeviceApiVersionValues;
   // coverage:ignore-end
 
-  static PushRemoveDeviceApiVersion valueOf(final String name) => _$valueOfPushRemoveDeviceApiVersion(name);
+  static PushRemoveDeviceApiVersion valueOf(String name) => _$valueOfPushRemoveDeviceApiVersion(name);
 
   static Serializer<PushRemoveDeviceApiVersion> get serializer => _$pushRemoveDeviceApiVersionSerializer;
 }
@@ -1930,7 +1925,7 @@ abstract class PushRemoveDeviceResponseApplicationJson_Ocs
         $PushRemoveDeviceResponseApplicationJson_OcsInterface,
         Built<PushRemoveDeviceResponseApplicationJson_Ocs, PushRemoveDeviceResponseApplicationJson_OcsBuilder> {
   factory PushRemoveDeviceResponseApplicationJson_Ocs([
-    final void Function(PushRemoveDeviceResponseApplicationJson_OcsBuilder)? b,
+    void Function(PushRemoveDeviceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$PushRemoveDeviceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1938,7 +1933,7 @@ abstract class PushRemoveDeviceResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PushRemoveDeviceResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PushRemoveDeviceResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1959,16 +1954,15 @@ abstract class PushRemoveDeviceResponseApplicationJson
     implements
         $PushRemoveDeviceResponseApplicationJsonInterface,
         Built<PushRemoveDeviceResponseApplicationJson, PushRemoveDeviceResponseApplicationJsonBuilder> {
-  factory PushRemoveDeviceResponseApplicationJson([
-    final void Function(PushRemoveDeviceResponseApplicationJsonBuilder)? b,
-  ]) = _$PushRemoveDeviceResponseApplicationJson;
+  factory PushRemoveDeviceResponseApplicationJson([void Function(PushRemoveDeviceResponseApplicationJsonBuilder)? b]) =
+      _$PushRemoveDeviceResponseApplicationJson;
 
   // coverage:ignore-start
   const PushRemoveDeviceResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PushRemoveDeviceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PushRemoveDeviceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1989,7 +1983,7 @@ class SettingsPersonalApiVersion extends EnumClass {
   static BuiltSet<SettingsPersonalApiVersion> get values => _$settingsPersonalApiVersionValues;
   // coverage:ignore-end
 
-  static SettingsPersonalApiVersion valueOf(final String name) => _$valueOfSettingsPersonalApiVersion(name);
+  static SettingsPersonalApiVersion valueOf(String name) => _$valueOfSettingsPersonalApiVersion(name);
 
   static Serializer<SettingsPersonalApiVersion> get serializer => _$settingsPersonalApiVersionSerializer;
 }
@@ -2005,7 +1999,7 @@ abstract class SettingsPersonalResponseApplicationJson_Ocs
         $SettingsPersonalResponseApplicationJson_OcsInterface,
         Built<SettingsPersonalResponseApplicationJson_Ocs, SettingsPersonalResponseApplicationJson_OcsBuilder> {
   factory SettingsPersonalResponseApplicationJson_Ocs([
-    final void Function(SettingsPersonalResponseApplicationJson_OcsBuilder)? b,
+    void Function(SettingsPersonalResponseApplicationJson_OcsBuilder)? b,
   ]) = _$SettingsPersonalResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2013,7 +2007,7 @@ abstract class SettingsPersonalResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SettingsPersonalResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory SettingsPersonalResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2034,16 +2028,15 @@ abstract class SettingsPersonalResponseApplicationJson
     implements
         $SettingsPersonalResponseApplicationJsonInterface,
         Built<SettingsPersonalResponseApplicationJson, SettingsPersonalResponseApplicationJsonBuilder> {
-  factory SettingsPersonalResponseApplicationJson([
-    final void Function(SettingsPersonalResponseApplicationJsonBuilder)? b,
-  ]) = _$SettingsPersonalResponseApplicationJson;
+  factory SettingsPersonalResponseApplicationJson([void Function(SettingsPersonalResponseApplicationJsonBuilder)? b]) =
+      _$SettingsPersonalResponseApplicationJson;
 
   // coverage:ignore-start
   const SettingsPersonalResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SettingsPersonalResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory SettingsPersonalResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2064,7 +2057,7 @@ class SettingsAdminApiVersion extends EnumClass {
   static BuiltSet<SettingsAdminApiVersion> get values => _$settingsAdminApiVersionValues;
   // coverage:ignore-end
 
-  static SettingsAdminApiVersion valueOf(final String name) => _$valueOfSettingsAdminApiVersion(name);
+  static SettingsAdminApiVersion valueOf(String name) => _$valueOfSettingsAdminApiVersion(name);
 
   static Serializer<SettingsAdminApiVersion> get serializer => _$settingsAdminApiVersionSerializer;
 }
@@ -2080,7 +2073,7 @@ abstract class SettingsAdminResponseApplicationJson_Ocs
         $SettingsAdminResponseApplicationJson_OcsInterface,
         Built<SettingsAdminResponseApplicationJson_Ocs, SettingsAdminResponseApplicationJson_OcsBuilder> {
   factory SettingsAdminResponseApplicationJson_Ocs([
-    final void Function(SettingsAdminResponseApplicationJson_OcsBuilder)? b,
+    void Function(SettingsAdminResponseApplicationJson_OcsBuilder)? b,
   ]) = _$SettingsAdminResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -2088,7 +2081,7 @@ abstract class SettingsAdminResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SettingsAdminResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory SettingsAdminResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2109,7 +2102,7 @@ abstract class SettingsAdminResponseApplicationJson
     implements
         $SettingsAdminResponseApplicationJsonInterface,
         Built<SettingsAdminResponseApplicationJson, SettingsAdminResponseApplicationJsonBuilder> {
-  factory SettingsAdminResponseApplicationJson([final void Function(SettingsAdminResponseApplicationJsonBuilder)? b]) =
+  factory SettingsAdminResponseApplicationJson([void Function(SettingsAdminResponseApplicationJsonBuilder)? b]) =
       _$SettingsAdminResponseApplicationJson;
 
   // coverage:ignore-start
@@ -2117,7 +2110,7 @@ abstract class SettingsAdminResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SettingsAdminResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory SettingsAdminResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2142,7 +2135,7 @@ abstract class Capabilities_Notifications
     implements
         $Capabilities_NotificationsInterface,
         Built<Capabilities_Notifications, Capabilities_NotificationsBuilder> {
-  factory Capabilities_Notifications([final void Function(Capabilities_NotificationsBuilder)? b]) =
+  factory Capabilities_Notifications([void Function(Capabilities_NotificationsBuilder)? b]) =
       _$Capabilities_Notifications;
 
   // coverage:ignore-start
@@ -2150,7 +2143,7 @@ abstract class Capabilities_Notifications
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_Notifications.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_Notifications.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -2167,14 +2160,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -31,7 +31,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -71,7 +71,7 @@ class AppConfigClient {
   ///
   /// See:
   ///  * [getAppsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<AppConfigGetAppsResponseApplicationJson, void>> getApps({final bool? oCSAPIRequest}) async {
+  Future<DynamiteResponse<AppConfigGetAppsResponseApplicationJson, void>> getApps({bool? oCSAPIRequest}) async {
     final rawResponse = getAppsRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -97,7 +97,7 @@ class AppConfigClient {
   /// See:
   ///  * [getApps] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<AppConfigGetAppsResponseApplicationJson, void> getAppsRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<AppConfigGetAppsResponseApplicationJson, void> getAppsRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -106,7 +106,7 @@ class AppConfigClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -158,8 +158,8 @@ class AppConfigClient {
   /// See:
   ///  * [getKeysRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppConfigGetKeysResponseApplicationJson, void>> getKeys({
-    required final String app,
-    final bool? oCSAPIRequest,
+    required String app,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getKeysRaw(
       app: app,
@@ -190,8 +190,8 @@ class AppConfigClient {
   ///  * [getKeys] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppConfigGetKeysResponseApplicationJson, void> getKeysRaw({
-    required final String app,
-    final bool? oCSAPIRequest,
+    required String app,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -201,7 +201,7 @@ class AppConfigClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -258,10 +258,10 @@ class AppConfigClient {
   /// See:
   ///  * [getValueRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppConfigGetValueResponseApplicationJson, void>> getValue({
-    required final String app,
-    required final String key,
-    final String? defaultValue,
-    final bool? oCSAPIRequest,
+    required String app,
+    required String key,
+    String? defaultValue,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getValueRaw(
       app: app,
@@ -296,10 +296,10 @@ class AppConfigClient {
   ///  * [getValue] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppConfigGetValueResponseApplicationJson, void> getValueRaw({
-    required final String app,
-    required final String key,
-    final String? defaultValue,
-    final bool? oCSAPIRequest,
+    required String app,
+    required String key,
+    String? defaultValue,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -309,7 +309,7 @@ class AppConfigClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -374,10 +374,10 @@ class AppConfigClient {
   /// See:
   ///  * [setValueRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppConfigSetValueResponseApplicationJson, void>> setValue({
-    required final String value,
-    required final String app,
-    required final String key,
-    final bool? oCSAPIRequest,
+    required String value,
+    required String app,
+    required String key,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setValueRaw(
       value: value,
@@ -410,10 +410,10 @@ class AppConfigClient {
   ///  * [setValue] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppConfigSetValueResponseApplicationJson, void> setValueRaw({
-    required final String value,
-    required final String app,
-    required final String key,
-    final bool? oCSAPIRequest,
+    required String value,
+    required String app,
+    required String key,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -423,7 +423,7 @@ class AppConfigClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -487,9 +487,9 @@ class AppConfigClient {
   /// See:
   ///  * [deleteKeyRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppConfigDeleteKeyResponseApplicationJson, void>> deleteKey({
-    required final String app,
-    required final String key,
-    final bool? oCSAPIRequest,
+    required String app,
+    required String key,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteKeyRaw(
       app: app,
@@ -522,9 +522,9 @@ class AppConfigClient {
   ///  * [deleteKey] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppConfigDeleteKeyResponseApplicationJson, void> deleteKeyRaw({
-    required final String app,
-    required final String key,
-    final bool? oCSAPIRequest,
+    required String app,
+    required String key,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -534,7 +534,7 @@ class AppConfigClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -598,8 +598,8 @@ class AppsClient {
   /// See:
   ///  * [getAppsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppsGetAppsResponseApplicationJson, void>> getApps({
-    final String? filter,
-    final bool? oCSAPIRequest,
+    String? filter,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getAppsRaw(
       filter: filter,
@@ -629,8 +629,8 @@ class AppsClient {
   ///  * [getApps] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppsGetAppsResponseApplicationJson, void> getAppsRaw({
-    final String? filter,
-    final bool? oCSAPIRequest,
+    String? filter,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -640,7 +640,7 @@ class AppsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -694,8 +694,8 @@ class AppsClient {
   /// See:
   ///  * [getAppInfoRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppsGetAppInfoResponseApplicationJson, void>> getAppInfo({
-    required final String app,
-    final bool? oCSAPIRequest,
+    required String app,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getAppInfoRaw(
       app: app,
@@ -725,8 +725,8 @@ class AppsClient {
   ///  * [getAppInfo] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppsGetAppInfoResponseApplicationJson, void> getAppInfoRaw({
-    required final String app,
-    final bool? oCSAPIRequest,
+    required String app,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -736,7 +736,7 @@ class AppsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -790,8 +790,8 @@ class AppsClient {
   /// See:
   ///  * [enableRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppsEnableResponseApplicationJson, void>> enable({
-    required final String app,
-    final bool? oCSAPIRequest,
+    required String app,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = enableRaw(
       app: app,
@@ -821,8 +821,8 @@ class AppsClient {
   ///  * [enable] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppsEnableResponseApplicationJson, void> enableRaw({
-    required final String app,
-    final bool? oCSAPIRequest,
+    required String app,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -832,7 +832,7 @@ class AppsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -886,8 +886,8 @@ class AppsClient {
   /// See:
   ///  * [disableRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AppsDisableResponseApplicationJson, void>> disable({
-    required final String app,
-    final bool? oCSAPIRequest,
+    required String app,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = disableRaw(
       app: app,
@@ -917,8 +917,8 @@ class AppsClient {
   ///  * [disable] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AppsDisableResponseApplicationJson, void> disableRaw({
-    required final String app,
-    final bool? oCSAPIRequest,
+    required String app,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -928,7 +928,7 @@ class AppsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -988,10 +988,10 @@ class GroupsClient {
   /// See:
   ///  * [getGroupsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<GroupsGetGroupsResponseApplicationJson, void>> getGroups({
-    final String? search,
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    String? search,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getGroupsRaw(
       search: search,
@@ -1023,10 +1023,10 @@ class GroupsClient {
   ///  * [getGroups] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GroupsGetGroupsResponseApplicationJson, void> getGroupsRaw({
-    final String? search,
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    String? search,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1036,7 +1036,7 @@ class GroupsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1099,9 +1099,9 @@ class GroupsClient {
   /// See:
   ///  * [addGroupRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<GroupsAddGroupResponseApplicationJson, void>> addGroup({
-    required final String groupid,
-    final String? displayname,
-    final bool? oCSAPIRequest,
+    required String groupid,
+    String? displayname,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = addGroupRaw(
       groupid: groupid,
@@ -1133,9 +1133,9 @@ class GroupsClient {
   ///  * [addGroup] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GroupsAddGroupResponseApplicationJson, void> addGroupRaw({
-    required final String groupid,
-    final String? displayname,
-    final bool? oCSAPIRequest,
+    required String groupid,
+    String? displayname,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1145,7 +1145,7 @@ class GroupsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1203,10 +1203,10 @@ class GroupsClient {
   /// See:
   ///  * [getGroupsDetailsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<GroupsGetGroupsDetailsResponseApplicationJson, void>> getGroupsDetails({
-    final String? search,
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    String? search,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getGroupsDetailsRaw(
       search: search,
@@ -1238,10 +1238,10 @@ class GroupsClient {
   ///  * [getGroupsDetails] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GroupsGetGroupsDetailsResponseApplicationJson, void> getGroupsDetailsRaw({
-    final String? search,
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    String? search,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1251,7 +1251,7 @@ class GroupsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1313,8 +1313,8 @@ class GroupsClient {
   /// See:
   ///  * [getGroupUsersRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<GroupsGetGroupUsersResponseApplicationJson, void>> getGroupUsers({
-    required final String groupId,
-    final bool? oCSAPIRequest,
+    required String groupId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getGroupUsersRaw(
       groupId: groupId,
@@ -1344,8 +1344,8 @@ class GroupsClient {
   ///  * [getGroupUsers] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GroupsGetGroupUsersResponseApplicationJson, void> getGroupUsersRaw({
-    required final String groupId,
-    final bool? oCSAPIRequest,
+    required String groupId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1355,7 +1355,7 @@ class GroupsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1411,11 +1411,11 @@ class GroupsClient {
   /// See:
   ///  * [getGroupUsersDetailsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<GroupsGetGroupUsersDetailsResponseApplicationJson, void>> getGroupUsersDetails({
-    required final String groupId,
-    final String? search,
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    required String groupId,
+    String? search,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getGroupUsersDetailsRaw(
       groupId: groupId,
@@ -1449,11 +1449,11 @@ class GroupsClient {
   ///  * [getGroupUsersDetails] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GroupsGetGroupUsersDetailsResponseApplicationJson, void> getGroupUsersDetailsRaw({
-    required final String groupId,
-    final String? search,
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    required String groupId,
+    String? search,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1463,7 +1463,7 @@ class GroupsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1531,8 +1531,8 @@ class GroupsClient {
   /// See:
   ///  * [getSubAdminsOfGroupRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<GroupsGetSubAdminsOfGroupResponseApplicationJson, void>> getSubAdminsOfGroup({
-    required final String groupId,
-    final bool? oCSAPIRequest,
+    required String groupId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getSubAdminsOfGroupRaw(
       groupId: groupId,
@@ -1562,8 +1562,8 @@ class GroupsClient {
   ///  * [getSubAdminsOfGroup] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GroupsGetSubAdminsOfGroupResponseApplicationJson, void> getSubAdminsOfGroupRaw({
-    required final String groupId,
-    final bool? oCSAPIRequest,
+    required String groupId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1573,7 +1573,7 @@ class GroupsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1627,8 +1627,8 @@ class GroupsClient {
   ///  * [getGroupRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   @Deprecated('')
   Future<DynamiteResponse<GroupsGetGroupResponseApplicationJson, void>> getGroup({
-    required final String groupId,
-    final bool? oCSAPIRequest,
+    required String groupId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getGroupRaw(
       groupId: groupId,
@@ -1657,8 +1657,8 @@ class GroupsClient {
   @experimental
   @Deprecated('')
   DynamiteRawResponse<GroupsGetGroupResponseApplicationJson, void> getGroupRaw({
-    required final String groupId,
-    final bool? oCSAPIRequest,
+    required String groupId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1668,7 +1668,7 @@ class GroupsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1725,10 +1725,10 @@ class GroupsClient {
   /// See:
   ///  * [updateGroupRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<GroupsUpdateGroupResponseApplicationJson, void>> updateGroup({
-    required final String key,
-    required final String value,
-    required final String groupId,
-    final bool? oCSAPIRequest,
+    required String key,
+    required String value,
+    required String groupId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = updateGroupRaw(
       key: key,
@@ -1762,10 +1762,10 @@ class GroupsClient {
   ///  * [updateGroup] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GroupsUpdateGroupResponseApplicationJson, void> updateGroupRaw({
-    required final String key,
-    required final String value,
-    required final String groupId,
-    final bool? oCSAPIRequest,
+    required String key,
+    required String value,
+    required String groupId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1775,7 +1775,7 @@ class GroupsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1836,8 +1836,8 @@ class GroupsClient {
   /// See:
   ///  * [deleteGroupRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<GroupsDeleteGroupResponseApplicationJson, void>> deleteGroup({
-    required final String groupId,
-    final bool? oCSAPIRequest,
+    required String groupId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteGroupRaw(
       groupId: groupId,
@@ -1867,8 +1867,8 @@ class GroupsClient {
   ///  * [deleteGroup] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GroupsDeleteGroupResponseApplicationJson, void> deleteGroupRaw({
-    required final String groupId,
-    final bool? oCSAPIRequest,
+    required String groupId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1878,7 +1878,7 @@ class GroupsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1940,10 +1940,10 @@ class PreferencesClient {
   /// See:
   ///  * [setPreferenceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PreferencesSetPreferenceResponseApplicationJson, void>> setPreference({
-    required final String configValue,
-    required final String appId,
-    required final String configKey,
-    final bool? oCSAPIRequest,
+    required String configValue,
+    required String appId,
+    required String configKey,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setPreferenceRaw(
       configValue: configValue,
@@ -1976,10 +1976,10 @@ class PreferencesClient {
   ///  * [setPreference] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PreferencesSetPreferenceResponseApplicationJson, void> setPreferenceRaw({
-    required final String configValue,
-    required final String appId,
-    required final String configKey,
-    final bool? oCSAPIRequest,
+    required String configValue,
+    required String appId,
+    required String configKey,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1989,7 +1989,7 @@ class PreferencesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2052,9 +2052,9 @@ class PreferencesClient {
   /// See:
   ///  * [deletePreferenceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PreferencesDeletePreferenceResponseApplicationJson, void>> deletePreference({
-    required final String appId,
-    required final String configKey,
-    final bool? oCSAPIRequest,
+    required String appId,
+    required String configKey,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deletePreferenceRaw(
       appId: appId,
@@ -2085,9 +2085,9 @@ class PreferencesClient {
   ///  * [deletePreference] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PreferencesDeletePreferenceResponseApplicationJson, void> deletePreferenceRaw({
-    required final String appId,
-    required final String configKey,
-    final bool? oCSAPIRequest,
+    required String appId,
+    required String configKey,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2097,7 +2097,7 @@ class PreferencesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2156,9 +2156,9 @@ class PreferencesClient {
   /// See:
   ///  * [setMultiplePreferencesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PreferencesSetMultiplePreferencesResponseApplicationJson, void>> setMultiplePreferences({
-    required final ContentString<BuiltMap<String, String>> configs,
-    required final String appId,
-    final bool? oCSAPIRequest,
+    required ContentString<BuiltMap<String, String>> configs,
+    required String appId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setMultiplePreferencesRaw(
       configs: configs,
@@ -2189,9 +2189,9 @@ class PreferencesClient {
   ///  * [setMultiplePreferences] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PreferencesSetMultiplePreferencesResponseApplicationJson, void> setMultiplePreferencesRaw({
-    required final ContentString<BuiltMap<String, String>> configs,
-    required final String appId,
-    final bool? oCSAPIRequest,
+    required ContentString<BuiltMap<String, String>> configs,
+    required String appId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2201,7 +2201,7 @@ class PreferencesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2265,9 +2265,9 @@ class PreferencesClient {
   /// See:
   ///  * [deleteMultiplePreferenceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PreferencesDeleteMultiplePreferenceResponseApplicationJson, void>> deleteMultiplePreference({
-    required final BuiltList<String> configKeys,
-    required final String appId,
-    final bool? oCSAPIRequest,
+    required BuiltList<String> configKeys,
+    required String appId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteMultiplePreferenceRaw(
       configKeys: configKeys,
@@ -2298,9 +2298,9 @@ class PreferencesClient {
   ///  * [deleteMultiplePreference] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PreferencesDeleteMultiplePreferenceResponseApplicationJson, void> deleteMultiplePreferenceRaw({
-    required final BuiltList<String> configKeys,
-    required final String appId,
-    final bool? oCSAPIRequest,
+    required BuiltList<String> configKeys,
+    required String appId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2310,7 +2310,7 @@ class PreferencesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2377,10 +2377,10 @@ class UsersClient {
   /// See:
   ///  * [getUsersRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersGetUsersResponseApplicationJson, void>> getUsers({
-    final String? search,
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    String? search,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getUsersRaw(
       search: search,
@@ -2412,10 +2412,10 @@ class UsersClient {
   ///  * [getUsers] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersGetUsersResponseApplicationJson, void> getUsersRaw({
-    final String? search,
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    String? search,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2425,7 +2425,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2494,16 +2494,16 @@ class UsersClient {
   /// See:
   ///  * [addUserRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersAddUserResponseApplicationJson, void>> addUser({
-    required final String userid,
-    final String? password,
-    final String? displayName,
-    final String? email,
-    final BuiltList<String>? groups,
-    final BuiltList<String>? subadmin,
-    final String? quota,
-    final String? language,
-    final String? manager,
-    final bool? oCSAPIRequest,
+    required String userid,
+    String? password,
+    String? displayName,
+    String? email,
+    BuiltList<String>? groups,
+    BuiltList<String>? subadmin,
+    String? quota,
+    String? language,
+    String? manager,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = addUserRaw(
       userid: userid,
@@ -2548,16 +2548,16 @@ class UsersClient {
   ///  * [addUser] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersAddUserResponseApplicationJson, void> addUserRaw({
-    required final String userid,
-    final String? password,
-    final String? displayName,
-    final String? email,
-    final BuiltList<String>? groups,
-    final BuiltList<String>? subadmin,
-    final String? quota,
-    final String? language,
-    final String? manager,
-    final bool? oCSAPIRequest,
+    required String userid,
+    String? password,
+    String? displayName,
+    String? email,
+    BuiltList<String>? groups,
+    BuiltList<String>? subadmin,
+    String? quota,
+    String? language,
+    String? manager,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2567,7 +2567,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2656,10 +2656,10 @@ class UsersClient {
   /// See:
   ///  * [getUsersDetailsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersGetUsersDetailsResponseApplicationJson, void>> getUsersDetails({
-    final String? search,
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    String? search,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getUsersDetailsRaw(
       search: search,
@@ -2691,10 +2691,10 @@ class UsersClient {
   ///  * [getUsersDetails] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersGetUsersDetailsResponseApplicationJson, void> getUsersDetailsRaw({
-    final String? search,
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    String? search,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2704,7 +2704,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2765,9 +2765,9 @@ class UsersClient {
   /// See:
   ///  * [getDisabledUsersDetailsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersGetDisabledUsersDetailsResponseApplicationJson, void>> getDisabledUsersDetails({
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getDisabledUsersDetailsRaw(
       limit: limit,
@@ -2797,9 +2797,9 @@ class UsersClient {
   ///  * [getDisabledUsersDetails] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersGetDisabledUsersDetailsResponseApplicationJson, void> getDisabledUsersDetailsRaw({
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2809,7 +2809,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2867,9 +2867,9 @@ class UsersClient {
   /// See:
   ///  * [searchByPhoneNumbersRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersSearchByPhoneNumbersResponseApplicationJson, void>> searchByPhoneNumbers({
-    required final String location,
-    required final ContentString<BuiltMap<String, BuiltList<String>>> search,
-    final bool? oCSAPIRequest,
+    required String location,
+    required ContentString<BuiltMap<String, BuiltList<String>>> search,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = searchByPhoneNumbersRaw(
       location: location,
@@ -2900,9 +2900,9 @@ class UsersClient {
   ///  * [searchByPhoneNumbers] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersSearchByPhoneNumbersResponseApplicationJson, void> searchByPhoneNumbersRaw({
-    required final String location,
-    required final ContentString<BuiltMap<String, BuiltList<String>>> search,
-    final bool? oCSAPIRequest,
+    required String location,
+    required ContentString<BuiltMap<String, BuiltList<String>>> search,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2912,7 +2912,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2976,8 +2976,8 @@ class UsersClient {
   /// See:
   ///  * [getUserRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersGetUserResponseApplicationJson, void>> getUser({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getUserRaw(
       userId: userId,
@@ -3005,8 +3005,8 @@ class UsersClient {
   ///  * [getUser] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersGetUserResponseApplicationJson, void> getUserRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3016,7 +3016,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3070,10 +3070,10 @@ class UsersClient {
   /// See:
   ///  * [editUserRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersEditUserResponseApplicationJson, void>> editUser({
-    required final String key,
-    required final String value,
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String key,
+    required String value,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = editUserRaw(
       key: key,
@@ -3105,10 +3105,10 @@ class UsersClient {
   ///  * [editUser] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersEditUserResponseApplicationJson, void> editUserRaw({
-    required final String key,
-    required final String value,
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String key,
+    required String value,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3118,7 +3118,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3176,8 +3176,8 @@ class UsersClient {
   /// See:
   ///  * [deleteUserRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersDeleteUserResponseApplicationJson, void>> deleteUser({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteUserRaw(
       userId: userId,
@@ -3205,8 +3205,8 @@ class UsersClient {
   ///  * [deleteUser] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersDeleteUserResponseApplicationJson, void> deleteUserRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3216,7 +3216,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3267,7 +3267,7 @@ class UsersClient {
   /// See:
   ///  * [getCurrentUserRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersGetCurrentUserResponseApplicationJson, void>> getCurrentUser({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getCurrentUserRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -3292,7 +3292,7 @@ class UsersClient {
   /// See:
   ///  * [getCurrentUser] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<UsersGetCurrentUserResponseApplicationJson, void> getCurrentUserRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<UsersGetCurrentUserResponseApplicationJson, void> getCurrentUserRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3301,7 +3301,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3349,7 +3349,7 @@ class UsersClient {
   /// See:
   ///  * [getEditableFieldsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersGetEditableFieldsResponseApplicationJson, void>> getEditableFields({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getEditableFieldsRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -3374,9 +3374,7 @@ class UsersClient {
   /// See:
   ///  * [getEditableFields] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<UsersGetEditableFieldsResponseApplicationJson, void> getEditableFieldsRaw({
-    final bool? oCSAPIRequest,
-  }) {
+  DynamiteRawResponse<UsersGetEditableFieldsResponseApplicationJson, void> getEditableFieldsRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -3385,7 +3383,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3434,8 +3432,8 @@ class UsersClient {
   /// See:
   ///  * [getEditableFieldsForUserRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersGetEditableFieldsForUserResponseApplicationJson, void>> getEditableFieldsForUser({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getEditableFieldsForUserRaw(
       userId: userId,
@@ -3463,8 +3461,8 @@ class UsersClient {
   ///  * [getEditableFieldsForUser] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersGetEditableFieldsForUserResponseApplicationJson, void> getEditableFieldsForUserRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3474,7 +3472,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3529,11 +3527,11 @@ class UsersClient {
   /// See:
   ///  * [editUserMultiValueRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersEditUserMultiValueResponseApplicationJson, void>> editUserMultiValue({
-    required final String key,
-    required final String value,
-    required final String userId,
-    required final String collectionName,
-    final bool? oCSAPIRequest,
+    required String key,
+    required String value,
+    required String userId,
+    required String collectionName,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = editUserMultiValueRaw(
       key: key,
@@ -3567,11 +3565,11 @@ class UsersClient {
   ///  * [editUserMultiValue] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersEditUserMultiValueResponseApplicationJson, void> editUserMultiValueRaw({
-    required final String key,
-    required final String value,
-    required final String userId,
-    required final String collectionName,
-    final bool? oCSAPIRequest,
+    required String key,
+    required String value,
+    required String userId,
+    required String collectionName,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3581,7 +3579,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3648,8 +3646,8 @@ class UsersClient {
   /// See:
   ///  * [wipeUserDevicesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersWipeUserDevicesResponseApplicationJson, void>> wipeUserDevices({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = wipeUserDevicesRaw(
       userId: userId,
@@ -3677,8 +3675,8 @@ class UsersClient {
   ///  * [wipeUserDevices] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersWipeUserDevicesResponseApplicationJson, void> wipeUserDevicesRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3688,7 +3686,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3740,8 +3738,8 @@ class UsersClient {
   /// See:
   ///  * [enableUserRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersEnableUserResponseApplicationJson, void>> enableUser({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = enableUserRaw(
       userId: userId,
@@ -3769,8 +3767,8 @@ class UsersClient {
   ///  * [enableUser] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersEnableUserResponseApplicationJson, void> enableUserRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3780,7 +3778,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3832,8 +3830,8 @@ class UsersClient {
   /// See:
   ///  * [disableUserRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersDisableUserResponseApplicationJson, void>> disableUser({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = disableUserRaw(
       userId: userId,
@@ -3861,8 +3859,8 @@ class UsersClient {
   ///  * [disableUser] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersDisableUserResponseApplicationJson, void> disableUserRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3872,7 +3870,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3924,8 +3922,8 @@ class UsersClient {
   /// See:
   ///  * [getUsersGroupsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersGetUsersGroupsResponseApplicationJson, void>> getUsersGroups({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getUsersGroupsRaw(
       userId: userId,
@@ -3953,8 +3951,8 @@ class UsersClient {
   ///  * [getUsersGroups] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersGetUsersGroupsResponseApplicationJson, void> getUsersGroupsRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3964,7 +3962,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4017,9 +4015,9 @@ class UsersClient {
   /// See:
   ///  * [addToGroupRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersAddToGroupResponseApplicationJson, void>> addToGroup({
-    required final String userId,
-    final String? groupid,
-    final bool? oCSAPIRequest,
+    required String userId,
+    String? groupid,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = addToGroupRaw(
       userId: userId,
@@ -4049,9 +4047,9 @@ class UsersClient {
   ///  * [addToGroup] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersAddToGroupResponseApplicationJson, void> addToGroupRaw({
-    required final String userId,
-    final String? groupid,
-    final bool? oCSAPIRequest,
+    required String userId,
+    String? groupid,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4061,7 +4059,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4118,9 +4116,9 @@ class UsersClient {
   /// See:
   ///  * [removeFromGroupRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersRemoveFromGroupResponseApplicationJson, void>> removeFromGroup({
-    required final String groupid,
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String groupid,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = removeFromGroupRaw(
       groupid: groupid,
@@ -4150,9 +4148,9 @@ class UsersClient {
   ///  * [removeFromGroup] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersRemoveFromGroupResponseApplicationJson, void> removeFromGroupRaw({
-    required final String groupid,
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String groupid,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4162,7 +4160,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4219,8 +4217,8 @@ class UsersClient {
   /// See:
   ///  * [getUserSubAdminGroupsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersGetUserSubAdminGroupsResponseApplicationJson, void>> getUserSubAdminGroups({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getUserSubAdminGroupsRaw(
       userId: userId,
@@ -4250,8 +4248,8 @@ class UsersClient {
   ///  * [getUserSubAdminGroups] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersGetUserSubAdminGroupsResponseApplicationJson, void> getUserSubAdminGroupsRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4261,7 +4259,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4316,9 +4314,9 @@ class UsersClient {
   /// See:
   ///  * [addSubAdminRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersAddSubAdminResponseApplicationJson, void>> addSubAdmin({
-    required final String groupid,
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String groupid,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = addSubAdminRaw(
       groupid: groupid,
@@ -4350,9 +4348,9 @@ class UsersClient {
   ///  * [addSubAdmin] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersAddSubAdminResponseApplicationJson, void> addSubAdminRaw({
-    required final String groupid,
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String groupid,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4362,7 +4360,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4420,9 +4418,9 @@ class UsersClient {
   /// See:
   ///  * [removeSubAdminRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersRemoveSubAdminResponseApplicationJson, void>> removeSubAdmin({
-    required final String groupid,
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String groupid,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = removeSubAdminRaw(
       groupid: groupid,
@@ -4454,9 +4452,9 @@ class UsersClient {
   ///  * [removeSubAdmin] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersRemoveSubAdminResponseApplicationJson, void> removeSubAdminRaw({
-    required final String groupid,
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String groupid,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4466,7 +4464,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4521,8 +4519,8 @@ class UsersClient {
   /// See:
   ///  * [resendWelcomeMessageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UsersResendWelcomeMessageResponseApplicationJson, void>> resendWelcomeMessage({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = resendWelcomeMessageRaw(
       userId: userId,
@@ -4550,8 +4548,8 @@ class UsersClient {
   ///  * [resendWelcomeMessage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UsersResendWelcomeMessageResponseApplicationJson, void> resendWelcomeMessageRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4561,7 +4559,7 @@ class UsersClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4609,14 +4607,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -4637,7 +4635,7 @@ abstract class AppConfigGetAppsResponseApplicationJson_Ocs_Data
         Built<AppConfigGetAppsResponseApplicationJson_Ocs_Data,
             AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder> {
   factory AppConfigGetAppsResponseApplicationJson_Ocs_Data([
-    final void Function(AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$AppConfigGetAppsResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -4645,7 +4643,7 @@ abstract class AppConfigGetAppsResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigGetAppsResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigGetAppsResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4668,7 +4666,7 @@ abstract class AppConfigGetAppsResponseApplicationJson_Ocs
         $AppConfigGetAppsResponseApplicationJson_OcsInterface,
         Built<AppConfigGetAppsResponseApplicationJson_Ocs, AppConfigGetAppsResponseApplicationJson_OcsBuilder> {
   factory AppConfigGetAppsResponseApplicationJson_Ocs([
-    final void Function(AppConfigGetAppsResponseApplicationJson_OcsBuilder)? b,
+    void Function(AppConfigGetAppsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AppConfigGetAppsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -4676,7 +4674,7 @@ abstract class AppConfigGetAppsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigGetAppsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigGetAppsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4697,16 +4695,15 @@ abstract class AppConfigGetAppsResponseApplicationJson
     implements
         $AppConfigGetAppsResponseApplicationJsonInterface,
         Built<AppConfigGetAppsResponseApplicationJson, AppConfigGetAppsResponseApplicationJsonBuilder> {
-  factory AppConfigGetAppsResponseApplicationJson([
-    final void Function(AppConfigGetAppsResponseApplicationJsonBuilder)? b,
-  ]) = _$AppConfigGetAppsResponseApplicationJson;
+  factory AppConfigGetAppsResponseApplicationJson([void Function(AppConfigGetAppsResponseApplicationJsonBuilder)? b]) =
+      _$AppConfigGetAppsResponseApplicationJson;
 
   // coverage:ignore-start
   const AppConfigGetAppsResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigGetAppsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigGetAppsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4729,7 +4726,7 @@ abstract class AppConfigGetKeysResponseApplicationJson_Ocs_Data
         Built<AppConfigGetKeysResponseApplicationJson_Ocs_Data,
             AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder> {
   factory AppConfigGetKeysResponseApplicationJson_Ocs_Data([
-    final void Function(AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$AppConfigGetKeysResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -4737,7 +4734,7 @@ abstract class AppConfigGetKeysResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigGetKeysResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigGetKeysResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4760,7 +4757,7 @@ abstract class AppConfigGetKeysResponseApplicationJson_Ocs
         $AppConfigGetKeysResponseApplicationJson_OcsInterface,
         Built<AppConfigGetKeysResponseApplicationJson_Ocs, AppConfigGetKeysResponseApplicationJson_OcsBuilder> {
   factory AppConfigGetKeysResponseApplicationJson_Ocs([
-    final void Function(AppConfigGetKeysResponseApplicationJson_OcsBuilder)? b,
+    void Function(AppConfigGetKeysResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AppConfigGetKeysResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -4768,7 +4765,7 @@ abstract class AppConfigGetKeysResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigGetKeysResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigGetKeysResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4789,16 +4786,15 @@ abstract class AppConfigGetKeysResponseApplicationJson
     implements
         $AppConfigGetKeysResponseApplicationJsonInterface,
         Built<AppConfigGetKeysResponseApplicationJson, AppConfigGetKeysResponseApplicationJsonBuilder> {
-  factory AppConfigGetKeysResponseApplicationJson([
-    final void Function(AppConfigGetKeysResponseApplicationJsonBuilder)? b,
-  ]) = _$AppConfigGetKeysResponseApplicationJson;
+  factory AppConfigGetKeysResponseApplicationJson([void Function(AppConfigGetKeysResponseApplicationJsonBuilder)? b]) =
+      _$AppConfigGetKeysResponseApplicationJson;
 
   // coverage:ignore-start
   const AppConfigGetKeysResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigGetKeysResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigGetKeysResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4821,7 +4817,7 @@ abstract class AppConfigGetValueResponseApplicationJson_Ocs_Data
         Built<AppConfigGetValueResponseApplicationJson_Ocs_Data,
             AppConfigGetValueResponseApplicationJson_Ocs_DataBuilder> {
   factory AppConfigGetValueResponseApplicationJson_Ocs_Data([
-    final void Function(AppConfigGetValueResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(AppConfigGetValueResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$AppConfigGetValueResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -4829,7 +4825,7 @@ abstract class AppConfigGetValueResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigGetValueResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigGetValueResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4852,7 +4848,7 @@ abstract class AppConfigGetValueResponseApplicationJson_Ocs
         $AppConfigGetValueResponseApplicationJson_OcsInterface,
         Built<AppConfigGetValueResponseApplicationJson_Ocs, AppConfigGetValueResponseApplicationJson_OcsBuilder> {
   factory AppConfigGetValueResponseApplicationJson_Ocs([
-    final void Function(AppConfigGetValueResponseApplicationJson_OcsBuilder)? b,
+    void Function(AppConfigGetValueResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AppConfigGetValueResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -4860,7 +4856,7 @@ abstract class AppConfigGetValueResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigGetValueResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigGetValueResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4882,7 +4878,7 @@ abstract class AppConfigGetValueResponseApplicationJson
         $AppConfigGetValueResponseApplicationJsonInterface,
         Built<AppConfigGetValueResponseApplicationJson, AppConfigGetValueResponseApplicationJsonBuilder> {
   factory AppConfigGetValueResponseApplicationJson([
-    final void Function(AppConfigGetValueResponseApplicationJsonBuilder)? b,
+    void Function(AppConfigGetValueResponseApplicationJsonBuilder)? b,
   ]) = _$AppConfigGetValueResponseApplicationJson;
 
   // coverage:ignore-start
@@ -4890,7 +4886,7 @@ abstract class AppConfigGetValueResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigGetValueResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigGetValueResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4913,7 +4909,7 @@ abstract class AppConfigSetValueResponseApplicationJson_Ocs
         $AppConfigSetValueResponseApplicationJson_OcsInterface,
         Built<AppConfigSetValueResponseApplicationJson_Ocs, AppConfigSetValueResponseApplicationJson_OcsBuilder> {
   factory AppConfigSetValueResponseApplicationJson_Ocs([
-    final void Function(AppConfigSetValueResponseApplicationJson_OcsBuilder)? b,
+    void Function(AppConfigSetValueResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AppConfigSetValueResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -4921,7 +4917,7 @@ abstract class AppConfigSetValueResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigSetValueResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigSetValueResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4943,7 +4939,7 @@ abstract class AppConfigSetValueResponseApplicationJson
         $AppConfigSetValueResponseApplicationJsonInterface,
         Built<AppConfigSetValueResponseApplicationJson, AppConfigSetValueResponseApplicationJsonBuilder> {
   factory AppConfigSetValueResponseApplicationJson([
-    final void Function(AppConfigSetValueResponseApplicationJsonBuilder)? b,
+    void Function(AppConfigSetValueResponseApplicationJsonBuilder)? b,
   ]) = _$AppConfigSetValueResponseApplicationJson;
 
   // coverage:ignore-start
@@ -4951,7 +4947,7 @@ abstract class AppConfigSetValueResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigSetValueResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigSetValueResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4974,7 +4970,7 @@ abstract class AppConfigDeleteKeyResponseApplicationJson_Ocs
         $AppConfigDeleteKeyResponseApplicationJson_OcsInterface,
         Built<AppConfigDeleteKeyResponseApplicationJson_Ocs, AppConfigDeleteKeyResponseApplicationJson_OcsBuilder> {
   factory AppConfigDeleteKeyResponseApplicationJson_Ocs([
-    final void Function(AppConfigDeleteKeyResponseApplicationJson_OcsBuilder)? b,
+    void Function(AppConfigDeleteKeyResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AppConfigDeleteKeyResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -4982,7 +4978,7 @@ abstract class AppConfigDeleteKeyResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigDeleteKeyResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigDeleteKeyResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5004,7 +5000,7 @@ abstract class AppConfigDeleteKeyResponseApplicationJson
         $AppConfigDeleteKeyResponseApplicationJsonInterface,
         Built<AppConfigDeleteKeyResponseApplicationJson, AppConfigDeleteKeyResponseApplicationJsonBuilder> {
   factory AppConfigDeleteKeyResponseApplicationJson([
-    final void Function(AppConfigDeleteKeyResponseApplicationJsonBuilder)? b,
+    void Function(AppConfigDeleteKeyResponseApplicationJsonBuilder)? b,
   ]) = _$AppConfigDeleteKeyResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5012,7 +5008,7 @@ abstract class AppConfigDeleteKeyResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppConfigDeleteKeyResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppConfigDeleteKeyResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5034,7 +5030,7 @@ abstract class AppsGetAppsResponseApplicationJson_Ocs_Data
         $AppsGetAppsResponseApplicationJson_Ocs_DataInterface,
         Built<AppsGetAppsResponseApplicationJson_Ocs_Data, AppsGetAppsResponseApplicationJson_Ocs_DataBuilder> {
   factory AppsGetAppsResponseApplicationJson_Ocs_Data([
-    final void Function(AppsGetAppsResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(AppsGetAppsResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$AppsGetAppsResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -5042,7 +5038,7 @@ abstract class AppsGetAppsResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppsGetAppsResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory AppsGetAppsResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5064,16 +5060,15 @@ abstract class AppsGetAppsResponseApplicationJson_Ocs
     implements
         $AppsGetAppsResponseApplicationJson_OcsInterface,
         Built<AppsGetAppsResponseApplicationJson_Ocs, AppsGetAppsResponseApplicationJson_OcsBuilder> {
-  factory AppsGetAppsResponseApplicationJson_Ocs([
-    final void Function(AppsGetAppsResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$AppsGetAppsResponseApplicationJson_Ocs;
+  factory AppsGetAppsResponseApplicationJson_Ocs([void Function(AppsGetAppsResponseApplicationJson_OcsBuilder)? b]) =
+      _$AppsGetAppsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const AppsGetAppsResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppsGetAppsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppsGetAppsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5094,7 +5089,7 @@ abstract class AppsGetAppsResponseApplicationJson
     implements
         $AppsGetAppsResponseApplicationJsonInterface,
         Built<AppsGetAppsResponseApplicationJson, AppsGetAppsResponseApplicationJsonBuilder> {
-  factory AppsGetAppsResponseApplicationJson([final void Function(AppsGetAppsResponseApplicationJsonBuilder)? b]) =
+  factory AppsGetAppsResponseApplicationJson([void Function(AppsGetAppsResponseApplicationJsonBuilder)? b]) =
       _$AppsGetAppsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5102,7 +5097,7 @@ abstract class AppsGetAppsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppsGetAppsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppsGetAppsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5162,14 +5157,14 @@ abstract interface class $AppInfoInterface {
 }
 
 abstract class AppInfo implements $AppInfoInterface, Built<AppInfo, AppInfoBuilder> {
-  factory AppInfo([final void Function(AppInfoBuilder)? b]) = _$AppInfo;
+  factory AppInfo([void Function(AppInfoBuilder)? b]) = _$AppInfo;
 
   // coverage:ignore-start
   const AppInfo._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppInfo.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory AppInfo.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5190,7 +5185,7 @@ abstract class AppsGetAppInfoResponseApplicationJson_Ocs
         $AppsGetAppInfoResponseApplicationJson_OcsInterface,
         Built<AppsGetAppInfoResponseApplicationJson_Ocs, AppsGetAppInfoResponseApplicationJson_OcsBuilder> {
   factory AppsGetAppInfoResponseApplicationJson_Ocs([
-    final void Function(AppsGetAppInfoResponseApplicationJson_OcsBuilder)? b,
+    void Function(AppsGetAppInfoResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AppsGetAppInfoResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5198,7 +5193,7 @@ abstract class AppsGetAppInfoResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppsGetAppInfoResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppsGetAppInfoResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5219,16 +5214,15 @@ abstract class AppsGetAppInfoResponseApplicationJson
     implements
         $AppsGetAppInfoResponseApplicationJsonInterface,
         Built<AppsGetAppInfoResponseApplicationJson, AppsGetAppInfoResponseApplicationJsonBuilder> {
-  factory AppsGetAppInfoResponseApplicationJson([
-    final void Function(AppsGetAppInfoResponseApplicationJsonBuilder)? b,
-  ]) = _$AppsGetAppInfoResponseApplicationJson;
+  factory AppsGetAppInfoResponseApplicationJson([void Function(AppsGetAppInfoResponseApplicationJsonBuilder)? b]) =
+      _$AppsGetAppInfoResponseApplicationJson;
 
   // coverage:ignore-start
   const AppsGetAppInfoResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppsGetAppInfoResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppsGetAppInfoResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5250,16 +5244,15 @@ abstract class AppsEnableResponseApplicationJson_Ocs
     implements
         $AppsEnableResponseApplicationJson_OcsInterface,
         Built<AppsEnableResponseApplicationJson_Ocs, AppsEnableResponseApplicationJson_OcsBuilder> {
-  factory AppsEnableResponseApplicationJson_Ocs([
-    final void Function(AppsEnableResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$AppsEnableResponseApplicationJson_Ocs;
+  factory AppsEnableResponseApplicationJson_Ocs([void Function(AppsEnableResponseApplicationJson_OcsBuilder)? b]) =
+      _$AppsEnableResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const AppsEnableResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppsEnableResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppsEnableResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5280,7 +5273,7 @@ abstract class AppsEnableResponseApplicationJson
     implements
         $AppsEnableResponseApplicationJsonInterface,
         Built<AppsEnableResponseApplicationJson, AppsEnableResponseApplicationJsonBuilder> {
-  factory AppsEnableResponseApplicationJson([final void Function(AppsEnableResponseApplicationJsonBuilder)? b]) =
+  factory AppsEnableResponseApplicationJson([void Function(AppsEnableResponseApplicationJsonBuilder)? b]) =
       _$AppsEnableResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5288,7 +5281,7 @@ abstract class AppsEnableResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppsEnableResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppsEnableResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5309,16 +5302,15 @@ abstract class AppsDisableResponseApplicationJson_Ocs
     implements
         $AppsDisableResponseApplicationJson_OcsInterface,
         Built<AppsDisableResponseApplicationJson_Ocs, AppsDisableResponseApplicationJson_OcsBuilder> {
-  factory AppsDisableResponseApplicationJson_Ocs([
-    final void Function(AppsDisableResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$AppsDisableResponseApplicationJson_Ocs;
+  factory AppsDisableResponseApplicationJson_Ocs([void Function(AppsDisableResponseApplicationJson_OcsBuilder)? b]) =
+      _$AppsDisableResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const AppsDisableResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppsDisableResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AppsDisableResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5339,7 +5331,7 @@ abstract class AppsDisableResponseApplicationJson
     implements
         $AppsDisableResponseApplicationJsonInterface,
         Built<AppsDisableResponseApplicationJson, AppsDisableResponseApplicationJsonBuilder> {
-  factory AppsDisableResponseApplicationJson([final void Function(AppsDisableResponseApplicationJsonBuilder)? b]) =
+  factory AppsDisableResponseApplicationJson([void Function(AppsDisableResponseApplicationJsonBuilder)? b]) =
       _$AppsDisableResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5347,7 +5339,7 @@ abstract class AppsDisableResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AppsDisableResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AppsDisableResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5369,7 +5361,7 @@ abstract class GroupsGetGroupsResponseApplicationJson_Ocs_Data
         $GroupsGetGroupsResponseApplicationJson_Ocs_DataInterface,
         Built<GroupsGetGroupsResponseApplicationJson_Ocs_Data, GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder> {
   factory GroupsGetGroupsResponseApplicationJson_Ocs_Data([
-    final void Function(GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$GroupsGetGroupsResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -5377,7 +5369,7 @@ abstract class GroupsGetGroupsResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupsResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupsResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5400,7 +5392,7 @@ abstract class GroupsGetGroupsResponseApplicationJson_Ocs
         $GroupsGetGroupsResponseApplicationJson_OcsInterface,
         Built<GroupsGetGroupsResponseApplicationJson_Ocs, GroupsGetGroupsResponseApplicationJson_OcsBuilder> {
   factory GroupsGetGroupsResponseApplicationJson_Ocs([
-    final void Function(GroupsGetGroupsResponseApplicationJson_OcsBuilder)? b,
+    void Function(GroupsGetGroupsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$GroupsGetGroupsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5408,7 +5400,7 @@ abstract class GroupsGetGroupsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5429,16 +5421,15 @@ abstract class GroupsGetGroupsResponseApplicationJson
     implements
         $GroupsGetGroupsResponseApplicationJsonInterface,
         Built<GroupsGetGroupsResponseApplicationJson, GroupsGetGroupsResponseApplicationJsonBuilder> {
-  factory GroupsGetGroupsResponseApplicationJson([
-    final void Function(GroupsGetGroupsResponseApplicationJsonBuilder)? b,
-  ]) = _$GroupsGetGroupsResponseApplicationJson;
+  factory GroupsGetGroupsResponseApplicationJson([void Function(GroupsGetGroupsResponseApplicationJsonBuilder)? b]) =
+      _$GroupsGetGroupsResponseApplicationJson;
 
   // coverage:ignore-start
   const GroupsGetGroupsResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5461,7 +5452,7 @@ abstract class GroupsAddGroupResponseApplicationJson_Ocs
         $GroupsAddGroupResponseApplicationJson_OcsInterface,
         Built<GroupsAddGroupResponseApplicationJson_Ocs, GroupsAddGroupResponseApplicationJson_OcsBuilder> {
   factory GroupsAddGroupResponseApplicationJson_Ocs([
-    final void Function(GroupsAddGroupResponseApplicationJson_OcsBuilder)? b,
+    void Function(GroupsAddGroupResponseApplicationJson_OcsBuilder)? b,
   ]) = _$GroupsAddGroupResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5469,7 +5460,7 @@ abstract class GroupsAddGroupResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsAddGroupResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsAddGroupResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5490,16 +5481,15 @@ abstract class GroupsAddGroupResponseApplicationJson
     implements
         $GroupsAddGroupResponseApplicationJsonInterface,
         Built<GroupsAddGroupResponseApplicationJson, GroupsAddGroupResponseApplicationJsonBuilder> {
-  factory GroupsAddGroupResponseApplicationJson([
-    final void Function(GroupsAddGroupResponseApplicationJsonBuilder)? b,
-  ]) = _$GroupsAddGroupResponseApplicationJson;
+  factory GroupsAddGroupResponseApplicationJson([void Function(GroupsAddGroupResponseApplicationJsonBuilder)? b]) =
+      _$GroupsAddGroupResponseApplicationJson;
 
   // coverage:ignore-start
   const GroupsAddGroupResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsAddGroupResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsAddGroupResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5522,14 +5512,14 @@ abstract interface class $GroupDetailsInterface {
 }
 
 abstract class GroupDetails implements $GroupDetailsInterface, Built<GroupDetails, GroupDetailsBuilder> {
-  factory GroupDetails([final void Function(GroupDetailsBuilder)? b]) = _$GroupDetails;
+  factory GroupDetails([void Function(GroupDetailsBuilder)? b]) = _$GroupDetails;
 
   // coverage:ignore-start
   const GroupDetails._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupDetails.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory GroupDetails.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5539,7 +5529,7 @@ abstract class GroupDetails implements $GroupDetailsInterface, Built<GroupDetail
   static Serializer<GroupDetails> get serializer => _$groupDetailsSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final GroupDetailsBuilder b) {
+  static void _validate(GroupDetailsBuilder b) {
     b.usercount?.validateOneOf();
     b.disabled?.validateOneOf();
   }
@@ -5556,7 +5546,7 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data
         Built<GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data,
             GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder> {
   factory GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data([
-    final void Function(GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -5564,7 +5554,7 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5588,7 +5578,7 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson_Ocs
         Built<GroupsGetGroupsDetailsResponseApplicationJson_Ocs,
             GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder> {
   factory GroupsGetGroupsDetailsResponseApplicationJson_Ocs([
-    final void Function(GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder)? b,
+    void Function(GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$GroupsGetGroupsDetailsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5596,7 +5586,7 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupsDetailsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupsDetailsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5618,7 +5608,7 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson
         $GroupsGetGroupsDetailsResponseApplicationJsonInterface,
         Built<GroupsGetGroupsDetailsResponseApplicationJson, GroupsGetGroupsDetailsResponseApplicationJsonBuilder> {
   factory GroupsGetGroupsDetailsResponseApplicationJson([
-    final void Function(GroupsGetGroupsDetailsResponseApplicationJsonBuilder)? b,
+    void Function(GroupsGetGroupsDetailsResponseApplicationJsonBuilder)? b,
   ]) = _$GroupsGetGroupsDetailsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5626,7 +5616,7 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupsDetailsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupsDetailsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5649,7 +5639,7 @@ abstract class GroupsGetGroupUsersResponseApplicationJson_Ocs_Data
         Built<GroupsGetGroupUsersResponseApplicationJson_Ocs_Data,
             GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder> {
   factory GroupsGetGroupUsersResponseApplicationJson_Ocs_Data([
-    final void Function(GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$GroupsGetGroupUsersResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -5657,7 +5647,7 @@ abstract class GroupsGetGroupUsersResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupUsersResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupUsersResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5680,7 +5670,7 @@ abstract class GroupsGetGroupUsersResponseApplicationJson_Ocs
         $GroupsGetGroupUsersResponseApplicationJson_OcsInterface,
         Built<GroupsGetGroupUsersResponseApplicationJson_Ocs, GroupsGetGroupUsersResponseApplicationJson_OcsBuilder> {
   factory GroupsGetGroupUsersResponseApplicationJson_Ocs([
-    final void Function(GroupsGetGroupUsersResponseApplicationJson_OcsBuilder)? b,
+    void Function(GroupsGetGroupUsersResponseApplicationJson_OcsBuilder)? b,
   ]) = _$GroupsGetGroupUsersResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5688,7 +5678,7 @@ abstract class GroupsGetGroupUsersResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupUsersResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupUsersResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5710,7 +5700,7 @@ abstract class GroupsGetGroupUsersResponseApplicationJson
         $GroupsGetGroupUsersResponseApplicationJsonInterface,
         Built<GroupsGetGroupUsersResponseApplicationJson, GroupsGetGroupUsersResponseApplicationJsonBuilder> {
   factory GroupsGetGroupUsersResponseApplicationJson([
-    final void Function(GroupsGetGroupUsersResponseApplicationJsonBuilder)? b,
+    void Function(GroupsGetGroupUsersResponseApplicationJsonBuilder)? b,
   ]) = _$GroupsGetGroupUsersResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5718,7 +5708,7 @@ abstract class GroupsGetGroupUsersResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupUsersResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupUsersResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5740,7 +5730,7 @@ abstract class UserDetails_BackendCapabilities
     implements
         $UserDetails_BackendCapabilitiesInterface,
         Built<UserDetails_BackendCapabilities, UserDetails_BackendCapabilitiesBuilder> {
-  factory UserDetails_BackendCapabilities([final void Function(UserDetails_BackendCapabilitiesBuilder)? b]) =
+  factory UserDetails_BackendCapabilities([void Function(UserDetails_BackendCapabilitiesBuilder)? b]) =
       _$UserDetails_BackendCapabilities;
 
   // coverage:ignore-start
@@ -5748,7 +5738,7 @@ abstract class UserDetails_BackendCapabilities
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserDetails_BackendCapabilities.fromJson(final Map<String, dynamic> json) =>
+  factory UserDetails_BackendCapabilities.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5770,15 +5760,14 @@ abstract interface class $UserDetailsQuotaInterface {
 
 abstract class UserDetailsQuota
     implements $UserDetailsQuotaInterface, Built<UserDetailsQuota, UserDetailsQuotaBuilder> {
-  factory UserDetailsQuota([final void Function(UserDetailsQuotaBuilder)? b]) = _$UserDetailsQuota;
+  factory UserDetailsQuota([void Function(UserDetailsQuotaBuilder)? b]) = _$UserDetailsQuota;
 
   // coverage:ignore-start
   const UserDetailsQuota._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserDetailsQuota.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory UserDetailsQuota.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5788,7 +5777,7 @@ abstract class UserDetailsQuota
   static Serializer<UserDetailsQuota> get serializer => _$userDetailsQuotaSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final UserDetailsQuotaBuilder b) {
+  static void _validate(UserDetailsQuotaBuilder b) {
     b.quota?.validateOneOf();
   }
 }
@@ -5845,14 +5834,14 @@ abstract interface class $UserDetailsInterface {
 }
 
 abstract class UserDetails implements $UserDetailsInterface, Built<UserDetails, UserDetailsBuilder> {
-  factory UserDetails([final void Function(UserDetailsBuilder)? b]) = _$UserDetails;
+  factory UserDetails([void Function(UserDetailsBuilder)? b]) = _$UserDetails;
 
   // coverage:ignore-start
   const UserDetails._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserDetails.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory UserDetails.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -5873,7 +5862,7 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1
         Built<GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1,
             GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder> {
   factory GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1([
-    final void Function(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder)? b,
+    void Function(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder)? b,
   ]) = _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1;
 
   // coverage:ignore-start
@@ -5881,7 +5870,7 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5904,7 +5893,7 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data
         Built<GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data,
             GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder> {
   factory GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data([
-    final void Function(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -5912,7 +5901,7 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5936,7 +5925,7 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs
         Built<GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs,
             GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder> {
   factory GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs([
-    final void Function(GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder)? b,
+    void Function(GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -5944,7 +5933,7 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5967,7 +5956,7 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson
         Built<GroupsGetGroupUsersDetailsResponseApplicationJson,
             GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder> {
   factory GroupsGetGroupUsersDetailsResponseApplicationJson([
-    final void Function(GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder)? b,
+    void Function(GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder)? b,
   ]) = _$GroupsGetGroupUsersDetailsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -5975,7 +5964,7 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupUsersDetailsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupUsersDetailsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -5999,7 +5988,7 @@ abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs
         Built<GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs,
             GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder> {
   factory GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs([
-    final void Function(GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder)? b,
+    void Function(GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder)? b,
   ]) = _$GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6007,7 +5996,7 @@ abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6030,7 +6019,7 @@ abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson
         Built<GroupsGetSubAdminsOfGroupResponseApplicationJson,
             GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder> {
   factory GroupsGetSubAdminsOfGroupResponseApplicationJson([
-    final void Function(GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder)? b,
+    void Function(GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder)? b,
   ]) = _$GroupsGetSubAdminsOfGroupResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6038,7 +6027,7 @@ abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetSubAdminsOfGroupResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetSubAdminsOfGroupResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6060,7 +6049,7 @@ abstract class GroupsGetGroupResponseApplicationJson_Ocs_Data
         $GroupsGetGroupResponseApplicationJson_Ocs_DataInterface,
         Built<GroupsGetGroupResponseApplicationJson_Ocs_Data, GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder> {
   factory GroupsGetGroupResponseApplicationJson_Ocs_Data([
-    final void Function(GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$GroupsGetGroupResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -6068,7 +6057,7 @@ abstract class GroupsGetGroupResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6091,7 +6080,7 @@ abstract class GroupsGetGroupResponseApplicationJson_Ocs
         $GroupsGetGroupResponseApplicationJson_OcsInterface,
         Built<GroupsGetGroupResponseApplicationJson_Ocs, GroupsGetGroupResponseApplicationJson_OcsBuilder> {
   factory GroupsGetGroupResponseApplicationJson_Ocs([
-    final void Function(GroupsGetGroupResponseApplicationJson_OcsBuilder)? b,
+    void Function(GroupsGetGroupResponseApplicationJson_OcsBuilder)? b,
   ]) = _$GroupsGetGroupResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6099,7 +6088,7 @@ abstract class GroupsGetGroupResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6120,16 +6109,15 @@ abstract class GroupsGetGroupResponseApplicationJson
     implements
         $GroupsGetGroupResponseApplicationJsonInterface,
         Built<GroupsGetGroupResponseApplicationJson, GroupsGetGroupResponseApplicationJsonBuilder> {
-  factory GroupsGetGroupResponseApplicationJson([
-    final void Function(GroupsGetGroupResponseApplicationJsonBuilder)? b,
-  ]) = _$GroupsGetGroupResponseApplicationJson;
+  factory GroupsGetGroupResponseApplicationJson([void Function(GroupsGetGroupResponseApplicationJsonBuilder)? b]) =
+      _$GroupsGetGroupResponseApplicationJson;
 
   // coverage:ignore-start
   const GroupsGetGroupResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsGetGroupResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsGetGroupResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6152,7 +6140,7 @@ abstract class GroupsUpdateGroupResponseApplicationJson_Ocs
         $GroupsUpdateGroupResponseApplicationJson_OcsInterface,
         Built<GroupsUpdateGroupResponseApplicationJson_Ocs, GroupsUpdateGroupResponseApplicationJson_OcsBuilder> {
   factory GroupsUpdateGroupResponseApplicationJson_Ocs([
-    final void Function(GroupsUpdateGroupResponseApplicationJson_OcsBuilder)? b,
+    void Function(GroupsUpdateGroupResponseApplicationJson_OcsBuilder)? b,
   ]) = _$GroupsUpdateGroupResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6160,7 +6148,7 @@ abstract class GroupsUpdateGroupResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsUpdateGroupResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsUpdateGroupResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6182,7 +6170,7 @@ abstract class GroupsUpdateGroupResponseApplicationJson
         $GroupsUpdateGroupResponseApplicationJsonInterface,
         Built<GroupsUpdateGroupResponseApplicationJson, GroupsUpdateGroupResponseApplicationJsonBuilder> {
   factory GroupsUpdateGroupResponseApplicationJson([
-    final void Function(GroupsUpdateGroupResponseApplicationJsonBuilder)? b,
+    void Function(GroupsUpdateGroupResponseApplicationJsonBuilder)? b,
   ]) = _$GroupsUpdateGroupResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6190,7 +6178,7 @@ abstract class GroupsUpdateGroupResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsUpdateGroupResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsUpdateGroupResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6213,7 +6201,7 @@ abstract class GroupsDeleteGroupResponseApplicationJson_Ocs
         $GroupsDeleteGroupResponseApplicationJson_OcsInterface,
         Built<GroupsDeleteGroupResponseApplicationJson_Ocs, GroupsDeleteGroupResponseApplicationJson_OcsBuilder> {
   factory GroupsDeleteGroupResponseApplicationJson_Ocs([
-    final void Function(GroupsDeleteGroupResponseApplicationJson_OcsBuilder)? b,
+    void Function(GroupsDeleteGroupResponseApplicationJson_OcsBuilder)? b,
   ]) = _$GroupsDeleteGroupResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6221,7 +6209,7 @@ abstract class GroupsDeleteGroupResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsDeleteGroupResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsDeleteGroupResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6243,7 +6231,7 @@ abstract class GroupsDeleteGroupResponseApplicationJson
         $GroupsDeleteGroupResponseApplicationJsonInterface,
         Built<GroupsDeleteGroupResponseApplicationJson, GroupsDeleteGroupResponseApplicationJsonBuilder> {
   factory GroupsDeleteGroupResponseApplicationJson([
-    final void Function(GroupsDeleteGroupResponseApplicationJsonBuilder)? b,
+    void Function(GroupsDeleteGroupResponseApplicationJsonBuilder)? b,
   ]) = _$GroupsDeleteGroupResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6251,7 +6239,7 @@ abstract class GroupsDeleteGroupResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GroupsDeleteGroupResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GroupsDeleteGroupResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6275,7 +6263,7 @@ abstract class PreferencesSetPreferenceResponseApplicationJson_Ocs
         Built<PreferencesSetPreferenceResponseApplicationJson_Ocs,
             PreferencesSetPreferenceResponseApplicationJson_OcsBuilder> {
   factory PreferencesSetPreferenceResponseApplicationJson_Ocs([
-    final void Function(PreferencesSetPreferenceResponseApplicationJson_OcsBuilder)? b,
+    void Function(PreferencesSetPreferenceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$PreferencesSetPreferenceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6283,7 +6271,7 @@ abstract class PreferencesSetPreferenceResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PreferencesSetPreferenceResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PreferencesSetPreferenceResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6305,7 +6293,7 @@ abstract class PreferencesSetPreferenceResponseApplicationJson
         $PreferencesSetPreferenceResponseApplicationJsonInterface,
         Built<PreferencesSetPreferenceResponseApplicationJson, PreferencesSetPreferenceResponseApplicationJsonBuilder> {
   factory PreferencesSetPreferenceResponseApplicationJson([
-    final void Function(PreferencesSetPreferenceResponseApplicationJsonBuilder)? b,
+    void Function(PreferencesSetPreferenceResponseApplicationJsonBuilder)? b,
   ]) = _$PreferencesSetPreferenceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6313,7 +6301,7 @@ abstract class PreferencesSetPreferenceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PreferencesSetPreferenceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PreferencesSetPreferenceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6337,7 +6325,7 @@ abstract class PreferencesDeletePreferenceResponseApplicationJson_Ocs
         Built<PreferencesDeletePreferenceResponseApplicationJson_Ocs,
             PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder> {
   factory PreferencesDeletePreferenceResponseApplicationJson_Ocs([
-    final void Function(PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder)? b,
+    void Function(PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$PreferencesDeletePreferenceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6345,7 +6333,7 @@ abstract class PreferencesDeletePreferenceResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PreferencesDeletePreferenceResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PreferencesDeletePreferenceResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6368,7 +6356,7 @@ abstract class PreferencesDeletePreferenceResponseApplicationJson
         Built<PreferencesDeletePreferenceResponseApplicationJson,
             PreferencesDeletePreferenceResponseApplicationJsonBuilder> {
   factory PreferencesDeletePreferenceResponseApplicationJson([
-    final void Function(PreferencesDeletePreferenceResponseApplicationJsonBuilder)? b,
+    void Function(PreferencesDeletePreferenceResponseApplicationJsonBuilder)? b,
   ]) = _$PreferencesDeletePreferenceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6376,7 +6364,7 @@ abstract class PreferencesDeletePreferenceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PreferencesDeletePreferenceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PreferencesDeletePreferenceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6400,7 +6388,7 @@ abstract class PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs
         Built<PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs,
             PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder> {
   factory PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs([
-    final void Function(PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder)? b,
+    void Function(PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6408,7 +6396,7 @@ abstract class PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6431,7 +6419,7 @@ abstract class PreferencesSetMultiplePreferencesResponseApplicationJson
         Built<PreferencesSetMultiplePreferencesResponseApplicationJson,
             PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder> {
   factory PreferencesSetMultiplePreferencesResponseApplicationJson([
-    final void Function(PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder)? b,
+    void Function(PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder)? b,
   ]) = _$PreferencesSetMultiplePreferencesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6439,7 +6427,7 @@ abstract class PreferencesSetMultiplePreferencesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PreferencesSetMultiplePreferencesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PreferencesSetMultiplePreferencesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6463,7 +6451,7 @@ abstract class PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs
         Built<PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs,
             PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder> {
   factory PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs([
-    final void Function(PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder)? b,
+    void Function(PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6471,7 +6459,7 @@ abstract class PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6494,7 +6482,7 @@ abstract class PreferencesDeleteMultiplePreferenceResponseApplicationJson
         Built<PreferencesDeleteMultiplePreferenceResponseApplicationJson,
             PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder> {
   factory PreferencesDeleteMultiplePreferenceResponseApplicationJson([
-    final void Function(PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder)? b,
+    void Function(PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder)? b,
   ]) = _$PreferencesDeleteMultiplePreferenceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6502,7 +6490,7 @@ abstract class PreferencesDeleteMultiplePreferenceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PreferencesDeleteMultiplePreferenceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PreferencesDeleteMultiplePreferenceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6524,7 +6512,7 @@ abstract class UsersGetUsersResponseApplicationJson_Ocs_Data
         $UsersGetUsersResponseApplicationJson_Ocs_DataInterface,
         Built<UsersGetUsersResponseApplicationJson_Ocs_Data, UsersGetUsersResponseApplicationJson_Ocs_DataBuilder> {
   factory UsersGetUsersResponseApplicationJson_Ocs_Data([
-    final void Function(UsersGetUsersResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(UsersGetUsersResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$UsersGetUsersResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -6532,7 +6520,7 @@ abstract class UsersGetUsersResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUsersResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUsersResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6555,7 +6543,7 @@ abstract class UsersGetUsersResponseApplicationJson_Ocs
         $UsersGetUsersResponseApplicationJson_OcsInterface,
         Built<UsersGetUsersResponseApplicationJson_Ocs, UsersGetUsersResponseApplicationJson_OcsBuilder> {
   factory UsersGetUsersResponseApplicationJson_Ocs([
-    final void Function(UsersGetUsersResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersGetUsersResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersGetUsersResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6563,7 +6551,7 @@ abstract class UsersGetUsersResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUsersResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUsersResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6584,7 +6572,7 @@ abstract class UsersGetUsersResponseApplicationJson
     implements
         $UsersGetUsersResponseApplicationJsonInterface,
         Built<UsersGetUsersResponseApplicationJson, UsersGetUsersResponseApplicationJsonBuilder> {
-  factory UsersGetUsersResponseApplicationJson([final void Function(UsersGetUsersResponseApplicationJsonBuilder)? b]) =
+  factory UsersGetUsersResponseApplicationJson([void Function(UsersGetUsersResponseApplicationJsonBuilder)? b]) =
       _$UsersGetUsersResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6592,7 +6580,7 @@ abstract class UsersGetUsersResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUsersResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUsersResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6614,7 +6602,7 @@ abstract class UsersAddUserResponseApplicationJson_Ocs_Data
         $UsersAddUserResponseApplicationJson_Ocs_DataInterface,
         Built<UsersAddUserResponseApplicationJson_Ocs_Data, UsersAddUserResponseApplicationJson_Ocs_DataBuilder> {
   factory UsersAddUserResponseApplicationJson_Ocs_Data([
-    final void Function(UsersAddUserResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(UsersAddUserResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$UsersAddUserResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -6622,7 +6610,7 @@ abstract class UsersAddUserResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersAddUserResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory UsersAddUserResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6644,16 +6632,15 @@ abstract class UsersAddUserResponseApplicationJson_Ocs
     implements
         $UsersAddUserResponseApplicationJson_OcsInterface,
         Built<UsersAddUserResponseApplicationJson_Ocs, UsersAddUserResponseApplicationJson_OcsBuilder> {
-  factory UsersAddUserResponseApplicationJson_Ocs([
-    final void Function(UsersAddUserResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$UsersAddUserResponseApplicationJson_Ocs;
+  factory UsersAddUserResponseApplicationJson_Ocs([void Function(UsersAddUserResponseApplicationJson_OcsBuilder)? b]) =
+      _$UsersAddUserResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const UsersAddUserResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersAddUserResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersAddUserResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6674,7 +6661,7 @@ abstract class UsersAddUserResponseApplicationJson
     implements
         $UsersAddUserResponseApplicationJsonInterface,
         Built<UsersAddUserResponseApplicationJson, UsersAddUserResponseApplicationJsonBuilder> {
-  factory UsersAddUserResponseApplicationJson([final void Function(UsersAddUserResponseApplicationJsonBuilder)? b]) =
+  factory UsersAddUserResponseApplicationJson([void Function(UsersAddUserResponseApplicationJsonBuilder)? b]) =
       _$UsersAddUserResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6682,7 +6669,7 @@ abstract class UsersAddUserResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersAddUserResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersAddUserResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6705,7 +6692,7 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1
         Built<UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1,
             UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder> {
   factory UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1([
-    final void Function(UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder)? b,
+    void Function(UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder)? b,
   ]) = _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1;
 
   // coverage:ignore-start
@@ -6713,7 +6700,7 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6736,7 +6723,7 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data
         Built<UsersGetUsersDetailsResponseApplicationJson_Ocs_Data,
             UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder> {
   factory UsersGetUsersDetailsResponseApplicationJson_Ocs_Data([
-    final void Function(UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -6744,7 +6731,7 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUsersDetailsResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUsersDetailsResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6767,7 +6754,7 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs
         $UsersGetUsersDetailsResponseApplicationJson_OcsInterface,
         Built<UsersGetUsersDetailsResponseApplicationJson_Ocs, UsersGetUsersDetailsResponseApplicationJson_OcsBuilder> {
   factory UsersGetUsersDetailsResponseApplicationJson_Ocs([
-    final void Function(UsersGetUsersDetailsResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersGetUsersDetailsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersGetUsersDetailsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6775,7 +6762,7 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUsersDetailsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUsersDetailsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6797,7 +6784,7 @@ abstract class UsersGetUsersDetailsResponseApplicationJson
         $UsersGetUsersDetailsResponseApplicationJsonInterface,
         Built<UsersGetUsersDetailsResponseApplicationJson, UsersGetUsersDetailsResponseApplicationJsonBuilder> {
   factory UsersGetUsersDetailsResponseApplicationJson([
-    final void Function(UsersGetUsersDetailsResponseApplicationJsonBuilder)? b,
+    void Function(UsersGetUsersDetailsResponseApplicationJsonBuilder)? b,
   ]) = _$UsersGetUsersDetailsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6805,7 +6792,7 @@ abstract class UsersGetUsersDetailsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUsersDetailsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUsersDetailsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6828,7 +6815,7 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_User
         Built<UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1,
             UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder> {
   factory UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1([
-    final void Function(UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder)? b,
+    void Function(UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder)? b,
   ]) = _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1;
 
   // coverage:ignore-start
@@ -6836,9 +6823,7 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_User
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1.fromJson(
-    final Map<String, dynamic> json,
-  ) =>
+  factory UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6861,7 +6846,7 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data
         Built<UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data,
             UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder> {
   factory UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data([
-    final void Function(UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -6869,7 +6854,7 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6893,7 +6878,7 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs
         Built<UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs,
             UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder> {
   factory UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs([
-    final void Function(UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6901,7 +6886,7 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6924,7 +6909,7 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson
         Built<UsersGetDisabledUsersDetailsResponseApplicationJson,
             UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder> {
   factory UsersGetDisabledUsersDetailsResponseApplicationJson([
-    final void Function(UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder)? b,
+    void Function(UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder)? b,
   ]) = _$UsersGetDisabledUsersDetailsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6932,7 +6917,7 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetDisabledUsersDetailsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetDisabledUsersDetailsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6956,7 +6941,7 @@ abstract class UsersSearchByPhoneNumbersResponseApplicationJson_Ocs
         Built<UsersSearchByPhoneNumbersResponseApplicationJson_Ocs,
             UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder> {
   factory UsersSearchByPhoneNumbersResponseApplicationJson_Ocs([
-    final void Function(UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersSearchByPhoneNumbersResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -6964,7 +6949,7 @@ abstract class UsersSearchByPhoneNumbersResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersSearchByPhoneNumbersResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersSearchByPhoneNumbersResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -6987,7 +6972,7 @@ abstract class UsersSearchByPhoneNumbersResponseApplicationJson
         Built<UsersSearchByPhoneNumbersResponseApplicationJson,
             UsersSearchByPhoneNumbersResponseApplicationJsonBuilder> {
   factory UsersSearchByPhoneNumbersResponseApplicationJson([
-    final void Function(UsersSearchByPhoneNumbersResponseApplicationJsonBuilder)? b,
+    void Function(UsersSearchByPhoneNumbersResponseApplicationJsonBuilder)? b,
   ]) = _$UsersSearchByPhoneNumbersResponseApplicationJson;
 
   // coverage:ignore-start
@@ -6995,7 +6980,7 @@ abstract class UsersSearchByPhoneNumbersResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersSearchByPhoneNumbersResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersSearchByPhoneNumbersResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7017,16 +7002,15 @@ abstract class UsersGetUserResponseApplicationJson_Ocs
     implements
         $UsersGetUserResponseApplicationJson_OcsInterface,
         Built<UsersGetUserResponseApplicationJson_Ocs, UsersGetUserResponseApplicationJson_OcsBuilder> {
-  factory UsersGetUserResponseApplicationJson_Ocs([
-    final void Function(UsersGetUserResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$UsersGetUserResponseApplicationJson_Ocs;
+  factory UsersGetUserResponseApplicationJson_Ocs([void Function(UsersGetUserResponseApplicationJson_OcsBuilder)? b]) =
+      _$UsersGetUserResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const UsersGetUserResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUserResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUserResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7047,7 +7031,7 @@ abstract class UsersGetUserResponseApplicationJson
     implements
         $UsersGetUserResponseApplicationJsonInterface,
         Built<UsersGetUserResponseApplicationJson, UsersGetUserResponseApplicationJsonBuilder> {
-  factory UsersGetUserResponseApplicationJson([final void Function(UsersGetUserResponseApplicationJsonBuilder)? b]) =
+  factory UsersGetUserResponseApplicationJson([void Function(UsersGetUserResponseApplicationJsonBuilder)? b]) =
       _$UsersGetUserResponseApplicationJson;
 
   // coverage:ignore-start
@@ -7055,7 +7039,7 @@ abstract class UsersGetUserResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUserResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUserResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7078,7 +7062,7 @@ abstract class UsersEditUserResponseApplicationJson_Ocs
         $UsersEditUserResponseApplicationJson_OcsInterface,
         Built<UsersEditUserResponseApplicationJson_Ocs, UsersEditUserResponseApplicationJson_OcsBuilder> {
   factory UsersEditUserResponseApplicationJson_Ocs([
-    final void Function(UsersEditUserResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersEditUserResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersEditUserResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7086,7 +7070,7 @@ abstract class UsersEditUserResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersEditUserResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersEditUserResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7107,7 +7091,7 @@ abstract class UsersEditUserResponseApplicationJson
     implements
         $UsersEditUserResponseApplicationJsonInterface,
         Built<UsersEditUserResponseApplicationJson, UsersEditUserResponseApplicationJsonBuilder> {
-  factory UsersEditUserResponseApplicationJson([final void Function(UsersEditUserResponseApplicationJsonBuilder)? b]) =
+  factory UsersEditUserResponseApplicationJson([void Function(UsersEditUserResponseApplicationJsonBuilder)? b]) =
       _$UsersEditUserResponseApplicationJson;
 
   // coverage:ignore-start
@@ -7115,7 +7099,7 @@ abstract class UsersEditUserResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersEditUserResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersEditUserResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7138,7 +7122,7 @@ abstract class UsersDeleteUserResponseApplicationJson_Ocs
         $UsersDeleteUserResponseApplicationJson_OcsInterface,
         Built<UsersDeleteUserResponseApplicationJson_Ocs, UsersDeleteUserResponseApplicationJson_OcsBuilder> {
   factory UsersDeleteUserResponseApplicationJson_Ocs([
-    final void Function(UsersDeleteUserResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersDeleteUserResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersDeleteUserResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7146,7 +7130,7 @@ abstract class UsersDeleteUserResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersDeleteUserResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersDeleteUserResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7167,16 +7151,15 @@ abstract class UsersDeleteUserResponseApplicationJson
     implements
         $UsersDeleteUserResponseApplicationJsonInterface,
         Built<UsersDeleteUserResponseApplicationJson, UsersDeleteUserResponseApplicationJsonBuilder> {
-  factory UsersDeleteUserResponseApplicationJson([
-    final void Function(UsersDeleteUserResponseApplicationJsonBuilder)? b,
-  ]) = _$UsersDeleteUserResponseApplicationJson;
+  factory UsersDeleteUserResponseApplicationJson([void Function(UsersDeleteUserResponseApplicationJsonBuilder)? b]) =
+      _$UsersDeleteUserResponseApplicationJson;
 
   // coverage:ignore-start
   const UsersDeleteUserResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersDeleteUserResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersDeleteUserResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7199,7 +7182,7 @@ abstract class UsersGetCurrentUserResponseApplicationJson_Ocs
         $UsersGetCurrentUserResponseApplicationJson_OcsInterface,
         Built<UsersGetCurrentUserResponseApplicationJson_Ocs, UsersGetCurrentUserResponseApplicationJson_OcsBuilder> {
   factory UsersGetCurrentUserResponseApplicationJson_Ocs([
-    final void Function(UsersGetCurrentUserResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersGetCurrentUserResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersGetCurrentUserResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7207,7 +7190,7 @@ abstract class UsersGetCurrentUserResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetCurrentUserResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetCurrentUserResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7229,7 +7212,7 @@ abstract class UsersGetCurrentUserResponseApplicationJson
         $UsersGetCurrentUserResponseApplicationJsonInterface,
         Built<UsersGetCurrentUserResponseApplicationJson, UsersGetCurrentUserResponseApplicationJsonBuilder> {
   factory UsersGetCurrentUserResponseApplicationJson([
-    final void Function(UsersGetCurrentUserResponseApplicationJsonBuilder)? b,
+    void Function(UsersGetCurrentUserResponseApplicationJsonBuilder)? b,
   ]) = _$UsersGetCurrentUserResponseApplicationJson;
 
   // coverage:ignore-start
@@ -7237,7 +7220,7 @@ abstract class UsersGetCurrentUserResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetCurrentUserResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetCurrentUserResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7261,7 +7244,7 @@ abstract class UsersGetEditableFieldsResponseApplicationJson_Ocs
         Built<UsersGetEditableFieldsResponseApplicationJson_Ocs,
             UsersGetEditableFieldsResponseApplicationJson_OcsBuilder> {
   factory UsersGetEditableFieldsResponseApplicationJson_Ocs([
-    final void Function(UsersGetEditableFieldsResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersGetEditableFieldsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersGetEditableFieldsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7269,7 +7252,7 @@ abstract class UsersGetEditableFieldsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetEditableFieldsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetEditableFieldsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7291,7 +7274,7 @@ abstract class UsersGetEditableFieldsResponseApplicationJson
         $UsersGetEditableFieldsResponseApplicationJsonInterface,
         Built<UsersGetEditableFieldsResponseApplicationJson, UsersGetEditableFieldsResponseApplicationJsonBuilder> {
   factory UsersGetEditableFieldsResponseApplicationJson([
-    final void Function(UsersGetEditableFieldsResponseApplicationJsonBuilder)? b,
+    void Function(UsersGetEditableFieldsResponseApplicationJsonBuilder)? b,
   ]) = _$UsersGetEditableFieldsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -7299,7 +7282,7 @@ abstract class UsersGetEditableFieldsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetEditableFieldsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetEditableFieldsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7323,7 +7306,7 @@ abstract class UsersGetEditableFieldsForUserResponseApplicationJson_Ocs
         Built<UsersGetEditableFieldsForUserResponseApplicationJson_Ocs,
             UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder> {
   factory UsersGetEditableFieldsForUserResponseApplicationJson_Ocs([
-    final void Function(UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersGetEditableFieldsForUserResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7331,7 +7314,7 @@ abstract class UsersGetEditableFieldsForUserResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetEditableFieldsForUserResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetEditableFieldsForUserResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7354,7 +7337,7 @@ abstract class UsersGetEditableFieldsForUserResponseApplicationJson
         Built<UsersGetEditableFieldsForUserResponseApplicationJson,
             UsersGetEditableFieldsForUserResponseApplicationJsonBuilder> {
   factory UsersGetEditableFieldsForUserResponseApplicationJson([
-    final void Function(UsersGetEditableFieldsForUserResponseApplicationJsonBuilder)? b,
+    void Function(UsersGetEditableFieldsForUserResponseApplicationJsonBuilder)? b,
   ]) = _$UsersGetEditableFieldsForUserResponseApplicationJson;
 
   // coverage:ignore-start
@@ -7362,7 +7345,7 @@ abstract class UsersGetEditableFieldsForUserResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetEditableFieldsForUserResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetEditableFieldsForUserResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7386,7 +7369,7 @@ abstract class UsersEditUserMultiValueResponseApplicationJson_Ocs
         Built<UsersEditUserMultiValueResponseApplicationJson_Ocs,
             UsersEditUserMultiValueResponseApplicationJson_OcsBuilder> {
   factory UsersEditUserMultiValueResponseApplicationJson_Ocs([
-    final void Function(UsersEditUserMultiValueResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersEditUserMultiValueResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersEditUserMultiValueResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7394,7 +7377,7 @@ abstract class UsersEditUserMultiValueResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersEditUserMultiValueResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersEditUserMultiValueResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7416,7 +7399,7 @@ abstract class UsersEditUserMultiValueResponseApplicationJson
         $UsersEditUserMultiValueResponseApplicationJsonInterface,
         Built<UsersEditUserMultiValueResponseApplicationJson, UsersEditUserMultiValueResponseApplicationJsonBuilder> {
   factory UsersEditUserMultiValueResponseApplicationJson([
-    final void Function(UsersEditUserMultiValueResponseApplicationJsonBuilder)? b,
+    void Function(UsersEditUserMultiValueResponseApplicationJsonBuilder)? b,
   ]) = _$UsersEditUserMultiValueResponseApplicationJson;
 
   // coverage:ignore-start
@@ -7424,7 +7407,7 @@ abstract class UsersEditUserMultiValueResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersEditUserMultiValueResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersEditUserMultiValueResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7447,7 +7430,7 @@ abstract class UsersWipeUserDevicesResponseApplicationJson_Ocs
         $UsersWipeUserDevicesResponseApplicationJson_OcsInterface,
         Built<UsersWipeUserDevicesResponseApplicationJson_Ocs, UsersWipeUserDevicesResponseApplicationJson_OcsBuilder> {
   factory UsersWipeUserDevicesResponseApplicationJson_Ocs([
-    final void Function(UsersWipeUserDevicesResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersWipeUserDevicesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersWipeUserDevicesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7455,7 +7438,7 @@ abstract class UsersWipeUserDevicesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersWipeUserDevicesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersWipeUserDevicesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7477,7 +7460,7 @@ abstract class UsersWipeUserDevicesResponseApplicationJson
         $UsersWipeUserDevicesResponseApplicationJsonInterface,
         Built<UsersWipeUserDevicesResponseApplicationJson, UsersWipeUserDevicesResponseApplicationJsonBuilder> {
   factory UsersWipeUserDevicesResponseApplicationJson([
-    final void Function(UsersWipeUserDevicesResponseApplicationJsonBuilder)? b,
+    void Function(UsersWipeUserDevicesResponseApplicationJsonBuilder)? b,
   ]) = _$UsersWipeUserDevicesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -7485,7 +7468,7 @@ abstract class UsersWipeUserDevicesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersWipeUserDevicesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersWipeUserDevicesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7508,7 +7491,7 @@ abstract class UsersEnableUserResponseApplicationJson_Ocs
         $UsersEnableUserResponseApplicationJson_OcsInterface,
         Built<UsersEnableUserResponseApplicationJson_Ocs, UsersEnableUserResponseApplicationJson_OcsBuilder> {
   factory UsersEnableUserResponseApplicationJson_Ocs([
-    final void Function(UsersEnableUserResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersEnableUserResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersEnableUserResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7516,7 +7499,7 @@ abstract class UsersEnableUserResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersEnableUserResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersEnableUserResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7537,16 +7520,15 @@ abstract class UsersEnableUserResponseApplicationJson
     implements
         $UsersEnableUserResponseApplicationJsonInterface,
         Built<UsersEnableUserResponseApplicationJson, UsersEnableUserResponseApplicationJsonBuilder> {
-  factory UsersEnableUserResponseApplicationJson([
-    final void Function(UsersEnableUserResponseApplicationJsonBuilder)? b,
-  ]) = _$UsersEnableUserResponseApplicationJson;
+  factory UsersEnableUserResponseApplicationJson([void Function(UsersEnableUserResponseApplicationJsonBuilder)? b]) =
+      _$UsersEnableUserResponseApplicationJson;
 
   // coverage:ignore-start
   const UsersEnableUserResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersEnableUserResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersEnableUserResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7569,7 +7551,7 @@ abstract class UsersDisableUserResponseApplicationJson_Ocs
         $UsersDisableUserResponseApplicationJson_OcsInterface,
         Built<UsersDisableUserResponseApplicationJson_Ocs, UsersDisableUserResponseApplicationJson_OcsBuilder> {
   factory UsersDisableUserResponseApplicationJson_Ocs([
-    final void Function(UsersDisableUserResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersDisableUserResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersDisableUserResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7577,7 +7559,7 @@ abstract class UsersDisableUserResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersDisableUserResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersDisableUserResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7598,16 +7580,15 @@ abstract class UsersDisableUserResponseApplicationJson
     implements
         $UsersDisableUserResponseApplicationJsonInterface,
         Built<UsersDisableUserResponseApplicationJson, UsersDisableUserResponseApplicationJsonBuilder> {
-  factory UsersDisableUserResponseApplicationJson([
-    final void Function(UsersDisableUserResponseApplicationJsonBuilder)? b,
-  ]) = _$UsersDisableUserResponseApplicationJson;
+  factory UsersDisableUserResponseApplicationJson([void Function(UsersDisableUserResponseApplicationJsonBuilder)? b]) =
+      _$UsersDisableUserResponseApplicationJson;
 
   // coverage:ignore-start
   const UsersDisableUserResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersDisableUserResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersDisableUserResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7630,7 +7611,7 @@ abstract class UsersGetUsersGroupsResponseApplicationJson_Ocs_Data
         Built<UsersGetUsersGroupsResponseApplicationJson_Ocs_Data,
             UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder> {
   factory UsersGetUsersGroupsResponseApplicationJson_Ocs_Data([
-    final void Function(UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$UsersGetUsersGroupsResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -7638,7 +7619,7 @@ abstract class UsersGetUsersGroupsResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUsersGroupsResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUsersGroupsResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7661,7 +7642,7 @@ abstract class UsersGetUsersGroupsResponseApplicationJson_Ocs
         $UsersGetUsersGroupsResponseApplicationJson_OcsInterface,
         Built<UsersGetUsersGroupsResponseApplicationJson_Ocs, UsersGetUsersGroupsResponseApplicationJson_OcsBuilder> {
   factory UsersGetUsersGroupsResponseApplicationJson_Ocs([
-    final void Function(UsersGetUsersGroupsResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersGetUsersGroupsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersGetUsersGroupsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7669,7 +7650,7 @@ abstract class UsersGetUsersGroupsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUsersGroupsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUsersGroupsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7691,7 +7672,7 @@ abstract class UsersGetUsersGroupsResponseApplicationJson
         $UsersGetUsersGroupsResponseApplicationJsonInterface,
         Built<UsersGetUsersGroupsResponseApplicationJson, UsersGetUsersGroupsResponseApplicationJsonBuilder> {
   factory UsersGetUsersGroupsResponseApplicationJson([
-    final void Function(UsersGetUsersGroupsResponseApplicationJsonBuilder)? b,
+    void Function(UsersGetUsersGroupsResponseApplicationJsonBuilder)? b,
   ]) = _$UsersGetUsersGroupsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -7699,7 +7680,7 @@ abstract class UsersGetUsersGroupsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUsersGroupsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUsersGroupsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7722,7 +7703,7 @@ abstract class UsersAddToGroupResponseApplicationJson_Ocs
         $UsersAddToGroupResponseApplicationJson_OcsInterface,
         Built<UsersAddToGroupResponseApplicationJson_Ocs, UsersAddToGroupResponseApplicationJson_OcsBuilder> {
   factory UsersAddToGroupResponseApplicationJson_Ocs([
-    final void Function(UsersAddToGroupResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersAddToGroupResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersAddToGroupResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7730,7 +7711,7 @@ abstract class UsersAddToGroupResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersAddToGroupResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersAddToGroupResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7751,16 +7732,15 @@ abstract class UsersAddToGroupResponseApplicationJson
     implements
         $UsersAddToGroupResponseApplicationJsonInterface,
         Built<UsersAddToGroupResponseApplicationJson, UsersAddToGroupResponseApplicationJsonBuilder> {
-  factory UsersAddToGroupResponseApplicationJson([
-    final void Function(UsersAddToGroupResponseApplicationJsonBuilder)? b,
-  ]) = _$UsersAddToGroupResponseApplicationJson;
+  factory UsersAddToGroupResponseApplicationJson([void Function(UsersAddToGroupResponseApplicationJsonBuilder)? b]) =
+      _$UsersAddToGroupResponseApplicationJson;
 
   // coverage:ignore-start
   const UsersAddToGroupResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersAddToGroupResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersAddToGroupResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7783,7 +7763,7 @@ abstract class UsersRemoveFromGroupResponseApplicationJson_Ocs
         $UsersRemoveFromGroupResponseApplicationJson_OcsInterface,
         Built<UsersRemoveFromGroupResponseApplicationJson_Ocs, UsersRemoveFromGroupResponseApplicationJson_OcsBuilder> {
   factory UsersRemoveFromGroupResponseApplicationJson_Ocs([
-    final void Function(UsersRemoveFromGroupResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersRemoveFromGroupResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersRemoveFromGroupResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7791,7 +7771,7 @@ abstract class UsersRemoveFromGroupResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersRemoveFromGroupResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersRemoveFromGroupResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7813,7 +7793,7 @@ abstract class UsersRemoveFromGroupResponseApplicationJson
         $UsersRemoveFromGroupResponseApplicationJsonInterface,
         Built<UsersRemoveFromGroupResponseApplicationJson, UsersRemoveFromGroupResponseApplicationJsonBuilder> {
   factory UsersRemoveFromGroupResponseApplicationJson([
-    final void Function(UsersRemoveFromGroupResponseApplicationJsonBuilder)? b,
+    void Function(UsersRemoveFromGroupResponseApplicationJsonBuilder)? b,
   ]) = _$UsersRemoveFromGroupResponseApplicationJson;
 
   // coverage:ignore-start
@@ -7821,7 +7801,7 @@ abstract class UsersRemoveFromGroupResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersRemoveFromGroupResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersRemoveFromGroupResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7845,7 +7825,7 @@ abstract class UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs
         Built<UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs,
             UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder> {
   factory UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs([
-    final void Function(UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7853,7 +7833,7 @@ abstract class UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7876,7 +7856,7 @@ abstract class UsersGetUserSubAdminGroupsResponseApplicationJson
         Built<UsersGetUserSubAdminGroupsResponseApplicationJson,
             UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder> {
   factory UsersGetUserSubAdminGroupsResponseApplicationJson([
-    final void Function(UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder)? b,
+    void Function(UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder)? b,
   ]) = _$UsersGetUserSubAdminGroupsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -7884,7 +7864,7 @@ abstract class UsersGetUserSubAdminGroupsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersGetUserSubAdminGroupsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersGetUserSubAdminGroupsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7907,7 +7887,7 @@ abstract class UsersAddSubAdminResponseApplicationJson_Ocs
         $UsersAddSubAdminResponseApplicationJson_OcsInterface,
         Built<UsersAddSubAdminResponseApplicationJson_Ocs, UsersAddSubAdminResponseApplicationJson_OcsBuilder> {
   factory UsersAddSubAdminResponseApplicationJson_Ocs([
-    final void Function(UsersAddSubAdminResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersAddSubAdminResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersAddSubAdminResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7915,7 +7895,7 @@ abstract class UsersAddSubAdminResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersAddSubAdminResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersAddSubAdminResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7936,16 +7916,15 @@ abstract class UsersAddSubAdminResponseApplicationJson
     implements
         $UsersAddSubAdminResponseApplicationJsonInterface,
         Built<UsersAddSubAdminResponseApplicationJson, UsersAddSubAdminResponseApplicationJsonBuilder> {
-  factory UsersAddSubAdminResponseApplicationJson([
-    final void Function(UsersAddSubAdminResponseApplicationJsonBuilder)? b,
-  ]) = _$UsersAddSubAdminResponseApplicationJson;
+  factory UsersAddSubAdminResponseApplicationJson([void Function(UsersAddSubAdminResponseApplicationJsonBuilder)? b]) =
+      _$UsersAddSubAdminResponseApplicationJson;
 
   // coverage:ignore-start
   const UsersAddSubAdminResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersAddSubAdminResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersAddSubAdminResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7968,7 +7947,7 @@ abstract class UsersRemoveSubAdminResponseApplicationJson_Ocs
         $UsersRemoveSubAdminResponseApplicationJson_OcsInterface,
         Built<UsersRemoveSubAdminResponseApplicationJson_Ocs, UsersRemoveSubAdminResponseApplicationJson_OcsBuilder> {
   factory UsersRemoveSubAdminResponseApplicationJson_Ocs([
-    final void Function(UsersRemoveSubAdminResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersRemoveSubAdminResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersRemoveSubAdminResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -7976,7 +7955,7 @@ abstract class UsersRemoveSubAdminResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersRemoveSubAdminResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersRemoveSubAdminResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -7998,7 +7977,7 @@ abstract class UsersRemoveSubAdminResponseApplicationJson
         $UsersRemoveSubAdminResponseApplicationJsonInterface,
         Built<UsersRemoveSubAdminResponseApplicationJson, UsersRemoveSubAdminResponseApplicationJsonBuilder> {
   factory UsersRemoveSubAdminResponseApplicationJson([
-    final void Function(UsersRemoveSubAdminResponseApplicationJsonBuilder)? b,
+    void Function(UsersRemoveSubAdminResponseApplicationJsonBuilder)? b,
   ]) = _$UsersRemoveSubAdminResponseApplicationJson;
 
   // coverage:ignore-start
@@ -8006,7 +7985,7 @@ abstract class UsersRemoveSubAdminResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersRemoveSubAdminResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersRemoveSubAdminResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8030,7 +8009,7 @@ abstract class UsersResendWelcomeMessageResponseApplicationJson_Ocs
         Built<UsersResendWelcomeMessageResponseApplicationJson_Ocs,
             UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder> {
   factory UsersResendWelcomeMessageResponseApplicationJson_Ocs([
-    final void Function(UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder)? b,
+    void Function(UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UsersResendWelcomeMessageResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -8038,7 +8017,7 @@ abstract class UsersResendWelcomeMessageResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersResendWelcomeMessageResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UsersResendWelcomeMessageResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8061,7 +8040,7 @@ abstract class UsersResendWelcomeMessageResponseApplicationJson
         Built<UsersResendWelcomeMessageResponseApplicationJson,
             UsersResendWelcomeMessageResponseApplicationJsonBuilder> {
   factory UsersResendWelcomeMessageResponseApplicationJson([
-    final void Function(UsersResendWelcomeMessageResponseApplicationJsonBuilder)? b,
+    void Function(UsersResendWelcomeMessageResponseApplicationJsonBuilder)? b,
   ]) = _$UsersResendWelcomeMessageResponseApplicationJson;
 
   // coverage:ignore-start
@@ -8069,7 +8048,7 @@ abstract class UsersResendWelcomeMessageResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UsersResendWelcomeMessageResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UsersResendWelcomeMessageResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8096,7 +8075,7 @@ abstract class Capabilities_ProvisioningApi
     implements
         $Capabilities_ProvisioningApiInterface,
         Built<Capabilities_ProvisioningApi, Capabilities_ProvisioningApiBuilder> {
-  factory Capabilities_ProvisioningApi([final void Function(Capabilities_ProvisioningApiBuilder)? b]) =
+  factory Capabilities_ProvisioningApi([void Function(Capabilities_ProvisioningApiBuilder)? b]) =
       _$Capabilities_ProvisioningApi;
 
   // coverage:ignore-start
@@ -8104,7 +8083,7 @@ abstract class Capabilities_ProvisioningApi
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_ProvisioningApi.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_ProvisioningApi.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -8122,14 +8101,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -8167,7 +8146,7 @@ extension $BoolIntExtension on $BoolInt {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BoolInt> get serializer => const _$BoolIntSerializer();
-  static $BoolInt fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BoolInt fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -8182,9 +8161,9 @@ class _$BoolIntSerializer implements PrimitiveSerializer<$BoolInt> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BoolInt object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BoolInt object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.$bool;
@@ -8201,9 +8180,9 @@ class _$BoolIntSerializer implements PrimitiveSerializer<$BoolInt> {
 
   @override
   $BoolInt deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     bool? $bool;
     try {
@@ -8224,7 +8203,7 @@ extension $NumStringExtension on $NumString {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$NumString> get serializer => const _$NumStringSerializer();
-  static $NumString fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $NumString fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -8239,9 +8218,9 @@ class _$NumStringSerializer implements PrimitiveSerializer<$NumString> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $NumString object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $NumString object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.$num;
@@ -8258,9 +8237,9 @@ class _$NumStringSerializer implements PrimitiveSerializer<$NumString> {
 
   @override
   $NumString deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     num? $num;
     try {
@@ -8286,7 +8265,7 @@ extension $GroupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1UserDet
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$GroupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1UserDetails> get serializer =>
       const _$GroupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1UserDetailsSerializer();
-  static $GroupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1UserDetails fromJson(final Object? json) =>
+  static $GroupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1UserDetails fromJson(Object? json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
@@ -8303,9 +8282,9 @@ class _$GroupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1UserDetail
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $GroupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1UserDetails object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $GroupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1UserDetails object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1;
@@ -8325,9 +8304,9 @@ class _$GroupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1UserDetail
 
   @override
   $GroupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1UserDetails deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1?
         groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1;
@@ -8361,7 +8340,7 @@ extension $UserDetailsUsersGetUsersDetailsResponseApplicationJsonOcsDataUsers1Ex
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$UserDetailsUsersGetUsersDetailsResponseApplicationJsonOcsDataUsers1> get serializer =>
       const _$UserDetailsUsersGetUsersDetailsResponseApplicationJsonOcsDataUsers1Serializer();
-  static $UserDetailsUsersGetUsersDetailsResponseApplicationJsonOcsDataUsers1 fromJson(final Object? json) =>
+  static $UserDetailsUsersGetUsersDetailsResponseApplicationJsonOcsDataUsers1 fromJson(Object? json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
@@ -8378,9 +8357,9 @@ class _$UserDetailsUsersGetUsersDetailsResponseApplicationJsonOcsDataUsers1Seria
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $UserDetailsUsersGetUsersDetailsResponseApplicationJsonOcsDataUsers1 object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $UserDetailsUsersGetUsersDetailsResponseApplicationJsonOcsDataUsers1 object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.userDetails;
@@ -8400,9 +8379,9 @@ class _$UserDetailsUsersGetUsersDetailsResponseApplicationJsonOcsDataUsers1Seria
 
   @override
   $UserDetailsUsersGetUsersDetailsResponseApplicationJsonOcsDataUsers1 deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     UserDetails? userDetails;
     try {
@@ -8435,7 +8414,7 @@ extension $UserDetailsUsersGetDisabledUsersDetailsResponseApplicationJsonOcsData
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$UserDetailsUsersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1> get serializer =>
       const _$UserDetailsUsersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1Serializer();
-  static $UserDetailsUsersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1 fromJson(final Object? json) =>
+  static $UserDetailsUsersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1 fromJson(Object? json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
@@ -8452,9 +8431,9 @@ class _$UserDetailsUsersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUse
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $UserDetailsUsersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1 object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $UserDetailsUsersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1 object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.userDetails;
@@ -8474,9 +8453,9 @@ class _$UserDetailsUsersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUse
 
   @override
   $UserDetailsUsersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1 deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     UserDetails? userDetails;
     try {

--- a/packages/nextcloud/lib/src/api/settings.openapi.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.dart
@@ -27,7 +27,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -86,7 +86,7 @@ class LogSettingsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -127,16 +127,15 @@ abstract class LogSettingsLogSettingsDownloadHeaders
     implements
         $LogSettingsLogSettingsDownloadHeadersInterface,
         Built<LogSettingsLogSettingsDownloadHeaders, LogSettingsLogSettingsDownloadHeadersBuilder> {
-  factory LogSettingsLogSettingsDownloadHeaders([
-    final void Function(LogSettingsLogSettingsDownloadHeadersBuilder)? b,
-  ]) = _$LogSettingsLogSettingsDownloadHeaders;
+  factory LogSettingsLogSettingsDownloadHeaders([void Function(LogSettingsLogSettingsDownloadHeadersBuilder)? b]) =
+      _$LogSettingsLogSettingsDownloadHeaders;
 
   // coverage:ignore-start
   const LogSettingsLogSettingsDownloadHeaders._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory LogSettingsLogSettingsDownloadHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory LogSettingsLogSettingsDownloadHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 

--- a/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
+++ b/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
@@ -25,7 +25,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -46,7 +46,7 @@ abstract class Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop
         Built<Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop,
             Capabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder> {
   factory Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop([
-    final void Function(Capabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder)? b,
+    void Function(Capabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder)? b,
   ]) = _$Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop;
 
   // coverage:ignore-start
@@ -54,7 +54,7 @@ abstract class Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -77,7 +77,7 @@ abstract class Capabilities0_FilesSharing_Sharebymail_Password
         $Capabilities0_FilesSharing_Sharebymail_PasswordInterface,
         Built<Capabilities0_FilesSharing_Sharebymail_Password, Capabilities0_FilesSharing_Sharebymail_PasswordBuilder> {
   factory Capabilities0_FilesSharing_Sharebymail_Password([
-    final void Function(Capabilities0_FilesSharing_Sharebymail_PasswordBuilder)? b,
+    void Function(Capabilities0_FilesSharing_Sharebymail_PasswordBuilder)? b,
   ]) = _$Capabilities0_FilesSharing_Sharebymail_Password;
 
   // coverage:ignore-start
@@ -85,7 +85,7 @@ abstract class Capabilities0_FilesSharing_Sharebymail_Password
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities0_FilesSharing_Sharebymail_Password.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities0_FilesSharing_Sharebymail_Password.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -109,7 +109,7 @@ abstract class Capabilities0_FilesSharing_Sharebymail_ExpireDate
         Built<Capabilities0_FilesSharing_Sharebymail_ExpireDate,
             Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder> {
   factory Capabilities0_FilesSharing_Sharebymail_ExpireDate([
-    final void Function(Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder)? b,
+    void Function(Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder)? b,
   ]) = _$Capabilities0_FilesSharing_Sharebymail_ExpireDate;
 
   // coverage:ignore-start
@@ -117,7 +117,7 @@ abstract class Capabilities0_FilesSharing_Sharebymail_ExpireDate
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities0_FilesSharing_Sharebymail_ExpireDate.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities0_FilesSharing_Sharebymail_ExpireDate.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -145,16 +145,15 @@ abstract class Capabilities0_FilesSharing_Sharebymail
     implements
         $Capabilities0_FilesSharing_SharebymailInterface,
         Built<Capabilities0_FilesSharing_Sharebymail, Capabilities0_FilesSharing_SharebymailBuilder> {
-  factory Capabilities0_FilesSharing_Sharebymail([
-    final void Function(Capabilities0_FilesSharing_SharebymailBuilder)? b,
-  ]) = _$Capabilities0_FilesSharing_Sharebymail;
+  factory Capabilities0_FilesSharing_Sharebymail([void Function(Capabilities0_FilesSharing_SharebymailBuilder)? b]) =
+      _$Capabilities0_FilesSharing_Sharebymail;
 
   // coverage:ignore-start
   const Capabilities0_FilesSharing_Sharebymail._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities0_FilesSharing_Sharebymail.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities0_FilesSharing_Sharebymail.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -175,7 +174,7 @@ abstract class Capabilities0_FilesSharing
     implements
         $Capabilities0_FilesSharingInterface,
         Built<Capabilities0_FilesSharing, Capabilities0_FilesSharingBuilder> {
-  factory Capabilities0_FilesSharing([final void Function(Capabilities0_FilesSharingBuilder)? b]) =
+  factory Capabilities0_FilesSharing([void Function(Capabilities0_FilesSharingBuilder)? b]) =
       _$Capabilities0_FilesSharing;
 
   // coverage:ignore-start
@@ -183,7 +182,7 @@ abstract class Capabilities0_FilesSharing
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities0_FilesSharing.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities0_FilesSharing.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -201,14 +200,14 @@ abstract interface class $Capabilities0Interface {
 }
 
 abstract class Capabilities0 implements $Capabilities0Interface, Built<Capabilities0, Capabilities0Builder> {
-  factory Capabilities0([final void Function(Capabilities0Builder)? b]) = _$Capabilities0;
+  factory Capabilities0([void Function(Capabilities0Builder)? b]) = _$Capabilities0;
 
   // coverage:ignore-start
   const Capabilities0._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities0.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities0.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -227,7 +226,7 @@ extension $BuiltListCapabilities0Extension on $BuiltListCapabilities0 {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BuiltListCapabilities0> get serializer => const _$BuiltListCapabilities0Serializer();
-  static $BuiltListCapabilities0 fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BuiltListCapabilities0 fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -242,9 +241,9 @@ class _$BuiltListCapabilities0Serializer implements PrimitiveSerializer<$BuiltLi
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BuiltListCapabilities0 object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BuiltListCapabilities0 object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.builtListNever;
@@ -261,9 +260,9 @@ class _$BuiltListCapabilities0Serializer implements PrimitiveSerializer<$BuiltLi
 
   @override
   $BuiltListCapabilities0 deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BuiltList<Never>? builtListNever;
     try {

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -31,7 +31,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -103,10 +103,10 @@ class AvatarClient {
   /// See:
   ///  * [getAvatarRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getAvatar({
-    required final String token,
-    final int? darkTheme,
-    final AvatarGetAvatarApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? darkTheme,
+    AvatarGetAvatarApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getAvatarRaw(
       token: token,
@@ -138,10 +138,10 @@ class AvatarClient {
   ///  * [getAvatar] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getAvatarRaw({
-    required final String token,
-    final int? darkTheme,
-    final AvatarGetAvatarApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? darkTheme,
+    AvatarGetAvatarApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -151,7 +151,7 @@ class AvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -214,9 +214,9 @@ class AvatarClient {
   /// See:
   ///  * [uploadAvatarRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AvatarUploadAvatarResponseApplicationJson, void>> uploadAvatar({
-    required final String token,
-    final AvatarUploadAvatarApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    AvatarUploadAvatarApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = uploadAvatarRaw(
       token: token,
@@ -247,9 +247,9 @@ class AvatarClient {
   ///  * [uploadAvatar] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AvatarUploadAvatarResponseApplicationJson, void> uploadAvatarRaw({
-    required final String token,
-    final AvatarUploadAvatarApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    AvatarUploadAvatarApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -259,7 +259,7 @@ class AvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -317,9 +317,9 @@ class AvatarClient {
   /// See:
   ///  * [deleteAvatarRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AvatarDeleteAvatarResponseApplicationJson, void>> deleteAvatar({
-    required final String token,
-    final AvatarDeleteAvatarApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    AvatarDeleteAvatarApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteAvatarRaw(
       token: token,
@@ -349,9 +349,9 @@ class AvatarClient {
   ///  * [deleteAvatar] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AvatarDeleteAvatarResponseApplicationJson, void> deleteAvatarRaw({
-    required final String token,
-    final AvatarDeleteAvatarApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    AvatarDeleteAvatarApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -361,7 +361,7 @@ class AvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -422,11 +422,11 @@ class AvatarClient {
   /// See:
   ///  * [emojiAvatarRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<AvatarEmojiAvatarResponseApplicationJson, void>> emojiAvatar({
-    required final String emoji,
-    required final String token,
-    final String? color,
-    final AvatarEmojiAvatarApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String emoji,
+    required String token,
+    String? color,
+    AvatarEmojiAvatarApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = emojiAvatarRaw(
       emoji: emoji,
@@ -461,11 +461,11 @@ class AvatarClient {
   ///  * [emojiAvatar] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<AvatarEmojiAvatarResponseApplicationJson, void> emojiAvatarRaw({
-    required final String emoji,
-    required final String token,
-    final String? color,
-    final AvatarEmojiAvatarApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String emoji,
+    required String token,
+    String? color,
+    AvatarEmojiAvatarApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -475,7 +475,7 @@ class AvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -540,9 +540,9 @@ class AvatarClient {
   /// See:
   ///  * [getAvatarDarkRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getAvatarDark({
-    required final String token,
-    final AvatarGetAvatarDarkApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    AvatarGetAvatarDarkApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getAvatarDarkRaw(
       token: token,
@@ -572,9 +572,9 @@ class AvatarClient {
   ///  * [getAvatarDark] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getAvatarDarkRaw({
-    required final String token,
-    final AvatarGetAvatarDarkApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    AvatarGetAvatarDarkApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -584,7 +584,7 @@ class AvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -657,13 +657,13 @@ class BotClient {
   /// See:
   ///  * [sendMessageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BotSendMessageResponseApplicationJson, void>> sendMessage({
-    required final String message,
-    required final String token,
-    final String? referenceId,
-    final int? replyTo,
-    final int? silent,
-    final BotSendMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String message,
+    required String token,
+    String? referenceId,
+    int? replyTo,
+    int? silent,
+    BotSendMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = sendMessageRaw(
       message: message,
@@ -706,13 +706,13 @@ class BotClient {
   ///  * [sendMessage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BotSendMessageResponseApplicationJson, void> sendMessageRaw({
-    required final String message,
-    required final String token,
-    final String? referenceId,
-    final int? replyTo,
-    final int? silent,
-    final BotSendMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String message,
+    required String token,
+    String? referenceId,
+    int? replyTo,
+    int? silent,
+    BotSendMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -722,7 +722,7 @@ class BotClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -803,11 +803,11 @@ class BotClient {
   /// See:
   ///  * [reactRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BotReactResponseApplicationJson, void>> react({
-    required final String reaction,
-    required final String token,
-    required final int messageId,
-    final BotReactApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String reaction,
+    required String token,
+    required int messageId,
+    BotReactApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = reactRaw(
       reaction: reaction,
@@ -845,11 +845,11 @@ class BotClient {
   ///  * [react] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BotReactResponseApplicationJson, void> reactRaw({
-    required final String reaction,
-    required final String token,
-    required final int messageId,
-    final BotReactApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String reaction,
+    required String token,
+    required int messageId,
+    BotReactApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -859,7 +859,7 @@ class BotClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -929,11 +929,11 @@ class BotClient {
   /// See:
   ///  * [deleteReactionRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BotDeleteReactionResponseApplicationJson, void>> deleteReaction({
-    required final String reaction,
-    required final String token,
-    required final int messageId,
-    final BotDeleteReactionApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String reaction,
+    required String token,
+    required int messageId,
+    BotDeleteReactionApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteReactionRaw(
       reaction: reaction,
@@ -970,11 +970,11 @@ class BotClient {
   ///  * [deleteReaction] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BotDeleteReactionResponseApplicationJson, void> deleteReactionRaw({
-    required final String reaction,
-    required final String token,
-    required final int messageId,
-    final BotDeleteReactionApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String reaction,
+    required String token,
+    required int messageId,
+    BotDeleteReactionApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -984,7 +984,7 @@ class BotClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1050,8 +1050,8 @@ class BotClient {
   /// See:
   ///  * [adminListBotsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BotAdminListBotsResponseApplicationJson, void>> adminListBots({
-    final BotAdminListBotsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    BotAdminListBotsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = adminListBotsRaw(
       apiVersion: apiVersion,
@@ -1081,8 +1081,8 @@ class BotClient {
   ///  * [adminListBots] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BotAdminListBotsResponseApplicationJson, void> adminListBotsRaw({
-    final BotAdminListBotsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    BotAdminListBotsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1092,7 +1092,7 @@ class BotClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1146,9 +1146,9 @@ class BotClient {
   /// See:
   ///  * [listBotsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BotListBotsResponseApplicationJson, void>> listBots({
-    required final String token,
-    final BotListBotsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BotListBotsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = listBotsRaw(
       token: token,
@@ -1178,9 +1178,9 @@ class BotClient {
   ///  * [listBots] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BotListBotsResponseApplicationJson, void> listBotsRaw({
-    required final String token,
-    final BotListBotsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BotListBotsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1190,7 +1190,7 @@ class BotClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1251,10 +1251,10 @@ class BotClient {
   /// See:
   ///  * [enableBotRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BotEnableBotResponseApplicationJson, void>> enableBot({
-    required final String token,
-    required final int botId,
-    final BotEnableBotApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int botId,
+    BotEnableBotApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = enableBotRaw(
       token: token,
@@ -1288,10 +1288,10 @@ class BotClient {
   ///  * [enableBot] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BotEnableBotResponseApplicationJson, void> enableBotRaw({
-    required final String token,
-    required final int botId,
-    final BotEnableBotApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int botId,
+    BotEnableBotApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1301,7 +1301,7 @@ class BotClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1365,10 +1365,10 @@ class BotClient {
   /// See:
   ///  * [disableBotRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BotDisableBotResponseApplicationJson, void>> disableBot({
-    required final String token,
-    required final int botId,
-    final BotDisableBotApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int botId,
+    BotDisableBotApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = disableBotRaw(
       token: token,
@@ -1401,10 +1401,10 @@ class BotClient {
   ///  * [disableBot] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BotDisableBotResponseApplicationJson, void> disableBotRaw({
-    required final String token,
-    required final int botId,
-    final BotDisableBotApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int botId,
+    BotDisableBotApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1414,7 +1414,7 @@ class BotClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1486,12 +1486,12 @@ class BreakoutRoomClient {
   /// See:
   ///  * [configureBreakoutRoomsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson, void>> configureBreakoutRooms({
-    required final int mode,
-    required final int amount,
-    required final String token,
-    final String? attendeeMap,
-    final BreakoutRoomConfigureBreakoutRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int mode,
+    required int amount,
+    required String token,
+    String? attendeeMap,
+    BreakoutRoomConfigureBreakoutRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = configureBreakoutRoomsRaw(
       mode: mode,
@@ -1528,12 +1528,12 @@ class BreakoutRoomClient {
   ///  * [configureBreakoutRooms] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson, void> configureBreakoutRoomsRaw({
-    required final int mode,
-    required final int amount,
-    required final String token,
-    final String? attendeeMap,
-    final BreakoutRoomConfigureBreakoutRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int mode,
+    required int amount,
+    required String token,
+    String? attendeeMap,
+    BreakoutRoomConfigureBreakoutRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1543,7 +1543,7 @@ class BreakoutRoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1617,9 +1617,9 @@ class BreakoutRoomClient {
   /// See:
   ///  * [removeBreakoutRoomsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson, void>> removeBreakoutRooms({
-    required final String token,
-    final BreakoutRoomRemoveBreakoutRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BreakoutRoomRemoveBreakoutRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = removeBreakoutRoomsRaw(
       token: token,
@@ -1649,9 +1649,9 @@ class BreakoutRoomClient {
   ///  * [removeBreakoutRooms] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson, void> removeBreakoutRoomsRaw({
-    required final String token,
-    final BreakoutRoomRemoveBreakoutRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BreakoutRoomRemoveBreakoutRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1661,7 +1661,7 @@ class BreakoutRoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1724,10 +1724,10 @@ class BreakoutRoomClient {
   /// See:
   ///  * [broadcastChatMessageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BreakoutRoomBroadcastChatMessageResponseApplicationJson, void>> broadcastChatMessage({
-    required final String message,
-    required final String token,
-    final BreakoutRoomBroadcastChatMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String message,
+    required String token,
+    BreakoutRoomBroadcastChatMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = broadcastChatMessageRaw(
       message: message,
@@ -1761,10 +1761,10 @@ class BreakoutRoomClient {
   ///  * [broadcastChatMessage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BreakoutRoomBroadcastChatMessageResponseApplicationJson, void> broadcastChatMessageRaw({
-    required final String message,
-    required final String token,
-    final BreakoutRoomBroadcastChatMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String message,
+    required String token,
+    BreakoutRoomBroadcastChatMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1774,7 +1774,7 @@ class BreakoutRoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1843,10 +1843,10 @@ class BreakoutRoomClient {
   /// See:
   ///  * [applyAttendeeMapRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BreakoutRoomApplyAttendeeMapResponseApplicationJson, void>> applyAttendeeMap({
-    required final String attendeeMap,
-    required final String token,
-    final BreakoutRoomApplyAttendeeMapApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String attendeeMap,
+    required String token,
+    BreakoutRoomApplyAttendeeMapApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = applyAttendeeMapRaw(
       attendeeMap: attendeeMap,
@@ -1879,10 +1879,10 @@ class BreakoutRoomClient {
   ///  * [applyAttendeeMap] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BreakoutRoomApplyAttendeeMapResponseApplicationJson, void> applyAttendeeMapRaw({
-    required final String attendeeMap,
-    required final String token,
-    final BreakoutRoomApplyAttendeeMapApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String attendeeMap,
+    required String token,
+    BreakoutRoomApplyAttendeeMapApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1892,7 +1892,7 @@ class BreakoutRoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1958,9 +1958,9 @@ class BreakoutRoomClient {
   /// See:
   ///  * [requestAssistanceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BreakoutRoomRequestAssistanceResponseApplicationJson, void>> requestAssistance({
-    required final String token,
-    final BreakoutRoomRequestAssistanceApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BreakoutRoomRequestAssistanceApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = requestAssistanceRaw(
       token: token,
@@ -1991,9 +1991,9 @@ class BreakoutRoomClient {
   ///  * [requestAssistance] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BreakoutRoomRequestAssistanceResponseApplicationJson, void> requestAssistanceRaw({
-    required final String token,
-    final BreakoutRoomRequestAssistanceApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BreakoutRoomRequestAssistanceApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2003,7 +2003,7 @@ class BreakoutRoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2067,9 +2067,9 @@ class BreakoutRoomClient {
   ///  * [resetRequestForAssistanceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BreakoutRoomResetRequestForAssistanceResponseApplicationJson, void>>
       resetRequestForAssistance({
-    required final String token,
-    final BreakoutRoomResetRequestForAssistanceApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BreakoutRoomResetRequestForAssistanceApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = resetRequestForAssistanceRaw(
       token: token,
@@ -2100,9 +2100,9 @@ class BreakoutRoomClient {
   ///  * [resetRequestForAssistance] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BreakoutRoomResetRequestForAssistanceResponseApplicationJson, void> resetRequestForAssistanceRaw({
-    required final String token,
-    final BreakoutRoomResetRequestForAssistanceApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BreakoutRoomResetRequestForAssistanceApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2112,7 +2112,7 @@ class BreakoutRoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2177,9 +2177,9 @@ class BreakoutRoomClient {
   /// See:
   ///  * [startBreakoutRoomsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BreakoutRoomStartBreakoutRoomsResponseApplicationJson, void>> startBreakoutRooms({
-    required final String token,
-    final BreakoutRoomStartBreakoutRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BreakoutRoomStartBreakoutRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = startBreakoutRoomsRaw(
       token: token,
@@ -2210,9 +2210,9 @@ class BreakoutRoomClient {
   ///  * [startBreakoutRooms] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BreakoutRoomStartBreakoutRoomsResponseApplicationJson, void> startBreakoutRoomsRaw({
-    required final String token,
-    final BreakoutRoomStartBreakoutRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BreakoutRoomStartBreakoutRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2222,7 +2222,7 @@ class BreakoutRoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2284,9 +2284,9 @@ class BreakoutRoomClient {
   /// See:
   ///  * [stopBreakoutRoomsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BreakoutRoomStopBreakoutRoomsResponseApplicationJson, void>> stopBreakoutRooms({
-    required final String token,
-    final BreakoutRoomStopBreakoutRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BreakoutRoomStopBreakoutRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = stopBreakoutRoomsRaw(
       token: token,
@@ -2317,9 +2317,9 @@ class BreakoutRoomClient {
   ///  * [stopBreakoutRooms] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BreakoutRoomStopBreakoutRoomsResponseApplicationJson, void> stopBreakoutRoomsRaw({
-    required final String token,
-    final BreakoutRoomStopBreakoutRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    BreakoutRoomStopBreakoutRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2329,7 +2329,7 @@ class BreakoutRoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2392,10 +2392,10 @@ class BreakoutRoomClient {
   /// See:
   ///  * [switchBreakoutRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson, void>> switchBreakoutRoom({
-    required final String target,
-    required final String token,
-    final BreakoutRoomSwitchBreakoutRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String target,
+    required String token,
+    BreakoutRoomSwitchBreakoutRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = switchBreakoutRoomRaw(
       target: target,
@@ -2428,10 +2428,10 @@ class BreakoutRoomClient {
   ///  * [switchBreakoutRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson, void> switchBreakoutRoomRaw({
-    required final String target,
-    required final String token,
-    final BreakoutRoomSwitchBreakoutRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String target,
+    required String token,
+    BreakoutRoomSwitchBreakoutRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2441,7 +2441,7 @@ class BreakoutRoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2512,9 +2512,9 @@ class CallClient {
   /// See:
   ///  * [getPeersForCallRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CallGetPeersForCallResponseApplicationJson, void>> getPeersForCall({
-    required final String token,
-    final CallGetPeersForCallApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    CallGetPeersForCallApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getPeersForCallRaw(
       token: token,
@@ -2544,9 +2544,9 @@ class CallClient {
   ///  * [getPeersForCall] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CallGetPeersForCallResponseApplicationJson, void> getPeersForCallRaw({
-    required final String token,
-    final CallGetPeersForCallApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    CallGetPeersForCallApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2556,7 +2556,7 @@ class CallClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2616,10 +2616,10 @@ class CallClient {
   /// See:
   ///  * [updateCallFlagsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CallUpdateCallFlagsResponseApplicationJson, void>> updateCallFlags({
-    required final int flags,
-    required final String token,
-    final CallUpdateCallFlagsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int flags,
+    required String token,
+    CallUpdateCallFlagsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = updateCallFlagsRaw(
       flags: flags,
@@ -2653,10 +2653,10 @@ class CallClient {
   ///  * [updateCallFlags] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CallUpdateCallFlagsResponseApplicationJson, void> updateCallFlagsRaw({
-    required final int flags,
-    required final String token,
-    final CallUpdateCallFlagsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int flags,
+    required String token,
+    CallUpdateCallFlagsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2666,7 +2666,7 @@ class CallClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2733,13 +2733,13 @@ class CallClient {
   /// See:
   ///  * [joinCallRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CallJoinCallResponseApplicationJson, void>> joinCall({
-    required final String token,
-    final int? flags,
-    final int? forcePermissions,
-    final int? silent,
-    final int? recordingConsent,
-    final CallJoinCallApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? flags,
+    int? forcePermissions,
+    int? silent,
+    int? recordingConsent,
+    CallJoinCallApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = joinCallRaw(
       token: token,
@@ -2779,13 +2779,13 @@ class CallClient {
   ///  * [joinCall] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CallJoinCallResponseApplicationJson, void> joinCallRaw({
-    required final String token,
-    final int? flags,
-    final int? forcePermissions,
-    final int? silent,
-    final int? recordingConsent,
-    final CallJoinCallApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? flags,
+    int? forcePermissions,
+    int? silent,
+    int? recordingConsent,
+    CallJoinCallApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2795,7 +2795,7 @@ class CallClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2871,10 +2871,10 @@ class CallClient {
   /// See:
   ///  * [leaveCallRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CallLeaveCallResponseApplicationJson, void>> leaveCall({
-    required final String token,
-    final int? all,
-    final CallLeaveCallApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? all,
+    CallLeaveCallApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = leaveCallRaw(
       token: token,
@@ -2907,10 +2907,10 @@ class CallClient {
   ///  * [leaveCall] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CallLeaveCallResponseApplicationJson, void> leaveCallRaw({
-    required final String token,
-    final int? all,
-    final CallLeaveCallApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? all,
+    CallLeaveCallApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -2920,7 +2920,7 @@ class CallClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -2983,10 +2983,10 @@ class CallClient {
   /// See:
   ///  * [ringAttendeeRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CallRingAttendeeResponseApplicationJson, void>> ringAttendee({
-    required final String token,
-    required final int attendeeId,
-    final CallRingAttendeeApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int attendeeId,
+    CallRingAttendeeApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = ringAttendeeRaw(
       token: token,
@@ -3019,10 +3019,10 @@ class CallClient {
   ///  * [ringAttendee] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CallRingAttendeeResponseApplicationJson, void> ringAttendeeRaw({
-    required final String token,
-    required final int attendeeId,
-    final CallRingAttendeeApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int attendeeId,
+    CallRingAttendeeApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3032,7 +3032,7 @@ class CallClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3097,10 +3097,10 @@ class CallClient {
   /// See:
   ///  * [sipDialOutRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CallSipDialOutResponseApplicationJson, void>> sipDialOut({
-    required final String token,
-    required final int attendeeId,
-    final CallSipDialOutApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int attendeeId,
+    CallSipDialOutApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = sipDialOutRaw(
       token: token,
@@ -3135,10 +3135,10 @@ class CallClient {
   ///  * [sipDialOut] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CallSipDialOutResponseApplicationJson, void> sipDialOutRaw({
-    required final String token,
-    required final int attendeeId,
-    final CallSipDialOutApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int attendeeId,
+    CallSipDialOutApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3148,7 +3148,7 @@ class CallClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3218,9 +3218,9 @@ class CertificateClient {
   /// See:
   ///  * [getCertificateExpirationRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CertificateGetCertificateExpirationResponseApplicationJson, void>> getCertificateExpiration({
-    required final String host,
-    final CertificateGetCertificateExpirationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String host,
+    CertificateGetCertificateExpirationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getCertificateExpirationRaw(
       host: host,
@@ -3253,9 +3253,9 @@ class CertificateClient {
   ///  * [getCertificateExpiration] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CertificateGetCertificateExpirationResponseApplicationJson, void> getCertificateExpirationRaw({
-    required final String host,
-    final CertificateGetCertificateExpirationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String host,
+    CertificateGetCertificateExpirationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3265,7 +3265,7 @@ class CertificateClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3347,18 +3347,18 @@ class ChatClient {
   /// See:
   ///  * [receiveMessagesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatReceiveMessagesResponseApplicationJson, ChatChatReceiveMessagesHeaders>> receiveMessages({
-    required final int lookIntoFuture,
-    required final String token,
-    final int? limit,
-    final int? lastKnownMessageId,
-    final int? lastCommonReadId,
-    final int? timeout,
-    final int? setReadMarker,
-    final int? includeLastKnown,
-    final int? noStatusUpdate,
-    final int? markNotificationsAsRead,
-    final ChatReceiveMessagesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int lookIntoFuture,
+    required String token,
+    int? limit,
+    int? lastKnownMessageId,
+    int? lastCommonReadId,
+    int? timeout,
+    int? setReadMarker,
+    int? includeLastKnown,
+    int? noStatusUpdate,
+    int? markNotificationsAsRead,
+    ChatReceiveMessagesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = receiveMessagesRaw(
       lookIntoFuture: lookIntoFuture,
@@ -3411,18 +3411,18 @@ class ChatClient {
   ///  * [receiveMessages] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ChatReceiveMessagesResponseApplicationJson, ChatChatReceiveMessagesHeaders> receiveMessagesRaw({
-    required final int lookIntoFuture,
-    required final String token,
-    final int? limit,
-    final int? lastKnownMessageId,
-    final int? lastCommonReadId,
-    final int? timeout,
-    final int? setReadMarker,
-    final int? includeLastKnown,
-    final int? noStatusUpdate,
-    final int? markNotificationsAsRead,
-    final ChatReceiveMessagesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int lookIntoFuture,
+    required String token,
+    int? limit,
+    int? lastKnownMessageId,
+    int? lastCommonReadId,
+    int? timeout,
+    int? setReadMarker,
+    int? includeLastKnown,
+    int? noStatusUpdate,
+    int? markNotificationsAsRead,
+    ChatReceiveMessagesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3432,7 +3432,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3539,14 +3539,14 @@ class ChatClient {
   /// See:
   ///  * [sendMessageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatSendMessageResponseApplicationJson, ChatChatSendMessageHeaders>> sendMessage({
-    required final String message,
-    required final String token,
-    final String? actorDisplayName,
-    final String? referenceId,
-    final int? replyTo,
-    final int? silent,
-    final ChatSendMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String message,
+    required String token,
+    String? actorDisplayName,
+    String? referenceId,
+    int? replyTo,
+    int? silent,
+    ChatSendMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = sendMessageRaw(
       message: message,
@@ -3591,14 +3591,14 @@ class ChatClient {
   ///  * [sendMessage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ChatSendMessageResponseApplicationJson, ChatChatSendMessageHeaders> sendMessageRaw({
-    required final String message,
-    required final String token,
-    final String? actorDisplayName,
-    final String? referenceId,
-    final int? replyTo,
-    final int? silent,
-    final ChatSendMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String message,
+    required String token,
+    String? actorDisplayName,
+    String? referenceId,
+    int? replyTo,
+    int? silent,
+    ChatSendMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3608,7 +3608,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3689,9 +3689,9 @@ class ChatClient {
   /// See:
   ///  * [clearHistoryRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatClearHistoryResponseApplicationJson, ChatChatClearHistoryHeaders>> clearHistory({
-    required final String token,
-    final ChatClearHistoryApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    ChatClearHistoryApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = clearHistoryRaw(
       token: token,
@@ -3723,9 +3723,9 @@ class ChatClient {
   ///  * [clearHistory] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ChatClearHistoryResponseApplicationJson, ChatChatClearHistoryHeaders> clearHistoryRaw({
-    required final String token,
-    final ChatClearHistoryApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    ChatClearHistoryApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3735,7 +3735,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3799,10 +3799,10 @@ class ChatClient {
   /// See:
   ///  * [deleteMessageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatDeleteMessageResponseApplicationJson, ChatChatDeleteMessageHeaders>> deleteMessage({
-    required final String token,
-    required final int messageId,
-    final ChatDeleteMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int messageId,
+    ChatDeleteMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteMessageRaw(
       token: token,
@@ -3839,10 +3839,10 @@ class ChatClient {
   ///  * [deleteMessage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ChatDeleteMessageResponseApplicationJson, ChatChatDeleteMessageHeaders> deleteMessageRaw({
-    required final String token,
-    required final int messageId,
-    final ChatDeleteMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int messageId,
+    ChatDeleteMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3852,7 +3852,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -3918,11 +3918,11 @@ class ChatClient {
   ///  * [getMessageContextRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatGetMessageContextResponseApplicationJson, ChatChatGetMessageContextHeaders>>
       getMessageContext({
-    required final String token,
-    required final int messageId,
-    final int? limit,
-    final ChatGetMessageContextApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int messageId,
+    int? limit,
+    ChatGetMessageContextApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getMessageContextRaw(
       token: token,
@@ -3958,11 +3958,11 @@ class ChatClient {
   @experimental
   DynamiteRawResponse<ChatGetMessageContextResponseApplicationJson, ChatChatGetMessageContextHeaders>
       getMessageContextRaw({
-    required final String token,
-    required final int messageId,
-    final int? limit,
-    final ChatGetMessageContextApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int messageId,
+    int? limit,
+    ChatGetMessageContextApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -3972,7 +3972,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4041,10 +4041,10 @@ class ChatClient {
   /// See:
   ///  * [getReminderRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatGetReminderResponseApplicationJson, void>> getReminder({
-    required final String token,
-    required final int messageId,
-    final ChatGetReminderApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int messageId,
+    ChatGetReminderApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getReminderRaw(
       token: token,
@@ -4077,10 +4077,10 @@ class ChatClient {
   ///  * [getReminder] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ChatGetReminderResponseApplicationJson, void> getReminderRaw({
-    required final String token,
-    required final int messageId,
-    final ChatGetReminderApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int messageId,
+    ChatGetReminderApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4090,7 +4090,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4156,11 +4156,11 @@ class ChatClient {
   /// See:
   ///  * [setReminderRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatSetReminderResponseApplicationJson, void>> setReminder({
-    required final int timestamp,
-    required final String token,
-    required final int messageId,
-    final ChatSetReminderApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int timestamp,
+    required String token,
+    required int messageId,
+    ChatSetReminderApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setReminderRaw(
       timestamp: timestamp,
@@ -4195,11 +4195,11 @@ class ChatClient {
   ///  * [setReminder] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ChatSetReminderResponseApplicationJson, void> setReminderRaw({
-    required final int timestamp,
-    required final String token,
-    required final int messageId,
-    final ChatSetReminderApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int timestamp,
+    required String token,
+    required int messageId,
+    ChatSetReminderApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4209,7 +4209,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4278,10 +4278,10 @@ class ChatClient {
   /// See:
   ///  * [deleteReminderRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatDeleteReminderResponseApplicationJson, void>> deleteReminder({
-    required final String token,
-    required final int messageId,
-    final ChatDeleteReminderApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int messageId,
+    ChatDeleteReminderApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteReminderRaw(
       token: token,
@@ -4314,10 +4314,10 @@ class ChatClient {
   ///  * [deleteReminder] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ChatDeleteReminderResponseApplicationJson, void> deleteReminderRaw({
-    required final String token,
-    required final int messageId,
-    final ChatDeleteReminderApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int messageId,
+    ChatDeleteReminderApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4327,7 +4327,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4392,10 +4392,10 @@ class ChatClient {
   /// See:
   ///  * [setReadMarkerRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatSetReadMarkerResponseApplicationJson, ChatChatSetReadMarkerHeaders>> setReadMarker({
-    required final int lastReadMessage,
-    required final String token,
-    final ChatSetReadMarkerApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int lastReadMessage,
+    required String token,
+    ChatSetReadMarkerApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setReadMarkerRaw(
       lastReadMessage: lastReadMessage,
@@ -4427,10 +4427,10 @@ class ChatClient {
   ///  * [setReadMarker] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ChatSetReadMarkerResponseApplicationJson, ChatChatSetReadMarkerHeaders> setReadMarkerRaw({
-    required final int lastReadMessage,
-    required final String token,
-    final ChatSetReadMarkerApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int lastReadMessage,
+    required String token,
+    ChatSetReadMarkerApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4440,7 +4440,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4503,9 +4503,9 @@ class ChatClient {
   /// See:
   ///  * [markUnreadRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatMarkUnreadResponseApplicationJson, ChatChatMarkUnreadHeaders>> markUnread({
-    required final String token,
-    final ChatMarkUnreadApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    ChatMarkUnreadApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = markUnreadRaw(
       token: token,
@@ -4535,9 +4535,9 @@ class ChatClient {
   ///  * [markUnread] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ChatMarkUnreadResponseApplicationJson, ChatChatMarkUnreadHeaders> markUnreadRaw({
-    required final String token,
-    final ChatMarkUnreadApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    ChatMarkUnreadApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4547,7 +4547,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4608,12 +4608,12 @@ class ChatClient {
   /// See:
   ///  * [mentionsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatMentionsResponseApplicationJson, void>> mentions({
-    required final String search,
-    required final String token,
-    final int? limit,
-    final int? includeStatus,
-    final ChatMentionsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String search,
+    required String token,
+    int? limit,
+    int? includeStatus,
+    ChatMentionsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = mentionsRaw(
       search: search,
@@ -4649,12 +4649,12 @@ class ChatClient {
   ///  * [mentions] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ChatMentionsResponseApplicationJson, void> mentionsRaw({
-    required final String search,
-    required final String token,
-    final int? limit,
-    final int? includeStatus,
-    final ChatMentionsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String search,
+    required String token,
+    int? limit,
+    int? includeStatus,
+    ChatMentionsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4664,7 +4664,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4738,12 +4738,12 @@ class ChatClient {
   ///  * [getObjectsSharedInRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatGetObjectsSharedInRoomResponseApplicationJson, ChatChatGetObjectsSharedInRoomHeaders>>
       getObjectsSharedInRoom({
-    required final String objectType,
-    required final String token,
-    final int? lastKnownMessageId,
-    final int? limit,
-    final ChatGetObjectsSharedInRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String objectType,
+    required String token,
+    int? lastKnownMessageId,
+    int? limit,
+    ChatGetObjectsSharedInRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getObjectsSharedInRoomRaw(
       objectType: objectType,
@@ -4780,12 +4780,12 @@ class ChatClient {
   @experimental
   DynamiteRawResponse<ChatGetObjectsSharedInRoomResponseApplicationJson, ChatChatGetObjectsSharedInRoomHeaders>
       getObjectsSharedInRoomRaw({
-    required final String objectType,
-    required final String token,
-    final int? lastKnownMessageId,
-    final int? limit,
-    final ChatGetObjectsSharedInRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String objectType,
+    required String token,
+    int? lastKnownMessageId,
+    int? limit,
+    ChatGetObjectsSharedInRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4795,7 +4795,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -4879,14 +4879,14 @@ class ChatClient {
   ///  * [shareObjectToChatRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatShareObjectToChatResponseApplicationJson, ChatChatShareObjectToChatHeaders>>
       shareObjectToChat({
-    required final String objectType,
-    required final String objectId,
-    required final String token,
-    final String? metaData,
-    final String? actorDisplayName,
-    final String? referenceId,
-    final ChatShareObjectToChatApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String objectType,
+    required String objectId,
+    required String token,
+    String? metaData,
+    String? actorDisplayName,
+    String? referenceId,
+    ChatShareObjectToChatApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = shareObjectToChatRaw(
       objectType: objectType,
@@ -4932,14 +4932,14 @@ class ChatClient {
   @experimental
   DynamiteRawResponse<ChatShareObjectToChatResponseApplicationJson, ChatChatShareObjectToChatHeaders>
       shareObjectToChatRaw({
-    required final String objectType,
-    required final String objectId,
-    required final String token,
-    final String? metaData,
-    final String? actorDisplayName,
-    final String? referenceId,
-    final ChatShareObjectToChatApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String objectType,
+    required String objectId,
+    required String token,
+    String? metaData,
+    String? actorDisplayName,
+    String? referenceId,
+    ChatShareObjectToChatApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -4949,7 +4949,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5030,10 +5030,10 @@ class ChatClient {
   ///  * [getObjectsSharedInRoomOverviewRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson, void>>
       getObjectsSharedInRoomOverview({
-    required final String token,
-    final int? limit,
-    final ChatGetObjectsSharedInRoomOverviewApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? limit,
+    ChatGetObjectsSharedInRoomOverviewApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getObjectsSharedInRoomOverviewRaw(
       token: token,
@@ -5066,10 +5066,10 @@ class ChatClient {
   @experimental
   DynamiteRawResponse<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson, void>
       getObjectsSharedInRoomOverviewRaw({
-    required final String token,
-    final int? limit,
-    final ChatGetObjectsSharedInRoomOverviewApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? limit,
+    ChatGetObjectsSharedInRoomOverviewApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -5079,7 +5079,7 @@ class ChatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5151,9 +5151,9 @@ class FederationClient {
   /// See:
   ///  * [acceptShareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<FederationAcceptShareResponseApplicationJson, void>> acceptShare({
-    required final int id,
-    final FederationAcceptShareApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int id,
+    FederationAcceptShareApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = acceptShareRaw(
       id: id,
@@ -5184,9 +5184,9 @@ class FederationClient {
   ///  * [acceptShare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<FederationAcceptShareResponseApplicationJson, void> acceptShareRaw({
-    required final int id,
-    final FederationAcceptShareApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int id,
+    FederationAcceptShareApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -5196,7 +5196,7 @@ class FederationClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5257,9 +5257,9 @@ class FederationClient {
   /// See:
   ///  * [rejectShareRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<FederationRejectShareResponseApplicationJson, void>> rejectShare({
-    required final int id,
-    final FederationRejectShareApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int id,
+    FederationRejectShareApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = rejectShareRaw(
       id: id,
@@ -5290,9 +5290,9 @@ class FederationClient {
   ///  * [rejectShare] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<FederationRejectShareResponseApplicationJson, void> rejectShareRaw({
-    required final int id,
-    final FederationRejectShareApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int id,
+    FederationRejectShareApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -5302,7 +5302,7 @@ class FederationClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5361,8 +5361,8 @@ class FederationClient {
   /// See:
   ///  * [getSharesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<FederationGetSharesResponseApplicationJson, void>> getShares({
-    final FederationGetSharesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    FederationGetSharesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getSharesRaw(
       apiVersion: apiVersion,
@@ -5390,8 +5390,8 @@ class FederationClient {
   ///  * [getShares] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<FederationGetSharesResponseApplicationJson, void> getSharesRaw({
-    final FederationGetSharesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    FederationGetSharesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -5401,7 +5401,7 @@ class FederationClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5469,9 +5469,9 @@ class FilesIntegrationClient {
   /// See:
   ///  * [getRoomByFileIdRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<FilesIntegrationGetRoomByFileIdResponseApplicationJson, void>> getRoomByFileId({
-    required final String fileId,
-    final FilesIntegrationGetRoomByFileIdApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String fileId,
+    FilesIntegrationGetRoomByFileIdApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getRoomByFileIdRaw(
       fileId: fileId,
@@ -5507,9 +5507,9 @@ class FilesIntegrationClient {
   ///  * [getRoomByFileId] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<FilesIntegrationGetRoomByFileIdResponseApplicationJson, void> getRoomByFileIdRaw({
-    required final String fileId,
-    final FilesIntegrationGetRoomByFileIdApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String fileId,
+    FilesIntegrationGetRoomByFileIdApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -5519,7 +5519,7 @@ class FilesIntegrationClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5585,9 +5585,9 @@ class FilesIntegrationClient {
   /// See:
   ///  * [getRoomByShareTokenRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<FilesIntegrationGetRoomByShareTokenResponseApplicationJson, void>> getRoomByShareToken({
-    required final String shareToken,
-    final FilesIntegrationGetRoomByShareTokenApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String shareToken,
+    FilesIntegrationGetRoomByShareTokenApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getRoomByShareTokenRaw(
       shareToken: shareToken,
@@ -5624,9 +5624,9 @@ class FilesIntegrationClient {
   ///  * [getRoomByShareToken] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<FilesIntegrationGetRoomByShareTokenResponseApplicationJson, void> getRoomByShareTokenRaw({
-    required final String shareToken,
-    final FilesIntegrationGetRoomByShareTokenApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String shareToken,
+    FilesIntegrationGetRoomByShareTokenApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -5636,7 +5636,7 @@ class FilesIntegrationClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5705,10 +5705,10 @@ class GuestClient {
   /// See:
   ///  * [setDisplayNameRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<GuestSetDisplayNameResponseApplicationJson, void>> setDisplayName({
-    required final String displayName,
-    required final String token,
-    final GuestSetDisplayNameApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String displayName,
+    required String token,
+    GuestSetDisplayNameApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setDisplayNameRaw(
       displayName: displayName,
@@ -5742,10 +5742,10 @@ class GuestClient {
   ///  * [setDisplayName] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<GuestSetDisplayNameResponseApplicationJson, void> setDisplayNameRaw({
-    required final String displayName,
-    required final String token,
-    final GuestSetDisplayNameApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String displayName,
+    required String token,
+    GuestSetDisplayNameApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -5755,7 +5755,7 @@ class GuestClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5831,13 +5831,13 @@ class HostedSignalingServerClient {
   /// See:
   ///  * [requestTrialRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<HostedSignalingServerRequestTrialResponseApplicationJson, void>> requestTrial({
-    required final String url,
-    required final String name,
-    required final String email,
-    required final String language,
-    required final String country,
-    final HostedSignalingServerRequestTrialApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String url,
+    required String name,
+    required String email,
+    required String language,
+    required String country,
+    HostedSignalingServerRequestTrialApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = requestTrialRaw(
       url: url,
@@ -5879,13 +5879,13 @@ class HostedSignalingServerClient {
   ///  * [requestTrial] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<HostedSignalingServerRequestTrialResponseApplicationJson, void> requestTrialRaw({
-    required final String url,
-    required final String name,
-    required final String email,
-    required final String language,
-    required final String country,
-    final HostedSignalingServerRequestTrialApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String url,
+    required String name,
+    required String email,
+    required String language,
+    required String country,
+    HostedSignalingServerRequestTrialApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -5895,7 +5895,7 @@ class HostedSignalingServerClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -5974,8 +5974,8 @@ class HostedSignalingServerClient {
   /// See:
   ///  * [deleteAccountRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<HostedSignalingServerDeleteAccountResponseApplicationJson, void>> deleteAccount({
-    final HostedSignalingServerDeleteAccountApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    HostedSignalingServerDeleteAccountApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteAccountRaw(
       apiVersion: apiVersion,
@@ -6007,8 +6007,8 @@ class HostedSignalingServerClient {
   ///  * [deleteAccount] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<HostedSignalingServerDeleteAccountResponseApplicationJson, void> deleteAccountRaw({
-    final HostedSignalingServerDeleteAccountApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    HostedSignalingServerDeleteAccountApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -6018,7 +6018,7 @@ class HostedSignalingServerClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -6083,9 +6083,9 @@ class MatterbridgeClient {
   /// See:
   ///  * [getBridgeOfRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<MatterbridgeGetBridgeOfRoomResponseApplicationJson, void>> getBridgeOfRoom({
-    required final String token,
-    final MatterbridgeGetBridgeOfRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    MatterbridgeGetBridgeOfRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getBridgeOfRoomRaw(
       token: token,
@@ -6115,9 +6115,9 @@ class MatterbridgeClient {
   ///  * [getBridgeOfRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<MatterbridgeGetBridgeOfRoomResponseApplicationJson, void> getBridgeOfRoomRaw({
-    required final String token,
-    final MatterbridgeGetBridgeOfRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    MatterbridgeGetBridgeOfRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -6127,7 +6127,7 @@ class MatterbridgeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -6189,11 +6189,11 @@ class MatterbridgeClient {
   /// See:
   ///  * [editBridgeOfRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void>> editBridgeOfRoom({
-    required final int enabled,
-    required final String token,
-    final ContentString<BuiltList<BuiltMap<String, JsonObject>>>? parts,
-    final MatterbridgeEditBridgeOfRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int enabled,
+    required String token,
+    ContentString<BuiltList<BuiltMap<String, JsonObject>>>? parts,
+    MatterbridgeEditBridgeOfRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = editBridgeOfRoomRaw(
       enabled: enabled,
@@ -6228,11 +6228,11 @@ class MatterbridgeClient {
   ///  * [editBridgeOfRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void> editBridgeOfRoomRaw({
-    required final int enabled,
-    required final String token,
-    final ContentString<BuiltList<BuiltMap<String, JsonObject>>>? parts,
-    final MatterbridgeEditBridgeOfRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int enabled,
+    required String token,
+    ContentString<BuiltList<BuiltMap<String, JsonObject>>>? parts,
+    MatterbridgeEditBridgeOfRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -6242,7 +6242,7 @@ class MatterbridgeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -6317,9 +6317,9 @@ class MatterbridgeClient {
   /// See:
   ///  * [deleteBridgeOfRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson, void>> deleteBridgeOfRoom({
-    required final String token,
-    final MatterbridgeDeleteBridgeOfRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    MatterbridgeDeleteBridgeOfRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteBridgeOfRoomRaw(
       token: token,
@@ -6350,9 +6350,9 @@ class MatterbridgeClient {
   ///  * [deleteBridgeOfRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson, void> deleteBridgeOfRoomRaw({
-    required final String token,
-    final MatterbridgeDeleteBridgeOfRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    MatterbridgeDeleteBridgeOfRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -6362,7 +6362,7 @@ class MatterbridgeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -6421,9 +6421,9 @@ class MatterbridgeClient {
   /// See:
   ///  * [getBridgeProcessStateRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<MatterbridgeGetBridgeProcessStateResponseApplicationJson, void>> getBridgeProcessState({
-    required final String token,
-    final MatterbridgeGetBridgeProcessStateApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    MatterbridgeGetBridgeProcessStateApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getBridgeProcessStateRaw(
       token: token,
@@ -6453,9 +6453,9 @@ class MatterbridgeClient {
   ///  * [getBridgeProcessState] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<MatterbridgeGetBridgeProcessStateResponseApplicationJson, void> getBridgeProcessStateRaw({
-    required final String token,
-    final MatterbridgeGetBridgeProcessStateApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    MatterbridgeGetBridgeProcessStateApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -6465,7 +6465,7 @@ class MatterbridgeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -6535,8 +6535,8 @@ class MatterbridgeSettingsClient {
   /// See:
   ///  * [stopAllBridgesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<MatterbridgeSettingsStopAllBridgesResponseApplicationJson, void>> stopAllBridges({
-    final MatterbridgeSettingsStopAllBridgesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    MatterbridgeSettingsStopAllBridgesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = stopAllBridgesRaw(
       apiVersion: apiVersion,
@@ -6567,8 +6567,8 @@ class MatterbridgeSettingsClient {
   ///  * [stopAllBridges] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<MatterbridgeSettingsStopAllBridgesResponseApplicationJson, void> stopAllBridgesRaw({
-    final MatterbridgeSettingsStopAllBridgesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    MatterbridgeSettingsStopAllBridgesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -6578,7 +6578,7 @@ class MatterbridgeSettingsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -6638,8 +6638,8 @@ class MatterbridgeSettingsClient {
   ///  * [getMatterbridgeVersionRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson, void>>
       getMatterbridgeVersion({
-    final MatterbridgeSettingsGetMatterbridgeVersionApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    MatterbridgeSettingsGetMatterbridgeVersionApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getMatterbridgeVersionRaw(
       apiVersion: apiVersion,
@@ -6671,8 +6671,8 @@ class MatterbridgeSettingsClient {
   @experimental
   DynamiteRawResponse<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson, void>
       getMatterbridgeVersionRaw({
-    final MatterbridgeSettingsGetMatterbridgeVersionApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    MatterbridgeSettingsGetMatterbridgeVersionApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -6682,7 +6682,7 @@ class MatterbridgeSettingsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -6750,13 +6750,13 @@ class PollClient {
   /// See:
   ///  * [createPollRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PollCreatePollResponseApplicationJson, void>> createPoll({
-    required final String question,
-    required final BuiltList<String> options,
-    required final int resultMode,
-    required final int maxVotes,
-    required final String token,
-    final PollCreatePollApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String question,
+    required BuiltList<String> options,
+    required int resultMode,
+    required int maxVotes,
+    required String token,
+    PollCreatePollApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = createPollRaw(
       question: question,
@@ -6795,13 +6795,13 @@ class PollClient {
   ///  * [createPoll] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PollCreatePollResponseApplicationJson, void> createPollRaw({
-    required final String question,
-    required final BuiltList<String> options,
-    required final int resultMode,
-    required final int maxVotes,
-    required final String token,
-    final PollCreatePollApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String question,
+    required BuiltList<String> options,
+    required int resultMode,
+    required int maxVotes,
+    required String token,
+    PollCreatePollApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -6811,7 +6811,7 @@ class PollClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -6885,10 +6885,10 @@ class PollClient {
   /// See:
   ///  * [showPollRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PollShowPollResponseApplicationJson, void>> showPoll({
-    required final String token,
-    required final int pollId,
-    final PollShowPollApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int pollId,
+    PollShowPollApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = showPollRaw(
       token: token,
@@ -6921,10 +6921,10 @@ class PollClient {
   ///  * [showPoll] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PollShowPollResponseApplicationJson, void> showPollRaw({
-    required final String token,
-    required final int pollId,
-    final PollShowPollApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int pollId,
+    PollShowPollApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -6934,7 +6934,7 @@ class PollClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -6998,11 +6998,11 @@ class PollClient {
   /// See:
   ///  * [votePollRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PollVotePollResponseApplicationJson, void>> votePoll({
-    required final String token,
-    required final int pollId,
-    final BuiltList<int>? optionIds,
-    final PollVotePollApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int pollId,
+    BuiltList<int>? optionIds,
+    PollVotePollApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = votePollRaw(
       token: token,
@@ -7038,11 +7038,11 @@ class PollClient {
   ///  * [votePoll] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PollVotePollResponseApplicationJson, void> votePollRaw({
-    required final String token,
-    required final int pollId,
-    final BuiltList<int>? optionIds,
-    final PollVotePollApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int pollId,
+    BuiltList<int>? optionIds,
+    PollVotePollApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -7052,7 +7052,7 @@ class PollClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -7123,10 +7123,10 @@ class PollClient {
   /// See:
   ///  * [closePollRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PollClosePollResponseApplicationJson, void>> closePoll({
-    required final String token,
-    required final int pollId,
-    final PollClosePollApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int pollId,
+    PollClosePollApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = closePollRaw(
       token: token,
@@ -7162,10 +7162,10 @@ class PollClient {
   ///  * [closePoll] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PollClosePollResponseApplicationJson, void> closePollRaw({
-    required final String token,
-    required final int pollId,
-    final PollClosePollApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int pollId,
+    PollClosePollApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -7175,7 +7175,7 @@ class PollClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -7245,9 +7245,9 @@ class PublicShareAuthClient {
   /// See:
   ///  * [createRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<PublicShareAuthCreateRoomResponseApplicationJson, void>> createRoom({
-    required final String shareToken,
-    final PublicShareAuthCreateRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String shareToken,
+    PublicShareAuthCreateRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = createRoomRaw(
       shareToken: shareToken,
@@ -7281,9 +7281,9 @@ class PublicShareAuthClient {
   ///  * [createRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<PublicShareAuthCreateRoomResponseApplicationJson, void> createRoomRaw({
-    required final String shareToken,
-    final PublicShareAuthCreateRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String shareToken,
+    PublicShareAuthCreateRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -7293,7 +7293,7 @@ class PublicShareAuthClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -7360,11 +7360,11 @@ class ReactionClient {
   /// See:
   ///  * [getReactionsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ReactionGetReactionsResponseApplicationJson, void>> getReactions({
-    required final String token,
-    required final int messageId,
-    final String? reaction,
-    final ReactionGetReactionsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int messageId,
+    String? reaction,
+    ReactionGetReactionsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getReactionsRaw(
       token: token,
@@ -7399,11 +7399,11 @@ class ReactionClient {
   ///  * [getReactions] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ReactionGetReactionsResponseApplicationJson, void> getReactionsRaw({
-    required final String token,
-    required final int messageId,
-    final String? reaction,
-    final ReactionGetReactionsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    required int messageId,
+    String? reaction,
+    ReactionGetReactionsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -7413,7 +7413,7 @@ class ReactionClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -7484,11 +7484,11 @@ class ReactionClient {
   /// See:
   ///  * [reactRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ReactionReactResponseApplicationJson, void>> react({
-    required final String reaction,
-    required final String token,
-    required final int messageId,
-    final ReactionReactApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String reaction,
+    required String token,
+    required int messageId,
+    ReactionReactApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = reactRaw(
       reaction: reaction,
@@ -7525,11 +7525,11 @@ class ReactionClient {
   ///  * [react] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ReactionReactResponseApplicationJson, void> reactRaw({
-    required final String reaction,
-    required final String token,
-    required final int messageId,
-    final ReactionReactApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String reaction,
+    required String token,
+    required int messageId,
+    ReactionReactApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -7539,7 +7539,7 @@ class ReactionClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -7608,11 +7608,11 @@ class ReactionClient {
   /// See:
   ///  * [deleteRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ReactionDeleteResponseApplicationJson, void>> delete({
-    required final String reaction,
-    required final String token,
-    required final int messageId,
-    final ReactionDeleteApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String reaction,
+    required String token,
+    required int messageId,
+    ReactionDeleteApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteRaw(
       reaction: reaction,
@@ -7648,11 +7648,11 @@ class ReactionClient {
   ///  * [delete] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ReactionDeleteResponseApplicationJson, void> deleteRaw({
-    required final String reaction,
-    required final String token,
-    required final int messageId,
-    final ReactionDeleteApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String reaction,
+    required String token,
+    required int messageId,
+    ReactionDeleteApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -7662,7 +7662,7 @@ class ReactionClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -7737,9 +7737,9 @@ class RecordingClient {
   /// See:
   ///  * [getWelcomeMessageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RecordingGetWelcomeMessageResponseApplicationJson, void>> getWelcomeMessage({
-    required final int serverId,
-    final RecordingGetWelcomeMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int serverId,
+    RecordingGetWelcomeMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getWelcomeMessageRaw(
       serverId: serverId,
@@ -7773,9 +7773,9 @@ class RecordingClient {
   ///  * [getWelcomeMessage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RecordingGetWelcomeMessageResponseApplicationJson, void> getWelcomeMessageRaw({
-    required final int serverId,
-    final RecordingGetWelcomeMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int serverId,
+    RecordingGetWelcomeMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -7785,7 +7785,7 @@ class RecordingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -7847,10 +7847,10 @@ class RecordingClient {
   /// See:
   ///  * [startRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RecordingStartResponseApplicationJson, void>> start({
-    required final int status,
-    required final String token,
-    final RecordingStartApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int status,
+    required String token,
+    RecordingStartApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = startRaw(
       status: status,
@@ -7883,10 +7883,10 @@ class RecordingClient {
   ///  * [start] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RecordingStartResponseApplicationJson, void> startRaw({
-    required final int status,
-    required final String token,
-    final RecordingStartApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int status,
+    required String token,
+    RecordingStartApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -7896,7 +7896,7 @@ class RecordingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -7960,9 +7960,9 @@ class RecordingClient {
   /// See:
   ///  * [stopRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RecordingStopResponseApplicationJson, void>> stop({
-    required final String token,
-    final RecordingStopApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RecordingStopApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = stopRaw(
       token: token,
@@ -7993,9 +7993,9 @@ class RecordingClient {
   ///  * [stop] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RecordingStopResponseApplicationJson, void> stopRaw({
-    required final String token,
-    final RecordingStopApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RecordingStopApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -8005,7 +8005,7 @@ class RecordingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -8066,10 +8066,10 @@ class RecordingClient {
   /// See:
   ///  * [storeRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RecordingStoreResponseApplicationJson, void>> store({
-    required final String owner,
-    required final String token,
-    final RecordingStoreApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String owner,
+    required String token,
+    RecordingStoreApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = storeRaw(
       owner: owner,
@@ -8103,10 +8103,10 @@ class RecordingClient {
   ///  * [store] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RecordingStoreResponseApplicationJson, void> storeRaw({
-    required final String owner,
-    required final String token,
-    final RecordingStoreApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String owner,
+    required String token,
+    RecordingStoreApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -8116,7 +8116,7 @@ class RecordingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -8179,10 +8179,10 @@ class RecordingClient {
   /// See:
   ///  * [notificationDismissRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RecordingNotificationDismissResponseApplicationJson, void>> notificationDismiss({
-    required final int timestamp,
-    required final String token,
-    final RecordingNotificationDismissApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int timestamp,
+    required String token,
+    RecordingNotificationDismissApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = notificationDismissRaw(
       timestamp: timestamp,
@@ -8215,10 +8215,10 @@ class RecordingClient {
   ///  * [notificationDismiss] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RecordingNotificationDismissResponseApplicationJson, void> notificationDismissRaw({
-    required final int timestamp,
-    required final String token,
-    final RecordingNotificationDismissApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int timestamp,
+    required String token,
+    RecordingNotificationDismissApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -8228,7 +8228,7 @@ class RecordingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -8296,11 +8296,11 @@ class RecordingClient {
   /// See:
   ///  * [shareToChatRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RecordingShareToChatResponseApplicationJson, void>> shareToChat({
-    required final int fileId,
-    required final int timestamp,
-    required final String token,
-    final RecordingShareToChatApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int fileId,
+    required int timestamp,
+    required String token,
+    RecordingShareToChatApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = shareToChatRaw(
       fileId: fileId,
@@ -8335,11 +8335,11 @@ class RecordingClient {
   ///  * [shareToChat] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RecordingShareToChatResponseApplicationJson, void> shareToChatRaw({
-    required final int fileId,
-    required final int timestamp,
-    required final String token,
-    final RecordingShareToChatApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int fileId,
+    required int timestamp,
+    required String token,
+    RecordingShareToChatApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -8349,7 +8349,7 @@ class RecordingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -8425,11 +8425,11 @@ class RoomClient {
   /// See:
   ///  * [getRoomsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders>> getRooms({
-    final int? noStatusUpdate,
-    final int? includeStatus,
-    final int? modifiedSince,
-    final RoomGetRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    int? noStatusUpdate,
+    int? includeStatus,
+    int? modifiedSince,
+    RoomGetRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getRoomsRaw(
       noStatusUpdate: noStatusUpdate,
@@ -8463,11 +8463,11 @@ class RoomClient {
   ///  * [getRooms] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders> getRoomsRaw({
-    final int? noStatusUpdate,
-    final int? includeStatus,
-    final int? modifiedSince,
-    final RoomGetRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    int? noStatusUpdate,
+    int? includeStatus,
+    int? modifiedSince,
+    RoomGetRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -8477,7 +8477,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -8555,14 +8555,14 @@ class RoomClient {
   /// See:
   ///  * [createRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomCreateRoomResponseApplicationJson, void>> createRoom({
-    required final int roomType,
-    final String? invite,
-    final String? roomName,
-    final String? source,
-    final String? objectType,
-    final String? objectId,
-    final RoomCreateRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int roomType,
+    String? invite,
+    String? roomName,
+    String? source,
+    String? objectType,
+    String? objectId,
+    RoomCreateRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = createRoomRaw(
       roomType: roomType,
@@ -8606,14 +8606,14 @@ class RoomClient {
   ///  * [createRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomCreateRoomResponseApplicationJson, void> createRoomRaw({
-    required final int roomType,
-    final String? invite,
-    final String? roomName,
-    final String? source,
-    final String? objectType,
-    final String? objectId,
-    final RoomCreateRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int roomType,
+    String? invite,
+    String? roomName,
+    String? source,
+    String? objectType,
+    String? objectId,
+    RoomCreateRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -8623,7 +8623,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -8704,9 +8704,9 @@ class RoomClient {
   /// See:
   ///  * [getListedRoomsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomGetListedRoomsResponseApplicationJson, void>> getListedRooms({
-    final String? searchTerm,
-    final RoomGetListedRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    String? searchTerm,
+    RoomGetListedRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getListedRoomsRaw(
       searchTerm: searchTerm,
@@ -8736,9 +8736,9 @@ class RoomClient {
   ///  * [getListedRooms] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomGetListedRoomsResponseApplicationJson, void> getListedRoomsRaw({
-    final String? searchTerm,
-    final RoomGetListedRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    String? searchTerm,
+    RoomGetListedRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -8748,7 +8748,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -8812,8 +8812,8 @@ class RoomClient {
   Future<
       DynamiteResponse<RoomGetNoteToSelfConversationResponseApplicationJson,
           RoomRoomGetNoteToSelfConversationHeaders>> getNoteToSelfConversation({
-    final RoomGetNoteToSelfConversationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    RoomGetNoteToSelfConversationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getNoteToSelfConversationRaw(
       apiVersion: apiVersion,
@@ -8844,8 +8844,8 @@ class RoomClient {
   @experimental
   DynamiteRawResponse<RoomGetNoteToSelfConversationResponseApplicationJson, RoomRoomGetNoteToSelfConversationHeaders>
       getNoteToSelfConversationRaw({
-    final RoomGetNoteToSelfConversationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    RoomGetNoteToSelfConversationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -8855,7 +8855,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -8913,9 +8913,9 @@ class RoomClient {
   /// See:
   ///  * [getSingleRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomGetSingleRoomResponseApplicationJson, RoomRoomGetSingleRoomHeaders>> getSingleRoom({
-    required final String token,
-    final RoomGetSingleRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomGetSingleRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getSingleRoomRaw(
       token: token,
@@ -8947,9 +8947,9 @@ class RoomClient {
   ///  * [getSingleRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomGetSingleRoomResponseApplicationJson, RoomRoomGetSingleRoomHeaders> getSingleRoomRaw({
-    required final String token,
-    final RoomGetSingleRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomGetSingleRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -8959,7 +8959,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -9017,10 +9017,10 @@ class RoomClient {
   /// See:
   ///  * [renameRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomRenameRoomResponseApplicationJson, void>> renameRoom({
-    required final String roomName,
-    required final String token,
-    final RoomRenameRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String roomName,
+    required String token,
+    RoomRenameRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = renameRoomRaw(
       roomName: roomName,
@@ -9053,10 +9053,10 @@ class RoomClient {
   ///  * [renameRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomRenameRoomResponseApplicationJson, void> renameRoomRaw({
-    required final String roomName,
-    required final String token,
-    final RoomRenameRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String roomName,
+    required String token,
+    RoomRenameRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -9066,7 +9066,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -9127,9 +9127,9 @@ class RoomClient {
   /// See:
   ///  * [deleteRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomDeleteRoomResponseApplicationJson, void>> deleteRoom({
-    required final String token,
-    final RoomDeleteRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomDeleteRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteRoomRaw(
       token: token,
@@ -9160,9 +9160,9 @@ class RoomClient {
   ///  * [deleteRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomDeleteRoomResponseApplicationJson, void> deleteRoomRaw({
-    required final String token,
-    final RoomDeleteRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomDeleteRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -9172,7 +9172,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -9229,9 +9229,9 @@ class RoomClient {
   /// See:
   ///  * [getBreakoutRoomsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomGetBreakoutRoomsResponseApplicationJson, void>> getBreakoutRooms({
-    required final String token,
-    final RoomGetBreakoutRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomGetBreakoutRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getBreakoutRoomsRaw(
       token: token,
@@ -9262,9 +9262,9 @@ class RoomClient {
   ///  * [getBreakoutRooms] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomGetBreakoutRoomsResponseApplicationJson, void> getBreakoutRoomsRaw({
-    required final String token,
-    final RoomGetBreakoutRoomsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomGetBreakoutRoomsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -9274,7 +9274,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -9336,9 +9336,9 @@ class RoomClient {
   /// See:
   ///  * [makePublicRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomMakePublicResponseApplicationJson, void>> makePublic({
-    required final String token,
-    final RoomMakePublicApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomMakePublicApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = makePublicRaw(
       token: token,
@@ -9369,9 +9369,9 @@ class RoomClient {
   ///  * [makePublic] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomMakePublicResponseApplicationJson, void> makePublicRaw({
-    required final String token,
-    final RoomMakePublicApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomMakePublicApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -9381,7 +9381,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -9441,9 +9441,9 @@ class RoomClient {
   /// See:
   ///  * [makePrivateRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomMakePrivateResponseApplicationJson, void>> makePrivate({
-    required final String token,
-    final RoomMakePrivateApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomMakePrivateApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = makePrivateRaw(
       token: token,
@@ -9474,9 +9474,9 @@ class RoomClient {
   ///  * [makePrivate] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomMakePrivateResponseApplicationJson, void> makePrivateRaw({
-    required final String token,
-    final RoomMakePrivateApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomMakePrivateApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -9486,7 +9486,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -9547,10 +9547,10 @@ class RoomClient {
   /// See:
   ///  * [setDescriptionRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetDescriptionResponseApplicationJson, void>> setDescription({
-    required final String description,
-    required final String token,
-    final RoomSetDescriptionApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String description,
+    required String token,
+    RoomSetDescriptionApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setDescriptionRaw(
       description: description,
@@ -9583,10 +9583,10 @@ class RoomClient {
   ///  * [setDescription] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetDescriptionResponseApplicationJson, void> setDescriptionRaw({
-    required final String description,
-    required final String token,
-    final RoomSetDescriptionApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String description,
+    required String token,
+    RoomSetDescriptionApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -9596,7 +9596,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -9661,10 +9661,10 @@ class RoomClient {
   /// See:
   ///  * [setReadOnlyRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetReadOnlyResponseApplicationJson, void>> setReadOnly({
-    required final int state,
-    required final String token,
-    final RoomSetReadOnlyApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int state,
+    required String token,
+    RoomSetReadOnlyApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setReadOnlyRaw(
       state: state,
@@ -9697,10 +9697,10 @@ class RoomClient {
   ///  * [setReadOnly] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetReadOnlyResponseApplicationJson, void> setReadOnlyRaw({
-    required final int state,
-    required final String token,
-    final RoomSetReadOnlyApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int state,
+    required String token,
+    RoomSetReadOnlyApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -9710,7 +9710,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -9775,10 +9775,10 @@ class RoomClient {
   /// See:
   ///  * [setListableRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetListableResponseApplicationJson, void>> setListable({
-    required final int scope,
-    required final String token,
-    final RoomSetListableApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int scope,
+    required String token,
+    RoomSetListableApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setListableRaw(
       scope: scope,
@@ -9811,10 +9811,10 @@ class RoomClient {
   ///  * [setListable] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetListableResponseApplicationJson, void> setListableRaw({
-    required final int scope,
-    required final String token,
-    final RoomSetListableApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int scope,
+    required String token,
+    RoomSetListableApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -9824,7 +9824,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -9890,10 +9890,10 @@ class RoomClient {
   /// See:
   ///  * [setPasswordRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetPasswordResponseApplicationJson, void>> setPassword({
-    required final String password,
-    required final String token,
-    final RoomSetPasswordApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String password,
+    required String token,
+    RoomSetPasswordApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setPasswordRaw(
       password: password,
@@ -9927,10 +9927,10 @@ class RoomClient {
   ///  * [setPassword] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetPasswordResponseApplicationJson, void> setPasswordRaw({
-    required final String password,
-    required final String token,
-    final RoomSetPasswordApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String password,
+    required String token,
+    RoomSetPasswordApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -9940,7 +9940,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -10004,11 +10004,11 @@ class RoomClient {
   /// See:
   ///  * [setPermissionsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetPermissionsResponseApplicationJson, void>> setPermissions({
-    required final int permissions,
-    required final String token,
-    required final String mode,
-    final RoomSetPermissionsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int permissions,
+    required String token,
+    required String mode,
+    RoomSetPermissionsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setPermissionsRaw(
       permissions: permissions,
@@ -10043,11 +10043,11 @@ class RoomClient {
   ///  * [setPermissions] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetPermissionsResponseApplicationJson, void> setPermissionsRaw({
-    required final int permissions,
-    required final String token,
-    required final String mode,
-    final RoomSetPermissionsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int permissions,
+    required String token,
+    required String mode,
+    RoomSetPermissionsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -10057,7 +10057,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -10126,10 +10126,10 @@ class RoomClient {
   /// See:
   ///  * [getParticipantsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>> getParticipants({
-    required final String token,
-    final int? includeStatus,
-    final RoomGetParticipantsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? includeStatus,
+    RoomGetParticipantsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getParticipantsRaw(
       token: token,
@@ -10162,10 +10162,10 @@ class RoomClient {
   ///  * [getParticipants] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders> getParticipantsRaw({
-    required final String token,
-    final int? includeStatus,
-    final RoomGetParticipantsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? includeStatus,
+    RoomGetParticipantsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -10175,7 +10175,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -10244,11 +10244,11 @@ class RoomClient {
   /// See:
   ///  * [addParticipantToRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomAddParticipantToRoomResponseApplicationJson, void>> addParticipantToRoom({
-    required final String newParticipant,
-    required final String token,
-    final String? source,
-    final RoomAddParticipantToRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String newParticipant,
+    required String token,
+    String? source,
+    RoomAddParticipantToRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = addParticipantToRoomRaw(
       newParticipant: newParticipant,
@@ -10285,11 +10285,11 @@ class RoomClient {
   ///  * [addParticipantToRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomAddParticipantToRoomResponseApplicationJson, void> addParticipantToRoomRaw({
-    required final String newParticipant,
-    required final String token,
-    final String? source,
-    final RoomAddParticipantToRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String newParticipant,
+    required String token,
+    String? source,
+    RoomAddParticipantToRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -10299,7 +10299,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -10373,10 +10373,10 @@ class RoomClient {
   Future<
       DynamiteResponse<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
           RoomRoomGetBreakoutRoomParticipantsHeaders>> getBreakoutRoomParticipants({
-    required final String token,
-    final int? includeStatus,
-    final RoomGetBreakoutRoomParticipantsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? includeStatus,
+    RoomGetBreakoutRoomParticipantsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getBreakoutRoomParticipantsRaw(
       token: token,
@@ -10411,10 +10411,10 @@ class RoomClient {
   @experimental
   DynamiteRawResponse<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
       RoomRoomGetBreakoutRoomParticipantsHeaders> getBreakoutRoomParticipantsRaw({
-    required final String token,
-    final int? includeStatus,
-    final RoomGetBreakoutRoomParticipantsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? includeStatus,
+    RoomGetBreakoutRoomParticipantsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -10424,7 +10424,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -10492,9 +10492,9 @@ class RoomClient {
   /// See:
   ///  * [removeSelfFromRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomRemoveSelfFromRoomResponseApplicationJson, void>> removeSelfFromRoom({
-    required final String token,
-    final RoomRemoveSelfFromRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomRemoveSelfFromRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = removeSelfFromRoomRaw(
       token: token,
@@ -10526,9 +10526,9 @@ class RoomClient {
   ///  * [removeSelfFromRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomRemoveSelfFromRoomResponseApplicationJson, void> removeSelfFromRoomRaw({
-    required final String token,
-    final RoomRemoveSelfFromRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomRemoveSelfFromRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -10538,7 +10538,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -10603,10 +10603,10 @@ class RoomClient {
   /// See:
   ///  * [removeAttendeeFromRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomRemoveAttendeeFromRoomResponseApplicationJson, void>> removeAttendeeFromRoom({
-    required final int attendeeId,
-    required final String token,
-    final RoomRemoveAttendeeFromRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int attendeeId,
+    required String token,
+    RoomRemoveAttendeeFromRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = removeAttendeeFromRoomRaw(
       attendeeId: attendeeId,
@@ -10641,10 +10641,10 @@ class RoomClient {
   ///  * [removeAttendeeFromRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomRemoveAttendeeFromRoomResponseApplicationJson, void> removeAttendeeFromRoomRaw({
-    required final int attendeeId,
-    required final String token,
-    final RoomRemoveAttendeeFromRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int attendeeId,
+    required String token,
+    RoomRemoveAttendeeFromRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -10654,7 +10654,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -10722,12 +10722,12 @@ class RoomClient {
   /// See:
   ///  * [setAttendeePermissionsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetAttendeePermissionsResponseApplicationJson, void>> setAttendeePermissions({
-    required final int attendeeId,
-    required final String method,
-    required final int permissions,
-    required final String token,
-    final RoomSetAttendeePermissionsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int attendeeId,
+    required String method,
+    required int permissions,
+    required String token,
+    RoomSetAttendeePermissionsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setAttendeePermissionsRaw(
       attendeeId: attendeeId,
@@ -10766,12 +10766,12 @@ class RoomClient {
   ///  * [setAttendeePermissions] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetAttendeePermissionsResponseApplicationJson, void> setAttendeePermissionsRaw({
-    required final int attendeeId,
-    required final String method,
-    required final int permissions,
-    required final String token,
-    final RoomSetAttendeePermissionsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int attendeeId,
+    required String method,
+    required int permissions,
+    required String token,
+    RoomSetAttendeePermissionsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -10781,7 +10781,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -10854,11 +10854,11 @@ class RoomClient {
   /// See:
   ///  * [setAllAttendeesPermissionsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetAllAttendeesPermissionsResponseApplicationJson, void>> setAllAttendeesPermissions({
-    required final String method,
-    required final int permissions,
-    required final String token,
-    final RoomSetAllAttendeesPermissionsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String method,
+    required int permissions,
+    required String token,
+    RoomSetAllAttendeesPermissionsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setAllAttendeesPermissionsRaw(
       method: method,
@@ -10893,11 +10893,11 @@ class RoomClient {
   ///  * [setAllAttendeesPermissions] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetAllAttendeesPermissionsResponseApplicationJson, void> setAllAttendeesPermissionsRaw({
-    required final String method,
-    required final int permissions,
-    required final String token,
-    final RoomSetAllAttendeesPermissionsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String method,
+    required int permissions,
+    required String token,
+    RoomSetAllAttendeesPermissionsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -10907,7 +10907,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -10979,11 +10979,11 @@ class RoomClient {
   /// See:
   ///  * [joinRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomJoinRoomResponseApplicationJson, void>> joinRoom({
-    required final String token,
-    final String? password,
-    final int? force,
-    final RoomJoinRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    String? password,
+    int? force,
+    RoomJoinRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = joinRoomRaw(
       token: token,
@@ -11020,11 +11020,11 @@ class RoomClient {
   ///  * [joinRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomJoinRoomResponseApplicationJson, void> joinRoomRaw({
-    required final String token,
-    final String? password,
-    final int? force,
-    final RoomJoinRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    String? password,
+    int? force,
+    RoomJoinRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -11034,7 +11034,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -11101,9 +11101,9 @@ class RoomClient {
   /// See:
   ///  * [leaveRoomRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomLeaveRoomResponseApplicationJson, void>> leaveRoom({
-    required final String token,
-    final RoomLeaveRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomLeaveRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = leaveRoomRaw(
       token: token,
@@ -11133,9 +11133,9 @@ class RoomClient {
   ///  * [leaveRoom] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomLeaveRoomResponseApplicationJson, void> leaveRoomRaw({
-    required final String token,
-    final RoomLeaveRoomApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomLeaveRoomApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -11145,7 +11145,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -11205,10 +11205,10 @@ class RoomClient {
   /// See:
   ///  * [resendInvitationsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomResendInvitationsResponseApplicationJson, void>> resendInvitations({
-    required final String token,
-    final int? attendeeId,
-    final RoomResendInvitationsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? attendeeId,
+    RoomResendInvitationsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = resendInvitationsRaw(
       token: token,
@@ -11241,10 +11241,10 @@ class RoomClient {
   ///  * [resendInvitations] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomResendInvitationsResponseApplicationJson, void> resendInvitationsRaw({
-    required final String token,
-    final int? attendeeId,
-    final RoomResendInvitationsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    int? attendeeId,
+    RoomResendInvitationsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -11254,7 +11254,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -11322,10 +11322,10 @@ class RoomClient {
   /// See:
   ///  * [setSessionStateRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetSessionStateResponseApplicationJson, void>> setSessionState({
-    required final int state,
-    required final String token,
-    final RoomSetSessionStateApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int state,
+    required String token,
+    RoomSetSessionStateApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setSessionStateRaw(
       state: state,
@@ -11358,10 +11358,10 @@ class RoomClient {
   ///  * [setSessionState] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetSessionStateResponseApplicationJson, void> setSessionStateRaw({
-    required final int state,
-    required final String token,
-    final RoomSetSessionStateApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int state,
+    required String token,
+    RoomSetSessionStateApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -11371,7 +11371,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -11438,10 +11438,10 @@ class RoomClient {
   /// See:
   ///  * [promoteModeratorRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomPromoteModeratorResponseApplicationJson, void>> promoteModerator({
-    required final int attendeeId,
-    required final String token,
-    final RoomPromoteModeratorApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int attendeeId,
+    required String token,
+    RoomPromoteModeratorApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = promoteModeratorRaw(
       attendeeId: attendeeId,
@@ -11476,10 +11476,10 @@ class RoomClient {
   ///  * [promoteModerator] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomPromoteModeratorResponseApplicationJson, void> promoteModeratorRaw({
-    required final int attendeeId,
-    required final String token,
-    final RoomPromoteModeratorApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int attendeeId,
+    required String token,
+    RoomPromoteModeratorApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -11489,7 +11489,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -11555,10 +11555,10 @@ class RoomClient {
   /// See:
   ///  * [demoteModeratorRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomDemoteModeratorResponseApplicationJson, void>> demoteModerator({
-    required final int attendeeId,
-    required final String token,
-    final RoomDemoteModeratorApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int attendeeId,
+    required String token,
+    RoomDemoteModeratorApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = demoteModeratorRaw(
       attendeeId: attendeeId,
@@ -11593,10 +11593,10 @@ class RoomClient {
   ///  * [demoteModerator] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomDemoteModeratorResponseApplicationJson, void> demoteModeratorRaw({
-    required final int attendeeId,
-    required final String token,
-    final RoomDemoteModeratorApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int attendeeId,
+    required String token,
+    RoomDemoteModeratorApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -11606,7 +11606,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -11668,9 +11668,9 @@ class RoomClient {
   /// See:
   ///  * [addToFavoritesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomAddToFavoritesResponseApplicationJson, void>> addToFavorites({
-    required final String token,
-    final RoomAddToFavoritesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomAddToFavoritesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = addToFavoritesRaw(
       token: token,
@@ -11700,9 +11700,9 @@ class RoomClient {
   ///  * [addToFavorites] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomAddToFavoritesResponseApplicationJson, void> addToFavoritesRaw({
-    required final String token,
-    final RoomAddToFavoritesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomAddToFavoritesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -11712,7 +11712,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -11772,9 +11772,9 @@ class RoomClient {
   /// See:
   ///  * [removeFromFavoritesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomRemoveFromFavoritesResponseApplicationJson, void>> removeFromFavorites({
-    required final String token,
-    final RoomRemoveFromFavoritesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomRemoveFromFavoritesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = removeFromFavoritesRaw(
       token: token,
@@ -11804,9 +11804,9 @@ class RoomClient {
   ///  * [removeFromFavorites] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomRemoveFromFavoritesResponseApplicationJson, void> removeFromFavoritesRaw({
-    required final String token,
-    final RoomRemoveFromFavoritesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    RoomRemoveFromFavoritesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -11816,7 +11816,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -11878,10 +11878,10 @@ class RoomClient {
   /// See:
   ///  * [setNotificationLevelRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetNotificationLevelResponseApplicationJson, void>> setNotificationLevel({
-    required final int level,
-    required final String token,
-    final RoomSetNotificationLevelApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int level,
+    required String token,
+    RoomSetNotificationLevelApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setNotificationLevelRaw(
       level: level,
@@ -11914,10 +11914,10 @@ class RoomClient {
   ///  * [setNotificationLevel] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetNotificationLevelResponseApplicationJson, void> setNotificationLevelRaw({
-    required final int level,
-    required final String token,
-    final RoomSetNotificationLevelApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int level,
+    required String token,
+    RoomSetNotificationLevelApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -11927,7 +11927,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -11993,10 +11993,10 @@ class RoomClient {
   /// See:
   ///  * [setNotificationCallsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetNotificationCallsResponseApplicationJson, void>> setNotificationCalls({
-    required final int level,
-    required final String token,
-    final RoomSetNotificationCallsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int level,
+    required String token,
+    RoomSetNotificationCallsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setNotificationCallsRaw(
       level: level,
@@ -12029,10 +12029,10 @@ class RoomClient {
   ///  * [setNotificationCalls] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetNotificationCallsResponseApplicationJson, void> setNotificationCallsRaw({
-    required final int level,
-    required final String token,
-    final RoomSetNotificationCallsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int level,
+    required String token,
+    RoomSetNotificationCallsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -12042,7 +12042,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -12109,11 +12109,11 @@ class RoomClient {
   /// See:
   ///  * [setLobbyRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetLobbyResponseApplicationJson, void>> setLobby({
-    required final int state,
-    required final String token,
-    final int? timer,
-    final RoomSetLobbyApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int state,
+    required String token,
+    int? timer,
+    RoomSetLobbyApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setLobbyRaw(
       state: state,
@@ -12148,11 +12148,11 @@ class RoomClient {
   ///  * [setLobby] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetLobbyResponseApplicationJson, void> setLobbyRaw({
-    required final int state,
-    required final String token,
-    final int? timer,
-    final RoomSetLobbyApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int state,
+    required String token,
+    int? timer,
+    RoomSetLobbyApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -12162,7 +12162,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -12234,10 +12234,10 @@ class RoomClient {
   /// See:
   ///  * [setsipEnabledRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetsipEnabledResponseApplicationJson, void>> setsipEnabled({
-    required final int state,
-    required final String token,
-    final RoomSetsipEnabledApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int state,
+    required String token,
+    RoomSetsipEnabledApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setsipEnabledRaw(
       state: state,
@@ -12273,10 +12273,10 @@ class RoomClient {
   ///  * [setsipEnabled] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetsipEnabledResponseApplicationJson, void> setsipEnabledRaw({
-    required final int state,
-    required final String token,
-    final RoomSetsipEnabledApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int state,
+    required String token,
+    RoomSetsipEnabledApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -12286,7 +12286,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -12352,10 +12352,10 @@ class RoomClient {
   /// See:
   ///  * [setRecordingConsentRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetRecordingConsentResponseApplicationJson, void>> setRecordingConsent({
-    required final int recordingConsent,
-    required final String token,
-    final RoomSetRecordingConsentApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int recordingConsent,
+    required String token,
+    RoomSetRecordingConsentApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setRecordingConsentRaw(
       recordingConsent: recordingConsent,
@@ -12389,10 +12389,10 @@ class RoomClient {
   ///  * [setRecordingConsent] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetRecordingConsentResponseApplicationJson, void> setRecordingConsentRaw({
-    required final int recordingConsent,
-    required final String token,
-    final RoomSetRecordingConsentApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int recordingConsent,
+    required String token,
+    RoomSetRecordingConsentApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -12402,7 +12402,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -12469,10 +12469,10 @@ class RoomClient {
   /// See:
   ///  * [setMessageExpirationRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<RoomSetMessageExpirationResponseApplicationJson, void>> setMessageExpiration({
-    required final int seconds,
-    required final String token,
-    final RoomSetMessageExpirationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int seconds,
+    required String token,
+    RoomSetMessageExpirationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setMessageExpirationRaw(
       seconds: seconds,
@@ -12505,10 +12505,10 @@ class RoomClient {
   ///  * [setMessageExpiration] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<RoomSetMessageExpirationResponseApplicationJson, void> setMessageExpirationRaw({
-    required final int seconds,
-    required final String token,
-    final RoomSetMessageExpirationApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int seconds,
+    required String token,
+    RoomSetMessageExpirationApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -12518,7 +12518,7 @@ class RoomClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -12591,11 +12591,11 @@ class SettingsClient {
   /// See:
   ///  * [setsipSettingsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<SettingsSetsipSettingsResponseApplicationJson, void>> setsipSettings({
-    final BuiltList<String>? sipGroups,
-    final String? dialInInfo,
-    final String? sharedSecret,
-    final SettingsSetsipSettingsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    BuiltList<String>? sipGroups,
+    String? dialInInfo,
+    String? sharedSecret,
+    SettingsSetsipSettingsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setsipSettingsRaw(
       sipGroups: sipGroups,
@@ -12631,11 +12631,11 @@ class SettingsClient {
   ///  * [setsipSettings] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SettingsSetsipSettingsResponseApplicationJson, void> setsipSettingsRaw({
-    final BuiltList<String>? sipGroups,
-    final String? dialInInfo,
-    final String? sharedSecret,
-    final SettingsSetsipSettingsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    BuiltList<String>? sipGroups,
+    String? dialInInfo,
+    String? sharedSecret,
+    SettingsSetsipSettingsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -12645,7 +12645,7 @@ class SettingsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -12718,10 +12718,10 @@ class SettingsClient {
   /// See:
   ///  * [setUserSettingRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<SettingsSetUserSettingResponseApplicationJson, void>> setUserSetting({
-    required final String key,
-    final ContentString<SettingsSetUserSettingValue>? value,
-    final SettingsSetUserSettingApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String key,
+    ContentString<SettingsSetUserSettingValue>? value,
+    SettingsSetUserSettingApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setUserSettingRaw(
       key: key,
@@ -12754,10 +12754,10 @@ class SettingsClient {
   ///  * [setUserSetting] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SettingsSetUserSettingResponseApplicationJson, void> setUserSettingRaw({
-    required final String key,
-    final ContentString<SettingsSetUserSettingValue>? value,
-    final SettingsSetUserSettingApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String key,
+    ContentString<SettingsSetUserSettingValue>? value,
+    SettingsSetUserSettingApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -12767,7 +12767,7 @@ class SettingsClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -12841,9 +12841,9 @@ class SignalingClient {
   /// See:
   ///  * [getSettingsRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<SignalingGetSettingsResponseApplicationJson, void>> getSettings({
-    final String? token,
-    final SignalingGetSettingsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    String? token,
+    SignalingGetSettingsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getSettingsRaw(
       token: token,
@@ -12875,9 +12875,9 @@ class SignalingClient {
   ///  * [getSettings] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SignalingGetSettingsResponseApplicationJson, void> getSettingsRaw({
-    final String? token,
-    final SignalingGetSettingsApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    String? token,
+    SignalingGetSettingsApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -12887,7 +12887,7 @@ class SignalingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -12951,9 +12951,9 @@ class SignalingClient {
   /// See:
   ///  * [getWelcomeMessageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<SignalingGetWelcomeMessageResponseApplicationJson, void>> getWelcomeMessage({
-    required final int serverId,
-    final SignalingGetWelcomeMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int serverId,
+    SignalingGetWelcomeMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getWelcomeMessageRaw(
       serverId: serverId,
@@ -12988,9 +12988,9 @@ class SignalingClient {
   ///  * [getWelcomeMessage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SignalingGetWelcomeMessageResponseApplicationJson, void> getWelcomeMessageRaw({
-    required final int serverId,
-    final SignalingGetWelcomeMessageApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required int serverId,
+    SignalingGetWelcomeMessageApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -13000,7 +13000,7 @@ class SignalingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -13063,9 +13063,9 @@ class SignalingClient {
   /// See:
   ///  * [pullMessagesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<SignalingPullMessagesResponseApplicationJson, void>> pullMessages({
-    required final String token,
-    final SignalingPullMessagesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    SignalingPullMessagesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = pullMessagesRaw(
       token: token,
@@ -13098,9 +13098,9 @@ class SignalingClient {
   ///  * [pullMessages] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SignalingPullMessagesResponseApplicationJson, void> pullMessagesRaw({
-    required final String token,
-    final SignalingPullMessagesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String token,
+    SignalingPullMessagesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -13110,7 +13110,7 @@ class SignalingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -13169,10 +13169,10 @@ class SignalingClient {
   /// See:
   ///  * [sendMessagesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<SignalingSendMessagesResponseApplicationJson, void>> sendMessages({
-    required final String messages,
-    required final String token,
-    final SignalingSendMessagesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String messages,
+    required String token,
+    SignalingSendMessagesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = sendMessagesRaw(
       messages: messages,
@@ -13205,10 +13205,10 @@ class SignalingClient {
   ///  * [sendMessages] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<SignalingSendMessagesResponseApplicationJson, void> sendMessagesRaw({
-    required final String messages,
-    required final String token,
-    final SignalingSendMessagesApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String messages,
+    required String token,
+    SignalingSendMessagesApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -13218,7 +13218,7 @@ class SignalingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -13284,9 +13284,7 @@ class TempAvatarClient {
   ///
   /// See:
   ///  * [postAvatarRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<TempAvatarPostAvatarResponseApplicationJson, void>> postAvatar({
-    final bool? oCSAPIRequest,
-  }) async {
+  Future<DynamiteResponse<TempAvatarPostAvatarResponseApplicationJson, void>> postAvatar({bool? oCSAPIRequest}) async {
     final rawResponse = postAvatarRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -13311,7 +13309,7 @@ class TempAvatarClient {
   /// See:
   ///  * [postAvatar] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<TempAvatarPostAvatarResponseApplicationJson, void> postAvatarRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<TempAvatarPostAvatarResponseApplicationJson, void> postAvatarRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -13320,7 +13318,7 @@ class TempAvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -13369,7 +13367,7 @@ class TempAvatarClient {
   /// See:
   ///  * [deleteAvatarRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<TempAvatarDeleteAvatarResponseApplicationJson, void>> deleteAvatar({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = deleteAvatarRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -13395,9 +13393,7 @@ class TempAvatarClient {
   /// See:
   ///  * [deleteAvatar] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<TempAvatarDeleteAvatarResponseApplicationJson, void> deleteAvatarRaw({
-    final bool? oCSAPIRequest,
-  }) {
+  DynamiteRawResponse<TempAvatarDeleteAvatarResponseApplicationJson, void> deleteAvatarRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -13406,7 +13402,7 @@ class TempAvatarClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -13450,7 +13446,7 @@ class AvatarGetAvatarApiVersion extends EnumClass {
   static BuiltSet<AvatarGetAvatarApiVersion> get values => _$avatarGetAvatarApiVersionValues;
   // coverage:ignore-end
 
-  static AvatarGetAvatarApiVersion valueOf(final String name) => _$valueOfAvatarGetAvatarApiVersion(name);
+  static AvatarGetAvatarApiVersion valueOf(String name) => _$valueOfAvatarGetAvatarApiVersion(name);
 
   static Serializer<AvatarGetAvatarApiVersion> get serializer => _$avatarGetAvatarApiVersionSerializer;
 }
@@ -13464,7 +13460,7 @@ class AvatarUploadAvatarApiVersion extends EnumClass {
   static BuiltSet<AvatarUploadAvatarApiVersion> get values => _$avatarUploadAvatarApiVersionValues;
   // coverage:ignore-end
 
-  static AvatarUploadAvatarApiVersion valueOf(final String name) => _$valueOfAvatarUploadAvatarApiVersion(name);
+  static AvatarUploadAvatarApiVersion valueOf(String name) => _$valueOfAvatarUploadAvatarApiVersion(name);
 
   static Serializer<AvatarUploadAvatarApiVersion> get serializer => _$avatarUploadAvatarApiVersionSerializer;
 }
@@ -13479,14 +13475,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -13517,14 +13513,14 @@ abstract interface class $ChatMessageInterface {
 }
 
 abstract class ChatMessage implements $ChatMessageInterface, Built<ChatMessage, ChatMessageBuilder> {
-  factory ChatMessage([final void Function(ChatMessageBuilder)? b]) = _$ChatMessage;
+  factory ChatMessage([void Function(ChatMessageBuilder)? b]) = _$ChatMessage;
 
   // coverage:ignore-start
   const ChatMessage._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatMessage.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ChatMessage.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -13593,14 +13589,14 @@ abstract interface class $RoomInterface {
 }
 
 abstract class Room implements $RoomInterface, Built<Room, RoomBuilder> {
-  factory Room([final void Function(RoomBuilder)? b]) = _$Room;
+  factory Room([void Function(RoomBuilder)? b]) = _$Room;
 
   // coverage:ignore-start
   const Room._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Room.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Room.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -13610,7 +13606,7 @@ abstract class Room implements $RoomInterface, Built<Room, RoomBuilder> {
   static Serializer<Room> get serializer => _$roomSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final RoomBuilder b) {
+  static void _validate(RoomBuilder b) {
     b.lastMessage?.validateOneOf();
   }
 }
@@ -13626,7 +13622,7 @@ abstract class AvatarUploadAvatarResponseApplicationJson_Ocs
         $AvatarUploadAvatarResponseApplicationJson_OcsInterface,
         Built<AvatarUploadAvatarResponseApplicationJson_Ocs, AvatarUploadAvatarResponseApplicationJson_OcsBuilder> {
   factory AvatarUploadAvatarResponseApplicationJson_Ocs([
-    final void Function(AvatarUploadAvatarResponseApplicationJson_OcsBuilder)? b,
+    void Function(AvatarUploadAvatarResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AvatarUploadAvatarResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -13634,7 +13630,7 @@ abstract class AvatarUploadAvatarResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AvatarUploadAvatarResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AvatarUploadAvatarResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -13656,7 +13652,7 @@ abstract class AvatarUploadAvatarResponseApplicationJson
         $AvatarUploadAvatarResponseApplicationJsonInterface,
         Built<AvatarUploadAvatarResponseApplicationJson, AvatarUploadAvatarResponseApplicationJsonBuilder> {
   factory AvatarUploadAvatarResponseApplicationJson([
-    final void Function(AvatarUploadAvatarResponseApplicationJsonBuilder)? b,
+    void Function(AvatarUploadAvatarResponseApplicationJsonBuilder)? b,
   ]) = _$AvatarUploadAvatarResponseApplicationJson;
 
   // coverage:ignore-start
@@ -13664,7 +13660,7 @@ abstract class AvatarUploadAvatarResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AvatarUploadAvatarResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AvatarUploadAvatarResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -13685,7 +13681,7 @@ class AvatarDeleteAvatarApiVersion extends EnumClass {
   static BuiltSet<AvatarDeleteAvatarApiVersion> get values => _$avatarDeleteAvatarApiVersionValues;
   // coverage:ignore-end
 
-  static AvatarDeleteAvatarApiVersion valueOf(final String name) => _$valueOfAvatarDeleteAvatarApiVersion(name);
+  static AvatarDeleteAvatarApiVersion valueOf(String name) => _$valueOfAvatarDeleteAvatarApiVersion(name);
 
   static Serializer<AvatarDeleteAvatarApiVersion> get serializer => _$avatarDeleteAvatarApiVersionSerializer;
 }
@@ -13701,7 +13697,7 @@ abstract class AvatarDeleteAvatarResponseApplicationJson_Ocs
         $AvatarDeleteAvatarResponseApplicationJson_OcsInterface,
         Built<AvatarDeleteAvatarResponseApplicationJson_Ocs, AvatarDeleteAvatarResponseApplicationJson_OcsBuilder> {
   factory AvatarDeleteAvatarResponseApplicationJson_Ocs([
-    final void Function(AvatarDeleteAvatarResponseApplicationJson_OcsBuilder)? b,
+    void Function(AvatarDeleteAvatarResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AvatarDeleteAvatarResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -13709,7 +13705,7 @@ abstract class AvatarDeleteAvatarResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AvatarDeleteAvatarResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AvatarDeleteAvatarResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -13731,7 +13727,7 @@ abstract class AvatarDeleteAvatarResponseApplicationJson
         $AvatarDeleteAvatarResponseApplicationJsonInterface,
         Built<AvatarDeleteAvatarResponseApplicationJson, AvatarDeleteAvatarResponseApplicationJsonBuilder> {
   factory AvatarDeleteAvatarResponseApplicationJson([
-    final void Function(AvatarDeleteAvatarResponseApplicationJsonBuilder)? b,
+    void Function(AvatarDeleteAvatarResponseApplicationJsonBuilder)? b,
   ]) = _$AvatarDeleteAvatarResponseApplicationJson;
 
   // coverage:ignore-start
@@ -13739,7 +13735,7 @@ abstract class AvatarDeleteAvatarResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AvatarDeleteAvatarResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AvatarDeleteAvatarResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -13760,7 +13756,7 @@ class AvatarEmojiAvatarApiVersion extends EnumClass {
   static BuiltSet<AvatarEmojiAvatarApiVersion> get values => _$avatarEmojiAvatarApiVersionValues;
   // coverage:ignore-end
 
-  static AvatarEmojiAvatarApiVersion valueOf(final String name) => _$valueOfAvatarEmojiAvatarApiVersion(name);
+  static AvatarEmojiAvatarApiVersion valueOf(String name) => _$valueOfAvatarEmojiAvatarApiVersion(name);
 
   static Serializer<AvatarEmojiAvatarApiVersion> get serializer => _$avatarEmojiAvatarApiVersionSerializer;
 }
@@ -13776,7 +13772,7 @@ abstract class AvatarEmojiAvatarResponseApplicationJson_Ocs
         $AvatarEmojiAvatarResponseApplicationJson_OcsInterface,
         Built<AvatarEmojiAvatarResponseApplicationJson_Ocs, AvatarEmojiAvatarResponseApplicationJson_OcsBuilder> {
   factory AvatarEmojiAvatarResponseApplicationJson_Ocs([
-    final void Function(AvatarEmojiAvatarResponseApplicationJson_OcsBuilder)? b,
+    void Function(AvatarEmojiAvatarResponseApplicationJson_OcsBuilder)? b,
   ]) = _$AvatarEmojiAvatarResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -13784,7 +13780,7 @@ abstract class AvatarEmojiAvatarResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AvatarEmojiAvatarResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory AvatarEmojiAvatarResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -13806,7 +13802,7 @@ abstract class AvatarEmojiAvatarResponseApplicationJson
         $AvatarEmojiAvatarResponseApplicationJsonInterface,
         Built<AvatarEmojiAvatarResponseApplicationJson, AvatarEmojiAvatarResponseApplicationJsonBuilder> {
   factory AvatarEmojiAvatarResponseApplicationJson([
-    final void Function(AvatarEmojiAvatarResponseApplicationJsonBuilder)? b,
+    void Function(AvatarEmojiAvatarResponseApplicationJsonBuilder)? b,
   ]) = _$AvatarEmojiAvatarResponseApplicationJson;
 
   // coverage:ignore-start
@@ -13814,7 +13810,7 @@ abstract class AvatarEmojiAvatarResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory AvatarEmojiAvatarResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory AvatarEmojiAvatarResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -13835,7 +13831,7 @@ class AvatarGetAvatarDarkApiVersion extends EnumClass {
   static BuiltSet<AvatarGetAvatarDarkApiVersion> get values => _$avatarGetAvatarDarkApiVersionValues;
   // coverage:ignore-end
 
-  static AvatarGetAvatarDarkApiVersion valueOf(final String name) => _$valueOfAvatarGetAvatarDarkApiVersion(name);
+  static AvatarGetAvatarDarkApiVersion valueOf(String name) => _$valueOfAvatarGetAvatarDarkApiVersion(name);
 
   static Serializer<AvatarGetAvatarDarkApiVersion> get serializer => _$avatarGetAvatarDarkApiVersionSerializer;
 }
@@ -13849,7 +13845,7 @@ class BotSendMessageApiVersion extends EnumClass {
   static BuiltSet<BotSendMessageApiVersion> get values => _$botSendMessageApiVersionValues;
   // coverage:ignore-end
 
-  static BotSendMessageApiVersion valueOf(final String name) => _$valueOfBotSendMessageApiVersion(name);
+  static BotSendMessageApiVersion valueOf(String name) => _$valueOfBotSendMessageApiVersion(name);
 
   static Serializer<BotSendMessageApiVersion> get serializer => _$botSendMessageApiVersionSerializer;
 }
@@ -13865,7 +13861,7 @@ abstract class BotSendMessageResponseApplicationJson_Ocs
         $BotSendMessageResponseApplicationJson_OcsInterface,
         Built<BotSendMessageResponseApplicationJson_Ocs, BotSendMessageResponseApplicationJson_OcsBuilder> {
   factory BotSendMessageResponseApplicationJson_Ocs([
-    final void Function(BotSendMessageResponseApplicationJson_OcsBuilder)? b,
+    void Function(BotSendMessageResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BotSendMessageResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -13873,7 +13869,7 @@ abstract class BotSendMessageResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotSendMessageResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BotSendMessageResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -13894,16 +13890,15 @@ abstract class BotSendMessageResponseApplicationJson
     implements
         $BotSendMessageResponseApplicationJsonInterface,
         Built<BotSendMessageResponseApplicationJson, BotSendMessageResponseApplicationJsonBuilder> {
-  factory BotSendMessageResponseApplicationJson([
-    final void Function(BotSendMessageResponseApplicationJsonBuilder)? b,
-  ]) = _$BotSendMessageResponseApplicationJson;
+  factory BotSendMessageResponseApplicationJson([void Function(BotSendMessageResponseApplicationJsonBuilder)? b]) =
+      _$BotSendMessageResponseApplicationJson;
 
   // coverage:ignore-start
   const BotSendMessageResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotSendMessageResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BotSendMessageResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -13924,7 +13919,7 @@ class BotReactApiVersion extends EnumClass {
   static BuiltSet<BotReactApiVersion> get values => _$botReactApiVersionValues;
   // coverage:ignore-end
 
-  static BotReactApiVersion valueOf(final String name) => _$valueOfBotReactApiVersion(name);
+  static BotReactApiVersion valueOf(String name) => _$valueOfBotReactApiVersion(name);
 
   static Serializer<BotReactApiVersion> get serializer => _$botReactApiVersionSerializer;
 }
@@ -13939,7 +13934,7 @@ abstract class BotReactResponseApplicationJson_Ocs
     implements
         $BotReactResponseApplicationJson_OcsInterface,
         Built<BotReactResponseApplicationJson_Ocs, BotReactResponseApplicationJson_OcsBuilder> {
-  factory BotReactResponseApplicationJson_Ocs([final void Function(BotReactResponseApplicationJson_OcsBuilder)? b]) =
+  factory BotReactResponseApplicationJson_Ocs([void Function(BotReactResponseApplicationJson_OcsBuilder)? b]) =
       _$BotReactResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -13947,7 +13942,7 @@ abstract class BotReactResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotReactResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BotReactResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -13968,7 +13963,7 @@ abstract class BotReactResponseApplicationJson
     implements
         $BotReactResponseApplicationJsonInterface,
         Built<BotReactResponseApplicationJson, BotReactResponseApplicationJsonBuilder> {
-  factory BotReactResponseApplicationJson([final void Function(BotReactResponseApplicationJsonBuilder)? b]) =
+  factory BotReactResponseApplicationJson([void Function(BotReactResponseApplicationJsonBuilder)? b]) =
       _$BotReactResponseApplicationJson;
 
   // coverage:ignore-start
@@ -13976,7 +13971,7 @@ abstract class BotReactResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotReactResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BotReactResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -13996,7 +13991,7 @@ class BotDeleteReactionApiVersion extends EnumClass {
   static BuiltSet<BotDeleteReactionApiVersion> get values => _$botDeleteReactionApiVersionValues;
   // coverage:ignore-end
 
-  static BotDeleteReactionApiVersion valueOf(final String name) => _$valueOfBotDeleteReactionApiVersion(name);
+  static BotDeleteReactionApiVersion valueOf(String name) => _$valueOfBotDeleteReactionApiVersion(name);
 
   static Serializer<BotDeleteReactionApiVersion> get serializer => _$botDeleteReactionApiVersionSerializer;
 }
@@ -14012,7 +14007,7 @@ abstract class BotDeleteReactionResponseApplicationJson_Ocs
         $BotDeleteReactionResponseApplicationJson_OcsInterface,
         Built<BotDeleteReactionResponseApplicationJson_Ocs, BotDeleteReactionResponseApplicationJson_OcsBuilder> {
   factory BotDeleteReactionResponseApplicationJson_Ocs([
-    final void Function(BotDeleteReactionResponseApplicationJson_OcsBuilder)? b,
+    void Function(BotDeleteReactionResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BotDeleteReactionResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -14020,7 +14015,7 @@ abstract class BotDeleteReactionResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotDeleteReactionResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BotDeleteReactionResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14042,7 +14037,7 @@ abstract class BotDeleteReactionResponseApplicationJson
         $BotDeleteReactionResponseApplicationJsonInterface,
         Built<BotDeleteReactionResponseApplicationJson, BotDeleteReactionResponseApplicationJsonBuilder> {
   factory BotDeleteReactionResponseApplicationJson([
-    final void Function(BotDeleteReactionResponseApplicationJsonBuilder)? b,
+    void Function(BotDeleteReactionResponseApplicationJsonBuilder)? b,
   ]) = _$BotDeleteReactionResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14050,7 +14045,7 @@ abstract class BotDeleteReactionResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotDeleteReactionResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BotDeleteReactionResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14071,7 +14066,7 @@ class BotAdminListBotsApiVersion extends EnumClass {
   static BuiltSet<BotAdminListBotsApiVersion> get values => _$botAdminListBotsApiVersionValues;
   // coverage:ignore-end
 
-  static BotAdminListBotsApiVersion valueOf(final String name) => _$valueOfBotAdminListBotsApiVersion(name);
+  static BotAdminListBotsApiVersion valueOf(String name) => _$valueOfBotAdminListBotsApiVersion(name);
 
   static Serializer<BotAdminListBotsApiVersion> get serializer => _$botAdminListBotsApiVersionSerializer;
 }
@@ -14085,14 +14080,14 @@ abstract interface class $BotInterface {
 }
 
 abstract class Bot implements $BotInterface, Built<Bot, BotBuilder> {
-  factory Bot([final void Function(BotBuilder)? b]) = _$Bot;
+  factory Bot([void Function(BotBuilder)? b]) = _$Bot;
 
   // coverage:ignore-start
   const Bot._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Bot.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Bot.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -14120,15 +14115,14 @@ abstract interface class $BotWithDetails_1Interface {
 abstract interface class $BotWithDetailsInterface implements $BotInterface, $BotWithDetails_1Interface {}
 
 abstract class BotWithDetails implements $BotWithDetailsInterface, Built<BotWithDetails, BotWithDetailsBuilder> {
-  factory BotWithDetails([final void Function(BotWithDetailsBuilder)? b]) = _$BotWithDetails;
+  factory BotWithDetails([void Function(BotWithDetailsBuilder)? b]) = _$BotWithDetails;
 
   // coverage:ignore-start
   const BotWithDetails._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotWithDetails.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory BotWithDetails.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -14149,7 +14143,7 @@ abstract class BotAdminListBotsResponseApplicationJson_Ocs
         $BotAdminListBotsResponseApplicationJson_OcsInterface,
         Built<BotAdminListBotsResponseApplicationJson_Ocs, BotAdminListBotsResponseApplicationJson_OcsBuilder> {
   factory BotAdminListBotsResponseApplicationJson_Ocs([
-    final void Function(BotAdminListBotsResponseApplicationJson_OcsBuilder)? b,
+    void Function(BotAdminListBotsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BotAdminListBotsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -14157,7 +14151,7 @@ abstract class BotAdminListBotsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotAdminListBotsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BotAdminListBotsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14178,16 +14172,15 @@ abstract class BotAdminListBotsResponseApplicationJson
     implements
         $BotAdminListBotsResponseApplicationJsonInterface,
         Built<BotAdminListBotsResponseApplicationJson, BotAdminListBotsResponseApplicationJsonBuilder> {
-  factory BotAdminListBotsResponseApplicationJson([
-    final void Function(BotAdminListBotsResponseApplicationJsonBuilder)? b,
-  ]) = _$BotAdminListBotsResponseApplicationJson;
+  factory BotAdminListBotsResponseApplicationJson([void Function(BotAdminListBotsResponseApplicationJsonBuilder)? b]) =
+      _$BotAdminListBotsResponseApplicationJson;
 
   // coverage:ignore-start
   const BotAdminListBotsResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotAdminListBotsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BotAdminListBotsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14208,7 +14201,7 @@ class BotListBotsApiVersion extends EnumClass {
   static BuiltSet<BotListBotsApiVersion> get values => _$botListBotsApiVersionValues;
   // coverage:ignore-end
 
-  static BotListBotsApiVersion valueOf(final String name) => _$valueOfBotListBotsApiVersion(name);
+  static BotListBotsApiVersion valueOf(String name) => _$valueOfBotListBotsApiVersion(name);
 
   static Serializer<BotListBotsApiVersion> get serializer => _$botListBotsApiVersionSerializer;
 }
@@ -14223,16 +14216,15 @@ abstract class BotListBotsResponseApplicationJson_Ocs
     implements
         $BotListBotsResponseApplicationJson_OcsInterface,
         Built<BotListBotsResponseApplicationJson_Ocs, BotListBotsResponseApplicationJson_OcsBuilder> {
-  factory BotListBotsResponseApplicationJson_Ocs([
-    final void Function(BotListBotsResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$BotListBotsResponseApplicationJson_Ocs;
+  factory BotListBotsResponseApplicationJson_Ocs([void Function(BotListBotsResponseApplicationJson_OcsBuilder)? b]) =
+      _$BotListBotsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const BotListBotsResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotListBotsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BotListBotsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14253,7 +14245,7 @@ abstract class BotListBotsResponseApplicationJson
     implements
         $BotListBotsResponseApplicationJsonInterface,
         Built<BotListBotsResponseApplicationJson, BotListBotsResponseApplicationJsonBuilder> {
-  factory BotListBotsResponseApplicationJson([final void Function(BotListBotsResponseApplicationJsonBuilder)? b]) =
+  factory BotListBotsResponseApplicationJson([void Function(BotListBotsResponseApplicationJsonBuilder)? b]) =
       _$BotListBotsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14261,7 +14253,7 @@ abstract class BotListBotsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotListBotsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BotListBotsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14282,7 +14274,7 @@ class BotEnableBotApiVersion extends EnumClass {
   static BuiltSet<BotEnableBotApiVersion> get values => _$botEnableBotApiVersionValues;
   // coverage:ignore-end
 
-  static BotEnableBotApiVersion valueOf(final String name) => _$valueOfBotEnableBotApiVersion(name);
+  static BotEnableBotApiVersion valueOf(String name) => _$valueOfBotEnableBotApiVersion(name);
 
   static Serializer<BotEnableBotApiVersion> get serializer => _$botEnableBotApiVersionSerializer;
 }
@@ -14297,16 +14289,15 @@ abstract class BotEnableBotResponseApplicationJson_Ocs
     implements
         $BotEnableBotResponseApplicationJson_OcsInterface,
         Built<BotEnableBotResponseApplicationJson_Ocs, BotEnableBotResponseApplicationJson_OcsBuilder> {
-  factory BotEnableBotResponseApplicationJson_Ocs([
-    final void Function(BotEnableBotResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$BotEnableBotResponseApplicationJson_Ocs;
+  factory BotEnableBotResponseApplicationJson_Ocs([void Function(BotEnableBotResponseApplicationJson_OcsBuilder)? b]) =
+      _$BotEnableBotResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const BotEnableBotResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotEnableBotResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BotEnableBotResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14327,7 +14318,7 @@ abstract class BotEnableBotResponseApplicationJson
     implements
         $BotEnableBotResponseApplicationJsonInterface,
         Built<BotEnableBotResponseApplicationJson, BotEnableBotResponseApplicationJsonBuilder> {
-  factory BotEnableBotResponseApplicationJson([final void Function(BotEnableBotResponseApplicationJsonBuilder)? b]) =
+  factory BotEnableBotResponseApplicationJson([void Function(BotEnableBotResponseApplicationJsonBuilder)? b]) =
       _$BotEnableBotResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14335,7 +14326,7 @@ abstract class BotEnableBotResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotEnableBotResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BotEnableBotResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14356,7 +14347,7 @@ class BotDisableBotApiVersion extends EnumClass {
   static BuiltSet<BotDisableBotApiVersion> get values => _$botDisableBotApiVersionValues;
   // coverage:ignore-end
 
-  static BotDisableBotApiVersion valueOf(final String name) => _$valueOfBotDisableBotApiVersion(name);
+  static BotDisableBotApiVersion valueOf(String name) => _$valueOfBotDisableBotApiVersion(name);
 
   static Serializer<BotDisableBotApiVersion> get serializer => _$botDisableBotApiVersionSerializer;
 }
@@ -14372,7 +14363,7 @@ abstract class BotDisableBotResponseApplicationJson_Ocs
         $BotDisableBotResponseApplicationJson_OcsInterface,
         Built<BotDisableBotResponseApplicationJson_Ocs, BotDisableBotResponseApplicationJson_OcsBuilder> {
   factory BotDisableBotResponseApplicationJson_Ocs([
-    final void Function(BotDisableBotResponseApplicationJson_OcsBuilder)? b,
+    void Function(BotDisableBotResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BotDisableBotResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -14380,7 +14371,7 @@ abstract class BotDisableBotResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotDisableBotResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BotDisableBotResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14401,7 +14392,7 @@ abstract class BotDisableBotResponseApplicationJson
     implements
         $BotDisableBotResponseApplicationJsonInterface,
         Built<BotDisableBotResponseApplicationJson, BotDisableBotResponseApplicationJsonBuilder> {
-  factory BotDisableBotResponseApplicationJson([final void Function(BotDisableBotResponseApplicationJsonBuilder)? b]) =
+  factory BotDisableBotResponseApplicationJson([void Function(BotDisableBotResponseApplicationJsonBuilder)? b]) =
       _$BotDisableBotResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14409,7 +14400,7 @@ abstract class BotDisableBotResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotDisableBotResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BotDisableBotResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14431,7 +14422,7 @@ class BreakoutRoomConfigureBreakoutRoomsApiVersion extends EnumClass {
       _$breakoutRoomConfigureBreakoutRoomsApiVersionValues;
   // coverage:ignore-end
 
-  static BreakoutRoomConfigureBreakoutRoomsApiVersion valueOf(final String name) =>
+  static BreakoutRoomConfigureBreakoutRoomsApiVersion valueOf(String name) =>
       _$valueOfBreakoutRoomConfigureBreakoutRoomsApiVersion(name);
 
   static Serializer<BreakoutRoomConfigureBreakoutRoomsApiVersion> get serializer =>
@@ -14450,7 +14441,7 @@ abstract class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs
         Built<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs,
             BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder> {
   factory BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs([
-    final void Function(BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder)? b,
+    void Function(BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -14458,7 +14449,7 @@ abstract class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14481,7 +14472,7 @@ abstract class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson
         Built<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson,
             BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder> {
   factory BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson([
-    final void Function(BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder)? b,
+    void Function(BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder)? b,
   ]) = _$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14489,7 +14480,7 @@ abstract class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14511,7 +14502,7 @@ class BreakoutRoomRemoveBreakoutRoomsApiVersion extends EnumClass {
       _$breakoutRoomRemoveBreakoutRoomsApiVersionValues;
   // coverage:ignore-end
 
-  static BreakoutRoomRemoveBreakoutRoomsApiVersion valueOf(final String name) =>
+  static BreakoutRoomRemoveBreakoutRoomsApiVersion valueOf(String name) =>
       _$valueOfBreakoutRoomRemoveBreakoutRoomsApiVersion(name);
 
   static Serializer<BreakoutRoomRemoveBreakoutRoomsApiVersion> get serializer =>
@@ -14530,7 +14521,7 @@ abstract class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs
         Built<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs,
             BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder> {
   factory BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs([
-    final void Function(BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder)? b,
+    void Function(BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -14538,7 +14529,7 @@ abstract class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14561,7 +14552,7 @@ abstract class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson
         Built<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson,
             BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder> {
   factory BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson([
-    final void Function(BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder)? b,
+    void Function(BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder)? b,
   ]) = _$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14569,7 +14560,7 @@ abstract class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14591,7 +14582,7 @@ class BreakoutRoomBroadcastChatMessageApiVersion extends EnumClass {
       _$breakoutRoomBroadcastChatMessageApiVersionValues;
   // coverage:ignore-end
 
-  static BreakoutRoomBroadcastChatMessageApiVersion valueOf(final String name) =>
+  static BreakoutRoomBroadcastChatMessageApiVersion valueOf(String name) =>
       _$valueOfBreakoutRoomBroadcastChatMessageApiVersion(name);
 
   static Serializer<BreakoutRoomBroadcastChatMessageApiVersion> get serializer =>
@@ -14610,7 +14601,7 @@ abstract class BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs
         Built<BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs,
             BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder> {
   factory BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs([
-    final void Function(BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder)? b,
+    void Function(BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -14618,7 +14609,7 @@ abstract class BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14641,7 +14632,7 @@ abstract class BreakoutRoomBroadcastChatMessageResponseApplicationJson
         Built<BreakoutRoomBroadcastChatMessageResponseApplicationJson,
             BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder> {
   factory BreakoutRoomBroadcastChatMessageResponseApplicationJson([
-    final void Function(BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder)? b,
+    void Function(BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder)? b,
   ]) = _$BreakoutRoomBroadcastChatMessageResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14649,7 +14640,7 @@ abstract class BreakoutRoomBroadcastChatMessageResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomBroadcastChatMessageResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomBroadcastChatMessageResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14670,7 +14661,7 @@ class BreakoutRoomApplyAttendeeMapApiVersion extends EnumClass {
   static BuiltSet<BreakoutRoomApplyAttendeeMapApiVersion> get values => _$breakoutRoomApplyAttendeeMapApiVersionValues;
   // coverage:ignore-end
 
-  static BreakoutRoomApplyAttendeeMapApiVersion valueOf(final String name) =>
+  static BreakoutRoomApplyAttendeeMapApiVersion valueOf(String name) =>
       _$valueOfBreakoutRoomApplyAttendeeMapApiVersion(name);
 
   static Serializer<BreakoutRoomApplyAttendeeMapApiVersion> get serializer =>
@@ -14689,7 +14680,7 @@ abstract class BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs
         Built<BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs,
             BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder> {
   factory BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs([
-    final void Function(BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder)? b,
+    void Function(BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -14697,7 +14688,7 @@ abstract class BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14720,7 +14711,7 @@ abstract class BreakoutRoomApplyAttendeeMapResponseApplicationJson
         Built<BreakoutRoomApplyAttendeeMapResponseApplicationJson,
             BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder> {
   factory BreakoutRoomApplyAttendeeMapResponseApplicationJson([
-    final void Function(BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder)? b,
+    void Function(BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder)? b,
   ]) = _$BreakoutRoomApplyAttendeeMapResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14728,7 +14719,7 @@ abstract class BreakoutRoomApplyAttendeeMapResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomApplyAttendeeMapResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomApplyAttendeeMapResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14750,7 +14741,7 @@ class BreakoutRoomRequestAssistanceApiVersion extends EnumClass {
       _$breakoutRoomRequestAssistanceApiVersionValues;
   // coverage:ignore-end
 
-  static BreakoutRoomRequestAssistanceApiVersion valueOf(final String name) =>
+  static BreakoutRoomRequestAssistanceApiVersion valueOf(String name) =>
       _$valueOfBreakoutRoomRequestAssistanceApiVersion(name);
 
   static Serializer<BreakoutRoomRequestAssistanceApiVersion> get serializer =>
@@ -14769,7 +14760,7 @@ abstract class BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs
         Built<BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs,
             BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder> {
   factory BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs([
-    final void Function(BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder)? b,
+    void Function(BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -14777,7 +14768,7 @@ abstract class BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14800,7 +14791,7 @@ abstract class BreakoutRoomRequestAssistanceResponseApplicationJson
         Built<BreakoutRoomRequestAssistanceResponseApplicationJson,
             BreakoutRoomRequestAssistanceResponseApplicationJsonBuilder> {
   factory BreakoutRoomRequestAssistanceResponseApplicationJson([
-    final void Function(BreakoutRoomRequestAssistanceResponseApplicationJsonBuilder)? b,
+    void Function(BreakoutRoomRequestAssistanceResponseApplicationJsonBuilder)? b,
   ]) = _$BreakoutRoomRequestAssistanceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14808,7 +14799,7 @@ abstract class BreakoutRoomRequestAssistanceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomRequestAssistanceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomRequestAssistanceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14830,7 +14821,7 @@ class BreakoutRoomResetRequestForAssistanceApiVersion extends EnumClass {
       _$breakoutRoomResetRequestForAssistanceApiVersionValues;
   // coverage:ignore-end
 
-  static BreakoutRoomResetRequestForAssistanceApiVersion valueOf(final String name) =>
+  static BreakoutRoomResetRequestForAssistanceApiVersion valueOf(String name) =>
       _$valueOfBreakoutRoomResetRequestForAssistanceApiVersion(name);
 
   static Serializer<BreakoutRoomResetRequestForAssistanceApiVersion> get serializer =>
@@ -14849,7 +14840,7 @@ abstract class BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs
         Built<BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs,
             BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder> {
   factory BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs([
-    final void Function(BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder)? b,
+    void Function(BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -14857,7 +14848,7 @@ abstract class BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14880,7 +14871,7 @@ abstract class BreakoutRoomResetRequestForAssistanceResponseApplicationJson
         Built<BreakoutRoomResetRequestForAssistanceResponseApplicationJson,
             BreakoutRoomResetRequestForAssistanceResponseApplicationJsonBuilder> {
   factory BreakoutRoomResetRequestForAssistanceResponseApplicationJson([
-    final void Function(BreakoutRoomResetRequestForAssistanceResponseApplicationJsonBuilder)? b,
+    void Function(BreakoutRoomResetRequestForAssistanceResponseApplicationJsonBuilder)? b,
   ]) = _$BreakoutRoomResetRequestForAssistanceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14888,7 +14879,7 @@ abstract class BreakoutRoomResetRequestForAssistanceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomResetRequestForAssistanceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomResetRequestForAssistanceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14910,7 +14901,7 @@ class BreakoutRoomStartBreakoutRoomsApiVersion extends EnumClass {
       _$breakoutRoomStartBreakoutRoomsApiVersionValues;
   // coverage:ignore-end
 
-  static BreakoutRoomStartBreakoutRoomsApiVersion valueOf(final String name) =>
+  static BreakoutRoomStartBreakoutRoomsApiVersion valueOf(String name) =>
       _$valueOfBreakoutRoomStartBreakoutRoomsApiVersion(name);
 
   static Serializer<BreakoutRoomStartBreakoutRoomsApiVersion> get serializer =>
@@ -14929,7 +14920,7 @@ abstract class BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs
         Built<BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs,
             BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder> {
   factory BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs([
-    final void Function(BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder)? b,
+    void Function(BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -14937,7 +14928,7 @@ abstract class BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14960,7 +14951,7 @@ abstract class BreakoutRoomStartBreakoutRoomsResponseApplicationJson
         Built<BreakoutRoomStartBreakoutRoomsResponseApplicationJson,
             BreakoutRoomStartBreakoutRoomsResponseApplicationJsonBuilder> {
   factory BreakoutRoomStartBreakoutRoomsResponseApplicationJson([
-    final void Function(BreakoutRoomStartBreakoutRoomsResponseApplicationJsonBuilder)? b,
+    void Function(BreakoutRoomStartBreakoutRoomsResponseApplicationJsonBuilder)? b,
   ]) = _$BreakoutRoomStartBreakoutRoomsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -14968,7 +14959,7 @@ abstract class BreakoutRoomStartBreakoutRoomsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomStartBreakoutRoomsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomStartBreakoutRoomsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -14990,7 +14981,7 @@ class BreakoutRoomStopBreakoutRoomsApiVersion extends EnumClass {
       _$breakoutRoomStopBreakoutRoomsApiVersionValues;
   // coverage:ignore-end
 
-  static BreakoutRoomStopBreakoutRoomsApiVersion valueOf(final String name) =>
+  static BreakoutRoomStopBreakoutRoomsApiVersion valueOf(String name) =>
       _$valueOfBreakoutRoomStopBreakoutRoomsApiVersion(name);
 
   static Serializer<BreakoutRoomStopBreakoutRoomsApiVersion> get serializer =>
@@ -15009,7 +15000,7 @@ abstract class BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs
         Built<BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs,
             BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder> {
   factory BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs([
-    final void Function(BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder)? b,
+    void Function(BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -15017,7 +15008,7 @@ abstract class BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15040,7 +15031,7 @@ abstract class BreakoutRoomStopBreakoutRoomsResponseApplicationJson
         Built<BreakoutRoomStopBreakoutRoomsResponseApplicationJson,
             BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder> {
   factory BreakoutRoomStopBreakoutRoomsResponseApplicationJson([
-    final void Function(BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder)? b,
+    void Function(BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder)? b,
   ]) = _$BreakoutRoomStopBreakoutRoomsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -15048,7 +15039,7 @@ abstract class BreakoutRoomStopBreakoutRoomsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomStopBreakoutRoomsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomStopBreakoutRoomsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15070,7 +15061,7 @@ class BreakoutRoomSwitchBreakoutRoomApiVersion extends EnumClass {
       _$breakoutRoomSwitchBreakoutRoomApiVersionValues;
   // coverage:ignore-end
 
-  static BreakoutRoomSwitchBreakoutRoomApiVersion valueOf(final String name) =>
+  static BreakoutRoomSwitchBreakoutRoomApiVersion valueOf(String name) =>
       _$valueOfBreakoutRoomSwitchBreakoutRoomApiVersion(name);
 
   static Serializer<BreakoutRoomSwitchBreakoutRoomApiVersion> get serializer =>
@@ -15089,7 +15080,7 @@ abstract class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs
         Built<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs,
             BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder> {
   factory BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs([
-    final void Function(BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -15097,7 +15088,7 @@ abstract class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15120,7 +15111,7 @@ abstract class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson
         Built<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson,
             BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder> {
   factory BreakoutRoomSwitchBreakoutRoomResponseApplicationJson([
-    final void Function(BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder)? b,
+    void Function(BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder)? b,
   ]) = _$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -15128,7 +15119,7 @@ abstract class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BreakoutRoomSwitchBreakoutRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory BreakoutRoomSwitchBreakoutRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15149,7 +15140,7 @@ class CallGetPeersForCallApiVersion extends EnumClass {
   static BuiltSet<CallGetPeersForCallApiVersion> get values => _$callGetPeersForCallApiVersionValues;
   // coverage:ignore-end
 
-  static CallGetPeersForCallApiVersion valueOf(final String name) => _$valueOfCallGetPeersForCallApiVersion(name);
+  static CallGetPeersForCallApiVersion valueOf(String name) => _$valueOfCallGetPeersForCallApiVersion(name);
 
   static Serializer<CallGetPeersForCallApiVersion> get serializer => _$callGetPeersForCallApiVersionSerializer;
 }
@@ -15165,14 +15156,14 @@ abstract interface class $CallPeerInterface {
 }
 
 abstract class CallPeer implements $CallPeerInterface, Built<CallPeer, CallPeerBuilder> {
-  factory CallPeer([final void Function(CallPeerBuilder)? b]) = _$CallPeer;
+  factory CallPeer([void Function(CallPeerBuilder)? b]) = _$CallPeer;
 
   // coverage:ignore-start
   const CallPeer._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallPeer.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory CallPeer.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -15193,7 +15184,7 @@ abstract class CallGetPeersForCallResponseApplicationJson_Ocs
         $CallGetPeersForCallResponseApplicationJson_OcsInterface,
         Built<CallGetPeersForCallResponseApplicationJson_Ocs, CallGetPeersForCallResponseApplicationJson_OcsBuilder> {
   factory CallGetPeersForCallResponseApplicationJson_Ocs([
-    final void Function(CallGetPeersForCallResponseApplicationJson_OcsBuilder)? b,
+    void Function(CallGetPeersForCallResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CallGetPeersForCallResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -15201,7 +15192,7 @@ abstract class CallGetPeersForCallResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallGetPeersForCallResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CallGetPeersForCallResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15223,7 +15214,7 @@ abstract class CallGetPeersForCallResponseApplicationJson
         $CallGetPeersForCallResponseApplicationJsonInterface,
         Built<CallGetPeersForCallResponseApplicationJson, CallGetPeersForCallResponseApplicationJsonBuilder> {
   factory CallGetPeersForCallResponseApplicationJson([
-    final void Function(CallGetPeersForCallResponseApplicationJsonBuilder)? b,
+    void Function(CallGetPeersForCallResponseApplicationJsonBuilder)? b,
   ]) = _$CallGetPeersForCallResponseApplicationJson;
 
   // coverage:ignore-start
@@ -15231,7 +15222,7 @@ abstract class CallGetPeersForCallResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallGetPeersForCallResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CallGetPeersForCallResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15252,7 +15243,7 @@ class CallUpdateCallFlagsApiVersion extends EnumClass {
   static BuiltSet<CallUpdateCallFlagsApiVersion> get values => _$callUpdateCallFlagsApiVersionValues;
   // coverage:ignore-end
 
-  static CallUpdateCallFlagsApiVersion valueOf(final String name) => _$valueOfCallUpdateCallFlagsApiVersion(name);
+  static CallUpdateCallFlagsApiVersion valueOf(String name) => _$valueOfCallUpdateCallFlagsApiVersion(name);
 
   static Serializer<CallUpdateCallFlagsApiVersion> get serializer => _$callUpdateCallFlagsApiVersionSerializer;
 }
@@ -15268,7 +15259,7 @@ abstract class CallUpdateCallFlagsResponseApplicationJson_Ocs
         $CallUpdateCallFlagsResponseApplicationJson_OcsInterface,
         Built<CallUpdateCallFlagsResponseApplicationJson_Ocs, CallUpdateCallFlagsResponseApplicationJson_OcsBuilder> {
   factory CallUpdateCallFlagsResponseApplicationJson_Ocs([
-    final void Function(CallUpdateCallFlagsResponseApplicationJson_OcsBuilder)? b,
+    void Function(CallUpdateCallFlagsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CallUpdateCallFlagsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -15276,7 +15267,7 @@ abstract class CallUpdateCallFlagsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallUpdateCallFlagsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CallUpdateCallFlagsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15298,7 +15289,7 @@ abstract class CallUpdateCallFlagsResponseApplicationJson
         $CallUpdateCallFlagsResponseApplicationJsonInterface,
         Built<CallUpdateCallFlagsResponseApplicationJson, CallUpdateCallFlagsResponseApplicationJsonBuilder> {
   factory CallUpdateCallFlagsResponseApplicationJson([
-    final void Function(CallUpdateCallFlagsResponseApplicationJsonBuilder)? b,
+    void Function(CallUpdateCallFlagsResponseApplicationJsonBuilder)? b,
   ]) = _$CallUpdateCallFlagsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -15306,7 +15297,7 @@ abstract class CallUpdateCallFlagsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallUpdateCallFlagsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CallUpdateCallFlagsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15327,7 +15318,7 @@ class CallJoinCallApiVersion extends EnumClass {
   static BuiltSet<CallJoinCallApiVersion> get values => _$callJoinCallApiVersionValues;
   // coverage:ignore-end
 
-  static CallJoinCallApiVersion valueOf(final String name) => _$valueOfCallJoinCallApiVersion(name);
+  static CallJoinCallApiVersion valueOf(String name) => _$valueOfCallJoinCallApiVersion(name);
 
   static Serializer<CallJoinCallApiVersion> get serializer => _$callJoinCallApiVersionSerializer;
 }
@@ -15342,16 +15333,15 @@ abstract class CallJoinCallResponseApplicationJson_Ocs
     implements
         $CallJoinCallResponseApplicationJson_OcsInterface,
         Built<CallJoinCallResponseApplicationJson_Ocs, CallJoinCallResponseApplicationJson_OcsBuilder> {
-  factory CallJoinCallResponseApplicationJson_Ocs([
-    final void Function(CallJoinCallResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$CallJoinCallResponseApplicationJson_Ocs;
+  factory CallJoinCallResponseApplicationJson_Ocs([void Function(CallJoinCallResponseApplicationJson_OcsBuilder)? b]) =
+      _$CallJoinCallResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const CallJoinCallResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallJoinCallResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CallJoinCallResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15372,7 +15362,7 @@ abstract class CallJoinCallResponseApplicationJson
     implements
         $CallJoinCallResponseApplicationJsonInterface,
         Built<CallJoinCallResponseApplicationJson, CallJoinCallResponseApplicationJsonBuilder> {
-  factory CallJoinCallResponseApplicationJson([final void Function(CallJoinCallResponseApplicationJsonBuilder)? b]) =
+  factory CallJoinCallResponseApplicationJson([void Function(CallJoinCallResponseApplicationJsonBuilder)? b]) =
       _$CallJoinCallResponseApplicationJson;
 
   // coverage:ignore-start
@@ -15380,7 +15370,7 @@ abstract class CallJoinCallResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallJoinCallResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CallJoinCallResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15401,7 +15391,7 @@ class CallLeaveCallApiVersion extends EnumClass {
   static BuiltSet<CallLeaveCallApiVersion> get values => _$callLeaveCallApiVersionValues;
   // coverage:ignore-end
 
-  static CallLeaveCallApiVersion valueOf(final String name) => _$valueOfCallLeaveCallApiVersion(name);
+  static CallLeaveCallApiVersion valueOf(String name) => _$valueOfCallLeaveCallApiVersion(name);
 
   static Serializer<CallLeaveCallApiVersion> get serializer => _$callLeaveCallApiVersionSerializer;
 }
@@ -15417,7 +15407,7 @@ abstract class CallLeaveCallResponseApplicationJson_Ocs
         $CallLeaveCallResponseApplicationJson_OcsInterface,
         Built<CallLeaveCallResponseApplicationJson_Ocs, CallLeaveCallResponseApplicationJson_OcsBuilder> {
   factory CallLeaveCallResponseApplicationJson_Ocs([
-    final void Function(CallLeaveCallResponseApplicationJson_OcsBuilder)? b,
+    void Function(CallLeaveCallResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CallLeaveCallResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -15425,7 +15415,7 @@ abstract class CallLeaveCallResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallLeaveCallResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CallLeaveCallResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15446,7 +15436,7 @@ abstract class CallLeaveCallResponseApplicationJson
     implements
         $CallLeaveCallResponseApplicationJsonInterface,
         Built<CallLeaveCallResponseApplicationJson, CallLeaveCallResponseApplicationJsonBuilder> {
-  factory CallLeaveCallResponseApplicationJson([final void Function(CallLeaveCallResponseApplicationJsonBuilder)? b]) =
+  factory CallLeaveCallResponseApplicationJson([void Function(CallLeaveCallResponseApplicationJsonBuilder)? b]) =
       _$CallLeaveCallResponseApplicationJson;
 
   // coverage:ignore-start
@@ -15454,7 +15444,7 @@ abstract class CallLeaveCallResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallLeaveCallResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CallLeaveCallResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15475,7 +15465,7 @@ class CallRingAttendeeApiVersion extends EnumClass {
   static BuiltSet<CallRingAttendeeApiVersion> get values => _$callRingAttendeeApiVersionValues;
   // coverage:ignore-end
 
-  static CallRingAttendeeApiVersion valueOf(final String name) => _$valueOfCallRingAttendeeApiVersion(name);
+  static CallRingAttendeeApiVersion valueOf(String name) => _$valueOfCallRingAttendeeApiVersion(name);
 
   static Serializer<CallRingAttendeeApiVersion> get serializer => _$callRingAttendeeApiVersionSerializer;
 }
@@ -15491,7 +15481,7 @@ abstract class CallRingAttendeeResponseApplicationJson_Ocs
         $CallRingAttendeeResponseApplicationJson_OcsInterface,
         Built<CallRingAttendeeResponseApplicationJson_Ocs, CallRingAttendeeResponseApplicationJson_OcsBuilder> {
   factory CallRingAttendeeResponseApplicationJson_Ocs([
-    final void Function(CallRingAttendeeResponseApplicationJson_OcsBuilder)? b,
+    void Function(CallRingAttendeeResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CallRingAttendeeResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -15499,7 +15489,7 @@ abstract class CallRingAttendeeResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallRingAttendeeResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CallRingAttendeeResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15520,16 +15510,15 @@ abstract class CallRingAttendeeResponseApplicationJson
     implements
         $CallRingAttendeeResponseApplicationJsonInterface,
         Built<CallRingAttendeeResponseApplicationJson, CallRingAttendeeResponseApplicationJsonBuilder> {
-  factory CallRingAttendeeResponseApplicationJson([
-    final void Function(CallRingAttendeeResponseApplicationJsonBuilder)? b,
-  ]) = _$CallRingAttendeeResponseApplicationJson;
+  factory CallRingAttendeeResponseApplicationJson([void Function(CallRingAttendeeResponseApplicationJsonBuilder)? b]) =
+      _$CallRingAttendeeResponseApplicationJson;
 
   // coverage:ignore-start
   const CallRingAttendeeResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallRingAttendeeResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CallRingAttendeeResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15550,7 +15539,7 @@ class CallSipDialOutApiVersion extends EnumClass {
   static BuiltSet<CallSipDialOutApiVersion> get values => _$callSipDialOutApiVersionValues;
   // coverage:ignore-end
 
-  static CallSipDialOutApiVersion valueOf(final String name) => _$valueOfCallSipDialOutApiVersion(name);
+  static CallSipDialOutApiVersion valueOf(String name) => _$valueOfCallSipDialOutApiVersion(name);
 
   static Serializer<CallSipDialOutApiVersion> get serializer => _$callSipDialOutApiVersionSerializer;
 }
@@ -15566,7 +15555,7 @@ abstract class CallSipDialOutResponseApplicationJson_Ocs_Data
         $CallSipDialOutResponseApplicationJson_Ocs_DataInterface,
         Built<CallSipDialOutResponseApplicationJson_Ocs_Data, CallSipDialOutResponseApplicationJson_Ocs_DataBuilder> {
   factory CallSipDialOutResponseApplicationJson_Ocs_Data([
-    final void Function(CallSipDialOutResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(CallSipDialOutResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$CallSipDialOutResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -15574,7 +15563,7 @@ abstract class CallSipDialOutResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallSipDialOutResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory CallSipDialOutResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15597,7 +15586,7 @@ abstract class CallSipDialOutResponseApplicationJson_Ocs
         $CallSipDialOutResponseApplicationJson_OcsInterface,
         Built<CallSipDialOutResponseApplicationJson_Ocs, CallSipDialOutResponseApplicationJson_OcsBuilder> {
   factory CallSipDialOutResponseApplicationJson_Ocs([
-    final void Function(CallSipDialOutResponseApplicationJson_OcsBuilder)? b,
+    void Function(CallSipDialOutResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CallSipDialOutResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -15605,7 +15594,7 @@ abstract class CallSipDialOutResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallSipDialOutResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CallSipDialOutResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15626,16 +15615,15 @@ abstract class CallSipDialOutResponseApplicationJson
     implements
         $CallSipDialOutResponseApplicationJsonInterface,
         Built<CallSipDialOutResponseApplicationJson, CallSipDialOutResponseApplicationJsonBuilder> {
-  factory CallSipDialOutResponseApplicationJson([
-    final void Function(CallSipDialOutResponseApplicationJsonBuilder)? b,
-  ]) = _$CallSipDialOutResponseApplicationJson;
+  factory CallSipDialOutResponseApplicationJson([void Function(CallSipDialOutResponseApplicationJsonBuilder)? b]) =
+      _$CallSipDialOutResponseApplicationJson;
 
   // coverage:ignore-start
   const CallSipDialOutResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CallSipDialOutResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CallSipDialOutResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15657,7 +15645,7 @@ class CertificateGetCertificateExpirationApiVersion extends EnumClass {
       _$certificateGetCertificateExpirationApiVersionValues;
   // coverage:ignore-end
 
-  static CertificateGetCertificateExpirationApiVersion valueOf(final String name) =>
+  static CertificateGetCertificateExpirationApiVersion valueOf(String name) =>
       _$valueOfCertificateGetCertificateExpirationApiVersion(name);
 
   static Serializer<CertificateGetCertificateExpirationApiVersion> get serializer =>
@@ -15676,7 +15664,7 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Da
         Built<CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data,
             CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder> {
   factory CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data([
-    final void Function(CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -15684,9 +15672,7 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Da
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data.fromJson(
-    final Map<String, dynamic> json,
-  ) =>
+  factory CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15710,7 +15696,7 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson_Ocs
         Built<CertificateGetCertificateExpirationResponseApplicationJson_Ocs,
             CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder> {
   factory CertificateGetCertificateExpirationResponseApplicationJson_Ocs([
-    final void Function(CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder)? b,
+    void Function(CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder)? b,
   ]) = _$CertificateGetCertificateExpirationResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -15718,7 +15704,7 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CertificateGetCertificateExpirationResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory CertificateGetCertificateExpirationResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15741,7 +15727,7 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson
         Built<CertificateGetCertificateExpirationResponseApplicationJson,
             CertificateGetCertificateExpirationResponseApplicationJsonBuilder> {
   factory CertificateGetCertificateExpirationResponseApplicationJson([
-    final void Function(CertificateGetCertificateExpirationResponseApplicationJsonBuilder)? b,
+    void Function(CertificateGetCertificateExpirationResponseApplicationJsonBuilder)? b,
   ]) = _$CertificateGetCertificateExpirationResponseApplicationJson;
 
   // coverage:ignore-start
@@ -15749,7 +15735,7 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CertificateGetCertificateExpirationResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CertificateGetCertificateExpirationResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15770,7 +15756,7 @@ class ChatReceiveMessagesApiVersion extends EnumClass {
   static BuiltSet<ChatReceiveMessagesApiVersion> get values => _$chatReceiveMessagesApiVersionValues;
   // coverage:ignore-end
 
-  static ChatReceiveMessagesApiVersion valueOf(final String name) => _$valueOfChatReceiveMessagesApiVersion(name);
+  static ChatReceiveMessagesApiVersion valueOf(String name) => _$valueOfChatReceiveMessagesApiVersion(name);
 
   static Serializer<ChatReceiveMessagesApiVersion> get serializer => _$chatReceiveMessagesApiVersionSerializer;
 }
@@ -15787,7 +15773,7 @@ abstract class ChatChatReceiveMessagesHeaders
     implements
         $ChatChatReceiveMessagesHeadersInterface,
         Built<ChatChatReceiveMessagesHeaders, ChatChatReceiveMessagesHeadersBuilder> {
-  factory ChatChatReceiveMessagesHeaders([final void Function(ChatChatReceiveMessagesHeadersBuilder)? b]) =
+  factory ChatChatReceiveMessagesHeaders([void Function(ChatChatReceiveMessagesHeadersBuilder)? b]) =
       _$ChatChatReceiveMessagesHeaders;
 
   // coverage:ignore-start
@@ -15795,7 +15781,7 @@ abstract class ChatChatReceiveMessagesHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatChatReceiveMessagesHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory ChatChatReceiveMessagesHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15817,14 +15803,14 @@ abstract interface class $ChatMessageWithParentInterface
 
 abstract class ChatMessageWithParent
     implements $ChatMessageWithParentInterface, Built<ChatMessageWithParent, ChatMessageWithParentBuilder> {
-  factory ChatMessageWithParent([final void Function(ChatMessageWithParentBuilder)? b]) = _$ChatMessageWithParent;
+  factory ChatMessageWithParent([void Function(ChatMessageWithParentBuilder)? b]) = _$ChatMessageWithParent;
 
   // coverage:ignore-start
   const ChatMessageWithParent._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatMessageWithParent.fromJson(final Map<String, dynamic> json) =>
+  factory ChatMessageWithParent.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15846,7 +15832,7 @@ abstract class ChatReceiveMessagesResponseApplicationJson_Ocs
         $ChatReceiveMessagesResponseApplicationJson_OcsInterface,
         Built<ChatReceiveMessagesResponseApplicationJson_Ocs, ChatReceiveMessagesResponseApplicationJson_OcsBuilder> {
   factory ChatReceiveMessagesResponseApplicationJson_Ocs([
-    final void Function(ChatReceiveMessagesResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatReceiveMessagesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatReceiveMessagesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -15854,7 +15840,7 @@ abstract class ChatReceiveMessagesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatReceiveMessagesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatReceiveMessagesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15876,7 +15862,7 @@ abstract class ChatReceiveMessagesResponseApplicationJson
         $ChatReceiveMessagesResponseApplicationJsonInterface,
         Built<ChatReceiveMessagesResponseApplicationJson, ChatReceiveMessagesResponseApplicationJsonBuilder> {
   factory ChatReceiveMessagesResponseApplicationJson([
-    final void Function(ChatReceiveMessagesResponseApplicationJsonBuilder)? b,
+    void Function(ChatReceiveMessagesResponseApplicationJsonBuilder)? b,
   ]) = _$ChatReceiveMessagesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -15884,7 +15870,7 @@ abstract class ChatReceiveMessagesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatReceiveMessagesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatReceiveMessagesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15905,7 +15891,7 @@ class ChatSendMessageApiVersion extends EnumClass {
   static BuiltSet<ChatSendMessageApiVersion> get values => _$chatSendMessageApiVersionValues;
   // coverage:ignore-end
 
-  static ChatSendMessageApiVersion valueOf(final String name) => _$valueOfChatSendMessageApiVersion(name);
+  static ChatSendMessageApiVersion valueOf(String name) => _$valueOfChatSendMessageApiVersion(name);
 
   static Serializer<ChatSendMessageApiVersion> get serializer => _$chatSendMessageApiVersionSerializer;
 }
@@ -15920,7 +15906,7 @@ abstract class ChatChatSendMessageHeaders
     implements
         $ChatChatSendMessageHeadersInterface,
         Built<ChatChatSendMessageHeaders, ChatChatSendMessageHeadersBuilder> {
-  factory ChatChatSendMessageHeaders([final void Function(ChatChatSendMessageHeadersBuilder)? b]) =
+  factory ChatChatSendMessageHeaders([void Function(ChatChatSendMessageHeadersBuilder)? b]) =
       _$ChatChatSendMessageHeaders;
 
   // coverage:ignore-start
@@ -15928,7 +15914,7 @@ abstract class ChatChatSendMessageHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatChatSendMessageHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory ChatChatSendMessageHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15950,7 +15936,7 @@ abstract class ChatSendMessageResponseApplicationJson_Ocs
         $ChatSendMessageResponseApplicationJson_OcsInterface,
         Built<ChatSendMessageResponseApplicationJson_Ocs, ChatSendMessageResponseApplicationJson_OcsBuilder> {
   factory ChatSendMessageResponseApplicationJson_Ocs([
-    final void Function(ChatSendMessageResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatSendMessageResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatSendMessageResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -15958,7 +15944,7 @@ abstract class ChatSendMessageResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatSendMessageResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatSendMessageResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -15979,16 +15965,15 @@ abstract class ChatSendMessageResponseApplicationJson
     implements
         $ChatSendMessageResponseApplicationJsonInterface,
         Built<ChatSendMessageResponseApplicationJson, ChatSendMessageResponseApplicationJsonBuilder> {
-  factory ChatSendMessageResponseApplicationJson([
-    final void Function(ChatSendMessageResponseApplicationJsonBuilder)? b,
-  ]) = _$ChatSendMessageResponseApplicationJson;
+  factory ChatSendMessageResponseApplicationJson([void Function(ChatSendMessageResponseApplicationJsonBuilder)? b]) =
+      _$ChatSendMessageResponseApplicationJson;
 
   // coverage:ignore-start
   const ChatSendMessageResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatSendMessageResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatSendMessageResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16009,7 +15994,7 @@ class ChatClearHistoryApiVersion extends EnumClass {
   static BuiltSet<ChatClearHistoryApiVersion> get values => _$chatClearHistoryApiVersionValues;
   // coverage:ignore-end
 
-  static ChatClearHistoryApiVersion valueOf(final String name) => _$valueOfChatClearHistoryApiVersion(name);
+  static ChatClearHistoryApiVersion valueOf(String name) => _$valueOfChatClearHistoryApiVersion(name);
 
   static Serializer<ChatClearHistoryApiVersion> get serializer => _$chatClearHistoryApiVersionSerializer;
 }
@@ -16024,7 +16009,7 @@ abstract class ChatChatClearHistoryHeaders
     implements
         $ChatChatClearHistoryHeadersInterface,
         Built<ChatChatClearHistoryHeaders, ChatChatClearHistoryHeadersBuilder> {
-  factory ChatChatClearHistoryHeaders([final void Function(ChatChatClearHistoryHeadersBuilder)? b]) =
+  factory ChatChatClearHistoryHeaders([void Function(ChatChatClearHistoryHeadersBuilder)? b]) =
       _$ChatChatClearHistoryHeaders;
 
   // coverage:ignore-start
@@ -16032,7 +16017,7 @@ abstract class ChatChatClearHistoryHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatChatClearHistoryHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory ChatChatClearHistoryHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16054,7 +16039,7 @@ abstract class ChatClearHistoryResponseApplicationJson_Ocs
         $ChatClearHistoryResponseApplicationJson_OcsInterface,
         Built<ChatClearHistoryResponseApplicationJson_Ocs, ChatClearHistoryResponseApplicationJson_OcsBuilder> {
   factory ChatClearHistoryResponseApplicationJson_Ocs([
-    final void Function(ChatClearHistoryResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatClearHistoryResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatClearHistoryResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -16062,7 +16047,7 @@ abstract class ChatClearHistoryResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatClearHistoryResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatClearHistoryResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16083,16 +16068,15 @@ abstract class ChatClearHistoryResponseApplicationJson
     implements
         $ChatClearHistoryResponseApplicationJsonInterface,
         Built<ChatClearHistoryResponseApplicationJson, ChatClearHistoryResponseApplicationJsonBuilder> {
-  factory ChatClearHistoryResponseApplicationJson([
-    final void Function(ChatClearHistoryResponseApplicationJsonBuilder)? b,
-  ]) = _$ChatClearHistoryResponseApplicationJson;
+  factory ChatClearHistoryResponseApplicationJson([void Function(ChatClearHistoryResponseApplicationJsonBuilder)? b]) =
+      _$ChatClearHistoryResponseApplicationJson;
 
   // coverage:ignore-start
   const ChatClearHistoryResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatClearHistoryResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatClearHistoryResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16113,7 +16097,7 @@ class ChatDeleteMessageApiVersion extends EnumClass {
   static BuiltSet<ChatDeleteMessageApiVersion> get values => _$chatDeleteMessageApiVersionValues;
   // coverage:ignore-end
 
-  static ChatDeleteMessageApiVersion valueOf(final String name) => _$valueOfChatDeleteMessageApiVersion(name);
+  static ChatDeleteMessageApiVersion valueOf(String name) => _$valueOfChatDeleteMessageApiVersion(name);
 
   static Serializer<ChatDeleteMessageApiVersion> get serializer => _$chatDeleteMessageApiVersionSerializer;
 }
@@ -16128,7 +16112,7 @@ abstract class ChatChatDeleteMessageHeaders
     implements
         $ChatChatDeleteMessageHeadersInterface,
         Built<ChatChatDeleteMessageHeaders, ChatChatDeleteMessageHeadersBuilder> {
-  factory ChatChatDeleteMessageHeaders([final void Function(ChatChatDeleteMessageHeadersBuilder)? b]) =
+  factory ChatChatDeleteMessageHeaders([void Function(ChatChatDeleteMessageHeadersBuilder)? b]) =
       _$ChatChatDeleteMessageHeaders;
 
   // coverage:ignore-start
@@ -16136,7 +16120,7 @@ abstract class ChatChatDeleteMessageHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatChatDeleteMessageHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory ChatChatDeleteMessageHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16158,7 +16142,7 @@ abstract class ChatDeleteMessageResponseApplicationJson_Ocs
         $ChatDeleteMessageResponseApplicationJson_OcsInterface,
         Built<ChatDeleteMessageResponseApplicationJson_Ocs, ChatDeleteMessageResponseApplicationJson_OcsBuilder> {
   factory ChatDeleteMessageResponseApplicationJson_Ocs([
-    final void Function(ChatDeleteMessageResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatDeleteMessageResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatDeleteMessageResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -16166,7 +16150,7 @@ abstract class ChatDeleteMessageResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatDeleteMessageResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatDeleteMessageResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16188,7 +16172,7 @@ abstract class ChatDeleteMessageResponseApplicationJson
         $ChatDeleteMessageResponseApplicationJsonInterface,
         Built<ChatDeleteMessageResponseApplicationJson, ChatDeleteMessageResponseApplicationJsonBuilder> {
   factory ChatDeleteMessageResponseApplicationJson([
-    final void Function(ChatDeleteMessageResponseApplicationJsonBuilder)? b,
+    void Function(ChatDeleteMessageResponseApplicationJsonBuilder)? b,
   ]) = _$ChatDeleteMessageResponseApplicationJson;
 
   // coverage:ignore-start
@@ -16196,7 +16180,7 @@ abstract class ChatDeleteMessageResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatDeleteMessageResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatDeleteMessageResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16217,7 +16201,7 @@ class ChatGetMessageContextApiVersion extends EnumClass {
   static BuiltSet<ChatGetMessageContextApiVersion> get values => _$chatGetMessageContextApiVersionValues;
   // coverage:ignore-end
 
-  static ChatGetMessageContextApiVersion valueOf(final String name) => _$valueOfChatGetMessageContextApiVersion(name);
+  static ChatGetMessageContextApiVersion valueOf(String name) => _$valueOfChatGetMessageContextApiVersion(name);
 
   static Serializer<ChatGetMessageContextApiVersion> get serializer => _$chatGetMessageContextApiVersionSerializer;
 }
@@ -16234,7 +16218,7 @@ abstract class ChatChatGetMessageContextHeaders
     implements
         $ChatChatGetMessageContextHeadersInterface,
         Built<ChatChatGetMessageContextHeaders, ChatChatGetMessageContextHeadersBuilder> {
-  factory ChatChatGetMessageContextHeaders([final void Function(ChatChatGetMessageContextHeadersBuilder)? b]) =
+  factory ChatChatGetMessageContextHeaders([void Function(ChatChatGetMessageContextHeadersBuilder)? b]) =
       _$ChatChatGetMessageContextHeaders;
 
   // coverage:ignore-start
@@ -16242,7 +16226,7 @@ abstract class ChatChatGetMessageContextHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatChatGetMessageContextHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory ChatChatGetMessageContextHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16265,7 +16249,7 @@ abstract class ChatGetMessageContextResponseApplicationJson_Ocs
         Built<ChatGetMessageContextResponseApplicationJson_Ocs,
             ChatGetMessageContextResponseApplicationJson_OcsBuilder> {
   factory ChatGetMessageContextResponseApplicationJson_Ocs([
-    final void Function(ChatGetMessageContextResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatGetMessageContextResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatGetMessageContextResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -16273,7 +16257,7 @@ abstract class ChatGetMessageContextResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatGetMessageContextResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatGetMessageContextResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16295,7 +16279,7 @@ abstract class ChatGetMessageContextResponseApplicationJson
         $ChatGetMessageContextResponseApplicationJsonInterface,
         Built<ChatGetMessageContextResponseApplicationJson, ChatGetMessageContextResponseApplicationJsonBuilder> {
   factory ChatGetMessageContextResponseApplicationJson([
-    final void Function(ChatGetMessageContextResponseApplicationJsonBuilder)? b,
+    void Function(ChatGetMessageContextResponseApplicationJsonBuilder)? b,
   ]) = _$ChatGetMessageContextResponseApplicationJson;
 
   // coverage:ignore-start
@@ -16303,7 +16287,7 @@ abstract class ChatGetMessageContextResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatGetMessageContextResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatGetMessageContextResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16324,7 +16308,7 @@ class ChatGetReminderApiVersion extends EnumClass {
   static BuiltSet<ChatGetReminderApiVersion> get values => _$chatGetReminderApiVersionValues;
   // coverage:ignore-end
 
-  static ChatGetReminderApiVersion valueOf(final String name) => _$valueOfChatGetReminderApiVersion(name);
+  static ChatGetReminderApiVersion valueOf(String name) => _$valueOfChatGetReminderApiVersion(name);
 
   static Serializer<ChatGetReminderApiVersion> get serializer => _$chatGetReminderApiVersionSerializer;
 }
@@ -16338,14 +16322,14 @@ abstract interface class $ChatReminderInterface {
 }
 
 abstract class ChatReminder implements $ChatReminderInterface, Built<ChatReminder, ChatReminderBuilder> {
-  factory ChatReminder([final void Function(ChatReminderBuilder)? b]) = _$ChatReminder;
+  factory ChatReminder([void Function(ChatReminderBuilder)? b]) = _$ChatReminder;
 
   // coverage:ignore-start
   const ChatReminder._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatReminder.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ChatReminder.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -16366,7 +16350,7 @@ abstract class ChatGetReminderResponseApplicationJson_Ocs
         $ChatGetReminderResponseApplicationJson_OcsInterface,
         Built<ChatGetReminderResponseApplicationJson_Ocs, ChatGetReminderResponseApplicationJson_OcsBuilder> {
   factory ChatGetReminderResponseApplicationJson_Ocs([
-    final void Function(ChatGetReminderResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatGetReminderResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatGetReminderResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -16374,7 +16358,7 @@ abstract class ChatGetReminderResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatGetReminderResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatGetReminderResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16395,16 +16379,15 @@ abstract class ChatGetReminderResponseApplicationJson
     implements
         $ChatGetReminderResponseApplicationJsonInterface,
         Built<ChatGetReminderResponseApplicationJson, ChatGetReminderResponseApplicationJsonBuilder> {
-  factory ChatGetReminderResponseApplicationJson([
-    final void Function(ChatGetReminderResponseApplicationJsonBuilder)? b,
-  ]) = _$ChatGetReminderResponseApplicationJson;
+  factory ChatGetReminderResponseApplicationJson([void Function(ChatGetReminderResponseApplicationJsonBuilder)? b]) =
+      _$ChatGetReminderResponseApplicationJson;
 
   // coverage:ignore-start
   const ChatGetReminderResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatGetReminderResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatGetReminderResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16425,7 +16408,7 @@ class ChatSetReminderApiVersion extends EnumClass {
   static BuiltSet<ChatSetReminderApiVersion> get values => _$chatSetReminderApiVersionValues;
   // coverage:ignore-end
 
-  static ChatSetReminderApiVersion valueOf(final String name) => _$valueOfChatSetReminderApiVersion(name);
+  static ChatSetReminderApiVersion valueOf(String name) => _$valueOfChatSetReminderApiVersion(name);
 
   static Serializer<ChatSetReminderApiVersion> get serializer => _$chatSetReminderApiVersionSerializer;
 }
@@ -16441,7 +16424,7 @@ abstract class ChatSetReminderResponseApplicationJson_Ocs
         $ChatSetReminderResponseApplicationJson_OcsInterface,
         Built<ChatSetReminderResponseApplicationJson_Ocs, ChatSetReminderResponseApplicationJson_OcsBuilder> {
   factory ChatSetReminderResponseApplicationJson_Ocs([
-    final void Function(ChatSetReminderResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatSetReminderResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatSetReminderResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -16449,7 +16432,7 @@ abstract class ChatSetReminderResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatSetReminderResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatSetReminderResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16470,16 +16453,15 @@ abstract class ChatSetReminderResponseApplicationJson
     implements
         $ChatSetReminderResponseApplicationJsonInterface,
         Built<ChatSetReminderResponseApplicationJson, ChatSetReminderResponseApplicationJsonBuilder> {
-  factory ChatSetReminderResponseApplicationJson([
-    final void Function(ChatSetReminderResponseApplicationJsonBuilder)? b,
-  ]) = _$ChatSetReminderResponseApplicationJson;
+  factory ChatSetReminderResponseApplicationJson([void Function(ChatSetReminderResponseApplicationJsonBuilder)? b]) =
+      _$ChatSetReminderResponseApplicationJson;
 
   // coverage:ignore-start
   const ChatSetReminderResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatSetReminderResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatSetReminderResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16500,7 +16482,7 @@ class ChatDeleteReminderApiVersion extends EnumClass {
   static BuiltSet<ChatDeleteReminderApiVersion> get values => _$chatDeleteReminderApiVersionValues;
   // coverage:ignore-end
 
-  static ChatDeleteReminderApiVersion valueOf(final String name) => _$valueOfChatDeleteReminderApiVersion(name);
+  static ChatDeleteReminderApiVersion valueOf(String name) => _$valueOfChatDeleteReminderApiVersion(name);
 
   static Serializer<ChatDeleteReminderApiVersion> get serializer => _$chatDeleteReminderApiVersionSerializer;
 }
@@ -16516,7 +16498,7 @@ abstract class ChatDeleteReminderResponseApplicationJson_Ocs
         $ChatDeleteReminderResponseApplicationJson_OcsInterface,
         Built<ChatDeleteReminderResponseApplicationJson_Ocs, ChatDeleteReminderResponseApplicationJson_OcsBuilder> {
   factory ChatDeleteReminderResponseApplicationJson_Ocs([
-    final void Function(ChatDeleteReminderResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatDeleteReminderResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatDeleteReminderResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -16524,7 +16506,7 @@ abstract class ChatDeleteReminderResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatDeleteReminderResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatDeleteReminderResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16546,7 +16528,7 @@ abstract class ChatDeleteReminderResponseApplicationJson
         $ChatDeleteReminderResponseApplicationJsonInterface,
         Built<ChatDeleteReminderResponseApplicationJson, ChatDeleteReminderResponseApplicationJsonBuilder> {
   factory ChatDeleteReminderResponseApplicationJson([
-    final void Function(ChatDeleteReminderResponseApplicationJsonBuilder)? b,
+    void Function(ChatDeleteReminderResponseApplicationJsonBuilder)? b,
   ]) = _$ChatDeleteReminderResponseApplicationJson;
 
   // coverage:ignore-start
@@ -16554,7 +16536,7 @@ abstract class ChatDeleteReminderResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatDeleteReminderResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatDeleteReminderResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16575,7 +16557,7 @@ class ChatSetReadMarkerApiVersion extends EnumClass {
   static BuiltSet<ChatSetReadMarkerApiVersion> get values => _$chatSetReadMarkerApiVersionValues;
   // coverage:ignore-end
 
-  static ChatSetReadMarkerApiVersion valueOf(final String name) => _$valueOfChatSetReadMarkerApiVersion(name);
+  static ChatSetReadMarkerApiVersion valueOf(String name) => _$valueOfChatSetReadMarkerApiVersion(name);
 
   static Serializer<ChatSetReadMarkerApiVersion> get serializer => _$chatSetReadMarkerApiVersionSerializer;
 }
@@ -16590,7 +16572,7 @@ abstract class ChatChatSetReadMarkerHeaders
     implements
         $ChatChatSetReadMarkerHeadersInterface,
         Built<ChatChatSetReadMarkerHeaders, ChatChatSetReadMarkerHeadersBuilder> {
-  factory ChatChatSetReadMarkerHeaders([final void Function(ChatChatSetReadMarkerHeadersBuilder)? b]) =
+  factory ChatChatSetReadMarkerHeaders([void Function(ChatChatSetReadMarkerHeadersBuilder)? b]) =
       _$ChatChatSetReadMarkerHeaders;
 
   // coverage:ignore-start
@@ -16598,7 +16580,7 @@ abstract class ChatChatSetReadMarkerHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatChatSetReadMarkerHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory ChatChatSetReadMarkerHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16620,7 +16602,7 @@ abstract class ChatSetReadMarkerResponseApplicationJson_Ocs
         $ChatSetReadMarkerResponseApplicationJson_OcsInterface,
         Built<ChatSetReadMarkerResponseApplicationJson_Ocs, ChatSetReadMarkerResponseApplicationJson_OcsBuilder> {
   factory ChatSetReadMarkerResponseApplicationJson_Ocs([
-    final void Function(ChatSetReadMarkerResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatSetReadMarkerResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatSetReadMarkerResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -16628,7 +16610,7 @@ abstract class ChatSetReadMarkerResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatSetReadMarkerResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatSetReadMarkerResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16650,7 +16632,7 @@ abstract class ChatSetReadMarkerResponseApplicationJson
         $ChatSetReadMarkerResponseApplicationJsonInterface,
         Built<ChatSetReadMarkerResponseApplicationJson, ChatSetReadMarkerResponseApplicationJsonBuilder> {
   factory ChatSetReadMarkerResponseApplicationJson([
-    final void Function(ChatSetReadMarkerResponseApplicationJsonBuilder)? b,
+    void Function(ChatSetReadMarkerResponseApplicationJsonBuilder)? b,
   ]) = _$ChatSetReadMarkerResponseApplicationJson;
 
   // coverage:ignore-start
@@ -16658,7 +16640,7 @@ abstract class ChatSetReadMarkerResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatSetReadMarkerResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatSetReadMarkerResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16679,7 +16661,7 @@ class ChatMarkUnreadApiVersion extends EnumClass {
   static BuiltSet<ChatMarkUnreadApiVersion> get values => _$chatMarkUnreadApiVersionValues;
   // coverage:ignore-end
 
-  static ChatMarkUnreadApiVersion valueOf(final String name) => _$valueOfChatMarkUnreadApiVersion(name);
+  static ChatMarkUnreadApiVersion valueOf(String name) => _$valueOfChatMarkUnreadApiVersion(name);
 
   static Serializer<ChatMarkUnreadApiVersion> get serializer => _$chatMarkUnreadApiVersionSerializer;
 }
@@ -16692,15 +16674,14 @@ abstract interface class $ChatChatMarkUnreadHeadersInterface {
 
 abstract class ChatChatMarkUnreadHeaders
     implements $ChatChatMarkUnreadHeadersInterface, Built<ChatChatMarkUnreadHeaders, ChatChatMarkUnreadHeadersBuilder> {
-  factory ChatChatMarkUnreadHeaders([final void Function(ChatChatMarkUnreadHeadersBuilder)? b]) =
-      _$ChatChatMarkUnreadHeaders;
+  factory ChatChatMarkUnreadHeaders([void Function(ChatChatMarkUnreadHeadersBuilder)? b]) = _$ChatChatMarkUnreadHeaders;
 
   // coverage:ignore-start
   const ChatChatMarkUnreadHeaders._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatChatMarkUnreadHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory ChatChatMarkUnreadHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16722,7 +16703,7 @@ abstract class ChatMarkUnreadResponseApplicationJson_Ocs
         $ChatMarkUnreadResponseApplicationJson_OcsInterface,
         Built<ChatMarkUnreadResponseApplicationJson_Ocs, ChatMarkUnreadResponseApplicationJson_OcsBuilder> {
   factory ChatMarkUnreadResponseApplicationJson_Ocs([
-    final void Function(ChatMarkUnreadResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatMarkUnreadResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatMarkUnreadResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -16730,7 +16711,7 @@ abstract class ChatMarkUnreadResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatMarkUnreadResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatMarkUnreadResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16751,16 +16732,15 @@ abstract class ChatMarkUnreadResponseApplicationJson
     implements
         $ChatMarkUnreadResponseApplicationJsonInterface,
         Built<ChatMarkUnreadResponseApplicationJson, ChatMarkUnreadResponseApplicationJsonBuilder> {
-  factory ChatMarkUnreadResponseApplicationJson([
-    final void Function(ChatMarkUnreadResponseApplicationJsonBuilder)? b,
-  ]) = _$ChatMarkUnreadResponseApplicationJson;
+  factory ChatMarkUnreadResponseApplicationJson([void Function(ChatMarkUnreadResponseApplicationJsonBuilder)? b]) =
+      _$ChatMarkUnreadResponseApplicationJson;
 
   // coverage:ignore-start
   const ChatMarkUnreadResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatMarkUnreadResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatMarkUnreadResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16781,7 +16761,7 @@ class ChatMentionsApiVersion extends EnumClass {
   static BuiltSet<ChatMentionsApiVersion> get values => _$chatMentionsApiVersionValues;
   // coverage:ignore-end
 
-  static ChatMentionsApiVersion valueOf(final String name) => _$valueOfChatMentionsApiVersion(name);
+  static ChatMentionsApiVersion valueOf(String name) => _$valueOfChatMentionsApiVersion(name);
 
   static Serializer<ChatMentionsApiVersion> get serializer => _$chatMentionsApiVersionSerializer;
 }
@@ -16799,14 +16779,14 @@ abstract interface class $ChatMentionSuggestionInterface {
 
 abstract class ChatMentionSuggestion
     implements $ChatMentionSuggestionInterface, Built<ChatMentionSuggestion, ChatMentionSuggestionBuilder> {
-  factory ChatMentionSuggestion([final void Function(ChatMentionSuggestionBuilder)? b]) = _$ChatMentionSuggestion;
+  factory ChatMentionSuggestion([void Function(ChatMentionSuggestionBuilder)? b]) = _$ChatMentionSuggestion;
 
   // coverage:ignore-start
   const ChatMentionSuggestion._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatMentionSuggestion.fromJson(final Map<String, dynamic> json) =>
+  factory ChatMentionSuggestion.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16827,16 +16807,15 @@ abstract class ChatMentionsResponseApplicationJson_Ocs
     implements
         $ChatMentionsResponseApplicationJson_OcsInterface,
         Built<ChatMentionsResponseApplicationJson_Ocs, ChatMentionsResponseApplicationJson_OcsBuilder> {
-  factory ChatMentionsResponseApplicationJson_Ocs([
-    final void Function(ChatMentionsResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$ChatMentionsResponseApplicationJson_Ocs;
+  factory ChatMentionsResponseApplicationJson_Ocs([void Function(ChatMentionsResponseApplicationJson_OcsBuilder)? b]) =
+      _$ChatMentionsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const ChatMentionsResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatMentionsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatMentionsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16857,7 +16836,7 @@ abstract class ChatMentionsResponseApplicationJson
     implements
         $ChatMentionsResponseApplicationJsonInterface,
         Built<ChatMentionsResponseApplicationJson, ChatMentionsResponseApplicationJsonBuilder> {
-  factory ChatMentionsResponseApplicationJson([final void Function(ChatMentionsResponseApplicationJsonBuilder)? b]) =
+  factory ChatMentionsResponseApplicationJson([void Function(ChatMentionsResponseApplicationJsonBuilder)? b]) =
       _$ChatMentionsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -16865,7 +16844,7 @@ abstract class ChatMentionsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatMentionsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatMentionsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16886,7 +16865,7 @@ class ChatGetObjectsSharedInRoomApiVersion extends EnumClass {
   static BuiltSet<ChatGetObjectsSharedInRoomApiVersion> get values => _$chatGetObjectsSharedInRoomApiVersionValues;
   // coverage:ignore-end
 
-  static ChatGetObjectsSharedInRoomApiVersion valueOf(final String name) =>
+  static ChatGetObjectsSharedInRoomApiVersion valueOf(String name) =>
       _$valueOfChatGetObjectsSharedInRoomApiVersion(name);
 
   static Serializer<ChatGetObjectsSharedInRoomApiVersion> get serializer =>
@@ -16903,16 +16882,15 @@ abstract class ChatChatGetObjectsSharedInRoomHeaders
     implements
         $ChatChatGetObjectsSharedInRoomHeadersInterface,
         Built<ChatChatGetObjectsSharedInRoomHeaders, ChatChatGetObjectsSharedInRoomHeadersBuilder> {
-  factory ChatChatGetObjectsSharedInRoomHeaders([
-    final void Function(ChatChatGetObjectsSharedInRoomHeadersBuilder)? b,
-  ]) = _$ChatChatGetObjectsSharedInRoomHeaders;
+  factory ChatChatGetObjectsSharedInRoomHeaders([void Function(ChatChatGetObjectsSharedInRoomHeadersBuilder)? b]) =
+      _$ChatChatGetObjectsSharedInRoomHeaders;
 
   // coverage:ignore-start
   const ChatChatGetObjectsSharedInRoomHeaders._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatChatGetObjectsSharedInRoomHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory ChatChatGetObjectsSharedInRoomHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16936,7 +16914,7 @@ abstract class ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs
         Built<ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs,
             ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder> {
   factory ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs([
-    final void Function(ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -16944,7 +16922,7 @@ abstract class ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16967,7 +16945,7 @@ abstract class ChatGetObjectsSharedInRoomResponseApplicationJson
         Built<ChatGetObjectsSharedInRoomResponseApplicationJson,
             ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder> {
   factory ChatGetObjectsSharedInRoomResponseApplicationJson([
-    final void Function(ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder)? b,
+    void Function(ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder)? b,
   ]) = _$ChatGetObjectsSharedInRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -16975,7 +16953,7 @@ abstract class ChatGetObjectsSharedInRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatGetObjectsSharedInRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatGetObjectsSharedInRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -16996,7 +16974,7 @@ class ChatShareObjectToChatApiVersion extends EnumClass {
   static BuiltSet<ChatShareObjectToChatApiVersion> get values => _$chatShareObjectToChatApiVersionValues;
   // coverage:ignore-end
 
-  static ChatShareObjectToChatApiVersion valueOf(final String name) => _$valueOfChatShareObjectToChatApiVersion(name);
+  static ChatShareObjectToChatApiVersion valueOf(String name) => _$valueOfChatShareObjectToChatApiVersion(name);
 
   static Serializer<ChatShareObjectToChatApiVersion> get serializer => _$chatShareObjectToChatApiVersionSerializer;
 }
@@ -17011,7 +16989,7 @@ abstract class ChatChatShareObjectToChatHeaders
     implements
         $ChatChatShareObjectToChatHeadersInterface,
         Built<ChatChatShareObjectToChatHeaders, ChatChatShareObjectToChatHeadersBuilder> {
-  factory ChatChatShareObjectToChatHeaders([final void Function(ChatChatShareObjectToChatHeadersBuilder)? b]) =
+  factory ChatChatShareObjectToChatHeaders([void Function(ChatChatShareObjectToChatHeadersBuilder)? b]) =
       _$ChatChatShareObjectToChatHeaders;
 
   // coverage:ignore-start
@@ -17019,7 +16997,7 @@ abstract class ChatChatShareObjectToChatHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatChatShareObjectToChatHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory ChatChatShareObjectToChatHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17042,7 +17020,7 @@ abstract class ChatShareObjectToChatResponseApplicationJson_Ocs
         Built<ChatShareObjectToChatResponseApplicationJson_Ocs,
             ChatShareObjectToChatResponseApplicationJson_OcsBuilder> {
   factory ChatShareObjectToChatResponseApplicationJson_Ocs([
-    final void Function(ChatShareObjectToChatResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatShareObjectToChatResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatShareObjectToChatResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -17050,7 +17028,7 @@ abstract class ChatShareObjectToChatResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatShareObjectToChatResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatShareObjectToChatResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17072,7 +17050,7 @@ abstract class ChatShareObjectToChatResponseApplicationJson
         $ChatShareObjectToChatResponseApplicationJsonInterface,
         Built<ChatShareObjectToChatResponseApplicationJson, ChatShareObjectToChatResponseApplicationJsonBuilder> {
   factory ChatShareObjectToChatResponseApplicationJson([
-    final void Function(ChatShareObjectToChatResponseApplicationJsonBuilder)? b,
+    void Function(ChatShareObjectToChatResponseApplicationJsonBuilder)? b,
   ]) = _$ChatShareObjectToChatResponseApplicationJson;
 
   // coverage:ignore-start
@@ -17080,7 +17058,7 @@ abstract class ChatShareObjectToChatResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatShareObjectToChatResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatShareObjectToChatResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17102,7 +17080,7 @@ class ChatGetObjectsSharedInRoomOverviewApiVersion extends EnumClass {
       _$chatGetObjectsSharedInRoomOverviewApiVersionValues;
   // coverage:ignore-end
 
-  static ChatGetObjectsSharedInRoomOverviewApiVersion valueOf(final String name) =>
+  static ChatGetObjectsSharedInRoomOverviewApiVersion valueOf(String name) =>
       _$valueOfChatGetObjectsSharedInRoomOverviewApiVersion(name);
 
   static Serializer<ChatGetObjectsSharedInRoomOverviewApiVersion> get serializer =>
@@ -17121,7 +17099,7 @@ abstract class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs
         Built<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs,
             ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder> {
   factory ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs([
-    final void Function(ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder)? b,
+    void Function(ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -17129,7 +17107,7 @@ abstract class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17152,7 +17130,7 @@ abstract class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson
         Built<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson,
             ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder> {
   factory ChatGetObjectsSharedInRoomOverviewResponseApplicationJson([
-    final void Function(ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder)? b,
+    void Function(ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder)? b,
   ]) = _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson;
 
   // coverage:ignore-start
@@ -17160,7 +17138,7 @@ abstract class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ChatGetObjectsSharedInRoomOverviewResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ChatGetObjectsSharedInRoomOverviewResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17181,7 +17159,7 @@ class FederationAcceptShareApiVersion extends EnumClass {
   static BuiltSet<FederationAcceptShareApiVersion> get values => _$federationAcceptShareApiVersionValues;
   // coverage:ignore-end
 
-  static FederationAcceptShareApiVersion valueOf(final String name) => _$valueOfFederationAcceptShareApiVersion(name);
+  static FederationAcceptShareApiVersion valueOf(String name) => _$valueOfFederationAcceptShareApiVersion(name);
 
   static Serializer<FederationAcceptShareApiVersion> get serializer => _$federationAcceptShareApiVersionSerializer;
 }
@@ -17198,7 +17176,7 @@ abstract class FederationAcceptShareResponseApplicationJson_Ocs
         Built<FederationAcceptShareResponseApplicationJson_Ocs,
             FederationAcceptShareResponseApplicationJson_OcsBuilder> {
   factory FederationAcceptShareResponseApplicationJson_Ocs([
-    final void Function(FederationAcceptShareResponseApplicationJson_OcsBuilder)? b,
+    void Function(FederationAcceptShareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$FederationAcceptShareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -17206,7 +17184,7 @@ abstract class FederationAcceptShareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FederationAcceptShareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory FederationAcceptShareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17228,7 +17206,7 @@ abstract class FederationAcceptShareResponseApplicationJson
         $FederationAcceptShareResponseApplicationJsonInterface,
         Built<FederationAcceptShareResponseApplicationJson, FederationAcceptShareResponseApplicationJsonBuilder> {
   factory FederationAcceptShareResponseApplicationJson([
-    final void Function(FederationAcceptShareResponseApplicationJsonBuilder)? b,
+    void Function(FederationAcceptShareResponseApplicationJsonBuilder)? b,
   ]) = _$FederationAcceptShareResponseApplicationJson;
 
   // coverage:ignore-start
@@ -17236,7 +17214,7 @@ abstract class FederationAcceptShareResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FederationAcceptShareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory FederationAcceptShareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17257,7 +17235,7 @@ class FederationRejectShareApiVersion extends EnumClass {
   static BuiltSet<FederationRejectShareApiVersion> get values => _$federationRejectShareApiVersionValues;
   // coverage:ignore-end
 
-  static FederationRejectShareApiVersion valueOf(final String name) => _$valueOfFederationRejectShareApiVersion(name);
+  static FederationRejectShareApiVersion valueOf(String name) => _$valueOfFederationRejectShareApiVersion(name);
 
   static Serializer<FederationRejectShareApiVersion> get serializer => _$federationRejectShareApiVersionSerializer;
 }
@@ -17274,7 +17252,7 @@ abstract class FederationRejectShareResponseApplicationJson_Ocs
         Built<FederationRejectShareResponseApplicationJson_Ocs,
             FederationRejectShareResponseApplicationJson_OcsBuilder> {
   factory FederationRejectShareResponseApplicationJson_Ocs([
-    final void Function(FederationRejectShareResponseApplicationJson_OcsBuilder)? b,
+    void Function(FederationRejectShareResponseApplicationJson_OcsBuilder)? b,
   ]) = _$FederationRejectShareResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -17282,7 +17260,7 @@ abstract class FederationRejectShareResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FederationRejectShareResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory FederationRejectShareResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17304,7 +17282,7 @@ abstract class FederationRejectShareResponseApplicationJson
         $FederationRejectShareResponseApplicationJsonInterface,
         Built<FederationRejectShareResponseApplicationJson, FederationRejectShareResponseApplicationJsonBuilder> {
   factory FederationRejectShareResponseApplicationJson([
-    final void Function(FederationRejectShareResponseApplicationJsonBuilder)? b,
+    void Function(FederationRejectShareResponseApplicationJsonBuilder)? b,
   ]) = _$FederationRejectShareResponseApplicationJson;
 
   // coverage:ignore-start
@@ -17312,7 +17290,7 @@ abstract class FederationRejectShareResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FederationRejectShareResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory FederationRejectShareResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17333,7 +17311,7 @@ class FederationGetSharesApiVersion extends EnumClass {
   static BuiltSet<FederationGetSharesApiVersion> get values => _$federationGetSharesApiVersionValues;
   // coverage:ignore-end
 
-  static FederationGetSharesApiVersion valueOf(final String name) => _$valueOfFederationGetSharesApiVersion(name);
+  static FederationGetSharesApiVersion valueOf(String name) => _$valueOfFederationGetSharesApiVersion(name);
 
   static Serializer<FederationGetSharesApiVersion> get serializer => _$federationGetSharesApiVersionSerializer;
 }
@@ -17357,15 +17335,14 @@ abstract interface class $FederationInviteInterface {
 
 abstract class FederationInvite
     implements $FederationInviteInterface, Built<FederationInvite, FederationInviteBuilder> {
-  factory FederationInvite([final void Function(FederationInviteBuilder)? b]) = _$FederationInvite;
+  factory FederationInvite([void Function(FederationInviteBuilder)? b]) = _$FederationInvite;
 
   // coverage:ignore-start
   const FederationInvite._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FederationInvite.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory FederationInvite.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -17386,7 +17363,7 @@ abstract class FederationGetSharesResponseApplicationJson_Ocs
         $FederationGetSharesResponseApplicationJson_OcsInterface,
         Built<FederationGetSharesResponseApplicationJson_Ocs, FederationGetSharesResponseApplicationJson_OcsBuilder> {
   factory FederationGetSharesResponseApplicationJson_Ocs([
-    final void Function(FederationGetSharesResponseApplicationJson_OcsBuilder)? b,
+    void Function(FederationGetSharesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$FederationGetSharesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -17394,7 +17371,7 @@ abstract class FederationGetSharesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FederationGetSharesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory FederationGetSharesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17416,7 +17393,7 @@ abstract class FederationGetSharesResponseApplicationJson
         $FederationGetSharesResponseApplicationJsonInterface,
         Built<FederationGetSharesResponseApplicationJson, FederationGetSharesResponseApplicationJsonBuilder> {
   factory FederationGetSharesResponseApplicationJson([
-    final void Function(FederationGetSharesResponseApplicationJsonBuilder)? b,
+    void Function(FederationGetSharesResponseApplicationJsonBuilder)? b,
   ]) = _$FederationGetSharesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -17424,7 +17401,7 @@ abstract class FederationGetSharesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FederationGetSharesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory FederationGetSharesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17446,7 +17423,7 @@ class FilesIntegrationGetRoomByFileIdApiVersion extends EnumClass {
       _$filesIntegrationGetRoomByFileIdApiVersionValues;
   // coverage:ignore-end
 
-  static FilesIntegrationGetRoomByFileIdApiVersion valueOf(final String name) =>
+  static FilesIntegrationGetRoomByFileIdApiVersion valueOf(String name) =>
       _$valueOfFilesIntegrationGetRoomByFileIdApiVersion(name);
 
   static Serializer<FilesIntegrationGetRoomByFileIdApiVersion> get serializer =>
@@ -17464,7 +17441,7 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data
         Built<FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data,
             FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder> {
   factory FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data([
-    final void Function(FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -17472,7 +17449,7 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17496,7 +17473,7 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs
         Built<FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs,
             FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder> {
   factory FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs([
-    final void Function(FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder)? b,
+    void Function(FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder)? b,
   ]) = _$FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -17504,7 +17481,7 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17527,7 +17504,7 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson
         Built<FilesIntegrationGetRoomByFileIdResponseApplicationJson,
             FilesIntegrationGetRoomByFileIdResponseApplicationJsonBuilder> {
   factory FilesIntegrationGetRoomByFileIdResponseApplicationJson([
-    final void Function(FilesIntegrationGetRoomByFileIdResponseApplicationJsonBuilder)? b,
+    void Function(FilesIntegrationGetRoomByFileIdResponseApplicationJsonBuilder)? b,
   ]) = _$FilesIntegrationGetRoomByFileIdResponseApplicationJson;
 
   // coverage:ignore-start
@@ -17535,7 +17512,7 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesIntegrationGetRoomByFileIdResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory FilesIntegrationGetRoomByFileIdResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17557,7 +17534,7 @@ class FilesIntegrationGetRoomByShareTokenApiVersion extends EnumClass {
       _$filesIntegrationGetRoomByShareTokenApiVersionValues;
   // coverage:ignore-end
 
-  static FilesIntegrationGetRoomByShareTokenApiVersion valueOf(final String name) =>
+  static FilesIntegrationGetRoomByShareTokenApiVersion valueOf(String name) =>
       _$valueOfFilesIntegrationGetRoomByShareTokenApiVersion(name);
 
   static Serializer<FilesIntegrationGetRoomByShareTokenApiVersion> get serializer =>
@@ -17577,7 +17554,7 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Da
         Built<FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data,
             FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder> {
   factory FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data([
-    final void Function(FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -17585,9 +17562,7 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Da
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data.fromJson(
-    final Map<String, dynamic> json,
-  ) =>
+  factory FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17611,7 +17586,7 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs
         Built<FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs,
             FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder> {
   factory FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs([
-    final void Function(FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder)? b,
+    void Function(FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder)? b,
   ]) = _$FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -17619,7 +17594,7 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17642,7 +17617,7 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson
         Built<FilesIntegrationGetRoomByShareTokenResponseApplicationJson,
             FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder> {
   factory FilesIntegrationGetRoomByShareTokenResponseApplicationJson([
-    final void Function(FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder)? b,
+    void Function(FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder)? b,
   ]) = _$FilesIntegrationGetRoomByShareTokenResponseApplicationJson;
 
   // coverage:ignore-start
@@ -17650,7 +17625,7 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory FilesIntegrationGetRoomByShareTokenResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory FilesIntegrationGetRoomByShareTokenResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17671,7 +17646,7 @@ class GuestSetDisplayNameApiVersion extends EnumClass {
   static BuiltSet<GuestSetDisplayNameApiVersion> get values => _$guestSetDisplayNameApiVersionValues;
   // coverage:ignore-end
 
-  static GuestSetDisplayNameApiVersion valueOf(final String name) => _$valueOfGuestSetDisplayNameApiVersion(name);
+  static GuestSetDisplayNameApiVersion valueOf(String name) => _$valueOfGuestSetDisplayNameApiVersion(name);
 
   static Serializer<GuestSetDisplayNameApiVersion> get serializer => _$guestSetDisplayNameApiVersionSerializer;
 }
@@ -17687,7 +17662,7 @@ abstract class GuestSetDisplayNameResponseApplicationJson_Ocs
         $GuestSetDisplayNameResponseApplicationJson_OcsInterface,
         Built<GuestSetDisplayNameResponseApplicationJson_Ocs, GuestSetDisplayNameResponseApplicationJson_OcsBuilder> {
   factory GuestSetDisplayNameResponseApplicationJson_Ocs([
-    final void Function(GuestSetDisplayNameResponseApplicationJson_OcsBuilder)? b,
+    void Function(GuestSetDisplayNameResponseApplicationJson_OcsBuilder)? b,
   ]) = _$GuestSetDisplayNameResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -17695,7 +17670,7 @@ abstract class GuestSetDisplayNameResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GuestSetDisplayNameResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory GuestSetDisplayNameResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17717,7 +17692,7 @@ abstract class GuestSetDisplayNameResponseApplicationJson
         $GuestSetDisplayNameResponseApplicationJsonInterface,
         Built<GuestSetDisplayNameResponseApplicationJson, GuestSetDisplayNameResponseApplicationJsonBuilder> {
   factory GuestSetDisplayNameResponseApplicationJson([
-    final void Function(GuestSetDisplayNameResponseApplicationJsonBuilder)? b,
+    void Function(GuestSetDisplayNameResponseApplicationJsonBuilder)? b,
   ]) = _$GuestSetDisplayNameResponseApplicationJson;
 
   // coverage:ignore-start
@@ -17725,7 +17700,7 @@ abstract class GuestSetDisplayNameResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GuestSetDisplayNameResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GuestSetDisplayNameResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17747,7 +17722,7 @@ class HostedSignalingServerRequestTrialApiVersion extends EnumClass {
       _$hostedSignalingServerRequestTrialApiVersionValues;
   // coverage:ignore-end
 
-  static HostedSignalingServerRequestTrialApiVersion valueOf(final String name) =>
+  static HostedSignalingServerRequestTrialApiVersion valueOf(String name) =>
       _$valueOfHostedSignalingServerRequestTrialApiVersion(name);
 
   static Serializer<HostedSignalingServerRequestTrialApiVersion> get serializer =>
@@ -17766,7 +17741,7 @@ abstract class HostedSignalingServerRequestTrialResponseApplicationJson_Ocs
         Built<HostedSignalingServerRequestTrialResponseApplicationJson_Ocs,
             HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder> {
   factory HostedSignalingServerRequestTrialResponseApplicationJson_Ocs([
-    final void Function(HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder)? b,
+    void Function(HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder)? b,
   ]) = _$HostedSignalingServerRequestTrialResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -17774,7 +17749,7 @@ abstract class HostedSignalingServerRequestTrialResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory HostedSignalingServerRequestTrialResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory HostedSignalingServerRequestTrialResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17797,7 +17772,7 @@ abstract class HostedSignalingServerRequestTrialResponseApplicationJson
         Built<HostedSignalingServerRequestTrialResponseApplicationJson,
             HostedSignalingServerRequestTrialResponseApplicationJsonBuilder> {
   factory HostedSignalingServerRequestTrialResponseApplicationJson([
-    final void Function(HostedSignalingServerRequestTrialResponseApplicationJsonBuilder)? b,
+    void Function(HostedSignalingServerRequestTrialResponseApplicationJsonBuilder)? b,
   ]) = _$HostedSignalingServerRequestTrialResponseApplicationJson;
 
   // coverage:ignore-start
@@ -17805,7 +17780,7 @@ abstract class HostedSignalingServerRequestTrialResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory HostedSignalingServerRequestTrialResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory HostedSignalingServerRequestTrialResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17827,7 +17802,7 @@ class HostedSignalingServerDeleteAccountApiVersion extends EnumClass {
       _$hostedSignalingServerDeleteAccountApiVersionValues;
   // coverage:ignore-end
 
-  static HostedSignalingServerDeleteAccountApiVersion valueOf(final String name) =>
+  static HostedSignalingServerDeleteAccountApiVersion valueOf(String name) =>
       _$valueOfHostedSignalingServerDeleteAccountApiVersion(name);
 
   static Serializer<HostedSignalingServerDeleteAccountApiVersion> get serializer =>
@@ -17846,7 +17821,7 @@ abstract class HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs
         Built<HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs,
             HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder> {
   factory HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs([
-    final void Function(HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder)? b,
+    void Function(HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder)? b,
   ]) = _$HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -17854,7 +17829,7 @@ abstract class HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17877,7 +17852,7 @@ abstract class HostedSignalingServerDeleteAccountResponseApplicationJson
         Built<HostedSignalingServerDeleteAccountResponseApplicationJson,
             HostedSignalingServerDeleteAccountResponseApplicationJsonBuilder> {
   factory HostedSignalingServerDeleteAccountResponseApplicationJson([
-    final void Function(HostedSignalingServerDeleteAccountResponseApplicationJsonBuilder)? b,
+    void Function(HostedSignalingServerDeleteAccountResponseApplicationJsonBuilder)? b,
   ]) = _$HostedSignalingServerDeleteAccountResponseApplicationJson;
 
   // coverage:ignore-start
@@ -17885,7 +17860,7 @@ abstract class HostedSignalingServerDeleteAccountResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory HostedSignalingServerDeleteAccountResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory HostedSignalingServerDeleteAccountResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17906,7 +17881,7 @@ class MatterbridgeGetBridgeOfRoomApiVersion extends EnumClass {
   static BuiltSet<MatterbridgeGetBridgeOfRoomApiVersion> get values => _$matterbridgeGetBridgeOfRoomApiVersionValues;
   // coverage:ignore-end
 
-  static MatterbridgeGetBridgeOfRoomApiVersion valueOf(final String name) =>
+  static MatterbridgeGetBridgeOfRoomApiVersion valueOf(String name) =>
       _$valueOfMatterbridgeGetBridgeOfRoomApiVersion(name);
 
   static Serializer<MatterbridgeGetBridgeOfRoomApiVersion> get serializer =>
@@ -17921,14 +17896,14 @@ abstract interface class $MatterbridgeInterface {
 }
 
 abstract class Matterbridge implements $MatterbridgeInterface, Built<Matterbridge, MatterbridgeBuilder> {
-  factory Matterbridge([final void Function(MatterbridgeBuilder)? b]) = _$Matterbridge;
+  factory Matterbridge([void Function(MatterbridgeBuilder)? b]) = _$Matterbridge;
 
   // coverage:ignore-start
   const Matterbridge._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Matterbridge.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Matterbridge.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -17946,15 +17921,14 @@ abstract interface class $MatterbridgeProcessStateInterface {
 
 abstract class MatterbridgeProcessState
     implements $MatterbridgeProcessStateInterface, Built<MatterbridgeProcessState, MatterbridgeProcessStateBuilder> {
-  factory MatterbridgeProcessState([final void Function(MatterbridgeProcessStateBuilder)? b]) =
-      _$MatterbridgeProcessState;
+  factory MatterbridgeProcessState([void Function(MatterbridgeProcessStateBuilder)? b]) = _$MatterbridgeProcessState;
 
   // coverage:ignore-start
   const MatterbridgeProcessState._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeProcessState.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeProcessState.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -17973,7 +17947,7 @@ abstract class MatterbridgeWithProcessState
     implements
         $MatterbridgeWithProcessStateInterface,
         Built<MatterbridgeWithProcessState, MatterbridgeWithProcessStateBuilder> {
-  factory MatterbridgeWithProcessState([final void Function(MatterbridgeWithProcessStateBuilder)? b]) =
+  factory MatterbridgeWithProcessState([void Function(MatterbridgeWithProcessStateBuilder)? b]) =
       _$MatterbridgeWithProcessState;
 
   // coverage:ignore-start
@@ -17981,7 +17955,7 @@ abstract class MatterbridgeWithProcessState
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeWithProcessState.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeWithProcessState.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18004,7 +17978,7 @@ abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs
         Built<MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs,
             MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder> {
   factory MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs([
-    final void Function(MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -18012,7 +17986,7 @@ abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18035,7 +18009,7 @@ abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson
         Built<MatterbridgeGetBridgeOfRoomResponseApplicationJson,
             MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder> {
   factory MatterbridgeGetBridgeOfRoomResponseApplicationJson([
-    final void Function(MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder)? b,
+    void Function(MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder)? b,
   ]) = _$MatterbridgeGetBridgeOfRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -18043,7 +18017,7 @@ abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeGetBridgeOfRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeGetBridgeOfRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18064,7 +18038,7 @@ class MatterbridgeEditBridgeOfRoomApiVersion extends EnumClass {
   static BuiltSet<MatterbridgeEditBridgeOfRoomApiVersion> get values => _$matterbridgeEditBridgeOfRoomApiVersionValues;
   // coverage:ignore-end
 
-  static MatterbridgeEditBridgeOfRoomApiVersion valueOf(final String name) =>
+  static MatterbridgeEditBridgeOfRoomApiVersion valueOf(String name) =>
       _$valueOfMatterbridgeEditBridgeOfRoomApiVersion(name);
 
   static Serializer<MatterbridgeEditBridgeOfRoomApiVersion> get serializer =>
@@ -18083,7 +18057,7 @@ abstract class MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs
         Built<MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs,
             MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder> {
   factory MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs([
-    final void Function(MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -18091,7 +18065,7 @@ abstract class MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18114,7 +18088,7 @@ abstract class MatterbridgeEditBridgeOfRoomResponseApplicationJson
         Built<MatterbridgeEditBridgeOfRoomResponseApplicationJson,
             MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder> {
   factory MatterbridgeEditBridgeOfRoomResponseApplicationJson([
-    final void Function(MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder)? b,
+    void Function(MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder)? b,
   ]) = _$MatterbridgeEditBridgeOfRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -18122,7 +18096,7 @@ abstract class MatterbridgeEditBridgeOfRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeEditBridgeOfRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeEditBridgeOfRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18144,7 +18118,7 @@ class MatterbridgeDeleteBridgeOfRoomApiVersion extends EnumClass {
       _$matterbridgeDeleteBridgeOfRoomApiVersionValues;
   // coverage:ignore-end
 
-  static MatterbridgeDeleteBridgeOfRoomApiVersion valueOf(final String name) =>
+  static MatterbridgeDeleteBridgeOfRoomApiVersion valueOf(String name) =>
       _$valueOfMatterbridgeDeleteBridgeOfRoomApiVersion(name);
 
   static Serializer<MatterbridgeDeleteBridgeOfRoomApiVersion> get serializer =>
@@ -18163,7 +18137,7 @@ abstract class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs
         Built<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs,
             MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder> {
   factory MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs([
-    final void Function(MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -18171,7 +18145,7 @@ abstract class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18194,7 +18168,7 @@ abstract class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson
         Built<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson,
             MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonBuilder> {
   factory MatterbridgeDeleteBridgeOfRoomResponseApplicationJson([
-    final void Function(MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonBuilder)? b,
+    void Function(MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonBuilder)? b,
   ]) = _$MatterbridgeDeleteBridgeOfRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -18202,7 +18176,7 @@ abstract class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeDeleteBridgeOfRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeDeleteBridgeOfRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18224,7 +18198,7 @@ class MatterbridgeGetBridgeProcessStateApiVersion extends EnumClass {
       _$matterbridgeGetBridgeProcessStateApiVersionValues;
   // coverage:ignore-end
 
-  static MatterbridgeGetBridgeProcessStateApiVersion valueOf(final String name) =>
+  static MatterbridgeGetBridgeProcessStateApiVersion valueOf(String name) =>
       _$valueOfMatterbridgeGetBridgeProcessStateApiVersion(name);
 
   static Serializer<MatterbridgeGetBridgeProcessStateApiVersion> get serializer =>
@@ -18243,7 +18217,7 @@ abstract class MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs
         Built<MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs,
             MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder> {
   factory MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs([
-    final void Function(MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder)? b,
+    void Function(MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder)? b,
   ]) = _$MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -18251,7 +18225,7 @@ abstract class MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18274,7 +18248,7 @@ abstract class MatterbridgeGetBridgeProcessStateResponseApplicationJson
         Built<MatterbridgeGetBridgeProcessStateResponseApplicationJson,
             MatterbridgeGetBridgeProcessStateResponseApplicationJsonBuilder> {
   factory MatterbridgeGetBridgeProcessStateResponseApplicationJson([
-    final void Function(MatterbridgeGetBridgeProcessStateResponseApplicationJsonBuilder)? b,
+    void Function(MatterbridgeGetBridgeProcessStateResponseApplicationJsonBuilder)? b,
   ]) = _$MatterbridgeGetBridgeProcessStateResponseApplicationJson;
 
   // coverage:ignore-start
@@ -18282,7 +18256,7 @@ abstract class MatterbridgeGetBridgeProcessStateResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeGetBridgeProcessStateResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeGetBridgeProcessStateResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18304,7 +18278,7 @@ class MatterbridgeSettingsStopAllBridgesApiVersion extends EnumClass {
       _$matterbridgeSettingsStopAllBridgesApiVersionValues;
   // coverage:ignore-end
 
-  static MatterbridgeSettingsStopAllBridgesApiVersion valueOf(final String name) =>
+  static MatterbridgeSettingsStopAllBridgesApiVersion valueOf(String name) =>
       _$valueOfMatterbridgeSettingsStopAllBridgesApiVersion(name);
 
   static Serializer<MatterbridgeSettingsStopAllBridgesApiVersion> get serializer =>
@@ -18323,7 +18297,7 @@ abstract class MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs
         Built<MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs,
             MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder> {
   factory MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs([
-    final void Function(MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder)? b,
+    void Function(MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -18331,7 +18305,7 @@ abstract class MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18354,7 +18328,7 @@ abstract class MatterbridgeSettingsStopAllBridgesResponseApplicationJson
         Built<MatterbridgeSettingsStopAllBridgesResponseApplicationJson,
             MatterbridgeSettingsStopAllBridgesResponseApplicationJsonBuilder> {
   factory MatterbridgeSettingsStopAllBridgesResponseApplicationJson([
-    final void Function(MatterbridgeSettingsStopAllBridgesResponseApplicationJsonBuilder)? b,
+    void Function(MatterbridgeSettingsStopAllBridgesResponseApplicationJsonBuilder)? b,
   ]) = _$MatterbridgeSettingsStopAllBridgesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -18362,7 +18336,7 @@ abstract class MatterbridgeSettingsStopAllBridgesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeSettingsStopAllBridgesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeSettingsStopAllBridgesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18385,7 +18359,7 @@ class MatterbridgeSettingsGetMatterbridgeVersionApiVersion extends EnumClass {
       _$matterbridgeSettingsGetMatterbridgeVersionApiVersionValues;
   // coverage:ignore-end
 
-  static MatterbridgeSettingsGetMatterbridgeVersionApiVersion valueOf(final String name) =>
+  static MatterbridgeSettingsGetMatterbridgeVersionApiVersion valueOf(String name) =>
       _$valueOfMatterbridgeSettingsGetMatterbridgeVersionApiVersion(name);
 
   static Serializer<MatterbridgeSettingsGetMatterbridgeVersionApiVersion> get serializer =>
@@ -18403,7 +18377,7 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
         Built<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data,
             MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataBuilder> {
   factory MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data([
-    final void Function(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -18412,7 +18386,7 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
 
   // coverage:ignore-start
   factory MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data.fromJson(
-    final Map<String, dynamic> json,
+    Map<String, dynamic> json,
   ) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
@@ -18437,7 +18411,7 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
         Built<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs,
             MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuilder> {
   factory MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs([
-    final void Function(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuilder)? b,
+    void Function(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuilder)? b,
   ]) = _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -18445,9 +18419,7 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs.fromJson(
-    final Map<String, dynamic> json,
-  ) =>
+  factory MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18470,7 +18442,7 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
         Built<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson,
             MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder> {
   factory MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson([
-    final void Function(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder)? b,
+    void Function(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder)? b,
   ]) = _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson;
 
   // coverage:ignore-start
@@ -18478,7 +18450,7 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18499,7 +18471,7 @@ class PollCreatePollApiVersion extends EnumClass {
   static BuiltSet<PollCreatePollApiVersion> get values => _$pollCreatePollApiVersionValues;
   // coverage:ignore-end
 
-  static PollCreatePollApiVersion valueOf(final String name) => _$valueOfPollCreatePollApiVersion(name);
+  static PollCreatePollApiVersion valueOf(String name) => _$valueOfPollCreatePollApiVersion(name);
 
   static Serializer<PollCreatePollApiVersion> get serializer => _$pollCreatePollApiVersionSerializer;
 }
@@ -18513,14 +18485,14 @@ abstract interface class $PollVoteInterface {
 }
 
 abstract class PollVote implements $PollVoteInterface, Built<PollVote, PollVoteBuilder> {
-  factory PollVote([final void Function(PollVoteBuilder)? b]) = _$PollVote;
+  factory PollVote([void Function(PollVoteBuilder)? b]) = _$PollVote;
 
   // coverage:ignore-start
   const PollVote._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PollVote.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory PollVote.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -18548,14 +18520,14 @@ abstract interface class $PollInterface {
 }
 
 abstract class Poll implements $PollInterface, Built<Poll, PollBuilder> {
-  factory Poll([final void Function(PollBuilder)? b]) = _$Poll;
+  factory Poll([void Function(PollBuilder)? b]) = _$Poll;
 
   // coverage:ignore-start
   const Poll._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Poll.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Poll.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -18576,7 +18548,7 @@ abstract class PollCreatePollResponseApplicationJson_Ocs
         $PollCreatePollResponseApplicationJson_OcsInterface,
         Built<PollCreatePollResponseApplicationJson_Ocs, PollCreatePollResponseApplicationJson_OcsBuilder> {
   factory PollCreatePollResponseApplicationJson_Ocs([
-    final void Function(PollCreatePollResponseApplicationJson_OcsBuilder)? b,
+    void Function(PollCreatePollResponseApplicationJson_OcsBuilder)? b,
   ]) = _$PollCreatePollResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -18584,7 +18556,7 @@ abstract class PollCreatePollResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PollCreatePollResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PollCreatePollResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18605,16 +18577,15 @@ abstract class PollCreatePollResponseApplicationJson
     implements
         $PollCreatePollResponseApplicationJsonInterface,
         Built<PollCreatePollResponseApplicationJson, PollCreatePollResponseApplicationJsonBuilder> {
-  factory PollCreatePollResponseApplicationJson([
-    final void Function(PollCreatePollResponseApplicationJsonBuilder)? b,
-  ]) = _$PollCreatePollResponseApplicationJson;
+  factory PollCreatePollResponseApplicationJson([void Function(PollCreatePollResponseApplicationJsonBuilder)? b]) =
+      _$PollCreatePollResponseApplicationJson;
 
   // coverage:ignore-start
   const PollCreatePollResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PollCreatePollResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PollCreatePollResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18635,7 +18606,7 @@ class PollShowPollApiVersion extends EnumClass {
   static BuiltSet<PollShowPollApiVersion> get values => _$pollShowPollApiVersionValues;
   // coverage:ignore-end
 
-  static PollShowPollApiVersion valueOf(final String name) => _$valueOfPollShowPollApiVersion(name);
+  static PollShowPollApiVersion valueOf(String name) => _$valueOfPollShowPollApiVersion(name);
 
   static Serializer<PollShowPollApiVersion> get serializer => _$pollShowPollApiVersionSerializer;
 }
@@ -18650,16 +18621,15 @@ abstract class PollShowPollResponseApplicationJson_Ocs
     implements
         $PollShowPollResponseApplicationJson_OcsInterface,
         Built<PollShowPollResponseApplicationJson_Ocs, PollShowPollResponseApplicationJson_OcsBuilder> {
-  factory PollShowPollResponseApplicationJson_Ocs([
-    final void Function(PollShowPollResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$PollShowPollResponseApplicationJson_Ocs;
+  factory PollShowPollResponseApplicationJson_Ocs([void Function(PollShowPollResponseApplicationJson_OcsBuilder)? b]) =
+      _$PollShowPollResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const PollShowPollResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PollShowPollResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PollShowPollResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18680,7 +18650,7 @@ abstract class PollShowPollResponseApplicationJson
     implements
         $PollShowPollResponseApplicationJsonInterface,
         Built<PollShowPollResponseApplicationJson, PollShowPollResponseApplicationJsonBuilder> {
-  factory PollShowPollResponseApplicationJson([final void Function(PollShowPollResponseApplicationJsonBuilder)? b]) =
+  factory PollShowPollResponseApplicationJson([void Function(PollShowPollResponseApplicationJsonBuilder)? b]) =
       _$PollShowPollResponseApplicationJson;
 
   // coverage:ignore-start
@@ -18688,7 +18658,7 @@ abstract class PollShowPollResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PollShowPollResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PollShowPollResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18709,7 +18679,7 @@ class PollVotePollApiVersion extends EnumClass {
   static BuiltSet<PollVotePollApiVersion> get values => _$pollVotePollApiVersionValues;
   // coverage:ignore-end
 
-  static PollVotePollApiVersion valueOf(final String name) => _$valueOfPollVotePollApiVersion(name);
+  static PollVotePollApiVersion valueOf(String name) => _$valueOfPollVotePollApiVersion(name);
 
   static Serializer<PollVotePollApiVersion> get serializer => _$pollVotePollApiVersionSerializer;
 }
@@ -18724,16 +18694,15 @@ abstract class PollVotePollResponseApplicationJson_Ocs
     implements
         $PollVotePollResponseApplicationJson_OcsInterface,
         Built<PollVotePollResponseApplicationJson_Ocs, PollVotePollResponseApplicationJson_OcsBuilder> {
-  factory PollVotePollResponseApplicationJson_Ocs([
-    final void Function(PollVotePollResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$PollVotePollResponseApplicationJson_Ocs;
+  factory PollVotePollResponseApplicationJson_Ocs([void Function(PollVotePollResponseApplicationJson_OcsBuilder)? b]) =
+      _$PollVotePollResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const PollVotePollResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PollVotePollResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PollVotePollResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18754,7 +18723,7 @@ abstract class PollVotePollResponseApplicationJson
     implements
         $PollVotePollResponseApplicationJsonInterface,
         Built<PollVotePollResponseApplicationJson, PollVotePollResponseApplicationJsonBuilder> {
-  factory PollVotePollResponseApplicationJson([final void Function(PollVotePollResponseApplicationJsonBuilder)? b]) =
+  factory PollVotePollResponseApplicationJson([void Function(PollVotePollResponseApplicationJsonBuilder)? b]) =
       _$PollVotePollResponseApplicationJson;
 
   // coverage:ignore-start
@@ -18762,7 +18731,7 @@ abstract class PollVotePollResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PollVotePollResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PollVotePollResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18783,7 +18752,7 @@ class PollClosePollApiVersion extends EnumClass {
   static BuiltSet<PollClosePollApiVersion> get values => _$pollClosePollApiVersionValues;
   // coverage:ignore-end
 
-  static PollClosePollApiVersion valueOf(final String name) => _$valueOfPollClosePollApiVersion(name);
+  static PollClosePollApiVersion valueOf(String name) => _$valueOfPollClosePollApiVersion(name);
 
   static Serializer<PollClosePollApiVersion> get serializer => _$pollClosePollApiVersionSerializer;
 }
@@ -18799,7 +18768,7 @@ abstract class PollClosePollResponseApplicationJson_Ocs
         $PollClosePollResponseApplicationJson_OcsInterface,
         Built<PollClosePollResponseApplicationJson_Ocs, PollClosePollResponseApplicationJson_OcsBuilder> {
   factory PollClosePollResponseApplicationJson_Ocs([
-    final void Function(PollClosePollResponseApplicationJson_OcsBuilder)? b,
+    void Function(PollClosePollResponseApplicationJson_OcsBuilder)? b,
   ]) = _$PollClosePollResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -18807,7 +18776,7 @@ abstract class PollClosePollResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PollClosePollResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PollClosePollResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18828,7 +18797,7 @@ abstract class PollClosePollResponseApplicationJson
     implements
         $PollClosePollResponseApplicationJsonInterface,
         Built<PollClosePollResponseApplicationJson, PollClosePollResponseApplicationJsonBuilder> {
-  factory PollClosePollResponseApplicationJson([final void Function(PollClosePollResponseApplicationJsonBuilder)? b]) =
+  factory PollClosePollResponseApplicationJson([void Function(PollClosePollResponseApplicationJsonBuilder)? b]) =
       _$PollClosePollResponseApplicationJson;
 
   // coverage:ignore-start
@@ -18836,7 +18805,7 @@ abstract class PollClosePollResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PollClosePollResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PollClosePollResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18857,8 +18826,7 @@ class PublicShareAuthCreateRoomApiVersion extends EnumClass {
   static BuiltSet<PublicShareAuthCreateRoomApiVersion> get values => _$publicShareAuthCreateRoomApiVersionValues;
   // coverage:ignore-end
 
-  static PublicShareAuthCreateRoomApiVersion valueOf(final String name) =>
-      _$valueOfPublicShareAuthCreateRoomApiVersion(name);
+  static PublicShareAuthCreateRoomApiVersion valueOf(String name) => _$valueOfPublicShareAuthCreateRoomApiVersion(name);
 
   static Serializer<PublicShareAuthCreateRoomApiVersion> get serializer =>
       _$publicShareAuthCreateRoomApiVersionSerializer;
@@ -18877,7 +18845,7 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data
         Built<PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data,
             PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder> {
   factory PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data([
-    final void Function(PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -18885,7 +18853,7 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18909,7 +18877,7 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson_Ocs
         Built<PublicShareAuthCreateRoomResponseApplicationJson_Ocs,
             PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder> {
   factory PublicShareAuthCreateRoomResponseApplicationJson_Ocs([
-    final void Function(PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$PublicShareAuthCreateRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -18917,7 +18885,7 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicShareAuthCreateRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PublicShareAuthCreateRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18940,7 +18908,7 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson
         Built<PublicShareAuthCreateRoomResponseApplicationJson,
             PublicShareAuthCreateRoomResponseApplicationJsonBuilder> {
   factory PublicShareAuthCreateRoomResponseApplicationJson([
-    final void Function(PublicShareAuthCreateRoomResponseApplicationJsonBuilder)? b,
+    void Function(PublicShareAuthCreateRoomResponseApplicationJsonBuilder)? b,
   ]) = _$PublicShareAuthCreateRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -18948,7 +18916,7 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicShareAuthCreateRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PublicShareAuthCreateRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -18969,7 +18937,7 @@ class ReactionGetReactionsApiVersion extends EnumClass {
   static BuiltSet<ReactionGetReactionsApiVersion> get values => _$reactionGetReactionsApiVersionValues;
   // coverage:ignore-end
 
-  static ReactionGetReactionsApiVersion valueOf(final String name) => _$valueOfReactionGetReactionsApiVersion(name);
+  static ReactionGetReactionsApiVersion valueOf(String name) => _$valueOfReactionGetReactionsApiVersion(name);
 
   static Serializer<ReactionGetReactionsApiVersion> get serializer => _$reactionGetReactionsApiVersionSerializer;
 }
@@ -18983,14 +18951,14 @@ abstract interface class $ReactionInterface {
 }
 
 abstract class Reaction implements $ReactionInterface, Built<Reaction, ReactionBuilder> {
-  factory Reaction([final void Function(ReactionBuilder)? b]) = _$Reaction;
+  factory Reaction([void Function(ReactionBuilder)? b]) = _$Reaction;
 
   // coverage:ignore-start
   const Reaction._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Reaction.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Reaction.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -19011,7 +18979,7 @@ abstract class ReactionGetReactionsResponseApplicationJson_Ocs
         $ReactionGetReactionsResponseApplicationJson_OcsInterface,
         Built<ReactionGetReactionsResponseApplicationJson_Ocs, ReactionGetReactionsResponseApplicationJson_OcsBuilder> {
   factory ReactionGetReactionsResponseApplicationJson_Ocs([
-    final void Function(ReactionGetReactionsResponseApplicationJson_OcsBuilder)? b,
+    void Function(ReactionGetReactionsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ReactionGetReactionsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19019,7 +18987,7 @@ abstract class ReactionGetReactionsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReactionGetReactionsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ReactionGetReactionsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19041,7 +19009,7 @@ abstract class ReactionGetReactionsResponseApplicationJson
         $ReactionGetReactionsResponseApplicationJsonInterface,
         Built<ReactionGetReactionsResponseApplicationJson, ReactionGetReactionsResponseApplicationJsonBuilder> {
   factory ReactionGetReactionsResponseApplicationJson([
-    final void Function(ReactionGetReactionsResponseApplicationJsonBuilder)? b,
+    void Function(ReactionGetReactionsResponseApplicationJsonBuilder)? b,
   ]) = _$ReactionGetReactionsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -19049,7 +19017,7 @@ abstract class ReactionGetReactionsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReactionGetReactionsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ReactionGetReactionsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19070,7 +19038,7 @@ class ReactionReactApiVersion extends EnumClass {
   static BuiltSet<ReactionReactApiVersion> get values => _$reactionReactApiVersionValues;
   // coverage:ignore-end
 
-  static ReactionReactApiVersion valueOf(final String name) => _$valueOfReactionReactApiVersion(name);
+  static ReactionReactApiVersion valueOf(String name) => _$valueOfReactionReactApiVersion(name);
 
   static Serializer<ReactionReactApiVersion> get serializer => _$reactionReactApiVersionSerializer;
 }
@@ -19086,7 +19054,7 @@ abstract class ReactionReactResponseApplicationJson_Ocs
         $ReactionReactResponseApplicationJson_OcsInterface,
         Built<ReactionReactResponseApplicationJson_Ocs, ReactionReactResponseApplicationJson_OcsBuilder> {
   factory ReactionReactResponseApplicationJson_Ocs([
-    final void Function(ReactionReactResponseApplicationJson_OcsBuilder)? b,
+    void Function(ReactionReactResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ReactionReactResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19094,7 +19062,7 @@ abstract class ReactionReactResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReactionReactResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ReactionReactResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19115,7 +19083,7 @@ abstract class ReactionReactResponseApplicationJson
     implements
         $ReactionReactResponseApplicationJsonInterface,
         Built<ReactionReactResponseApplicationJson, ReactionReactResponseApplicationJsonBuilder> {
-  factory ReactionReactResponseApplicationJson([final void Function(ReactionReactResponseApplicationJsonBuilder)? b]) =
+  factory ReactionReactResponseApplicationJson([void Function(ReactionReactResponseApplicationJsonBuilder)? b]) =
       _$ReactionReactResponseApplicationJson;
 
   // coverage:ignore-start
@@ -19123,7 +19091,7 @@ abstract class ReactionReactResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReactionReactResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ReactionReactResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19144,7 +19112,7 @@ class ReactionDeleteApiVersion extends EnumClass {
   static BuiltSet<ReactionDeleteApiVersion> get values => _$reactionDeleteApiVersionValues;
   // coverage:ignore-end
 
-  static ReactionDeleteApiVersion valueOf(final String name) => _$valueOfReactionDeleteApiVersion(name);
+  static ReactionDeleteApiVersion valueOf(String name) => _$valueOfReactionDeleteApiVersion(name);
 
   static Serializer<ReactionDeleteApiVersion> get serializer => _$reactionDeleteApiVersionSerializer;
 }
@@ -19160,7 +19128,7 @@ abstract class ReactionDeleteResponseApplicationJson_Ocs
         $ReactionDeleteResponseApplicationJson_OcsInterface,
         Built<ReactionDeleteResponseApplicationJson_Ocs, ReactionDeleteResponseApplicationJson_OcsBuilder> {
   factory ReactionDeleteResponseApplicationJson_Ocs([
-    final void Function(ReactionDeleteResponseApplicationJson_OcsBuilder)? b,
+    void Function(ReactionDeleteResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ReactionDeleteResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19168,7 +19136,7 @@ abstract class ReactionDeleteResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReactionDeleteResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ReactionDeleteResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19189,16 +19157,15 @@ abstract class ReactionDeleteResponseApplicationJson
     implements
         $ReactionDeleteResponseApplicationJsonInterface,
         Built<ReactionDeleteResponseApplicationJson, ReactionDeleteResponseApplicationJsonBuilder> {
-  factory ReactionDeleteResponseApplicationJson([
-    final void Function(ReactionDeleteResponseApplicationJsonBuilder)? b,
-  ]) = _$ReactionDeleteResponseApplicationJson;
+  factory ReactionDeleteResponseApplicationJson([void Function(ReactionDeleteResponseApplicationJsonBuilder)? b]) =
+      _$ReactionDeleteResponseApplicationJson;
 
   // coverage:ignore-start
   const ReactionDeleteResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ReactionDeleteResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ReactionDeleteResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19219,7 +19186,7 @@ class RecordingGetWelcomeMessageApiVersion extends EnumClass {
   static BuiltSet<RecordingGetWelcomeMessageApiVersion> get values => _$recordingGetWelcomeMessageApiVersionValues;
   // coverage:ignore-end
 
-  static RecordingGetWelcomeMessageApiVersion valueOf(final String name) =>
+  static RecordingGetWelcomeMessageApiVersion valueOf(String name) =>
       _$valueOfRecordingGetWelcomeMessageApiVersion(name);
 
   static Serializer<RecordingGetWelcomeMessageApiVersion> get serializer =>
@@ -19237,7 +19204,7 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data
         Built<RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data,
             RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder> {
   factory RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data([
-    final void Function(RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -19245,7 +19212,7 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19269,7 +19236,7 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson_Ocs
         Built<RecordingGetWelcomeMessageResponseApplicationJson_Ocs,
             RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder> {
   factory RecordingGetWelcomeMessageResponseApplicationJson_Ocs([
-    final void Function(RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder)? b,
+    void Function(RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RecordingGetWelcomeMessageResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19277,7 +19244,7 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingGetWelcomeMessageResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingGetWelcomeMessageResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19300,7 +19267,7 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson
         Built<RecordingGetWelcomeMessageResponseApplicationJson,
             RecordingGetWelcomeMessageResponseApplicationJsonBuilder> {
   factory RecordingGetWelcomeMessageResponseApplicationJson([
-    final void Function(RecordingGetWelcomeMessageResponseApplicationJsonBuilder)? b,
+    void Function(RecordingGetWelcomeMessageResponseApplicationJsonBuilder)? b,
   ]) = _$RecordingGetWelcomeMessageResponseApplicationJson;
 
   // coverage:ignore-start
@@ -19308,7 +19275,7 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingGetWelcomeMessageResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingGetWelcomeMessageResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19329,7 +19296,7 @@ class RecordingStartApiVersion extends EnumClass {
   static BuiltSet<RecordingStartApiVersion> get values => _$recordingStartApiVersionValues;
   // coverage:ignore-end
 
-  static RecordingStartApiVersion valueOf(final String name) => _$valueOfRecordingStartApiVersion(name);
+  static RecordingStartApiVersion valueOf(String name) => _$valueOfRecordingStartApiVersion(name);
 
   static Serializer<RecordingStartApiVersion> get serializer => _$recordingStartApiVersionSerializer;
 }
@@ -19345,7 +19312,7 @@ abstract class RecordingStartResponseApplicationJson_Ocs
         $RecordingStartResponseApplicationJson_OcsInterface,
         Built<RecordingStartResponseApplicationJson_Ocs, RecordingStartResponseApplicationJson_OcsBuilder> {
   factory RecordingStartResponseApplicationJson_Ocs([
-    final void Function(RecordingStartResponseApplicationJson_OcsBuilder)? b,
+    void Function(RecordingStartResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RecordingStartResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19353,7 +19320,7 @@ abstract class RecordingStartResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingStartResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingStartResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19374,16 +19341,15 @@ abstract class RecordingStartResponseApplicationJson
     implements
         $RecordingStartResponseApplicationJsonInterface,
         Built<RecordingStartResponseApplicationJson, RecordingStartResponseApplicationJsonBuilder> {
-  factory RecordingStartResponseApplicationJson([
-    final void Function(RecordingStartResponseApplicationJsonBuilder)? b,
-  ]) = _$RecordingStartResponseApplicationJson;
+  factory RecordingStartResponseApplicationJson([void Function(RecordingStartResponseApplicationJsonBuilder)? b]) =
+      _$RecordingStartResponseApplicationJson;
 
   // coverage:ignore-start
   const RecordingStartResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingStartResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingStartResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19404,7 +19370,7 @@ class RecordingStopApiVersion extends EnumClass {
   static BuiltSet<RecordingStopApiVersion> get values => _$recordingStopApiVersionValues;
   // coverage:ignore-end
 
-  static RecordingStopApiVersion valueOf(final String name) => _$valueOfRecordingStopApiVersion(name);
+  static RecordingStopApiVersion valueOf(String name) => _$valueOfRecordingStopApiVersion(name);
 
   static Serializer<RecordingStopApiVersion> get serializer => _$recordingStopApiVersionSerializer;
 }
@@ -19420,7 +19386,7 @@ abstract class RecordingStopResponseApplicationJson_Ocs
         $RecordingStopResponseApplicationJson_OcsInterface,
         Built<RecordingStopResponseApplicationJson_Ocs, RecordingStopResponseApplicationJson_OcsBuilder> {
   factory RecordingStopResponseApplicationJson_Ocs([
-    final void Function(RecordingStopResponseApplicationJson_OcsBuilder)? b,
+    void Function(RecordingStopResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RecordingStopResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19428,7 +19394,7 @@ abstract class RecordingStopResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingStopResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingStopResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19449,7 +19415,7 @@ abstract class RecordingStopResponseApplicationJson
     implements
         $RecordingStopResponseApplicationJsonInterface,
         Built<RecordingStopResponseApplicationJson, RecordingStopResponseApplicationJsonBuilder> {
-  factory RecordingStopResponseApplicationJson([final void Function(RecordingStopResponseApplicationJsonBuilder)? b]) =
+  factory RecordingStopResponseApplicationJson([void Function(RecordingStopResponseApplicationJsonBuilder)? b]) =
       _$RecordingStopResponseApplicationJson;
 
   // coverage:ignore-start
@@ -19457,7 +19423,7 @@ abstract class RecordingStopResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingStopResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingStopResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19478,7 +19444,7 @@ class RecordingStoreApiVersion extends EnumClass {
   static BuiltSet<RecordingStoreApiVersion> get values => _$recordingStoreApiVersionValues;
   // coverage:ignore-end
 
-  static RecordingStoreApiVersion valueOf(final String name) => _$valueOfRecordingStoreApiVersion(name);
+  static RecordingStoreApiVersion valueOf(String name) => _$valueOfRecordingStoreApiVersion(name);
 
   static Serializer<RecordingStoreApiVersion> get serializer => _$recordingStoreApiVersionSerializer;
 }
@@ -19494,7 +19460,7 @@ abstract class RecordingStoreResponseApplicationJson_Ocs
         $RecordingStoreResponseApplicationJson_OcsInterface,
         Built<RecordingStoreResponseApplicationJson_Ocs, RecordingStoreResponseApplicationJson_OcsBuilder> {
   factory RecordingStoreResponseApplicationJson_Ocs([
-    final void Function(RecordingStoreResponseApplicationJson_OcsBuilder)? b,
+    void Function(RecordingStoreResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RecordingStoreResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19502,7 +19468,7 @@ abstract class RecordingStoreResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingStoreResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingStoreResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19523,16 +19489,15 @@ abstract class RecordingStoreResponseApplicationJson
     implements
         $RecordingStoreResponseApplicationJsonInterface,
         Built<RecordingStoreResponseApplicationJson, RecordingStoreResponseApplicationJsonBuilder> {
-  factory RecordingStoreResponseApplicationJson([
-    final void Function(RecordingStoreResponseApplicationJsonBuilder)? b,
-  ]) = _$RecordingStoreResponseApplicationJson;
+  factory RecordingStoreResponseApplicationJson([void Function(RecordingStoreResponseApplicationJsonBuilder)? b]) =
+      _$RecordingStoreResponseApplicationJson;
 
   // coverage:ignore-start
   const RecordingStoreResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingStoreResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingStoreResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19553,7 +19518,7 @@ class RecordingNotificationDismissApiVersion extends EnumClass {
   static BuiltSet<RecordingNotificationDismissApiVersion> get values => _$recordingNotificationDismissApiVersionValues;
   // coverage:ignore-end
 
-  static RecordingNotificationDismissApiVersion valueOf(final String name) =>
+  static RecordingNotificationDismissApiVersion valueOf(String name) =>
       _$valueOfRecordingNotificationDismissApiVersion(name);
 
   static Serializer<RecordingNotificationDismissApiVersion> get serializer =>
@@ -19572,7 +19537,7 @@ abstract class RecordingNotificationDismissResponseApplicationJson_Ocs
         Built<RecordingNotificationDismissResponseApplicationJson_Ocs,
             RecordingNotificationDismissResponseApplicationJson_OcsBuilder> {
   factory RecordingNotificationDismissResponseApplicationJson_Ocs([
-    final void Function(RecordingNotificationDismissResponseApplicationJson_OcsBuilder)? b,
+    void Function(RecordingNotificationDismissResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RecordingNotificationDismissResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19580,7 +19545,7 @@ abstract class RecordingNotificationDismissResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingNotificationDismissResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingNotificationDismissResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19603,7 +19568,7 @@ abstract class RecordingNotificationDismissResponseApplicationJson
         Built<RecordingNotificationDismissResponseApplicationJson,
             RecordingNotificationDismissResponseApplicationJsonBuilder> {
   factory RecordingNotificationDismissResponseApplicationJson([
-    final void Function(RecordingNotificationDismissResponseApplicationJsonBuilder)? b,
+    void Function(RecordingNotificationDismissResponseApplicationJsonBuilder)? b,
   ]) = _$RecordingNotificationDismissResponseApplicationJson;
 
   // coverage:ignore-start
@@ -19611,7 +19576,7 @@ abstract class RecordingNotificationDismissResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingNotificationDismissResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingNotificationDismissResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19632,7 +19597,7 @@ class RecordingShareToChatApiVersion extends EnumClass {
   static BuiltSet<RecordingShareToChatApiVersion> get values => _$recordingShareToChatApiVersionValues;
   // coverage:ignore-end
 
-  static RecordingShareToChatApiVersion valueOf(final String name) => _$valueOfRecordingShareToChatApiVersion(name);
+  static RecordingShareToChatApiVersion valueOf(String name) => _$valueOfRecordingShareToChatApiVersion(name);
 
   static Serializer<RecordingShareToChatApiVersion> get serializer => _$recordingShareToChatApiVersionSerializer;
 }
@@ -19648,7 +19613,7 @@ abstract class RecordingShareToChatResponseApplicationJson_Ocs
         $RecordingShareToChatResponseApplicationJson_OcsInterface,
         Built<RecordingShareToChatResponseApplicationJson_Ocs, RecordingShareToChatResponseApplicationJson_OcsBuilder> {
   factory RecordingShareToChatResponseApplicationJson_Ocs([
-    final void Function(RecordingShareToChatResponseApplicationJson_OcsBuilder)? b,
+    void Function(RecordingShareToChatResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RecordingShareToChatResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19656,7 +19621,7 @@ abstract class RecordingShareToChatResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingShareToChatResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingShareToChatResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19678,7 +19643,7 @@ abstract class RecordingShareToChatResponseApplicationJson
         $RecordingShareToChatResponseApplicationJsonInterface,
         Built<RecordingShareToChatResponseApplicationJson, RecordingShareToChatResponseApplicationJsonBuilder> {
   factory RecordingShareToChatResponseApplicationJson([
-    final void Function(RecordingShareToChatResponseApplicationJsonBuilder)? b,
+    void Function(RecordingShareToChatResponseApplicationJsonBuilder)? b,
   ]) = _$RecordingShareToChatResponseApplicationJson;
 
   // coverage:ignore-start
@@ -19686,7 +19651,7 @@ abstract class RecordingShareToChatResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RecordingShareToChatResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RecordingShareToChatResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19707,7 +19672,7 @@ class RoomGetRoomsApiVersion extends EnumClass {
   static BuiltSet<RoomGetRoomsApiVersion> get values => _$roomGetRoomsApiVersionValues;
   // coverage:ignore-end
 
-  static RoomGetRoomsApiVersion valueOf(final String name) => _$valueOfRoomGetRoomsApiVersion(name);
+  static RoomGetRoomsApiVersion valueOf(String name) => _$valueOfRoomGetRoomsApiVersion(name);
 
   static Serializer<RoomGetRoomsApiVersion> get serializer => _$roomGetRoomsApiVersionSerializer;
 }
@@ -19722,14 +19687,14 @@ abstract interface class $RoomRoomGetRoomsHeadersInterface {
 
 abstract class RoomRoomGetRoomsHeaders
     implements $RoomRoomGetRoomsHeadersInterface, Built<RoomRoomGetRoomsHeaders, RoomRoomGetRoomsHeadersBuilder> {
-  factory RoomRoomGetRoomsHeaders([final void Function(RoomRoomGetRoomsHeadersBuilder)? b]) = _$RoomRoomGetRoomsHeaders;
+  factory RoomRoomGetRoomsHeaders([void Function(RoomRoomGetRoomsHeadersBuilder)? b]) = _$RoomRoomGetRoomsHeaders;
 
   // coverage:ignore-start
   const RoomRoomGetRoomsHeaders._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRoomGetRoomsHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRoomGetRoomsHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19750,16 +19715,15 @@ abstract class RoomGetRoomsResponseApplicationJson_Ocs
     implements
         $RoomGetRoomsResponseApplicationJson_OcsInterface,
         Built<RoomGetRoomsResponseApplicationJson_Ocs, RoomGetRoomsResponseApplicationJson_OcsBuilder> {
-  factory RoomGetRoomsResponseApplicationJson_Ocs([
-    final void Function(RoomGetRoomsResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$RoomGetRoomsResponseApplicationJson_Ocs;
+  factory RoomGetRoomsResponseApplicationJson_Ocs([void Function(RoomGetRoomsResponseApplicationJson_OcsBuilder)? b]) =
+      _$RoomGetRoomsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const RoomGetRoomsResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetRoomsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetRoomsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19780,7 +19744,7 @@ abstract class RoomGetRoomsResponseApplicationJson
     implements
         $RoomGetRoomsResponseApplicationJsonInterface,
         Built<RoomGetRoomsResponseApplicationJson, RoomGetRoomsResponseApplicationJsonBuilder> {
-  factory RoomGetRoomsResponseApplicationJson([final void Function(RoomGetRoomsResponseApplicationJsonBuilder)? b]) =
+  factory RoomGetRoomsResponseApplicationJson([void Function(RoomGetRoomsResponseApplicationJsonBuilder)? b]) =
       _$RoomGetRoomsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -19788,7 +19752,7 @@ abstract class RoomGetRoomsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetRoomsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetRoomsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19809,7 +19773,7 @@ class RoomCreateRoomApiVersion extends EnumClass {
   static BuiltSet<RoomCreateRoomApiVersion> get values => _$roomCreateRoomApiVersionValues;
   // coverage:ignore-end
 
-  static RoomCreateRoomApiVersion valueOf(final String name) => _$valueOfRoomCreateRoomApiVersion(name);
+  static RoomCreateRoomApiVersion valueOf(String name) => _$valueOfRoomCreateRoomApiVersion(name);
 
   static Serializer<RoomCreateRoomApiVersion> get serializer => _$roomCreateRoomApiVersionSerializer;
 }
@@ -19825,7 +19789,7 @@ abstract class RoomCreateRoomResponseApplicationJson_Ocs
         $RoomCreateRoomResponseApplicationJson_OcsInterface,
         Built<RoomCreateRoomResponseApplicationJson_Ocs, RoomCreateRoomResponseApplicationJson_OcsBuilder> {
   factory RoomCreateRoomResponseApplicationJson_Ocs([
-    final void Function(RoomCreateRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomCreateRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomCreateRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19833,7 +19797,7 @@ abstract class RoomCreateRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomCreateRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomCreateRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19854,16 +19818,15 @@ abstract class RoomCreateRoomResponseApplicationJson
     implements
         $RoomCreateRoomResponseApplicationJsonInterface,
         Built<RoomCreateRoomResponseApplicationJson, RoomCreateRoomResponseApplicationJsonBuilder> {
-  factory RoomCreateRoomResponseApplicationJson([
-    final void Function(RoomCreateRoomResponseApplicationJsonBuilder)? b,
-  ]) = _$RoomCreateRoomResponseApplicationJson;
+  factory RoomCreateRoomResponseApplicationJson([void Function(RoomCreateRoomResponseApplicationJsonBuilder)? b]) =
+      _$RoomCreateRoomResponseApplicationJson;
 
   // coverage:ignore-start
   const RoomCreateRoomResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomCreateRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomCreateRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19884,7 +19847,7 @@ class RoomGetListedRoomsApiVersion extends EnumClass {
   static BuiltSet<RoomGetListedRoomsApiVersion> get values => _$roomGetListedRoomsApiVersionValues;
   // coverage:ignore-end
 
-  static RoomGetListedRoomsApiVersion valueOf(final String name) => _$valueOfRoomGetListedRoomsApiVersion(name);
+  static RoomGetListedRoomsApiVersion valueOf(String name) => _$valueOfRoomGetListedRoomsApiVersion(name);
 
   static Serializer<RoomGetListedRoomsApiVersion> get serializer => _$roomGetListedRoomsApiVersionSerializer;
 }
@@ -19900,7 +19863,7 @@ abstract class RoomGetListedRoomsResponseApplicationJson_Ocs
         $RoomGetListedRoomsResponseApplicationJson_OcsInterface,
         Built<RoomGetListedRoomsResponseApplicationJson_Ocs, RoomGetListedRoomsResponseApplicationJson_OcsBuilder> {
   factory RoomGetListedRoomsResponseApplicationJson_Ocs([
-    final void Function(RoomGetListedRoomsResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomGetListedRoomsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomGetListedRoomsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -19908,7 +19871,7 @@ abstract class RoomGetListedRoomsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetListedRoomsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetListedRoomsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19930,7 +19893,7 @@ abstract class RoomGetListedRoomsResponseApplicationJson
         $RoomGetListedRoomsResponseApplicationJsonInterface,
         Built<RoomGetListedRoomsResponseApplicationJson, RoomGetListedRoomsResponseApplicationJsonBuilder> {
   factory RoomGetListedRoomsResponseApplicationJson([
-    final void Function(RoomGetListedRoomsResponseApplicationJsonBuilder)? b,
+    void Function(RoomGetListedRoomsResponseApplicationJsonBuilder)? b,
   ]) = _$RoomGetListedRoomsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -19938,7 +19901,7 @@ abstract class RoomGetListedRoomsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetListedRoomsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetListedRoomsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -19960,7 +19923,7 @@ class RoomGetNoteToSelfConversationApiVersion extends EnumClass {
       _$roomGetNoteToSelfConversationApiVersionValues;
   // coverage:ignore-end
 
-  static RoomGetNoteToSelfConversationApiVersion valueOf(final String name) =>
+  static RoomGetNoteToSelfConversationApiVersion valueOf(String name) =>
       _$valueOfRoomGetNoteToSelfConversationApiVersion(name);
 
   static Serializer<RoomGetNoteToSelfConversationApiVersion> get serializer =>
@@ -19978,7 +19941,7 @@ abstract class RoomRoomGetNoteToSelfConversationHeaders
         $RoomRoomGetNoteToSelfConversationHeadersInterface,
         Built<RoomRoomGetNoteToSelfConversationHeaders, RoomRoomGetNoteToSelfConversationHeadersBuilder> {
   factory RoomRoomGetNoteToSelfConversationHeaders([
-    final void Function(RoomRoomGetNoteToSelfConversationHeadersBuilder)? b,
+    void Function(RoomRoomGetNoteToSelfConversationHeadersBuilder)? b,
   ]) = _$RoomRoomGetNoteToSelfConversationHeaders;
 
   // coverage:ignore-start
@@ -19986,7 +19949,7 @@ abstract class RoomRoomGetNoteToSelfConversationHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRoomGetNoteToSelfConversationHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRoomGetNoteToSelfConversationHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20010,7 +19973,7 @@ abstract class RoomGetNoteToSelfConversationResponseApplicationJson_Ocs
         Built<RoomGetNoteToSelfConversationResponseApplicationJson_Ocs,
             RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder> {
   factory RoomGetNoteToSelfConversationResponseApplicationJson_Ocs([
-    final void Function(RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomGetNoteToSelfConversationResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20018,7 +19981,7 @@ abstract class RoomGetNoteToSelfConversationResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetNoteToSelfConversationResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetNoteToSelfConversationResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20041,7 +20004,7 @@ abstract class RoomGetNoteToSelfConversationResponseApplicationJson
         Built<RoomGetNoteToSelfConversationResponseApplicationJson,
             RoomGetNoteToSelfConversationResponseApplicationJsonBuilder> {
   factory RoomGetNoteToSelfConversationResponseApplicationJson([
-    final void Function(RoomGetNoteToSelfConversationResponseApplicationJsonBuilder)? b,
+    void Function(RoomGetNoteToSelfConversationResponseApplicationJsonBuilder)? b,
   ]) = _$RoomGetNoteToSelfConversationResponseApplicationJson;
 
   // coverage:ignore-start
@@ -20049,7 +20012,7 @@ abstract class RoomGetNoteToSelfConversationResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetNoteToSelfConversationResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetNoteToSelfConversationResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20070,7 +20033,7 @@ class RoomGetSingleRoomApiVersion extends EnumClass {
   static BuiltSet<RoomGetSingleRoomApiVersion> get values => _$roomGetSingleRoomApiVersionValues;
   // coverage:ignore-end
 
-  static RoomGetSingleRoomApiVersion valueOf(final String name) => _$valueOfRoomGetSingleRoomApiVersion(name);
+  static RoomGetSingleRoomApiVersion valueOf(String name) => _$valueOfRoomGetSingleRoomApiVersion(name);
 
   static Serializer<RoomGetSingleRoomApiVersion> get serializer => _$roomGetSingleRoomApiVersionSerializer;
 }
@@ -20085,7 +20048,7 @@ abstract class RoomRoomGetSingleRoomHeaders
     implements
         $RoomRoomGetSingleRoomHeadersInterface,
         Built<RoomRoomGetSingleRoomHeaders, RoomRoomGetSingleRoomHeadersBuilder> {
-  factory RoomRoomGetSingleRoomHeaders([final void Function(RoomRoomGetSingleRoomHeadersBuilder)? b]) =
+  factory RoomRoomGetSingleRoomHeaders([void Function(RoomRoomGetSingleRoomHeadersBuilder)? b]) =
       _$RoomRoomGetSingleRoomHeaders;
 
   // coverage:ignore-start
@@ -20093,7 +20056,7 @@ abstract class RoomRoomGetSingleRoomHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRoomGetSingleRoomHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRoomGetSingleRoomHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20115,7 +20078,7 @@ abstract class RoomGetSingleRoomResponseApplicationJson_Ocs
         $RoomGetSingleRoomResponseApplicationJson_OcsInterface,
         Built<RoomGetSingleRoomResponseApplicationJson_Ocs, RoomGetSingleRoomResponseApplicationJson_OcsBuilder> {
   factory RoomGetSingleRoomResponseApplicationJson_Ocs([
-    final void Function(RoomGetSingleRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomGetSingleRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomGetSingleRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20123,7 +20086,7 @@ abstract class RoomGetSingleRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetSingleRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetSingleRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20145,7 +20108,7 @@ abstract class RoomGetSingleRoomResponseApplicationJson
         $RoomGetSingleRoomResponseApplicationJsonInterface,
         Built<RoomGetSingleRoomResponseApplicationJson, RoomGetSingleRoomResponseApplicationJsonBuilder> {
   factory RoomGetSingleRoomResponseApplicationJson([
-    final void Function(RoomGetSingleRoomResponseApplicationJsonBuilder)? b,
+    void Function(RoomGetSingleRoomResponseApplicationJsonBuilder)? b,
   ]) = _$RoomGetSingleRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -20153,7 +20116,7 @@ abstract class RoomGetSingleRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetSingleRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetSingleRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20174,7 +20137,7 @@ class RoomRenameRoomApiVersion extends EnumClass {
   static BuiltSet<RoomRenameRoomApiVersion> get values => _$roomRenameRoomApiVersionValues;
   // coverage:ignore-end
 
-  static RoomRenameRoomApiVersion valueOf(final String name) => _$valueOfRoomRenameRoomApiVersion(name);
+  static RoomRenameRoomApiVersion valueOf(String name) => _$valueOfRoomRenameRoomApiVersion(name);
 
   static Serializer<RoomRenameRoomApiVersion> get serializer => _$roomRenameRoomApiVersionSerializer;
 }
@@ -20190,7 +20153,7 @@ abstract class RoomRenameRoomResponseApplicationJson_Ocs
         $RoomRenameRoomResponseApplicationJson_OcsInterface,
         Built<RoomRenameRoomResponseApplicationJson_Ocs, RoomRenameRoomResponseApplicationJson_OcsBuilder> {
   factory RoomRenameRoomResponseApplicationJson_Ocs([
-    final void Function(RoomRenameRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomRenameRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomRenameRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20198,7 +20161,7 @@ abstract class RoomRenameRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRenameRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRenameRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20219,16 +20182,15 @@ abstract class RoomRenameRoomResponseApplicationJson
     implements
         $RoomRenameRoomResponseApplicationJsonInterface,
         Built<RoomRenameRoomResponseApplicationJson, RoomRenameRoomResponseApplicationJsonBuilder> {
-  factory RoomRenameRoomResponseApplicationJson([
-    final void Function(RoomRenameRoomResponseApplicationJsonBuilder)? b,
-  ]) = _$RoomRenameRoomResponseApplicationJson;
+  factory RoomRenameRoomResponseApplicationJson([void Function(RoomRenameRoomResponseApplicationJsonBuilder)? b]) =
+      _$RoomRenameRoomResponseApplicationJson;
 
   // coverage:ignore-start
   const RoomRenameRoomResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRenameRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRenameRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20249,7 +20211,7 @@ class RoomDeleteRoomApiVersion extends EnumClass {
   static BuiltSet<RoomDeleteRoomApiVersion> get values => _$roomDeleteRoomApiVersionValues;
   // coverage:ignore-end
 
-  static RoomDeleteRoomApiVersion valueOf(final String name) => _$valueOfRoomDeleteRoomApiVersion(name);
+  static RoomDeleteRoomApiVersion valueOf(String name) => _$valueOfRoomDeleteRoomApiVersion(name);
 
   static Serializer<RoomDeleteRoomApiVersion> get serializer => _$roomDeleteRoomApiVersionSerializer;
 }
@@ -20265,7 +20227,7 @@ abstract class RoomDeleteRoomResponseApplicationJson_Ocs
         $RoomDeleteRoomResponseApplicationJson_OcsInterface,
         Built<RoomDeleteRoomResponseApplicationJson_Ocs, RoomDeleteRoomResponseApplicationJson_OcsBuilder> {
   factory RoomDeleteRoomResponseApplicationJson_Ocs([
-    final void Function(RoomDeleteRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomDeleteRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomDeleteRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20273,7 +20235,7 @@ abstract class RoomDeleteRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomDeleteRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomDeleteRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20294,16 +20256,15 @@ abstract class RoomDeleteRoomResponseApplicationJson
     implements
         $RoomDeleteRoomResponseApplicationJsonInterface,
         Built<RoomDeleteRoomResponseApplicationJson, RoomDeleteRoomResponseApplicationJsonBuilder> {
-  factory RoomDeleteRoomResponseApplicationJson([
-    final void Function(RoomDeleteRoomResponseApplicationJsonBuilder)? b,
-  ]) = _$RoomDeleteRoomResponseApplicationJson;
+  factory RoomDeleteRoomResponseApplicationJson([void Function(RoomDeleteRoomResponseApplicationJsonBuilder)? b]) =
+      _$RoomDeleteRoomResponseApplicationJson;
 
   // coverage:ignore-start
   const RoomDeleteRoomResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomDeleteRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomDeleteRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20324,7 +20285,7 @@ class RoomGetBreakoutRoomsApiVersion extends EnumClass {
   static BuiltSet<RoomGetBreakoutRoomsApiVersion> get values => _$roomGetBreakoutRoomsApiVersionValues;
   // coverage:ignore-end
 
-  static RoomGetBreakoutRoomsApiVersion valueOf(final String name) => _$valueOfRoomGetBreakoutRoomsApiVersion(name);
+  static RoomGetBreakoutRoomsApiVersion valueOf(String name) => _$valueOfRoomGetBreakoutRoomsApiVersion(name);
 
   static Serializer<RoomGetBreakoutRoomsApiVersion> get serializer => _$roomGetBreakoutRoomsApiVersionSerializer;
 }
@@ -20340,7 +20301,7 @@ abstract class RoomGetBreakoutRoomsResponseApplicationJson_Ocs
         $RoomGetBreakoutRoomsResponseApplicationJson_OcsInterface,
         Built<RoomGetBreakoutRoomsResponseApplicationJson_Ocs, RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder> {
   factory RoomGetBreakoutRoomsResponseApplicationJson_Ocs([
-    final void Function(RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomGetBreakoutRoomsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20348,7 +20309,7 @@ abstract class RoomGetBreakoutRoomsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetBreakoutRoomsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetBreakoutRoomsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20370,7 +20331,7 @@ abstract class RoomGetBreakoutRoomsResponseApplicationJson
         $RoomGetBreakoutRoomsResponseApplicationJsonInterface,
         Built<RoomGetBreakoutRoomsResponseApplicationJson, RoomGetBreakoutRoomsResponseApplicationJsonBuilder> {
   factory RoomGetBreakoutRoomsResponseApplicationJson([
-    final void Function(RoomGetBreakoutRoomsResponseApplicationJsonBuilder)? b,
+    void Function(RoomGetBreakoutRoomsResponseApplicationJsonBuilder)? b,
   ]) = _$RoomGetBreakoutRoomsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -20378,7 +20339,7 @@ abstract class RoomGetBreakoutRoomsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetBreakoutRoomsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetBreakoutRoomsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20399,7 +20360,7 @@ class RoomMakePublicApiVersion extends EnumClass {
   static BuiltSet<RoomMakePublicApiVersion> get values => _$roomMakePublicApiVersionValues;
   // coverage:ignore-end
 
-  static RoomMakePublicApiVersion valueOf(final String name) => _$valueOfRoomMakePublicApiVersion(name);
+  static RoomMakePublicApiVersion valueOf(String name) => _$valueOfRoomMakePublicApiVersion(name);
 
   static Serializer<RoomMakePublicApiVersion> get serializer => _$roomMakePublicApiVersionSerializer;
 }
@@ -20415,7 +20376,7 @@ abstract class RoomMakePublicResponseApplicationJson_Ocs
         $RoomMakePublicResponseApplicationJson_OcsInterface,
         Built<RoomMakePublicResponseApplicationJson_Ocs, RoomMakePublicResponseApplicationJson_OcsBuilder> {
   factory RoomMakePublicResponseApplicationJson_Ocs([
-    final void Function(RoomMakePublicResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomMakePublicResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomMakePublicResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20423,7 +20384,7 @@ abstract class RoomMakePublicResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomMakePublicResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomMakePublicResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20444,16 +20405,15 @@ abstract class RoomMakePublicResponseApplicationJson
     implements
         $RoomMakePublicResponseApplicationJsonInterface,
         Built<RoomMakePublicResponseApplicationJson, RoomMakePublicResponseApplicationJsonBuilder> {
-  factory RoomMakePublicResponseApplicationJson([
-    final void Function(RoomMakePublicResponseApplicationJsonBuilder)? b,
-  ]) = _$RoomMakePublicResponseApplicationJson;
+  factory RoomMakePublicResponseApplicationJson([void Function(RoomMakePublicResponseApplicationJsonBuilder)? b]) =
+      _$RoomMakePublicResponseApplicationJson;
 
   // coverage:ignore-start
   const RoomMakePublicResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomMakePublicResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomMakePublicResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20474,7 +20434,7 @@ class RoomMakePrivateApiVersion extends EnumClass {
   static BuiltSet<RoomMakePrivateApiVersion> get values => _$roomMakePrivateApiVersionValues;
   // coverage:ignore-end
 
-  static RoomMakePrivateApiVersion valueOf(final String name) => _$valueOfRoomMakePrivateApiVersion(name);
+  static RoomMakePrivateApiVersion valueOf(String name) => _$valueOfRoomMakePrivateApiVersion(name);
 
   static Serializer<RoomMakePrivateApiVersion> get serializer => _$roomMakePrivateApiVersionSerializer;
 }
@@ -20490,7 +20450,7 @@ abstract class RoomMakePrivateResponseApplicationJson_Ocs
         $RoomMakePrivateResponseApplicationJson_OcsInterface,
         Built<RoomMakePrivateResponseApplicationJson_Ocs, RoomMakePrivateResponseApplicationJson_OcsBuilder> {
   factory RoomMakePrivateResponseApplicationJson_Ocs([
-    final void Function(RoomMakePrivateResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomMakePrivateResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomMakePrivateResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20498,7 +20458,7 @@ abstract class RoomMakePrivateResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomMakePrivateResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomMakePrivateResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20519,16 +20479,15 @@ abstract class RoomMakePrivateResponseApplicationJson
     implements
         $RoomMakePrivateResponseApplicationJsonInterface,
         Built<RoomMakePrivateResponseApplicationJson, RoomMakePrivateResponseApplicationJsonBuilder> {
-  factory RoomMakePrivateResponseApplicationJson([
-    final void Function(RoomMakePrivateResponseApplicationJsonBuilder)? b,
-  ]) = _$RoomMakePrivateResponseApplicationJson;
+  factory RoomMakePrivateResponseApplicationJson([void Function(RoomMakePrivateResponseApplicationJsonBuilder)? b]) =
+      _$RoomMakePrivateResponseApplicationJson;
 
   // coverage:ignore-start
   const RoomMakePrivateResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomMakePrivateResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomMakePrivateResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20549,7 +20508,7 @@ class RoomSetDescriptionApiVersion extends EnumClass {
   static BuiltSet<RoomSetDescriptionApiVersion> get values => _$roomSetDescriptionApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetDescriptionApiVersion valueOf(final String name) => _$valueOfRoomSetDescriptionApiVersion(name);
+  static RoomSetDescriptionApiVersion valueOf(String name) => _$valueOfRoomSetDescriptionApiVersion(name);
 
   static Serializer<RoomSetDescriptionApiVersion> get serializer => _$roomSetDescriptionApiVersionSerializer;
 }
@@ -20565,7 +20524,7 @@ abstract class RoomSetDescriptionResponseApplicationJson_Ocs
         $RoomSetDescriptionResponseApplicationJson_OcsInterface,
         Built<RoomSetDescriptionResponseApplicationJson_Ocs, RoomSetDescriptionResponseApplicationJson_OcsBuilder> {
   factory RoomSetDescriptionResponseApplicationJson_Ocs([
-    final void Function(RoomSetDescriptionResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetDescriptionResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetDescriptionResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20573,7 +20532,7 @@ abstract class RoomSetDescriptionResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetDescriptionResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetDescriptionResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20595,7 +20554,7 @@ abstract class RoomSetDescriptionResponseApplicationJson
         $RoomSetDescriptionResponseApplicationJsonInterface,
         Built<RoomSetDescriptionResponseApplicationJson, RoomSetDescriptionResponseApplicationJsonBuilder> {
   factory RoomSetDescriptionResponseApplicationJson([
-    final void Function(RoomSetDescriptionResponseApplicationJsonBuilder)? b,
+    void Function(RoomSetDescriptionResponseApplicationJsonBuilder)? b,
   ]) = _$RoomSetDescriptionResponseApplicationJson;
 
   // coverage:ignore-start
@@ -20603,7 +20562,7 @@ abstract class RoomSetDescriptionResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetDescriptionResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetDescriptionResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20624,7 +20583,7 @@ class RoomSetReadOnlyApiVersion extends EnumClass {
   static BuiltSet<RoomSetReadOnlyApiVersion> get values => _$roomSetReadOnlyApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetReadOnlyApiVersion valueOf(final String name) => _$valueOfRoomSetReadOnlyApiVersion(name);
+  static RoomSetReadOnlyApiVersion valueOf(String name) => _$valueOfRoomSetReadOnlyApiVersion(name);
 
   static Serializer<RoomSetReadOnlyApiVersion> get serializer => _$roomSetReadOnlyApiVersionSerializer;
 }
@@ -20640,7 +20599,7 @@ abstract class RoomSetReadOnlyResponseApplicationJson_Ocs
         $RoomSetReadOnlyResponseApplicationJson_OcsInterface,
         Built<RoomSetReadOnlyResponseApplicationJson_Ocs, RoomSetReadOnlyResponseApplicationJson_OcsBuilder> {
   factory RoomSetReadOnlyResponseApplicationJson_Ocs([
-    final void Function(RoomSetReadOnlyResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetReadOnlyResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetReadOnlyResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20648,7 +20607,7 @@ abstract class RoomSetReadOnlyResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetReadOnlyResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetReadOnlyResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20669,16 +20628,15 @@ abstract class RoomSetReadOnlyResponseApplicationJson
     implements
         $RoomSetReadOnlyResponseApplicationJsonInterface,
         Built<RoomSetReadOnlyResponseApplicationJson, RoomSetReadOnlyResponseApplicationJsonBuilder> {
-  factory RoomSetReadOnlyResponseApplicationJson([
-    final void Function(RoomSetReadOnlyResponseApplicationJsonBuilder)? b,
-  ]) = _$RoomSetReadOnlyResponseApplicationJson;
+  factory RoomSetReadOnlyResponseApplicationJson([void Function(RoomSetReadOnlyResponseApplicationJsonBuilder)? b]) =
+      _$RoomSetReadOnlyResponseApplicationJson;
 
   // coverage:ignore-start
   const RoomSetReadOnlyResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetReadOnlyResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetReadOnlyResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20699,7 +20657,7 @@ class RoomSetListableApiVersion extends EnumClass {
   static BuiltSet<RoomSetListableApiVersion> get values => _$roomSetListableApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetListableApiVersion valueOf(final String name) => _$valueOfRoomSetListableApiVersion(name);
+  static RoomSetListableApiVersion valueOf(String name) => _$valueOfRoomSetListableApiVersion(name);
 
   static Serializer<RoomSetListableApiVersion> get serializer => _$roomSetListableApiVersionSerializer;
 }
@@ -20715,7 +20673,7 @@ abstract class RoomSetListableResponseApplicationJson_Ocs
         $RoomSetListableResponseApplicationJson_OcsInterface,
         Built<RoomSetListableResponseApplicationJson_Ocs, RoomSetListableResponseApplicationJson_OcsBuilder> {
   factory RoomSetListableResponseApplicationJson_Ocs([
-    final void Function(RoomSetListableResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetListableResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetListableResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20723,7 +20681,7 @@ abstract class RoomSetListableResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetListableResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetListableResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20744,16 +20702,15 @@ abstract class RoomSetListableResponseApplicationJson
     implements
         $RoomSetListableResponseApplicationJsonInterface,
         Built<RoomSetListableResponseApplicationJson, RoomSetListableResponseApplicationJsonBuilder> {
-  factory RoomSetListableResponseApplicationJson([
-    final void Function(RoomSetListableResponseApplicationJsonBuilder)? b,
-  ]) = _$RoomSetListableResponseApplicationJson;
+  factory RoomSetListableResponseApplicationJson([void Function(RoomSetListableResponseApplicationJsonBuilder)? b]) =
+      _$RoomSetListableResponseApplicationJson;
 
   // coverage:ignore-start
   const RoomSetListableResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetListableResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetListableResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20774,7 +20731,7 @@ class RoomSetPasswordApiVersion extends EnumClass {
   static BuiltSet<RoomSetPasswordApiVersion> get values => _$roomSetPasswordApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetPasswordApiVersion valueOf(final String name) => _$valueOfRoomSetPasswordApiVersion(name);
+  static RoomSetPasswordApiVersion valueOf(String name) => _$valueOfRoomSetPasswordApiVersion(name);
 
   static Serializer<RoomSetPasswordApiVersion> get serializer => _$roomSetPasswordApiVersionSerializer;
 }
@@ -20790,7 +20747,7 @@ abstract class RoomSetPasswordResponseApplicationJson_Ocs
         $RoomSetPasswordResponseApplicationJson_OcsInterface,
         Built<RoomSetPasswordResponseApplicationJson_Ocs, RoomSetPasswordResponseApplicationJson_OcsBuilder> {
   factory RoomSetPasswordResponseApplicationJson_Ocs([
-    final void Function(RoomSetPasswordResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetPasswordResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetPasswordResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20798,7 +20755,7 @@ abstract class RoomSetPasswordResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetPasswordResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetPasswordResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20819,16 +20776,15 @@ abstract class RoomSetPasswordResponseApplicationJson
     implements
         $RoomSetPasswordResponseApplicationJsonInterface,
         Built<RoomSetPasswordResponseApplicationJson, RoomSetPasswordResponseApplicationJsonBuilder> {
-  factory RoomSetPasswordResponseApplicationJson([
-    final void Function(RoomSetPasswordResponseApplicationJsonBuilder)? b,
-  ]) = _$RoomSetPasswordResponseApplicationJson;
+  factory RoomSetPasswordResponseApplicationJson([void Function(RoomSetPasswordResponseApplicationJsonBuilder)? b]) =
+      _$RoomSetPasswordResponseApplicationJson;
 
   // coverage:ignore-start
   const RoomSetPasswordResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetPasswordResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetPasswordResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20849,7 +20805,7 @@ class RoomSetPermissionsApiVersion extends EnumClass {
   static BuiltSet<RoomSetPermissionsApiVersion> get values => _$roomSetPermissionsApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetPermissionsApiVersion valueOf(final String name) => _$valueOfRoomSetPermissionsApiVersion(name);
+  static RoomSetPermissionsApiVersion valueOf(String name) => _$valueOfRoomSetPermissionsApiVersion(name);
 
   static Serializer<RoomSetPermissionsApiVersion> get serializer => _$roomSetPermissionsApiVersionSerializer;
 }
@@ -20865,7 +20821,7 @@ abstract class RoomSetPermissionsResponseApplicationJson_Ocs
         $RoomSetPermissionsResponseApplicationJson_OcsInterface,
         Built<RoomSetPermissionsResponseApplicationJson_Ocs, RoomSetPermissionsResponseApplicationJson_OcsBuilder> {
   factory RoomSetPermissionsResponseApplicationJson_Ocs([
-    final void Function(RoomSetPermissionsResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetPermissionsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetPermissionsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -20873,7 +20829,7 @@ abstract class RoomSetPermissionsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetPermissionsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetPermissionsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20895,7 +20851,7 @@ abstract class RoomSetPermissionsResponseApplicationJson
         $RoomSetPermissionsResponseApplicationJsonInterface,
         Built<RoomSetPermissionsResponseApplicationJson, RoomSetPermissionsResponseApplicationJsonBuilder> {
   factory RoomSetPermissionsResponseApplicationJson([
-    final void Function(RoomSetPermissionsResponseApplicationJsonBuilder)? b,
+    void Function(RoomSetPermissionsResponseApplicationJsonBuilder)? b,
   ]) = _$RoomSetPermissionsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -20903,7 +20859,7 @@ abstract class RoomSetPermissionsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetPermissionsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetPermissionsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20924,7 +20880,7 @@ class RoomGetParticipantsApiVersion extends EnumClass {
   static BuiltSet<RoomGetParticipantsApiVersion> get values => _$roomGetParticipantsApiVersionValues;
   // coverage:ignore-end
 
-  static RoomGetParticipantsApiVersion valueOf(final String name) => _$valueOfRoomGetParticipantsApiVersion(name);
+  static RoomGetParticipantsApiVersion valueOf(String name) => _$valueOfRoomGetParticipantsApiVersion(name);
 
   static Serializer<RoomGetParticipantsApiVersion> get serializer => _$roomGetParticipantsApiVersionSerializer;
 }
@@ -20939,7 +20895,7 @@ abstract class RoomRoomGetParticipantsHeaders
     implements
         $RoomRoomGetParticipantsHeadersInterface,
         Built<RoomRoomGetParticipantsHeaders, RoomRoomGetParticipantsHeadersBuilder> {
-  factory RoomRoomGetParticipantsHeaders([final void Function(RoomRoomGetParticipantsHeadersBuilder)? b]) =
+  factory RoomRoomGetParticipantsHeaders([void Function(RoomRoomGetParticipantsHeadersBuilder)? b]) =
       _$RoomRoomGetParticipantsHeaders;
 
   // coverage:ignore-start
@@ -20947,7 +20903,7 @@ abstract class RoomRoomGetParticipantsHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRoomGetParticipantsHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRoomGetParticipantsHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -20981,14 +20937,14 @@ abstract interface class $ParticipantInterface {
 }
 
 abstract class Participant implements $ParticipantInterface, Built<Participant, ParticipantBuilder> {
-  factory Participant([final void Function(ParticipantBuilder)? b]) = _$Participant;
+  factory Participant([void Function(ParticipantBuilder)? b]) = _$Participant;
 
   // coverage:ignore-start
   const Participant._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Participant.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Participant.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -21009,7 +20965,7 @@ abstract class RoomGetParticipantsResponseApplicationJson_Ocs
         $RoomGetParticipantsResponseApplicationJson_OcsInterface,
         Built<RoomGetParticipantsResponseApplicationJson_Ocs, RoomGetParticipantsResponseApplicationJson_OcsBuilder> {
   factory RoomGetParticipantsResponseApplicationJson_Ocs([
-    final void Function(RoomGetParticipantsResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomGetParticipantsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomGetParticipantsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21017,7 +20973,7 @@ abstract class RoomGetParticipantsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetParticipantsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetParticipantsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21039,7 +20995,7 @@ abstract class RoomGetParticipantsResponseApplicationJson
         $RoomGetParticipantsResponseApplicationJsonInterface,
         Built<RoomGetParticipantsResponseApplicationJson, RoomGetParticipantsResponseApplicationJsonBuilder> {
   factory RoomGetParticipantsResponseApplicationJson([
-    final void Function(RoomGetParticipantsResponseApplicationJsonBuilder)? b,
+    void Function(RoomGetParticipantsResponseApplicationJsonBuilder)? b,
   ]) = _$RoomGetParticipantsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21047,7 +21003,7 @@ abstract class RoomGetParticipantsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetParticipantsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetParticipantsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21068,8 +21024,7 @@ class RoomAddParticipantToRoomApiVersion extends EnumClass {
   static BuiltSet<RoomAddParticipantToRoomApiVersion> get values => _$roomAddParticipantToRoomApiVersionValues;
   // coverage:ignore-end
 
-  static RoomAddParticipantToRoomApiVersion valueOf(final String name) =>
-      _$valueOfRoomAddParticipantToRoomApiVersion(name);
+  static RoomAddParticipantToRoomApiVersion valueOf(String name) => _$valueOfRoomAddParticipantToRoomApiVersion(name);
 
   static Serializer<RoomAddParticipantToRoomApiVersion> get serializer =>
       _$roomAddParticipantToRoomApiVersionSerializer;
@@ -21086,7 +21041,7 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0
         Built<RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0,
             RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Builder> {
   factory RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0([
-    final void Function(RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Builder)? b,
+    void Function(RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Builder)? b,
   ]) = _$RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0;
 
   // coverage:ignore-start
@@ -21094,7 +21049,7 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0.fromJson(final Map<String, dynamic> json) =>
+  factory RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21118,7 +21073,7 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson_Ocs
         Built<RoomAddParticipantToRoomResponseApplicationJson_Ocs,
             RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder> {
   factory RoomAddParticipantToRoomResponseApplicationJson_Ocs([
-    final void Function(RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomAddParticipantToRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21126,7 +21081,7 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomAddParticipantToRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomAddParticipantToRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21138,7 +21093,7 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson_Ocs
       _$roomAddParticipantToRoomResponseApplicationJsonOcsSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder b) {
+  static void _validate(RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder b) {
     b.data?.validateOneOf();
   }
 }
@@ -21153,7 +21108,7 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson
         $RoomAddParticipantToRoomResponseApplicationJsonInterface,
         Built<RoomAddParticipantToRoomResponseApplicationJson, RoomAddParticipantToRoomResponseApplicationJsonBuilder> {
   factory RoomAddParticipantToRoomResponseApplicationJson([
-    final void Function(RoomAddParticipantToRoomResponseApplicationJsonBuilder)? b,
+    void Function(RoomAddParticipantToRoomResponseApplicationJsonBuilder)? b,
   ]) = _$RoomAddParticipantToRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21161,7 +21116,7 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomAddParticipantToRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomAddParticipantToRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21183,7 +21138,7 @@ class RoomGetBreakoutRoomParticipantsApiVersion extends EnumClass {
       _$roomGetBreakoutRoomParticipantsApiVersionValues;
   // coverage:ignore-end
 
-  static RoomGetBreakoutRoomParticipantsApiVersion valueOf(final String name) =>
+  static RoomGetBreakoutRoomParticipantsApiVersion valueOf(String name) =>
       _$valueOfRoomGetBreakoutRoomParticipantsApiVersion(name);
 
   static Serializer<RoomGetBreakoutRoomParticipantsApiVersion> get serializer =>
@@ -21201,7 +21156,7 @@ abstract class RoomRoomGetBreakoutRoomParticipantsHeaders
         $RoomRoomGetBreakoutRoomParticipantsHeadersInterface,
         Built<RoomRoomGetBreakoutRoomParticipantsHeaders, RoomRoomGetBreakoutRoomParticipantsHeadersBuilder> {
   factory RoomRoomGetBreakoutRoomParticipantsHeaders([
-    final void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder)? b,
+    void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder)? b,
   ]) = _$RoomRoomGetBreakoutRoomParticipantsHeaders;
 
   // coverage:ignore-start
@@ -21209,7 +21164,7 @@ abstract class RoomRoomGetBreakoutRoomParticipantsHeaders
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRoomGetBreakoutRoomParticipantsHeaders.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRoomGetBreakoutRoomParticipantsHeaders.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21233,7 +21188,7 @@ abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs
         Built<RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs,
             RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder> {
   factory RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs([
-    final void Function(RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21241,7 +21196,7 @@ abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21264,7 +21219,7 @@ abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson
         Built<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
             RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder> {
   factory RoomGetBreakoutRoomParticipantsResponseApplicationJson([
-    final void Function(RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder)? b,
+    void Function(RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder)? b,
   ]) = _$RoomGetBreakoutRoomParticipantsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21272,7 +21227,7 @@ abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomGetBreakoutRoomParticipantsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomGetBreakoutRoomParticipantsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21293,7 +21248,7 @@ class RoomRemoveSelfFromRoomApiVersion extends EnumClass {
   static BuiltSet<RoomRemoveSelfFromRoomApiVersion> get values => _$roomRemoveSelfFromRoomApiVersionValues;
   // coverage:ignore-end
 
-  static RoomRemoveSelfFromRoomApiVersion valueOf(final String name) => _$valueOfRoomRemoveSelfFromRoomApiVersion(name);
+  static RoomRemoveSelfFromRoomApiVersion valueOf(String name) => _$valueOfRoomRemoveSelfFromRoomApiVersion(name);
 
   static Serializer<RoomRemoveSelfFromRoomApiVersion> get serializer => _$roomRemoveSelfFromRoomApiVersionSerializer;
 }
@@ -21310,7 +21265,7 @@ abstract class RoomRemoveSelfFromRoomResponseApplicationJson_Ocs
         Built<RoomRemoveSelfFromRoomResponseApplicationJson_Ocs,
             RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder> {
   factory RoomRemoveSelfFromRoomResponseApplicationJson_Ocs([
-    final void Function(RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomRemoveSelfFromRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21318,7 +21273,7 @@ abstract class RoomRemoveSelfFromRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRemoveSelfFromRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRemoveSelfFromRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21340,7 +21295,7 @@ abstract class RoomRemoveSelfFromRoomResponseApplicationJson
         $RoomRemoveSelfFromRoomResponseApplicationJsonInterface,
         Built<RoomRemoveSelfFromRoomResponseApplicationJson, RoomRemoveSelfFromRoomResponseApplicationJsonBuilder> {
   factory RoomRemoveSelfFromRoomResponseApplicationJson([
-    final void Function(RoomRemoveSelfFromRoomResponseApplicationJsonBuilder)? b,
+    void Function(RoomRemoveSelfFromRoomResponseApplicationJsonBuilder)? b,
   ]) = _$RoomRemoveSelfFromRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21348,7 +21303,7 @@ abstract class RoomRemoveSelfFromRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRemoveSelfFromRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRemoveSelfFromRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21369,7 +21324,7 @@ class RoomRemoveAttendeeFromRoomApiVersion extends EnumClass {
   static BuiltSet<RoomRemoveAttendeeFromRoomApiVersion> get values => _$roomRemoveAttendeeFromRoomApiVersionValues;
   // coverage:ignore-end
 
-  static RoomRemoveAttendeeFromRoomApiVersion valueOf(final String name) =>
+  static RoomRemoveAttendeeFromRoomApiVersion valueOf(String name) =>
       _$valueOfRoomRemoveAttendeeFromRoomApiVersion(name);
 
   static Serializer<RoomRemoveAttendeeFromRoomApiVersion> get serializer =>
@@ -21388,7 +21343,7 @@ abstract class RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs
         Built<RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs,
             RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder> {
   factory RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs([
-    final void Function(RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21396,7 +21351,7 @@ abstract class RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21419,7 +21374,7 @@ abstract class RoomRemoveAttendeeFromRoomResponseApplicationJson
         Built<RoomRemoveAttendeeFromRoomResponseApplicationJson,
             RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder> {
   factory RoomRemoveAttendeeFromRoomResponseApplicationJson([
-    final void Function(RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder)? b,
+    void Function(RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder)? b,
   ]) = _$RoomRemoveAttendeeFromRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21427,7 +21382,7 @@ abstract class RoomRemoveAttendeeFromRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRemoveAttendeeFromRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRemoveAttendeeFromRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21448,7 +21403,7 @@ class RoomSetAttendeePermissionsApiVersion extends EnumClass {
   static BuiltSet<RoomSetAttendeePermissionsApiVersion> get values => _$roomSetAttendeePermissionsApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetAttendeePermissionsApiVersion valueOf(final String name) =>
+  static RoomSetAttendeePermissionsApiVersion valueOf(String name) =>
       _$valueOfRoomSetAttendeePermissionsApiVersion(name);
 
   static Serializer<RoomSetAttendeePermissionsApiVersion> get serializer =>
@@ -21467,7 +21422,7 @@ abstract class RoomSetAttendeePermissionsResponseApplicationJson_Ocs
         Built<RoomSetAttendeePermissionsResponseApplicationJson_Ocs,
             RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder> {
   factory RoomSetAttendeePermissionsResponseApplicationJson_Ocs([
-    final void Function(RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetAttendeePermissionsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21475,7 +21430,7 @@ abstract class RoomSetAttendeePermissionsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetAttendeePermissionsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetAttendeePermissionsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21498,7 +21453,7 @@ abstract class RoomSetAttendeePermissionsResponseApplicationJson
         Built<RoomSetAttendeePermissionsResponseApplicationJson,
             RoomSetAttendeePermissionsResponseApplicationJsonBuilder> {
   factory RoomSetAttendeePermissionsResponseApplicationJson([
-    final void Function(RoomSetAttendeePermissionsResponseApplicationJsonBuilder)? b,
+    void Function(RoomSetAttendeePermissionsResponseApplicationJsonBuilder)? b,
   ]) = _$RoomSetAttendeePermissionsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21506,7 +21461,7 @@ abstract class RoomSetAttendeePermissionsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetAttendeePermissionsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetAttendeePermissionsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21528,7 +21483,7 @@ class RoomSetAllAttendeesPermissionsApiVersion extends EnumClass {
       _$roomSetAllAttendeesPermissionsApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetAllAttendeesPermissionsApiVersion valueOf(final String name) =>
+  static RoomSetAllAttendeesPermissionsApiVersion valueOf(String name) =>
       _$valueOfRoomSetAllAttendeesPermissionsApiVersion(name);
 
   static Serializer<RoomSetAllAttendeesPermissionsApiVersion> get serializer =>
@@ -21547,7 +21502,7 @@ abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs
         Built<RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs,
             RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder> {
   factory RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs([
-    final void Function(RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21555,7 +21510,7 @@ abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21578,7 +21533,7 @@ abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson
         Built<RoomSetAllAttendeesPermissionsResponseApplicationJson,
             RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder> {
   factory RoomSetAllAttendeesPermissionsResponseApplicationJson([
-    final void Function(RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder)? b,
+    void Function(RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder)? b,
   ]) = _$RoomSetAllAttendeesPermissionsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21586,7 +21541,7 @@ abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetAllAttendeesPermissionsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetAllAttendeesPermissionsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21607,7 +21562,7 @@ class RoomJoinRoomApiVersion extends EnumClass {
   static BuiltSet<RoomJoinRoomApiVersion> get values => _$roomJoinRoomApiVersionValues;
   // coverage:ignore-end
 
-  static RoomJoinRoomApiVersion valueOf(final String name) => _$valueOfRoomJoinRoomApiVersion(name);
+  static RoomJoinRoomApiVersion valueOf(String name) => _$valueOfRoomJoinRoomApiVersion(name);
 
   static Serializer<RoomJoinRoomApiVersion> get serializer => _$roomJoinRoomApiVersionSerializer;
 }
@@ -21622,16 +21577,15 @@ abstract class RoomJoinRoomResponseApplicationJson_Ocs
     implements
         $RoomJoinRoomResponseApplicationJson_OcsInterface,
         Built<RoomJoinRoomResponseApplicationJson_Ocs, RoomJoinRoomResponseApplicationJson_OcsBuilder> {
-  factory RoomJoinRoomResponseApplicationJson_Ocs([
-    final void Function(RoomJoinRoomResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$RoomJoinRoomResponseApplicationJson_Ocs;
+  factory RoomJoinRoomResponseApplicationJson_Ocs([void Function(RoomJoinRoomResponseApplicationJson_OcsBuilder)? b]) =
+      _$RoomJoinRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const RoomJoinRoomResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomJoinRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomJoinRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21652,7 +21606,7 @@ abstract class RoomJoinRoomResponseApplicationJson
     implements
         $RoomJoinRoomResponseApplicationJsonInterface,
         Built<RoomJoinRoomResponseApplicationJson, RoomJoinRoomResponseApplicationJsonBuilder> {
-  factory RoomJoinRoomResponseApplicationJson([final void Function(RoomJoinRoomResponseApplicationJsonBuilder)? b]) =
+  factory RoomJoinRoomResponseApplicationJson([void Function(RoomJoinRoomResponseApplicationJsonBuilder)? b]) =
       _$RoomJoinRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21660,7 +21614,7 @@ abstract class RoomJoinRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomJoinRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomJoinRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21681,7 +21635,7 @@ class RoomLeaveRoomApiVersion extends EnumClass {
   static BuiltSet<RoomLeaveRoomApiVersion> get values => _$roomLeaveRoomApiVersionValues;
   // coverage:ignore-end
 
-  static RoomLeaveRoomApiVersion valueOf(final String name) => _$valueOfRoomLeaveRoomApiVersion(name);
+  static RoomLeaveRoomApiVersion valueOf(String name) => _$valueOfRoomLeaveRoomApiVersion(name);
 
   static Serializer<RoomLeaveRoomApiVersion> get serializer => _$roomLeaveRoomApiVersionSerializer;
 }
@@ -21697,7 +21651,7 @@ abstract class RoomLeaveRoomResponseApplicationJson_Ocs
         $RoomLeaveRoomResponseApplicationJson_OcsInterface,
         Built<RoomLeaveRoomResponseApplicationJson_Ocs, RoomLeaveRoomResponseApplicationJson_OcsBuilder> {
   factory RoomLeaveRoomResponseApplicationJson_Ocs([
-    final void Function(RoomLeaveRoomResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomLeaveRoomResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomLeaveRoomResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21705,7 +21659,7 @@ abstract class RoomLeaveRoomResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomLeaveRoomResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomLeaveRoomResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21726,7 +21680,7 @@ abstract class RoomLeaveRoomResponseApplicationJson
     implements
         $RoomLeaveRoomResponseApplicationJsonInterface,
         Built<RoomLeaveRoomResponseApplicationJson, RoomLeaveRoomResponseApplicationJsonBuilder> {
-  factory RoomLeaveRoomResponseApplicationJson([final void Function(RoomLeaveRoomResponseApplicationJsonBuilder)? b]) =
+  factory RoomLeaveRoomResponseApplicationJson([void Function(RoomLeaveRoomResponseApplicationJsonBuilder)? b]) =
       _$RoomLeaveRoomResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21734,7 +21688,7 @@ abstract class RoomLeaveRoomResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomLeaveRoomResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomLeaveRoomResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21755,7 +21709,7 @@ class RoomResendInvitationsApiVersion extends EnumClass {
   static BuiltSet<RoomResendInvitationsApiVersion> get values => _$roomResendInvitationsApiVersionValues;
   // coverage:ignore-end
 
-  static RoomResendInvitationsApiVersion valueOf(final String name) => _$valueOfRoomResendInvitationsApiVersion(name);
+  static RoomResendInvitationsApiVersion valueOf(String name) => _$valueOfRoomResendInvitationsApiVersion(name);
 
   static Serializer<RoomResendInvitationsApiVersion> get serializer => _$roomResendInvitationsApiVersionSerializer;
 }
@@ -21772,7 +21726,7 @@ abstract class RoomResendInvitationsResponseApplicationJson_Ocs
         Built<RoomResendInvitationsResponseApplicationJson_Ocs,
             RoomResendInvitationsResponseApplicationJson_OcsBuilder> {
   factory RoomResendInvitationsResponseApplicationJson_Ocs([
-    final void Function(RoomResendInvitationsResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomResendInvitationsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomResendInvitationsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21780,7 +21734,7 @@ abstract class RoomResendInvitationsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomResendInvitationsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomResendInvitationsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21802,7 +21756,7 @@ abstract class RoomResendInvitationsResponseApplicationJson
         $RoomResendInvitationsResponseApplicationJsonInterface,
         Built<RoomResendInvitationsResponseApplicationJson, RoomResendInvitationsResponseApplicationJsonBuilder> {
   factory RoomResendInvitationsResponseApplicationJson([
-    final void Function(RoomResendInvitationsResponseApplicationJsonBuilder)? b,
+    void Function(RoomResendInvitationsResponseApplicationJsonBuilder)? b,
   ]) = _$RoomResendInvitationsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21810,7 +21764,7 @@ abstract class RoomResendInvitationsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomResendInvitationsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomResendInvitationsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21831,7 +21785,7 @@ class RoomSetSessionStateApiVersion extends EnumClass {
   static BuiltSet<RoomSetSessionStateApiVersion> get values => _$roomSetSessionStateApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetSessionStateApiVersion valueOf(final String name) => _$valueOfRoomSetSessionStateApiVersion(name);
+  static RoomSetSessionStateApiVersion valueOf(String name) => _$valueOfRoomSetSessionStateApiVersion(name);
 
   static Serializer<RoomSetSessionStateApiVersion> get serializer => _$roomSetSessionStateApiVersionSerializer;
 }
@@ -21847,7 +21801,7 @@ abstract class RoomSetSessionStateResponseApplicationJson_Ocs
         $RoomSetSessionStateResponseApplicationJson_OcsInterface,
         Built<RoomSetSessionStateResponseApplicationJson_Ocs, RoomSetSessionStateResponseApplicationJson_OcsBuilder> {
   factory RoomSetSessionStateResponseApplicationJson_Ocs([
-    final void Function(RoomSetSessionStateResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetSessionStateResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetSessionStateResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21855,7 +21809,7 @@ abstract class RoomSetSessionStateResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetSessionStateResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetSessionStateResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21877,7 +21831,7 @@ abstract class RoomSetSessionStateResponseApplicationJson
         $RoomSetSessionStateResponseApplicationJsonInterface,
         Built<RoomSetSessionStateResponseApplicationJson, RoomSetSessionStateResponseApplicationJsonBuilder> {
   factory RoomSetSessionStateResponseApplicationJson([
-    final void Function(RoomSetSessionStateResponseApplicationJsonBuilder)? b,
+    void Function(RoomSetSessionStateResponseApplicationJsonBuilder)? b,
   ]) = _$RoomSetSessionStateResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21885,7 +21839,7 @@ abstract class RoomSetSessionStateResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetSessionStateResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetSessionStateResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21906,7 +21860,7 @@ class RoomPromoteModeratorApiVersion extends EnumClass {
   static BuiltSet<RoomPromoteModeratorApiVersion> get values => _$roomPromoteModeratorApiVersionValues;
   // coverage:ignore-end
 
-  static RoomPromoteModeratorApiVersion valueOf(final String name) => _$valueOfRoomPromoteModeratorApiVersion(name);
+  static RoomPromoteModeratorApiVersion valueOf(String name) => _$valueOfRoomPromoteModeratorApiVersion(name);
 
   static Serializer<RoomPromoteModeratorApiVersion> get serializer => _$roomPromoteModeratorApiVersionSerializer;
 }
@@ -21922,7 +21876,7 @@ abstract class RoomPromoteModeratorResponseApplicationJson_Ocs
         $RoomPromoteModeratorResponseApplicationJson_OcsInterface,
         Built<RoomPromoteModeratorResponseApplicationJson_Ocs, RoomPromoteModeratorResponseApplicationJson_OcsBuilder> {
   factory RoomPromoteModeratorResponseApplicationJson_Ocs([
-    final void Function(RoomPromoteModeratorResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomPromoteModeratorResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomPromoteModeratorResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -21930,7 +21884,7 @@ abstract class RoomPromoteModeratorResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomPromoteModeratorResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomPromoteModeratorResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21952,7 +21906,7 @@ abstract class RoomPromoteModeratorResponseApplicationJson
         $RoomPromoteModeratorResponseApplicationJsonInterface,
         Built<RoomPromoteModeratorResponseApplicationJson, RoomPromoteModeratorResponseApplicationJsonBuilder> {
   factory RoomPromoteModeratorResponseApplicationJson([
-    final void Function(RoomPromoteModeratorResponseApplicationJsonBuilder)? b,
+    void Function(RoomPromoteModeratorResponseApplicationJsonBuilder)? b,
   ]) = _$RoomPromoteModeratorResponseApplicationJson;
 
   // coverage:ignore-start
@@ -21960,7 +21914,7 @@ abstract class RoomPromoteModeratorResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomPromoteModeratorResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomPromoteModeratorResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -21981,7 +21935,7 @@ class RoomDemoteModeratorApiVersion extends EnumClass {
   static BuiltSet<RoomDemoteModeratorApiVersion> get values => _$roomDemoteModeratorApiVersionValues;
   // coverage:ignore-end
 
-  static RoomDemoteModeratorApiVersion valueOf(final String name) => _$valueOfRoomDemoteModeratorApiVersion(name);
+  static RoomDemoteModeratorApiVersion valueOf(String name) => _$valueOfRoomDemoteModeratorApiVersion(name);
 
   static Serializer<RoomDemoteModeratorApiVersion> get serializer => _$roomDemoteModeratorApiVersionSerializer;
 }
@@ -21997,7 +21951,7 @@ abstract class RoomDemoteModeratorResponseApplicationJson_Ocs
         $RoomDemoteModeratorResponseApplicationJson_OcsInterface,
         Built<RoomDemoteModeratorResponseApplicationJson_Ocs, RoomDemoteModeratorResponseApplicationJson_OcsBuilder> {
   factory RoomDemoteModeratorResponseApplicationJson_Ocs([
-    final void Function(RoomDemoteModeratorResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomDemoteModeratorResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomDemoteModeratorResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -22005,7 +21959,7 @@ abstract class RoomDemoteModeratorResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomDemoteModeratorResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomDemoteModeratorResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22027,7 +21981,7 @@ abstract class RoomDemoteModeratorResponseApplicationJson
         $RoomDemoteModeratorResponseApplicationJsonInterface,
         Built<RoomDemoteModeratorResponseApplicationJson, RoomDemoteModeratorResponseApplicationJsonBuilder> {
   factory RoomDemoteModeratorResponseApplicationJson([
-    final void Function(RoomDemoteModeratorResponseApplicationJsonBuilder)? b,
+    void Function(RoomDemoteModeratorResponseApplicationJsonBuilder)? b,
   ]) = _$RoomDemoteModeratorResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22035,7 +21989,7 @@ abstract class RoomDemoteModeratorResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomDemoteModeratorResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomDemoteModeratorResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22056,7 +22010,7 @@ class RoomAddToFavoritesApiVersion extends EnumClass {
   static BuiltSet<RoomAddToFavoritesApiVersion> get values => _$roomAddToFavoritesApiVersionValues;
   // coverage:ignore-end
 
-  static RoomAddToFavoritesApiVersion valueOf(final String name) => _$valueOfRoomAddToFavoritesApiVersion(name);
+  static RoomAddToFavoritesApiVersion valueOf(String name) => _$valueOfRoomAddToFavoritesApiVersion(name);
 
   static Serializer<RoomAddToFavoritesApiVersion> get serializer => _$roomAddToFavoritesApiVersionSerializer;
 }
@@ -22072,7 +22026,7 @@ abstract class RoomAddToFavoritesResponseApplicationJson_Ocs
         $RoomAddToFavoritesResponseApplicationJson_OcsInterface,
         Built<RoomAddToFavoritesResponseApplicationJson_Ocs, RoomAddToFavoritesResponseApplicationJson_OcsBuilder> {
   factory RoomAddToFavoritesResponseApplicationJson_Ocs([
-    final void Function(RoomAddToFavoritesResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomAddToFavoritesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomAddToFavoritesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -22080,7 +22034,7 @@ abstract class RoomAddToFavoritesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomAddToFavoritesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomAddToFavoritesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22102,7 +22056,7 @@ abstract class RoomAddToFavoritesResponseApplicationJson
         $RoomAddToFavoritesResponseApplicationJsonInterface,
         Built<RoomAddToFavoritesResponseApplicationJson, RoomAddToFavoritesResponseApplicationJsonBuilder> {
   factory RoomAddToFavoritesResponseApplicationJson([
-    final void Function(RoomAddToFavoritesResponseApplicationJsonBuilder)? b,
+    void Function(RoomAddToFavoritesResponseApplicationJsonBuilder)? b,
   ]) = _$RoomAddToFavoritesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22110,7 +22064,7 @@ abstract class RoomAddToFavoritesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomAddToFavoritesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomAddToFavoritesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22131,8 +22085,7 @@ class RoomRemoveFromFavoritesApiVersion extends EnumClass {
   static BuiltSet<RoomRemoveFromFavoritesApiVersion> get values => _$roomRemoveFromFavoritesApiVersionValues;
   // coverage:ignore-end
 
-  static RoomRemoveFromFavoritesApiVersion valueOf(final String name) =>
-      _$valueOfRoomRemoveFromFavoritesApiVersion(name);
+  static RoomRemoveFromFavoritesApiVersion valueOf(String name) => _$valueOfRoomRemoveFromFavoritesApiVersion(name);
 
   static Serializer<RoomRemoveFromFavoritesApiVersion> get serializer => _$roomRemoveFromFavoritesApiVersionSerializer;
 }
@@ -22149,7 +22102,7 @@ abstract class RoomRemoveFromFavoritesResponseApplicationJson_Ocs
         Built<RoomRemoveFromFavoritesResponseApplicationJson_Ocs,
             RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder> {
   factory RoomRemoveFromFavoritesResponseApplicationJson_Ocs([
-    final void Function(RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomRemoveFromFavoritesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -22157,7 +22110,7 @@ abstract class RoomRemoveFromFavoritesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRemoveFromFavoritesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRemoveFromFavoritesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22179,7 +22132,7 @@ abstract class RoomRemoveFromFavoritesResponseApplicationJson
         $RoomRemoveFromFavoritesResponseApplicationJsonInterface,
         Built<RoomRemoveFromFavoritesResponseApplicationJson, RoomRemoveFromFavoritesResponseApplicationJsonBuilder> {
   factory RoomRemoveFromFavoritesResponseApplicationJson([
-    final void Function(RoomRemoveFromFavoritesResponseApplicationJsonBuilder)? b,
+    void Function(RoomRemoveFromFavoritesResponseApplicationJsonBuilder)? b,
   ]) = _$RoomRemoveFromFavoritesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22187,7 +22140,7 @@ abstract class RoomRemoveFromFavoritesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomRemoveFromFavoritesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomRemoveFromFavoritesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22208,8 +22161,7 @@ class RoomSetNotificationLevelApiVersion extends EnumClass {
   static BuiltSet<RoomSetNotificationLevelApiVersion> get values => _$roomSetNotificationLevelApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetNotificationLevelApiVersion valueOf(final String name) =>
-      _$valueOfRoomSetNotificationLevelApiVersion(name);
+  static RoomSetNotificationLevelApiVersion valueOf(String name) => _$valueOfRoomSetNotificationLevelApiVersion(name);
 
   static Serializer<RoomSetNotificationLevelApiVersion> get serializer =>
       _$roomSetNotificationLevelApiVersionSerializer;
@@ -22227,7 +22179,7 @@ abstract class RoomSetNotificationLevelResponseApplicationJson_Ocs
         Built<RoomSetNotificationLevelResponseApplicationJson_Ocs,
             RoomSetNotificationLevelResponseApplicationJson_OcsBuilder> {
   factory RoomSetNotificationLevelResponseApplicationJson_Ocs([
-    final void Function(RoomSetNotificationLevelResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetNotificationLevelResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetNotificationLevelResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -22235,7 +22187,7 @@ abstract class RoomSetNotificationLevelResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetNotificationLevelResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetNotificationLevelResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22257,7 +22209,7 @@ abstract class RoomSetNotificationLevelResponseApplicationJson
         $RoomSetNotificationLevelResponseApplicationJsonInterface,
         Built<RoomSetNotificationLevelResponseApplicationJson, RoomSetNotificationLevelResponseApplicationJsonBuilder> {
   factory RoomSetNotificationLevelResponseApplicationJson([
-    final void Function(RoomSetNotificationLevelResponseApplicationJsonBuilder)? b,
+    void Function(RoomSetNotificationLevelResponseApplicationJsonBuilder)? b,
   ]) = _$RoomSetNotificationLevelResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22265,7 +22217,7 @@ abstract class RoomSetNotificationLevelResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetNotificationLevelResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetNotificationLevelResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22286,8 +22238,7 @@ class RoomSetNotificationCallsApiVersion extends EnumClass {
   static BuiltSet<RoomSetNotificationCallsApiVersion> get values => _$roomSetNotificationCallsApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetNotificationCallsApiVersion valueOf(final String name) =>
-      _$valueOfRoomSetNotificationCallsApiVersion(name);
+  static RoomSetNotificationCallsApiVersion valueOf(String name) => _$valueOfRoomSetNotificationCallsApiVersion(name);
 
   static Serializer<RoomSetNotificationCallsApiVersion> get serializer =>
       _$roomSetNotificationCallsApiVersionSerializer;
@@ -22305,7 +22256,7 @@ abstract class RoomSetNotificationCallsResponseApplicationJson_Ocs
         Built<RoomSetNotificationCallsResponseApplicationJson_Ocs,
             RoomSetNotificationCallsResponseApplicationJson_OcsBuilder> {
   factory RoomSetNotificationCallsResponseApplicationJson_Ocs([
-    final void Function(RoomSetNotificationCallsResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetNotificationCallsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetNotificationCallsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -22313,7 +22264,7 @@ abstract class RoomSetNotificationCallsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetNotificationCallsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetNotificationCallsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22335,7 +22286,7 @@ abstract class RoomSetNotificationCallsResponseApplicationJson
         $RoomSetNotificationCallsResponseApplicationJsonInterface,
         Built<RoomSetNotificationCallsResponseApplicationJson, RoomSetNotificationCallsResponseApplicationJsonBuilder> {
   factory RoomSetNotificationCallsResponseApplicationJson([
-    final void Function(RoomSetNotificationCallsResponseApplicationJsonBuilder)? b,
+    void Function(RoomSetNotificationCallsResponseApplicationJsonBuilder)? b,
   ]) = _$RoomSetNotificationCallsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22343,7 +22294,7 @@ abstract class RoomSetNotificationCallsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetNotificationCallsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetNotificationCallsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22364,7 +22315,7 @@ class RoomSetLobbyApiVersion extends EnumClass {
   static BuiltSet<RoomSetLobbyApiVersion> get values => _$roomSetLobbyApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetLobbyApiVersion valueOf(final String name) => _$valueOfRoomSetLobbyApiVersion(name);
+  static RoomSetLobbyApiVersion valueOf(String name) => _$valueOfRoomSetLobbyApiVersion(name);
 
   static Serializer<RoomSetLobbyApiVersion> get serializer => _$roomSetLobbyApiVersionSerializer;
 }
@@ -22379,16 +22330,15 @@ abstract class RoomSetLobbyResponseApplicationJson_Ocs
     implements
         $RoomSetLobbyResponseApplicationJson_OcsInterface,
         Built<RoomSetLobbyResponseApplicationJson_Ocs, RoomSetLobbyResponseApplicationJson_OcsBuilder> {
-  factory RoomSetLobbyResponseApplicationJson_Ocs([
-    final void Function(RoomSetLobbyResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$RoomSetLobbyResponseApplicationJson_Ocs;
+  factory RoomSetLobbyResponseApplicationJson_Ocs([void Function(RoomSetLobbyResponseApplicationJson_OcsBuilder)? b]) =
+      _$RoomSetLobbyResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const RoomSetLobbyResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetLobbyResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetLobbyResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22409,7 +22359,7 @@ abstract class RoomSetLobbyResponseApplicationJson
     implements
         $RoomSetLobbyResponseApplicationJsonInterface,
         Built<RoomSetLobbyResponseApplicationJson, RoomSetLobbyResponseApplicationJsonBuilder> {
-  factory RoomSetLobbyResponseApplicationJson([final void Function(RoomSetLobbyResponseApplicationJsonBuilder)? b]) =
+  factory RoomSetLobbyResponseApplicationJson([void Function(RoomSetLobbyResponseApplicationJsonBuilder)? b]) =
       _$RoomSetLobbyResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22417,7 +22367,7 @@ abstract class RoomSetLobbyResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetLobbyResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetLobbyResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22438,7 +22388,7 @@ class RoomSetsipEnabledApiVersion extends EnumClass {
   static BuiltSet<RoomSetsipEnabledApiVersion> get values => _$roomSetsipEnabledApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetsipEnabledApiVersion valueOf(final String name) => _$valueOfRoomSetsipEnabledApiVersion(name);
+  static RoomSetsipEnabledApiVersion valueOf(String name) => _$valueOfRoomSetsipEnabledApiVersion(name);
 
   static Serializer<RoomSetsipEnabledApiVersion> get serializer => _$roomSetsipEnabledApiVersionSerializer;
 }
@@ -22454,7 +22404,7 @@ abstract class RoomSetsipEnabledResponseApplicationJson_Ocs
         $RoomSetsipEnabledResponseApplicationJson_OcsInterface,
         Built<RoomSetsipEnabledResponseApplicationJson_Ocs, RoomSetsipEnabledResponseApplicationJson_OcsBuilder> {
   factory RoomSetsipEnabledResponseApplicationJson_Ocs([
-    final void Function(RoomSetsipEnabledResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetsipEnabledResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetsipEnabledResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -22462,7 +22412,7 @@ abstract class RoomSetsipEnabledResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetsipEnabledResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetsipEnabledResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22484,7 +22434,7 @@ abstract class RoomSetsipEnabledResponseApplicationJson
         $RoomSetsipEnabledResponseApplicationJsonInterface,
         Built<RoomSetsipEnabledResponseApplicationJson, RoomSetsipEnabledResponseApplicationJsonBuilder> {
   factory RoomSetsipEnabledResponseApplicationJson([
-    final void Function(RoomSetsipEnabledResponseApplicationJsonBuilder)? b,
+    void Function(RoomSetsipEnabledResponseApplicationJsonBuilder)? b,
   ]) = _$RoomSetsipEnabledResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22492,7 +22442,7 @@ abstract class RoomSetsipEnabledResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetsipEnabledResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetsipEnabledResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22513,8 +22463,7 @@ class RoomSetRecordingConsentApiVersion extends EnumClass {
   static BuiltSet<RoomSetRecordingConsentApiVersion> get values => _$roomSetRecordingConsentApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetRecordingConsentApiVersion valueOf(final String name) =>
-      _$valueOfRoomSetRecordingConsentApiVersion(name);
+  static RoomSetRecordingConsentApiVersion valueOf(String name) => _$valueOfRoomSetRecordingConsentApiVersion(name);
 
   static Serializer<RoomSetRecordingConsentApiVersion> get serializer => _$roomSetRecordingConsentApiVersionSerializer;
 }
@@ -22531,7 +22480,7 @@ abstract class RoomSetRecordingConsentResponseApplicationJson_Ocs
         Built<RoomSetRecordingConsentResponseApplicationJson_Ocs,
             RoomSetRecordingConsentResponseApplicationJson_OcsBuilder> {
   factory RoomSetRecordingConsentResponseApplicationJson_Ocs([
-    final void Function(RoomSetRecordingConsentResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetRecordingConsentResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetRecordingConsentResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -22539,7 +22488,7 @@ abstract class RoomSetRecordingConsentResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetRecordingConsentResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetRecordingConsentResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22561,7 +22510,7 @@ abstract class RoomSetRecordingConsentResponseApplicationJson
         $RoomSetRecordingConsentResponseApplicationJsonInterface,
         Built<RoomSetRecordingConsentResponseApplicationJson, RoomSetRecordingConsentResponseApplicationJsonBuilder> {
   factory RoomSetRecordingConsentResponseApplicationJson([
-    final void Function(RoomSetRecordingConsentResponseApplicationJsonBuilder)? b,
+    void Function(RoomSetRecordingConsentResponseApplicationJsonBuilder)? b,
   ]) = _$RoomSetRecordingConsentResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22569,7 +22518,7 @@ abstract class RoomSetRecordingConsentResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetRecordingConsentResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetRecordingConsentResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22590,8 +22539,7 @@ class RoomSetMessageExpirationApiVersion extends EnumClass {
   static BuiltSet<RoomSetMessageExpirationApiVersion> get values => _$roomSetMessageExpirationApiVersionValues;
   // coverage:ignore-end
 
-  static RoomSetMessageExpirationApiVersion valueOf(final String name) =>
-      _$valueOfRoomSetMessageExpirationApiVersion(name);
+  static RoomSetMessageExpirationApiVersion valueOf(String name) => _$valueOfRoomSetMessageExpirationApiVersion(name);
 
   static Serializer<RoomSetMessageExpirationApiVersion> get serializer =>
       _$roomSetMessageExpirationApiVersionSerializer;
@@ -22609,7 +22557,7 @@ abstract class RoomSetMessageExpirationResponseApplicationJson_Ocs
         Built<RoomSetMessageExpirationResponseApplicationJson_Ocs,
             RoomSetMessageExpirationResponseApplicationJson_OcsBuilder> {
   factory RoomSetMessageExpirationResponseApplicationJson_Ocs([
-    final void Function(RoomSetMessageExpirationResponseApplicationJson_OcsBuilder)? b,
+    void Function(RoomSetMessageExpirationResponseApplicationJson_OcsBuilder)? b,
   ]) = _$RoomSetMessageExpirationResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -22617,7 +22565,7 @@ abstract class RoomSetMessageExpirationResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetMessageExpirationResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetMessageExpirationResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22639,7 +22587,7 @@ abstract class RoomSetMessageExpirationResponseApplicationJson
         $RoomSetMessageExpirationResponseApplicationJsonInterface,
         Built<RoomSetMessageExpirationResponseApplicationJson, RoomSetMessageExpirationResponseApplicationJsonBuilder> {
   factory RoomSetMessageExpirationResponseApplicationJson([
-    final void Function(RoomSetMessageExpirationResponseApplicationJsonBuilder)? b,
+    void Function(RoomSetMessageExpirationResponseApplicationJsonBuilder)? b,
   ]) = _$RoomSetMessageExpirationResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22647,7 +22595,7 @@ abstract class RoomSetMessageExpirationResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory RoomSetMessageExpirationResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory RoomSetMessageExpirationResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22668,7 +22616,7 @@ class SettingsSetsipSettingsApiVersion extends EnumClass {
   static BuiltSet<SettingsSetsipSettingsApiVersion> get values => _$settingsSetsipSettingsApiVersionValues;
   // coverage:ignore-end
 
-  static SettingsSetsipSettingsApiVersion valueOf(final String name) => _$valueOfSettingsSetsipSettingsApiVersion(name);
+  static SettingsSetsipSettingsApiVersion valueOf(String name) => _$valueOfSettingsSetsipSettingsApiVersion(name);
 
   static Serializer<SettingsSetsipSettingsApiVersion> get serializer => _$settingsSetsipSettingsApiVersionSerializer;
 }
@@ -22685,7 +22633,7 @@ abstract class SettingsSetsipSettingsResponseApplicationJson_Ocs
         Built<SettingsSetsipSettingsResponseApplicationJson_Ocs,
             SettingsSetsipSettingsResponseApplicationJson_OcsBuilder> {
   factory SettingsSetsipSettingsResponseApplicationJson_Ocs([
-    final void Function(SettingsSetsipSettingsResponseApplicationJson_OcsBuilder)? b,
+    void Function(SettingsSetsipSettingsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$SettingsSetsipSettingsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -22693,7 +22641,7 @@ abstract class SettingsSetsipSettingsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SettingsSetsipSettingsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory SettingsSetsipSettingsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22715,7 +22663,7 @@ abstract class SettingsSetsipSettingsResponseApplicationJson
         $SettingsSetsipSettingsResponseApplicationJsonInterface,
         Built<SettingsSetsipSettingsResponseApplicationJson, SettingsSetsipSettingsResponseApplicationJsonBuilder> {
   factory SettingsSetsipSettingsResponseApplicationJson([
-    final void Function(SettingsSetsipSettingsResponseApplicationJsonBuilder)? b,
+    void Function(SettingsSetsipSettingsResponseApplicationJsonBuilder)? b,
   ]) = _$SettingsSetsipSettingsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22723,7 +22671,7 @@ abstract class SettingsSetsipSettingsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SettingsSetsipSettingsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory SettingsSetsipSettingsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22744,7 +22692,7 @@ class SettingsSetUserSettingApiVersion extends EnumClass {
   static BuiltSet<SettingsSetUserSettingApiVersion> get values => _$settingsSetUserSettingApiVersionValues;
   // coverage:ignore-end
 
-  static SettingsSetUserSettingApiVersion valueOf(final String name) => _$valueOfSettingsSetUserSettingApiVersion(name);
+  static SettingsSetUserSettingApiVersion valueOf(String name) => _$valueOfSettingsSetUserSettingApiVersion(name);
 
   static Serializer<SettingsSetUserSettingApiVersion> get serializer => _$settingsSetUserSettingApiVersionSerializer;
 }
@@ -22761,7 +22709,7 @@ abstract class SettingsSetUserSettingResponseApplicationJson_Ocs
         Built<SettingsSetUserSettingResponseApplicationJson_Ocs,
             SettingsSetUserSettingResponseApplicationJson_OcsBuilder> {
   factory SettingsSetUserSettingResponseApplicationJson_Ocs([
-    final void Function(SettingsSetUserSettingResponseApplicationJson_OcsBuilder)? b,
+    void Function(SettingsSetUserSettingResponseApplicationJson_OcsBuilder)? b,
   ]) = _$SettingsSetUserSettingResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -22769,7 +22717,7 @@ abstract class SettingsSetUserSettingResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SettingsSetUserSettingResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory SettingsSetUserSettingResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22791,7 +22739,7 @@ abstract class SettingsSetUserSettingResponseApplicationJson
         $SettingsSetUserSettingResponseApplicationJsonInterface,
         Built<SettingsSetUserSettingResponseApplicationJson, SettingsSetUserSettingResponseApplicationJsonBuilder> {
   factory SettingsSetUserSettingResponseApplicationJson([
-    final void Function(SettingsSetUserSettingResponseApplicationJsonBuilder)? b,
+    void Function(SettingsSetUserSettingResponseApplicationJsonBuilder)? b,
   ]) = _$SettingsSetUserSettingResponseApplicationJson;
 
   // coverage:ignore-start
@@ -22799,7 +22747,7 @@ abstract class SettingsSetUserSettingResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SettingsSetUserSettingResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory SettingsSetUserSettingResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22820,7 +22768,7 @@ class SignalingGetSettingsApiVersion extends EnumClass {
   static BuiltSet<SignalingGetSettingsApiVersion> get values => _$signalingGetSettingsApiVersionValues;
   // coverage:ignore-end
 
-  static SignalingGetSettingsApiVersion valueOf(final String name) => _$valueOfSignalingGetSettingsApiVersion(name);
+  static SignalingGetSettingsApiVersion valueOf(String name) => _$valueOfSignalingGetSettingsApiVersion(name);
 
   static Serializer<SignalingGetSettingsApiVersion> get serializer => _$signalingGetSettingsApiVersionSerializer;
 }
@@ -22835,16 +22783,15 @@ abstract class SignalingSettings_HelloAuthParams_$10
     implements
         $SignalingSettings_HelloAuthParams_$10Interface,
         Built<SignalingSettings_HelloAuthParams_$10, SignalingSettings_HelloAuthParams_$10Builder> {
-  factory SignalingSettings_HelloAuthParams_$10([
-    final void Function(SignalingSettings_HelloAuthParams_$10Builder)? b,
-  ]) = _$SignalingSettings_HelloAuthParams_$10;
+  factory SignalingSettings_HelloAuthParams_$10([void Function(SignalingSettings_HelloAuthParams_$10Builder)? b]) =
+      _$SignalingSettings_HelloAuthParams_$10;
 
   // coverage:ignore-start
   const SignalingSettings_HelloAuthParams_$10._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingSettings_HelloAuthParams_$10.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingSettings_HelloAuthParams_$10.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22865,16 +22812,15 @@ abstract class SignalingSettings_HelloAuthParams_$20
     implements
         $SignalingSettings_HelloAuthParams_$20Interface,
         Built<SignalingSettings_HelloAuthParams_$20, SignalingSettings_HelloAuthParams_$20Builder> {
-  factory SignalingSettings_HelloAuthParams_$20([
-    final void Function(SignalingSettings_HelloAuthParams_$20Builder)? b,
-  ]) = _$SignalingSettings_HelloAuthParams_$20;
+  factory SignalingSettings_HelloAuthParams_$20([void Function(SignalingSettings_HelloAuthParams_$20Builder)? b]) =
+      _$SignalingSettings_HelloAuthParams_$20;
 
   // coverage:ignore-start
   const SignalingSettings_HelloAuthParams_$20._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingSettings_HelloAuthParams_$20.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingSettings_HelloAuthParams_$20.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22898,7 +22844,7 @@ abstract class SignalingSettings_HelloAuthParams
     implements
         $SignalingSettings_HelloAuthParamsInterface,
         Built<SignalingSettings_HelloAuthParams, SignalingSettings_HelloAuthParamsBuilder> {
-  factory SignalingSettings_HelloAuthParams([final void Function(SignalingSettings_HelloAuthParamsBuilder)? b]) =
+  factory SignalingSettings_HelloAuthParams([void Function(SignalingSettings_HelloAuthParamsBuilder)? b]) =
       _$SignalingSettings_HelloAuthParams;
 
   // coverage:ignore-start
@@ -22906,7 +22852,7 @@ abstract class SignalingSettings_HelloAuthParams
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingSettings_HelloAuthParams.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingSettings_HelloAuthParams.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22926,7 +22872,7 @@ abstract class SignalingSettings_Stunservers
     implements
         $SignalingSettings_StunserversInterface,
         Built<SignalingSettings_Stunservers, SignalingSettings_StunserversBuilder> {
-  factory SignalingSettings_Stunservers([final void Function(SignalingSettings_StunserversBuilder)? b]) =
+  factory SignalingSettings_Stunservers([void Function(SignalingSettings_StunserversBuilder)? b]) =
       _$SignalingSettings_Stunservers;
 
   // coverage:ignore-start
@@ -22934,7 +22880,7 @@ abstract class SignalingSettings_Stunservers
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingSettings_Stunservers.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingSettings_Stunservers.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22956,7 +22902,7 @@ abstract class SignalingSettings_Turnservers
     implements
         $SignalingSettings_TurnserversInterface,
         Built<SignalingSettings_Turnservers, SignalingSettings_TurnserversBuilder> {
-  factory SignalingSettings_Turnservers([final void Function(SignalingSettings_TurnserversBuilder)? b]) =
+  factory SignalingSettings_Turnservers([void Function(SignalingSettings_TurnserversBuilder)? b]) =
       _$SignalingSettings_Turnservers;
 
   // coverage:ignore-start
@@ -22964,7 +22910,7 @@ abstract class SignalingSettings_Turnservers
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingSettings_Turnservers.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingSettings_Turnservers.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -22990,15 +22936,14 @@ abstract interface class $SignalingSettingsInterface {
 
 abstract class SignalingSettings
     implements $SignalingSettingsInterface, Built<SignalingSettings, SignalingSettingsBuilder> {
-  factory SignalingSettings([final void Function(SignalingSettingsBuilder)? b]) = _$SignalingSettings;
+  factory SignalingSettings([void Function(SignalingSettingsBuilder)? b]) = _$SignalingSettings;
 
   // coverage:ignore-start
   const SignalingSettings._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingSettings.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory SignalingSettings.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -23019,7 +22964,7 @@ abstract class SignalingGetSettingsResponseApplicationJson_Ocs
         $SignalingGetSettingsResponseApplicationJson_OcsInterface,
         Built<SignalingGetSettingsResponseApplicationJson_Ocs, SignalingGetSettingsResponseApplicationJson_OcsBuilder> {
   factory SignalingGetSettingsResponseApplicationJson_Ocs([
-    final void Function(SignalingGetSettingsResponseApplicationJson_OcsBuilder)? b,
+    void Function(SignalingGetSettingsResponseApplicationJson_OcsBuilder)? b,
   ]) = _$SignalingGetSettingsResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -23027,7 +22972,7 @@ abstract class SignalingGetSettingsResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingGetSettingsResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingGetSettingsResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23049,7 +22994,7 @@ abstract class SignalingGetSettingsResponseApplicationJson
         $SignalingGetSettingsResponseApplicationJsonInterface,
         Built<SignalingGetSettingsResponseApplicationJson, SignalingGetSettingsResponseApplicationJsonBuilder> {
   factory SignalingGetSettingsResponseApplicationJson([
-    final void Function(SignalingGetSettingsResponseApplicationJsonBuilder)? b,
+    void Function(SignalingGetSettingsResponseApplicationJsonBuilder)? b,
   ]) = _$SignalingGetSettingsResponseApplicationJson;
 
   // coverage:ignore-start
@@ -23057,7 +23002,7 @@ abstract class SignalingGetSettingsResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingGetSettingsResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingGetSettingsResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23078,7 +23023,7 @@ class SignalingGetWelcomeMessageApiVersion extends EnumClass {
   static BuiltSet<SignalingGetWelcomeMessageApiVersion> get values => _$signalingGetWelcomeMessageApiVersionValues;
   // coverage:ignore-end
 
-  static SignalingGetWelcomeMessageApiVersion valueOf(final String name) =>
+  static SignalingGetWelcomeMessageApiVersion valueOf(String name) =>
       _$valueOfSignalingGetWelcomeMessageApiVersion(name);
 
   static Serializer<SignalingGetWelcomeMessageApiVersion> get serializer =>
@@ -23097,7 +23042,7 @@ abstract class SignalingGetWelcomeMessageResponseApplicationJson_Ocs
         Built<SignalingGetWelcomeMessageResponseApplicationJson_Ocs,
             SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder> {
   factory SignalingGetWelcomeMessageResponseApplicationJson_Ocs([
-    final void Function(SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder)? b,
+    void Function(SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder)? b,
   ]) = _$SignalingGetWelcomeMessageResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -23105,7 +23050,7 @@ abstract class SignalingGetWelcomeMessageResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingGetWelcomeMessageResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingGetWelcomeMessageResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23128,7 +23073,7 @@ abstract class SignalingGetWelcomeMessageResponseApplicationJson
         Built<SignalingGetWelcomeMessageResponseApplicationJson,
             SignalingGetWelcomeMessageResponseApplicationJsonBuilder> {
   factory SignalingGetWelcomeMessageResponseApplicationJson([
-    final void Function(SignalingGetWelcomeMessageResponseApplicationJsonBuilder)? b,
+    void Function(SignalingGetWelcomeMessageResponseApplicationJsonBuilder)? b,
   ]) = _$SignalingGetWelcomeMessageResponseApplicationJson;
 
   // coverage:ignore-start
@@ -23136,7 +23081,7 @@ abstract class SignalingGetWelcomeMessageResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingGetWelcomeMessageResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingGetWelcomeMessageResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23157,7 +23102,7 @@ class SignalingPullMessagesApiVersion extends EnumClass {
   static BuiltSet<SignalingPullMessagesApiVersion> get values => _$signalingPullMessagesApiVersionValues;
   // coverage:ignore-end
 
-  static SignalingPullMessagesApiVersion valueOf(final String name) => _$valueOfSignalingPullMessagesApiVersion(name);
+  static SignalingPullMessagesApiVersion valueOf(String name) => _$valueOfSignalingPullMessagesApiVersion(name);
 
   static Serializer<SignalingPullMessagesApiVersion> get serializer => _$signalingPullMessagesApiVersionSerializer;
 }
@@ -23174,15 +23119,14 @@ abstract interface class $SignalingSessionInterface {
 
 abstract class SignalingSession
     implements $SignalingSessionInterface, Built<SignalingSession, SignalingSessionBuilder> {
-  factory SignalingSession([final void Function(SignalingSessionBuilder)? b]) = _$SignalingSession;
+  factory SignalingSession([void Function(SignalingSessionBuilder)? b]) = _$SignalingSession;
 
   // coverage:ignore-start
   const SignalingSession._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingSession.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory SignalingSession.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -23204,7 +23148,7 @@ abstract class SignalingPullMessagesResponseApplicationJson_Ocs_Data
         Built<SignalingPullMessagesResponseApplicationJson_Ocs_Data,
             SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder> {
   factory SignalingPullMessagesResponseApplicationJson_Ocs_Data([
-    final void Function(SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$SignalingPullMessagesResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -23212,7 +23156,7 @@ abstract class SignalingPullMessagesResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingPullMessagesResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingPullMessagesResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23224,7 +23168,7 @@ abstract class SignalingPullMessagesResponseApplicationJson_Ocs_Data
       _$signalingPullMessagesResponseApplicationJsonOcsDataSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder b) {
+  static void _validate(SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder b) {
     b.data?.validateOneOf();
   }
 }
@@ -23241,7 +23185,7 @@ abstract class SignalingPullMessagesResponseApplicationJson_Ocs
         Built<SignalingPullMessagesResponseApplicationJson_Ocs,
             SignalingPullMessagesResponseApplicationJson_OcsBuilder> {
   factory SignalingPullMessagesResponseApplicationJson_Ocs([
-    final void Function(SignalingPullMessagesResponseApplicationJson_OcsBuilder)? b,
+    void Function(SignalingPullMessagesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$SignalingPullMessagesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -23249,7 +23193,7 @@ abstract class SignalingPullMessagesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingPullMessagesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingPullMessagesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23271,7 +23215,7 @@ abstract class SignalingPullMessagesResponseApplicationJson
         $SignalingPullMessagesResponseApplicationJsonInterface,
         Built<SignalingPullMessagesResponseApplicationJson, SignalingPullMessagesResponseApplicationJsonBuilder> {
   factory SignalingPullMessagesResponseApplicationJson([
-    final void Function(SignalingPullMessagesResponseApplicationJsonBuilder)? b,
+    void Function(SignalingPullMessagesResponseApplicationJsonBuilder)? b,
   ]) = _$SignalingPullMessagesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -23279,7 +23223,7 @@ abstract class SignalingPullMessagesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingPullMessagesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingPullMessagesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23300,7 +23244,7 @@ class SignalingSendMessagesApiVersion extends EnumClass {
   static BuiltSet<SignalingSendMessagesApiVersion> get values => _$signalingSendMessagesApiVersionValues;
   // coverage:ignore-end
 
-  static SignalingSendMessagesApiVersion valueOf(final String name) => _$valueOfSignalingSendMessagesApiVersion(name);
+  static SignalingSendMessagesApiVersion valueOf(String name) => _$valueOfSignalingSendMessagesApiVersion(name);
 
   static Serializer<SignalingSendMessagesApiVersion> get serializer => _$signalingSendMessagesApiVersionSerializer;
 }
@@ -23317,7 +23261,7 @@ abstract class SignalingSendMessagesResponseApplicationJson_Ocs
         Built<SignalingSendMessagesResponseApplicationJson_Ocs,
             SignalingSendMessagesResponseApplicationJson_OcsBuilder> {
   factory SignalingSendMessagesResponseApplicationJson_Ocs([
-    final void Function(SignalingSendMessagesResponseApplicationJson_OcsBuilder)? b,
+    void Function(SignalingSendMessagesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$SignalingSendMessagesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -23325,7 +23269,7 @@ abstract class SignalingSendMessagesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingSendMessagesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingSendMessagesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23347,7 +23291,7 @@ abstract class SignalingSendMessagesResponseApplicationJson
         $SignalingSendMessagesResponseApplicationJsonInterface,
         Built<SignalingSendMessagesResponseApplicationJson, SignalingSendMessagesResponseApplicationJsonBuilder> {
   factory SignalingSendMessagesResponseApplicationJson([
-    final void Function(SignalingSendMessagesResponseApplicationJsonBuilder)? b,
+    void Function(SignalingSendMessagesResponseApplicationJsonBuilder)? b,
   ]) = _$SignalingSendMessagesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -23355,7 +23299,7 @@ abstract class SignalingSendMessagesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SignalingSendMessagesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory SignalingSendMessagesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23378,7 +23322,7 @@ abstract class TempAvatarPostAvatarResponseApplicationJson_Ocs
         $TempAvatarPostAvatarResponseApplicationJson_OcsInterface,
         Built<TempAvatarPostAvatarResponseApplicationJson_Ocs, TempAvatarPostAvatarResponseApplicationJson_OcsBuilder> {
   factory TempAvatarPostAvatarResponseApplicationJson_Ocs([
-    final void Function(TempAvatarPostAvatarResponseApplicationJson_OcsBuilder)? b,
+    void Function(TempAvatarPostAvatarResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TempAvatarPostAvatarResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -23386,7 +23330,7 @@ abstract class TempAvatarPostAvatarResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TempAvatarPostAvatarResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TempAvatarPostAvatarResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23408,7 +23352,7 @@ abstract class TempAvatarPostAvatarResponseApplicationJson
         $TempAvatarPostAvatarResponseApplicationJsonInterface,
         Built<TempAvatarPostAvatarResponseApplicationJson, TempAvatarPostAvatarResponseApplicationJsonBuilder> {
   factory TempAvatarPostAvatarResponseApplicationJson([
-    final void Function(TempAvatarPostAvatarResponseApplicationJsonBuilder)? b,
+    void Function(TempAvatarPostAvatarResponseApplicationJsonBuilder)? b,
   ]) = _$TempAvatarPostAvatarResponseApplicationJson;
 
   // coverage:ignore-start
@@ -23416,7 +23360,7 @@ abstract class TempAvatarPostAvatarResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TempAvatarPostAvatarResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TempAvatarPostAvatarResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23440,7 +23384,7 @@ abstract class TempAvatarDeleteAvatarResponseApplicationJson_Ocs
         Built<TempAvatarDeleteAvatarResponseApplicationJson_Ocs,
             TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder> {
   factory TempAvatarDeleteAvatarResponseApplicationJson_Ocs([
-    final void Function(TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder)? b,
+    void Function(TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder)? b,
   ]) = _$TempAvatarDeleteAvatarResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -23448,7 +23392,7 @@ abstract class TempAvatarDeleteAvatarResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TempAvatarDeleteAvatarResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory TempAvatarDeleteAvatarResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23470,7 +23414,7 @@ abstract class TempAvatarDeleteAvatarResponseApplicationJson
         $TempAvatarDeleteAvatarResponseApplicationJsonInterface,
         Built<TempAvatarDeleteAvatarResponseApplicationJson, TempAvatarDeleteAvatarResponseApplicationJsonBuilder> {
   factory TempAvatarDeleteAvatarResponseApplicationJson([
-    final void Function(TempAvatarDeleteAvatarResponseApplicationJsonBuilder)? b,
+    void Function(TempAvatarDeleteAvatarResponseApplicationJsonBuilder)? b,
   ]) = _$TempAvatarDeleteAvatarResponseApplicationJson;
 
   // coverage:ignore-start
@@ -23478,7 +23422,7 @@ abstract class TempAvatarDeleteAvatarResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory TempAvatarDeleteAvatarResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory TempAvatarDeleteAvatarResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23501,14 +23445,14 @@ abstract interface class $BotWithDetailsAndSecretInterface
 
 abstract class BotWithDetailsAndSecret
     implements $BotWithDetailsAndSecretInterface, Built<BotWithDetailsAndSecret, BotWithDetailsAndSecretBuilder> {
-  factory BotWithDetailsAndSecret([final void Function(BotWithDetailsAndSecretBuilder)? b]) = _$BotWithDetailsAndSecret;
+  factory BotWithDetailsAndSecret([void Function(BotWithDetailsAndSecretBuilder)? b]) = _$BotWithDetailsAndSecret;
 
   // coverage:ignore-start
   const BotWithDetailsAndSecret._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory BotWithDetailsAndSecret.fromJson(final Map<String, dynamic> json) =>
+  factory BotWithDetailsAndSecret.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23530,7 +23474,7 @@ abstract class PublicCapabilities0_Spreed_Config_Attachments
         $PublicCapabilities0_Spreed_Config_AttachmentsInterface,
         Built<PublicCapabilities0_Spreed_Config_Attachments, PublicCapabilities0_Spreed_Config_AttachmentsBuilder> {
   factory PublicCapabilities0_Spreed_Config_Attachments([
-    final void Function(PublicCapabilities0_Spreed_Config_AttachmentsBuilder)? b,
+    void Function(PublicCapabilities0_Spreed_Config_AttachmentsBuilder)? b,
   ]) = _$PublicCapabilities0_Spreed_Config_Attachments;
 
   // coverage:ignore-start
@@ -23538,7 +23482,7 @@ abstract class PublicCapabilities0_Spreed_Config_Attachments
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities0_Spreed_Config_Attachments.fromJson(final Map<String, dynamic> json) =>
+  factory PublicCapabilities0_Spreed_Config_Attachments.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23576,16 +23520,15 @@ abstract class PublicCapabilities0_Spreed_Config_Call
     implements
         $PublicCapabilities0_Spreed_Config_CallInterface,
         Built<PublicCapabilities0_Spreed_Config_Call, PublicCapabilities0_Spreed_Config_CallBuilder> {
-  factory PublicCapabilities0_Spreed_Config_Call([
-    final void Function(PublicCapabilities0_Spreed_Config_CallBuilder)? b,
-  ]) = _$PublicCapabilities0_Spreed_Config_Call;
+  factory PublicCapabilities0_Spreed_Config_Call([void Function(PublicCapabilities0_Spreed_Config_CallBuilder)? b]) =
+      _$PublicCapabilities0_Spreed_Config_Call;
 
   // coverage:ignore-start
   const PublicCapabilities0_Spreed_Config_Call._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities0_Spreed_Config_Call.fromJson(final Map<String, dynamic> json) =>
+  factory PublicCapabilities0_Spreed_Config_Call.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23614,16 +23557,15 @@ abstract class PublicCapabilities0_Spreed_Config_Chat
     implements
         $PublicCapabilities0_Spreed_Config_ChatInterface,
         Built<PublicCapabilities0_Spreed_Config_Chat, PublicCapabilities0_Spreed_Config_ChatBuilder> {
-  factory PublicCapabilities0_Spreed_Config_Chat([
-    final void Function(PublicCapabilities0_Spreed_Config_ChatBuilder)? b,
-  ]) = _$PublicCapabilities0_Spreed_Config_Chat;
+  factory PublicCapabilities0_Spreed_Config_Chat([void Function(PublicCapabilities0_Spreed_Config_ChatBuilder)? b]) =
+      _$PublicCapabilities0_Spreed_Config_Chat;
 
   // coverage:ignore-start
   const PublicCapabilities0_Spreed_Config_Chat._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities0_Spreed_Config_Chat.fromJson(final Map<String, dynamic> json) =>
+  factory PublicCapabilities0_Spreed_Config_Chat.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23646,7 +23588,7 @@ abstract class PublicCapabilities0_Spreed_Config_Conversations
         $PublicCapabilities0_Spreed_Config_ConversationsInterface,
         Built<PublicCapabilities0_Spreed_Config_Conversations, PublicCapabilities0_Spreed_Config_ConversationsBuilder> {
   factory PublicCapabilities0_Spreed_Config_Conversations([
-    final void Function(PublicCapabilities0_Spreed_Config_ConversationsBuilder)? b,
+    void Function(PublicCapabilities0_Spreed_Config_ConversationsBuilder)? b,
   ]) = _$PublicCapabilities0_Spreed_Config_Conversations;
 
   // coverage:ignore-start
@@ -23654,7 +23596,7 @@ abstract class PublicCapabilities0_Spreed_Config_Conversations
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities0_Spreed_Config_Conversations.fromJson(final Map<String, dynamic> json) =>
+  factory PublicCapabilities0_Spreed_Config_Conversations.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23677,7 +23619,7 @@ abstract class PublicCapabilities0_Spreed_Config_Previews
         $PublicCapabilities0_Spreed_Config_PreviewsInterface,
         Built<PublicCapabilities0_Spreed_Config_Previews, PublicCapabilities0_Spreed_Config_PreviewsBuilder> {
   factory PublicCapabilities0_Spreed_Config_Previews([
-    final void Function(PublicCapabilities0_Spreed_Config_PreviewsBuilder)? b,
+    void Function(PublicCapabilities0_Spreed_Config_PreviewsBuilder)? b,
   ]) = _$PublicCapabilities0_Spreed_Config_Previews;
 
   // coverage:ignore-start
@@ -23685,7 +23627,7 @@ abstract class PublicCapabilities0_Spreed_Config_Previews
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities0_Spreed_Config_Previews.fromJson(final Map<String, dynamic> json) =>
+  factory PublicCapabilities0_Spreed_Config_Previews.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23710,7 +23652,7 @@ abstract class PublicCapabilities0_Spreed_Config_Signaling
         $PublicCapabilities0_Spreed_Config_SignalingInterface,
         Built<PublicCapabilities0_Spreed_Config_Signaling, PublicCapabilities0_Spreed_Config_SignalingBuilder> {
   factory PublicCapabilities0_Spreed_Config_Signaling([
-    final void Function(PublicCapabilities0_Spreed_Config_SignalingBuilder)? b,
+    void Function(PublicCapabilities0_Spreed_Config_SignalingBuilder)? b,
   ]) = _$PublicCapabilities0_Spreed_Config_Signaling;
 
   // coverage:ignore-start
@@ -23718,7 +23660,7 @@ abstract class PublicCapabilities0_Spreed_Config_Signaling
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities0_Spreed_Config_Signaling.fromJson(final Map<String, dynamic> json) =>
+  factory PublicCapabilities0_Spreed_Config_Signaling.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23744,7 +23686,7 @@ abstract class PublicCapabilities0_Spreed_Config
     implements
         $PublicCapabilities0_Spreed_ConfigInterface,
         Built<PublicCapabilities0_Spreed_Config, PublicCapabilities0_Spreed_ConfigBuilder> {
-  factory PublicCapabilities0_Spreed_Config([final void Function(PublicCapabilities0_Spreed_ConfigBuilder)? b]) =
+  factory PublicCapabilities0_Spreed_Config([void Function(PublicCapabilities0_Spreed_ConfigBuilder)? b]) =
       _$PublicCapabilities0_Spreed_Config;
 
   // coverage:ignore-start
@@ -23752,7 +23694,7 @@ abstract class PublicCapabilities0_Spreed_Config
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities0_Spreed_Config.fromJson(final Map<String, dynamic> json) =>
+  factory PublicCapabilities0_Spreed_Config.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23774,7 +23716,7 @@ abstract class PublicCapabilities0_Spreed
     implements
         $PublicCapabilities0_SpreedInterface,
         Built<PublicCapabilities0_Spreed, PublicCapabilities0_SpreedBuilder> {
-  factory PublicCapabilities0_Spreed([final void Function(PublicCapabilities0_SpreedBuilder)? b]) =
+  factory PublicCapabilities0_Spreed([void Function(PublicCapabilities0_SpreedBuilder)? b]) =
       _$PublicCapabilities0_Spreed;
 
   // coverage:ignore-start
@@ -23782,7 +23724,7 @@ abstract class PublicCapabilities0_Spreed
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities0_Spreed.fromJson(final Map<String, dynamic> json) =>
+  factory PublicCapabilities0_Spreed.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -23800,15 +23742,14 @@ abstract interface class $PublicCapabilities0Interface {
 
 abstract class PublicCapabilities0
     implements $PublicCapabilities0Interface, Built<PublicCapabilities0, PublicCapabilities0Builder> {
-  factory PublicCapabilities0([final void Function(PublicCapabilities0Builder)? b]) = _$PublicCapabilities0;
+  factory PublicCapabilities0([void Function(PublicCapabilities0Builder)? b]) = _$PublicCapabilities0;
 
   // coverage:ignore-start
   const PublicCapabilities0._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities0.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory PublicCapabilities0.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -23841,7 +23782,7 @@ extension $BuiltListChatMessageExtension on $BuiltListChatMessage {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BuiltListChatMessage> get serializer => const _$BuiltListChatMessageSerializer();
-  static $BuiltListChatMessage fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BuiltListChatMessage fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -23856,9 +23797,9 @@ class _$BuiltListChatMessageSerializer implements PrimitiveSerializer<$BuiltList
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BuiltListChatMessage object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BuiltListChatMessage object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.builtListNever;
@@ -23875,9 +23816,9 @@ class _$BuiltListChatMessageSerializer implements PrimitiveSerializer<$BuiltList
 
   @override
   $BuiltListChatMessage deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BuiltList<Never>? builtListNever;
     try {
@@ -23904,7 +23845,7 @@ extension $BuiltListRoomAddParticipantToRoomResponseApplicationJsonOcsData0Exten
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BuiltListRoomAddParticipantToRoomResponseApplicationJsonOcsData0> get serializer =>
       const _$BuiltListRoomAddParticipantToRoomResponseApplicationJsonOcsData0Serializer();
-  static $BuiltListRoomAddParticipantToRoomResponseApplicationJsonOcsData0 fromJson(final Object? json) =>
+  static $BuiltListRoomAddParticipantToRoomResponseApplicationJsonOcsData0 fromJson(Object? json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
@@ -23921,9 +23862,9 @@ class _$BuiltListRoomAddParticipantToRoomResponseApplicationJsonOcsData0Serializ
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BuiltListRoomAddParticipantToRoomResponseApplicationJsonOcsData0 object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BuiltListRoomAddParticipantToRoomResponseApplicationJsonOcsData0 object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.builtListNever;
@@ -23943,9 +23884,9 @@ class _$BuiltListRoomAddParticipantToRoomResponseApplicationJsonOcsData0Serializ
 
   @override
   $BuiltListRoomAddParticipantToRoomResponseApplicationJsonOcsData0 deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BuiltList<Never>? builtListNever;
     try {
@@ -23973,7 +23914,7 @@ extension $IntStringExtension on $IntString {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$IntString> get serializer => const _$IntStringSerializer();
-  static $IntString fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $IntString fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -23988,9 +23929,9 @@ class _$IntStringSerializer implements PrimitiveSerializer<$IntString> {
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $IntString object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $IntString object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.$int;
@@ -24007,9 +23948,9 @@ class _$IntStringSerializer implements PrimitiveSerializer<$IntString> {
 
   @override
   $IntString deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     int? $int;
     try {
@@ -24030,7 +23971,7 @@ extension $BuiltListStringExtension on $BuiltListString {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BuiltListString> get serializer => const _$BuiltListStringSerializer();
-  static $BuiltListString fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BuiltListString fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -24045,9 +23986,9 @@ class _$BuiltListStringSerializer implements PrimitiveSerializer<$BuiltListStrin
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BuiltListString object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BuiltListString object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.builtListSignalingSession;
@@ -24064,9 +24005,9 @@ class _$BuiltListStringSerializer implements PrimitiveSerializer<$BuiltListStrin
 
   @override
   $BuiltListString deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BuiltList<SignalingSession>? builtListSignalingSession;
     try {
@@ -24090,8 +24031,7 @@ extension $BuiltListPublicCapabilities0Extension on $BuiltListPublicCapabilities
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BuiltListPublicCapabilities0> get serializer => const _$BuiltListPublicCapabilities0Serializer();
-  static $BuiltListPublicCapabilities0 fromJson(final Object? json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  static $BuiltListPublicCapabilities0 fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -24106,9 +24046,9 @@ class _$BuiltListPublicCapabilities0Serializer implements PrimitiveSerializer<$B
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BuiltListPublicCapabilities0 object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BuiltListPublicCapabilities0 object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.builtListNever;
@@ -24125,9 +24065,9 @@ class _$BuiltListPublicCapabilities0Serializer implements PrimitiveSerializer<$B
 
   @override
   $BuiltListPublicCapabilities0 deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BuiltList<Never>? builtListNever;
     try {

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -30,7 +30,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -66,7 +66,7 @@ class IconClient {
   ///
   /// See:
   ///  * [getFaviconRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<Uint8List, void>> getFavicon({final String? app}) async {
+  Future<DynamiteResponse<Uint8List, void>> getFavicon({String? app}) async {
     final rawResponse = getFaviconRaw(
       app: app,
     );
@@ -92,7 +92,7 @@ class IconClient {
   /// See:
   ///  * [getFavicon] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<Uint8List, void> getFaviconRaw({final String? app}) {
+  DynamiteRawResponse<Uint8List, void> getFaviconRaw({String? app}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'image/x-icon',
@@ -101,7 +101,7 @@ class IconClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -148,7 +148,7 @@ class IconClient {
   ///
   /// See:
   ///  * [getTouchIconRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<Uint8List, void>> getTouchIcon({final String? app}) async {
+  Future<DynamiteResponse<Uint8List, void>> getTouchIcon({String? app}) async {
     final rawResponse = getTouchIconRaw(
       app: app,
     );
@@ -174,7 +174,7 @@ class IconClient {
   /// See:
   ///  * [getTouchIcon] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<Uint8List, void> getTouchIconRaw({final String? app}) {
+  DynamiteRawResponse<Uint8List, void> getTouchIconRaw({String? app}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'image/png',
@@ -183,7 +183,7 @@ class IconClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -232,8 +232,8 @@ class IconClient {
   /// See:
   ///  * [getThemedIconRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getThemedIcon({
-    required final String app,
-    required final String image,
+    required String app,
+    required String image,
   }) async {
     final rawResponse = getThemedIconRaw(
       app: app,
@@ -263,8 +263,8 @@ class IconClient {
   ///  * [getThemedIcon] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getThemedIconRaw({
-    required final String app,
-    required final String image,
+    required String app,
+    required String image,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -274,7 +274,7 @@ class IconClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -334,9 +334,9 @@ class ThemingClient {
   /// See:
   ///  * [getThemeStylesheetRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<String, void>> getThemeStylesheet({
-    required final String themeId,
-    final int? plain,
-    final int? withCustomCss,
+    required String themeId,
+    int? plain,
+    int? withCustomCss,
   }) async {
     final rawResponse = getThemeStylesheetRaw(
       themeId: themeId,
@@ -367,9 +367,9 @@ class ThemingClient {
   ///  * [getThemeStylesheet] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<String, void> getThemeStylesheetRaw({
-    required final String themeId,
-    final int? plain,
-    final int? withCustomCss,
+    required String themeId,
+    int? plain,
+    int? withCustomCss,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -379,7 +379,7 @@ class ThemingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -437,8 +437,8 @@ class ThemingClient {
   /// See:
   ///  * [getImageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Uint8List, void>> getImage({
-    required final String key,
-    final int? useSvg,
+    required String key,
+    int? useSvg,
   }) async {
     final rawResponse = getImageRaw(
       key: key,
@@ -468,8 +468,8 @@ class ThemingClient {
   ///  * [getImage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Uint8List, void> getImageRaw({
-    required final String key,
-    final int? useSvg,
+    required String key,
+    int? useSvg,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -479,7 +479,7 @@ class ThemingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -527,9 +527,7 @@ class ThemingClient {
   ///
   /// See:
   ///  * [getManifestRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<ThemingGetManifestResponseApplicationJson, void>> getManifest({
-    required final String app,
-  }) async {
+  Future<DynamiteResponse<ThemingGetManifestResponseApplicationJson, void>> getManifest({required String app}) async {
     final rawResponse = getManifestRaw(
       app: app,
     );
@@ -553,7 +551,7 @@ class ThemingClient {
   /// See:
   ///  * [getManifest] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<ThemingGetManifestResponseApplicationJson, void> getManifestRaw({required final String app}) {
+  DynamiteRawResponse<ThemingGetManifestResponseApplicationJson, void> getManifestRaw({required String app}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -562,7 +560,7 @@ class ThemingClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -613,7 +611,7 @@ class UserThemeClient {
   ///
   /// See:
   ///  * [getBackgroundRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<Uint8List, void>> getBackground({final bool? oCSAPIRequest}) async {
+  Future<DynamiteResponse<Uint8List, void>> getBackground({bool? oCSAPIRequest}) async {
     final rawResponse = getBackgroundRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -638,7 +636,7 @@ class UserThemeClient {
   /// See:
   ///  * [getBackground] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<Uint8List, void> getBackgroundRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<Uint8List, void> getBackgroundRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': '*/*',
@@ -647,7 +645,7 @@ class UserThemeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -700,10 +698,10 @@ class UserThemeClient {
   /// See:
   ///  * [setBackgroundRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<Background, void>> setBackground({
-    required final String type,
-    final String? value,
-    final String? color,
-    final bool? oCSAPIRequest,
+    required String type,
+    String? value,
+    String? color,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setBackgroundRaw(
       type: type,
@@ -737,10 +735,10 @@ class UserThemeClient {
   ///  * [setBackground] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<Background, void> setBackgroundRaw({
-    required final String type,
-    final String? value,
-    final String? color,
-    final bool? oCSAPIRequest,
+    required String type,
+    String? value,
+    String? color,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -750,7 +748,7 @@ class UserThemeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -807,7 +805,7 @@ class UserThemeClient {
   ///
   /// See:
   ///  * [deleteBackgroundRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<Background, void>> deleteBackground({final bool? oCSAPIRequest}) async {
+  Future<DynamiteResponse<Background, void>> deleteBackground({bool? oCSAPIRequest}) async {
     final rawResponse = deleteBackgroundRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -831,7 +829,7 @@ class UserThemeClient {
   /// See:
   ///  * [deleteBackground] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<Background, void> deleteBackgroundRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<Background, void> deleteBackgroundRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -840,7 +838,7 @@ class UserThemeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -891,8 +889,8 @@ class UserThemeClient {
   /// See:
   ///  * [enableThemeRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UserThemeEnableThemeResponseApplicationJson, void>> enableTheme({
-    required final String themeId,
-    final bool? oCSAPIRequest,
+    required String themeId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = enableThemeRaw(
       themeId: themeId,
@@ -922,8 +920,8 @@ class UserThemeClient {
   ///  * [enableTheme] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UserThemeEnableThemeResponseApplicationJson, void> enableThemeRaw({
-    required final String themeId,
-    final bool? oCSAPIRequest,
+    required String themeId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -933,7 +931,7 @@ class UserThemeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -987,8 +985,8 @@ class UserThemeClient {
   /// See:
   ///  * [disableThemeRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UserThemeDisableThemeResponseApplicationJson, void>> disableTheme({
-    required final String themeId,
-    final bool? oCSAPIRequest,
+    required String themeId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = disableThemeRaw(
       themeId: themeId,
@@ -1018,8 +1016,8 @@ class UserThemeClient {
   ///  * [disableTheme] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UserThemeDisableThemeResponseApplicationJson, void> disableThemeRaw({
-    required final String themeId,
-    final bool? oCSAPIRequest,
+    required String themeId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -1029,7 +1027,7 @@ class UserThemeClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1079,7 +1077,7 @@ abstract class ThemingGetManifestResponseApplicationJson_Icons
         $ThemingGetManifestResponseApplicationJson_IconsInterface,
         Built<ThemingGetManifestResponseApplicationJson_Icons, ThemingGetManifestResponseApplicationJson_IconsBuilder> {
   factory ThemingGetManifestResponseApplicationJson_Icons([
-    final void Function(ThemingGetManifestResponseApplicationJson_IconsBuilder)? b,
+    void Function(ThemingGetManifestResponseApplicationJson_IconsBuilder)? b,
   ]) = _$ThemingGetManifestResponseApplicationJson_Icons;
 
   // coverage:ignore-start
@@ -1087,7 +1085,7 @@ abstract class ThemingGetManifestResponseApplicationJson_Icons
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ThemingGetManifestResponseApplicationJson_Icons.fromJson(final Map<String, dynamic> json) =>
+  factory ThemingGetManifestResponseApplicationJson_Icons.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1099,7 +1097,7 @@ abstract class ThemingGetManifestResponseApplicationJson_Icons
       _$themingGetManifestResponseApplicationJsonIconsSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final ThemingGetManifestResponseApplicationJson_IconsBuilder b) {
+  static void _validate(ThemingGetManifestResponseApplicationJson_IconsBuilder b) {
     dynamite_utils.checkMinLength(b.src, 1, 'src');
   }
 }
@@ -1125,7 +1123,7 @@ abstract class ThemingGetManifestResponseApplicationJson
         $ThemingGetManifestResponseApplicationJsonInterface,
         Built<ThemingGetManifestResponseApplicationJson, ThemingGetManifestResponseApplicationJsonBuilder> {
   factory ThemingGetManifestResponseApplicationJson([
-    final void Function(ThemingGetManifestResponseApplicationJsonBuilder)? b,
+    void Function(ThemingGetManifestResponseApplicationJsonBuilder)? b,
   ]) = _$ThemingGetManifestResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1133,7 +1131,7 @@ abstract class ThemingGetManifestResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ThemingGetManifestResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ThemingGetManifestResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1153,14 +1151,14 @@ abstract interface class $BackgroundInterface {
 }
 
 abstract class Background implements $BackgroundInterface, Built<Background, BackgroundBuilder> {
-  factory Background([final void Function(BackgroundBuilder)? b]) = _$Background;
+  factory Background([void Function(BackgroundBuilder)? b]) = _$Background;
 
   // coverage:ignore-start
   const Background._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Background.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Background.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1180,14 +1178,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1208,7 +1206,7 @@ abstract class UserThemeEnableThemeResponseApplicationJson_Ocs
         $UserThemeEnableThemeResponseApplicationJson_OcsInterface,
         Built<UserThemeEnableThemeResponseApplicationJson_Ocs, UserThemeEnableThemeResponseApplicationJson_OcsBuilder> {
   factory UserThemeEnableThemeResponseApplicationJson_Ocs([
-    final void Function(UserThemeEnableThemeResponseApplicationJson_OcsBuilder)? b,
+    void Function(UserThemeEnableThemeResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UserThemeEnableThemeResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1216,7 +1214,7 @@ abstract class UserThemeEnableThemeResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserThemeEnableThemeResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UserThemeEnableThemeResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1238,7 +1236,7 @@ abstract class UserThemeEnableThemeResponseApplicationJson
         $UserThemeEnableThemeResponseApplicationJsonInterface,
         Built<UserThemeEnableThemeResponseApplicationJson, UserThemeEnableThemeResponseApplicationJsonBuilder> {
   factory UserThemeEnableThemeResponseApplicationJson([
-    final void Function(UserThemeEnableThemeResponseApplicationJsonBuilder)? b,
+    void Function(UserThemeEnableThemeResponseApplicationJsonBuilder)? b,
   ]) = _$UserThemeEnableThemeResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1246,7 +1244,7 @@ abstract class UserThemeEnableThemeResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserThemeEnableThemeResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UserThemeEnableThemeResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1270,7 +1268,7 @@ abstract class UserThemeDisableThemeResponseApplicationJson_Ocs
         Built<UserThemeDisableThemeResponseApplicationJson_Ocs,
             UserThemeDisableThemeResponseApplicationJson_OcsBuilder> {
   factory UserThemeDisableThemeResponseApplicationJson_Ocs([
-    final void Function(UserThemeDisableThemeResponseApplicationJson_OcsBuilder)? b,
+    void Function(UserThemeDisableThemeResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UserThemeDisableThemeResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1278,7 +1276,7 @@ abstract class UserThemeDisableThemeResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserThemeDisableThemeResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UserThemeDisableThemeResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1300,7 +1298,7 @@ abstract class UserThemeDisableThemeResponseApplicationJson
         $UserThemeDisableThemeResponseApplicationJsonInterface,
         Built<UserThemeDisableThemeResponseApplicationJson, UserThemeDisableThemeResponseApplicationJsonBuilder> {
   factory UserThemeDisableThemeResponseApplicationJson([
-    final void Function(UserThemeDisableThemeResponseApplicationJsonBuilder)? b,
+    void Function(UserThemeDisableThemeResponseApplicationJsonBuilder)? b,
   ]) = _$UserThemeDisableThemeResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1308,7 +1306,7 @@ abstract class UserThemeDisableThemeResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserThemeDisableThemeResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UserThemeDisableThemeResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1348,7 +1346,7 @@ abstract class PublicCapabilities_Theming
     implements
         $PublicCapabilities_ThemingInterface,
         Built<PublicCapabilities_Theming, PublicCapabilities_ThemingBuilder> {
-  factory PublicCapabilities_Theming([final void Function(PublicCapabilities_ThemingBuilder)? b]) =
+  factory PublicCapabilities_Theming([void Function(PublicCapabilities_ThemingBuilder)? b]) =
       _$PublicCapabilities_Theming;
 
   // coverage:ignore-start
@@ -1356,7 +1354,7 @@ abstract class PublicCapabilities_Theming
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities_Theming.fromJson(final Map<String, dynamic> json) =>
+  factory PublicCapabilities_Theming.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1374,15 +1372,14 @@ abstract interface class $PublicCapabilitiesInterface {
 
 abstract class PublicCapabilities
     implements $PublicCapabilitiesInterface, Built<PublicCapabilities, PublicCapabilitiesBuilder> {
-  factory PublicCapabilities([final void Function(PublicCapabilitiesBuilder)? b]) = _$PublicCapabilities;
+  factory PublicCapabilities([void Function(PublicCapabilitiesBuilder)? b]) = _$PublicCapabilities;
 
   // coverage:ignore-start
   const PublicCapabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PublicCapabilities.fromJson(final Map<String, dynamic> json) =>
-      jsonSerializers.deserializeWith(serializer, json)!;
+  factory PublicCapabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
@@ -28,7 +28,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -64,9 +64,9 @@ class ApiClient {
   /// See:
   ///  * [getAppListRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<ApiGetAppListResponseApplicationJson, void>> getAppList({
-    required final String newVersion,
-    final ApiGetAppListApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String newVersion,
+    ApiGetAppListApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getAppListRaw(
       newVersion: newVersion,
@@ -99,9 +99,9 @@ class ApiClient {
   ///  * [getAppList] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<ApiGetAppListResponseApplicationJson, void> getAppListRaw({
-    required final String newVersion,
-    final ApiGetAppListApiVersion? apiVersion,
-    final bool? oCSAPIRequest,
+    required String newVersion,
+    ApiGetAppListApiVersion? apiVersion,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -111,7 +111,7 @@ class ApiClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -164,7 +164,7 @@ class ApiGetAppListApiVersion extends EnumClass {
   static BuiltSet<ApiGetAppListApiVersion> get values => _$apiGetAppListApiVersionValues;
   // coverage:ignore-end
 
-  static ApiGetAppListApiVersion valueOf(final String name) => _$valueOfApiGetAppListApiVersion(name);
+  static ApiGetAppListApiVersion valueOf(String name) => _$valueOfApiGetAppListApiVersion(name);
 
   static Serializer<ApiGetAppListApiVersion> get serializer => _$apiGetAppListApiVersionSerializer;
 }
@@ -179,14 +179,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -203,14 +203,14 @@ abstract interface class $AppInterface {
 }
 
 abstract class App implements $AppInterface, Built<App, AppBuilder> {
-  factory App([final void Function(AppBuilder)? b]) = _$App;
+  factory App([void Function(AppBuilder)? b]) = _$App;
 
   // coverage:ignore-start
   const App._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory App.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory App.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -231,7 +231,7 @@ abstract class ApiGetAppListResponseApplicationJson_Ocs_Data
         $ApiGetAppListResponseApplicationJson_Ocs_DataInterface,
         Built<ApiGetAppListResponseApplicationJson_Ocs_Data, ApiGetAppListResponseApplicationJson_Ocs_DataBuilder> {
   factory ApiGetAppListResponseApplicationJson_Ocs_Data([
-    final void Function(ApiGetAppListResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(ApiGetAppListResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$ApiGetAppListResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -239,7 +239,7 @@ abstract class ApiGetAppListResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiGetAppListResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory ApiGetAppListResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -262,7 +262,7 @@ abstract class ApiGetAppListResponseApplicationJson_Ocs
         $ApiGetAppListResponseApplicationJson_OcsInterface,
         Built<ApiGetAppListResponseApplicationJson_Ocs, ApiGetAppListResponseApplicationJson_OcsBuilder> {
   factory ApiGetAppListResponseApplicationJson_Ocs([
-    final void Function(ApiGetAppListResponseApplicationJson_OcsBuilder)? b,
+    void Function(ApiGetAppListResponseApplicationJson_OcsBuilder)? b,
   ]) = _$ApiGetAppListResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -270,7 +270,7 @@ abstract class ApiGetAppListResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiGetAppListResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory ApiGetAppListResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -291,7 +291,7 @@ abstract class ApiGetAppListResponseApplicationJson
     implements
         $ApiGetAppListResponseApplicationJsonInterface,
         Built<ApiGetAppListResponseApplicationJson, ApiGetAppListResponseApplicationJsonBuilder> {
-  factory ApiGetAppListResponseApplicationJson([final void Function(ApiGetAppListResponseApplicationJsonBuilder)? b]) =
+  factory ApiGetAppListResponseApplicationJson([void Function(ApiGetAppListResponseApplicationJsonBuilder)? b]) =
       _$ApiGetAppListResponseApplicationJson;
 
   // coverage:ignore-start
@@ -299,7 +299,7 @@ abstract class ApiGetAppListResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ApiGetAppListResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory ApiGetAppListResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 

--- a/packages/nextcloud/lib/src/api/uppush.openapi.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.dart
@@ -28,7 +28,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -75,7 +75,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -120,9 +120,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [setKeepaliveRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<SetKeepaliveResponseApplicationJson, void>> setKeepalive({
-    required final int keepalive,
-  }) async {
+  Future<DynamiteResponse<SetKeepaliveResponseApplicationJson, void>> setKeepalive({required int keepalive}) async {
     final rawResponse = setKeepaliveRaw(
       keepalive: keepalive,
     );
@@ -148,7 +146,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [setKeepalive] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<SetKeepaliveResponseApplicationJson, void> setKeepaliveRaw({required final int keepalive}) {
+  DynamiteRawResponse<SetKeepaliveResponseApplicationJson, void> setKeepaliveRaw({required int keepalive}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -157,7 +155,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -203,9 +201,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [createDeviceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<CreateDeviceResponseApplicationJson, void>> createDevice({
-    required final String deviceName,
-  }) async {
+  Future<DynamiteResponse<CreateDeviceResponseApplicationJson, void>> createDevice({required String deviceName}) async {
     final rawResponse = createDeviceRaw(
       deviceName: deviceName,
     );
@@ -229,7 +225,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [createDevice] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<CreateDeviceResponseApplicationJson, void> createDeviceRaw({required final String deviceName}) {
+  DynamiteRawResponse<CreateDeviceResponseApplicationJson, void> createDeviceRaw({required String deviceName}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -238,7 +234,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -283,7 +279,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [syncDeviceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<SyncDeviceResponseApplicationJson, void>> syncDevice({required final String deviceId}) async {
+  Future<DynamiteResponse<SyncDeviceResponseApplicationJson, void>> syncDevice({required String deviceId}) async {
     final rawResponse = syncDeviceRaw(
       deviceId: deviceId,
     );
@@ -306,7 +302,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [syncDevice] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<SyncDeviceResponseApplicationJson, void> syncDeviceRaw({required final String deviceId}) {
+  DynamiteRawResponse<SyncDeviceResponseApplicationJson, void> syncDeviceRaw({required String deviceId}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -315,7 +311,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -358,9 +354,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [deleteDeviceRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<DeleteDeviceResponseApplicationJson, void>> deleteDevice({
-    required final String deviceId,
-  }) async {
+  Future<DynamiteResponse<DeleteDeviceResponseApplicationJson, void>> deleteDevice({required String deviceId}) async {
     final rawResponse = deleteDeviceRaw(
       deviceId: deviceId,
     );
@@ -381,7 +375,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [deleteDevice] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<DeleteDeviceResponseApplicationJson, void> deleteDeviceRaw({required final String deviceId}) {
+  DynamiteRawResponse<DeleteDeviceResponseApplicationJson, void> deleteDeviceRaw({required String deviceId}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -390,7 +384,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -438,8 +432,8 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [createAppRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<CreateAppResponseApplicationJson, void>> createApp({
-    required final String deviceId,
-    required final String appName,
+    required String deviceId,
+    required String appName,
   }) async {
     final rawResponse = createAppRaw(
       deviceId: deviceId,
@@ -467,8 +461,8 @@ class Client extends DynamiteClient {
   ///  * [createApp] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<CreateAppResponseApplicationJson, void> createAppRaw({
-    required final String deviceId,
-    required final String appName,
+    required String deviceId,
+    required String appName,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -478,7 +472,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -524,7 +518,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [deleteAppRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<DeleteAppResponseApplicationJson, void>> deleteApp({required final String token}) async {
+  Future<DynamiteResponse<DeleteAppResponseApplicationJson, void>> deleteApp({required String token}) async {
     final rawResponse = deleteAppRaw(
       token: token,
     );
@@ -545,7 +539,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [deleteApp] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<DeleteAppResponseApplicationJson, void> deleteAppRaw({required final String token}) {
+  DynamiteRawResponse<DeleteAppResponseApplicationJson, void> deleteAppRaw({required String token}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -554,7 +548,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -598,7 +592,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [unifiedpushDiscoveryRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UnifiedpushDiscoveryResponseApplicationJson, void>> unifiedpushDiscovery({
-    required final String token,
+    required String token,
   }) async {
     final rawResponse = unifiedpushDiscoveryRaw(
       token: token,
@@ -621,7 +615,7 @@ class Client extends DynamiteClient {
   ///  * [unifiedpushDiscovery] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UnifiedpushDiscoveryResponseApplicationJson, void> unifiedpushDiscoveryRaw({
-    required final String token,
+    required String token,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -631,7 +625,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -674,7 +668,7 @@ class Client extends DynamiteClient {
   ///
   /// See:
   ///  * [pushRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<PushResponseApplicationJson, void>> push({required final String token}) async {
+  Future<DynamiteResponse<PushResponseApplicationJson, void>> push({required String token}) async {
     final rawResponse = pushRaw(
       token: token,
     );
@@ -695,7 +689,7 @@ class Client extends DynamiteClient {
   /// See:
   ///  * [push] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<PushResponseApplicationJson, void> pushRaw({required final String token}) {
+  DynamiteRawResponse<PushResponseApplicationJson, void> pushRaw({required String token}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -704,7 +698,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -775,7 +769,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -843,7 +837,7 @@ class Client extends DynamiteClient {
 
 // coverage:ignore-start
     final authentication = authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -883,7 +877,7 @@ abstract class CheckResponseApplicationJson
     implements
         $CheckResponseApplicationJsonInterface,
         Built<CheckResponseApplicationJson, CheckResponseApplicationJsonBuilder> {
-  factory CheckResponseApplicationJson([final void Function(CheckResponseApplicationJsonBuilder)? b]) =
+  factory CheckResponseApplicationJson([void Function(CheckResponseApplicationJsonBuilder)? b]) =
       _$CheckResponseApplicationJson;
 
   // coverage:ignore-start
@@ -891,7 +885,7 @@ abstract class CheckResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CheckResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CheckResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -911,7 +905,7 @@ abstract class SetKeepaliveResponseApplicationJson
     implements
         $SetKeepaliveResponseApplicationJsonInterface,
         Built<SetKeepaliveResponseApplicationJson, SetKeepaliveResponseApplicationJsonBuilder> {
-  factory SetKeepaliveResponseApplicationJson([final void Function(SetKeepaliveResponseApplicationJsonBuilder)? b]) =
+  factory SetKeepaliveResponseApplicationJson([void Function(SetKeepaliveResponseApplicationJsonBuilder)? b]) =
       _$SetKeepaliveResponseApplicationJson;
 
   // coverage:ignore-start
@@ -919,7 +913,7 @@ abstract class SetKeepaliveResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SetKeepaliveResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory SetKeepaliveResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -941,7 +935,7 @@ abstract class CreateDeviceResponseApplicationJson
     implements
         $CreateDeviceResponseApplicationJsonInterface,
         Built<CreateDeviceResponseApplicationJson, CreateDeviceResponseApplicationJsonBuilder> {
-  factory CreateDeviceResponseApplicationJson([final void Function(CreateDeviceResponseApplicationJsonBuilder)? b]) =
+  factory CreateDeviceResponseApplicationJson([void Function(CreateDeviceResponseApplicationJsonBuilder)? b]) =
       _$CreateDeviceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -949,7 +943,7 @@ abstract class CreateDeviceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CreateDeviceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CreateDeviceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -970,7 +964,7 @@ abstract class SyncDeviceResponseApplicationJson
     implements
         $SyncDeviceResponseApplicationJsonInterface,
         Built<SyncDeviceResponseApplicationJson, SyncDeviceResponseApplicationJsonBuilder> {
-  factory SyncDeviceResponseApplicationJson([final void Function(SyncDeviceResponseApplicationJsonBuilder)? b]) =
+  factory SyncDeviceResponseApplicationJson([void Function(SyncDeviceResponseApplicationJsonBuilder)? b]) =
       _$SyncDeviceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -978,7 +972,7 @@ abstract class SyncDeviceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory SyncDeviceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory SyncDeviceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -998,7 +992,7 @@ abstract class DeleteDeviceResponseApplicationJson
     implements
         $DeleteDeviceResponseApplicationJsonInterface,
         Built<DeleteDeviceResponseApplicationJson, DeleteDeviceResponseApplicationJsonBuilder> {
-  factory DeleteDeviceResponseApplicationJson([final void Function(DeleteDeviceResponseApplicationJsonBuilder)? b]) =
+  factory DeleteDeviceResponseApplicationJson([void Function(DeleteDeviceResponseApplicationJsonBuilder)? b]) =
       _$DeleteDeviceResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1006,7 +1000,7 @@ abstract class DeleteDeviceResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DeleteDeviceResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DeleteDeviceResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1028,7 +1022,7 @@ abstract class CreateAppResponseApplicationJson
     implements
         $CreateAppResponseApplicationJsonInterface,
         Built<CreateAppResponseApplicationJson, CreateAppResponseApplicationJsonBuilder> {
-  factory CreateAppResponseApplicationJson([final void Function(CreateAppResponseApplicationJsonBuilder)? b]) =
+  factory CreateAppResponseApplicationJson([void Function(CreateAppResponseApplicationJsonBuilder)? b]) =
       _$CreateAppResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1036,7 +1030,7 @@ abstract class CreateAppResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory CreateAppResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory CreateAppResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1056,7 +1050,7 @@ abstract class DeleteAppResponseApplicationJson
     implements
         $DeleteAppResponseApplicationJsonInterface,
         Built<DeleteAppResponseApplicationJson, DeleteAppResponseApplicationJsonBuilder> {
-  factory DeleteAppResponseApplicationJson([final void Function(DeleteAppResponseApplicationJsonBuilder)? b]) =
+  factory DeleteAppResponseApplicationJson([void Function(DeleteAppResponseApplicationJsonBuilder)? b]) =
       _$DeleteAppResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1064,7 +1058,7 @@ abstract class DeleteAppResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory DeleteAppResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory DeleteAppResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1086,7 +1080,7 @@ abstract class UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush
         Built<UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush,
             UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder> {
   factory UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush([
-    final void Function(UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder)? b,
+    void Function(UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder)? b,
   ]) = _$UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush;
 
   // coverage:ignore-start
@@ -1094,7 +1088,7 @@ abstract class UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush.fromJson(final Map<String, dynamic> json) =>
+  factory UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1116,7 +1110,7 @@ abstract class UnifiedpushDiscoveryResponseApplicationJson
         $UnifiedpushDiscoveryResponseApplicationJsonInterface,
         Built<UnifiedpushDiscoveryResponseApplicationJson, UnifiedpushDiscoveryResponseApplicationJsonBuilder> {
   factory UnifiedpushDiscoveryResponseApplicationJson([
-    final void Function(UnifiedpushDiscoveryResponseApplicationJsonBuilder)? b,
+    void Function(UnifiedpushDiscoveryResponseApplicationJsonBuilder)? b,
   ]) = _$UnifiedpushDiscoveryResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1124,7 +1118,7 @@ abstract class UnifiedpushDiscoveryResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UnifiedpushDiscoveryResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UnifiedpushDiscoveryResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1145,7 +1139,7 @@ abstract class PushResponseApplicationJson
     implements
         $PushResponseApplicationJsonInterface,
         Built<PushResponseApplicationJson, PushResponseApplicationJsonBuilder> {
-  factory PushResponseApplicationJson([final void Function(PushResponseApplicationJsonBuilder)? b]) =
+  factory PushResponseApplicationJson([void Function(PushResponseApplicationJsonBuilder)? b]) =
       _$PushResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1153,7 +1147,7 @@ abstract class PushResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PushResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PushResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1175,7 +1169,7 @@ abstract class GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush
         Built<GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush,
             GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder> {
   factory GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush([
-    final void Function(GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder)? b,
+    void Function(GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder)? b,
   ]) = _$GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush;
 
   // coverage:ignore-start
@@ -1183,7 +1177,7 @@ abstract class GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush.fromJson(final Map<String, dynamic> json) =>
+  factory GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1205,7 +1199,7 @@ abstract class GatewayMatrixDiscoveryResponseApplicationJson
         $GatewayMatrixDiscoveryResponseApplicationJsonInterface,
         Built<GatewayMatrixDiscoveryResponseApplicationJson, GatewayMatrixDiscoveryResponseApplicationJsonBuilder> {
   factory GatewayMatrixDiscoveryResponseApplicationJson([
-    final void Function(GatewayMatrixDiscoveryResponseApplicationJsonBuilder)? b,
+    void Function(GatewayMatrixDiscoveryResponseApplicationJsonBuilder)? b,
   ]) = _$GatewayMatrixDiscoveryResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1213,7 +1207,7 @@ abstract class GatewayMatrixDiscoveryResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GatewayMatrixDiscoveryResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GatewayMatrixDiscoveryResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1234,7 +1228,7 @@ abstract class GatewayMatrixResponseApplicationJson
     implements
         $GatewayMatrixResponseApplicationJsonInterface,
         Built<GatewayMatrixResponseApplicationJson, GatewayMatrixResponseApplicationJsonBuilder> {
-  factory GatewayMatrixResponseApplicationJson([final void Function(GatewayMatrixResponseApplicationJsonBuilder)? b]) =
+  factory GatewayMatrixResponseApplicationJson([void Function(GatewayMatrixResponseApplicationJsonBuilder)? b]) =
       _$GatewayMatrixResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1242,7 +1236,7 @@ abstract class GatewayMatrixResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory GatewayMatrixResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory GatewayMatrixResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -30,7 +30,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -71,8 +71,8 @@ class HeartbeatClient {
   /// See:
   ///  * [heartbeatRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<HeartbeatHeartbeatResponseApplicationJson, void>> heartbeat({
-    required final String status,
-    final bool? oCSAPIRequest,
+    required String status,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = heartbeatRaw(
       status: status,
@@ -103,8 +103,8 @@ class HeartbeatClient {
   ///  * [heartbeat] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<HeartbeatHeartbeatResponseApplicationJson, void> heartbeatRaw({
-    required final String status,
-    final bool? oCSAPIRequest,
+    required String status,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -114,7 +114,7 @@ class HeartbeatClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -170,9 +170,7 @@ class PredefinedStatusClient {
   ///
   /// See:
   ///  * [findAllRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<PredefinedStatusFindAllResponseApplicationJson, void>> findAll({
-    final bool? oCSAPIRequest,
-  }) async {
+  Future<DynamiteResponse<PredefinedStatusFindAllResponseApplicationJson, void>> findAll({bool? oCSAPIRequest}) async {
     final rawResponse = findAllRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -196,7 +194,7 @@ class PredefinedStatusClient {
   /// See:
   ///  * [findAll] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<PredefinedStatusFindAllResponseApplicationJson, void> findAllRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<PredefinedStatusFindAllResponseApplicationJson, void> findAllRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -205,7 +203,7 @@ class PredefinedStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -261,9 +259,9 @@ class StatusesClient {
   /// See:
   ///  * [findAllRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<StatusesFindAllResponseApplicationJson, void>> findAll({
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = findAllRaw(
       limit: limit,
@@ -293,9 +291,9 @@ class StatusesClient {
   ///  * [findAll] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<StatusesFindAllResponseApplicationJson, void> findAllRaw({
-    final int? limit,
-    final int? offset,
-    final bool? oCSAPIRequest,
+    int? limit,
+    int? offset,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -305,7 +303,7 @@ class StatusesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -362,8 +360,8 @@ class StatusesClient {
   /// See:
   ///  * [findRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<StatusesFindResponseApplicationJson, void>> find({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = findRaw(
       userId: userId,
@@ -392,8 +390,8 @@ class StatusesClient {
   ///  * [find] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<StatusesFindResponseApplicationJson, void> findRaw({
-    required final String userId,
-    final bool? oCSAPIRequest,
+    required String userId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -403,7 +401,7 @@ class StatusesClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -460,9 +458,7 @@ class UserStatusClient {
   ///
   /// See:
   ///  * [getStatusRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
-  Future<DynamiteResponse<UserStatusGetStatusResponseApplicationJson, void>> getStatus({
-    final bool? oCSAPIRequest,
-  }) async {
+  Future<DynamiteResponse<UserStatusGetStatusResponseApplicationJson, void>> getStatus({bool? oCSAPIRequest}) async {
     final rawResponse = getStatusRaw(
       oCSAPIRequest: oCSAPIRequest,
     );
@@ -487,7 +483,7 @@ class UserStatusClient {
   /// See:
   ///  * [getStatus] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<UserStatusGetStatusResponseApplicationJson, void> getStatusRaw({final bool? oCSAPIRequest}) {
+  DynamiteRawResponse<UserStatusGetStatusResponseApplicationJson, void> getStatusRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -496,7 +492,7 @@ class UserStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -546,8 +542,8 @@ class UserStatusClient {
   /// See:
   ///  * [setStatusRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UserStatusSetStatusResponseApplicationJson, void>> setStatus({
-    required final String statusType,
-    final bool? oCSAPIRequest,
+    required String statusType,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setStatusRaw(
       statusType: statusType,
@@ -576,8 +572,8 @@ class UserStatusClient {
   ///  * [setStatus] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UserStatusSetStatusResponseApplicationJson, void> setStatusRaw({
-    required final String statusType,
-    final bool? oCSAPIRequest,
+    required String statusType,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -587,7 +583,7 @@ class UserStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -643,9 +639,9 @@ class UserStatusClient {
   /// See:
   ///  * [setPredefinedMessageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UserStatusSetPredefinedMessageResponseApplicationJson, void>> setPredefinedMessage({
-    required final String messageId,
-    final int? clearAt,
-    final bool? oCSAPIRequest,
+    required String messageId,
+    int? clearAt,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setPredefinedMessageRaw(
       messageId: messageId,
@@ -676,9 +672,9 @@ class UserStatusClient {
   ///  * [setPredefinedMessage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UserStatusSetPredefinedMessageResponseApplicationJson, void> setPredefinedMessageRaw({
-    required final String messageId,
-    final int? clearAt,
-    final bool? oCSAPIRequest,
+    required String messageId,
+    int? clearAt,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -688,7 +684,7 @@ class UserStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -749,10 +745,10 @@ class UserStatusClient {
   /// See:
   ///  * [setCustomMessageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UserStatusSetCustomMessageResponseApplicationJson, void>> setCustomMessage({
-    final String? statusIcon,
-    final String? message,
-    final int? clearAt,
-    final bool? oCSAPIRequest,
+    String? statusIcon,
+    String? message,
+    int? clearAt,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setCustomMessageRaw(
       statusIcon: statusIcon,
@@ -785,10 +781,10 @@ class UserStatusClient {
   ///  * [setCustomMessage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UserStatusSetCustomMessageResponseApplicationJson, void> setCustomMessageRaw({
-    final String? statusIcon,
-    final String? message,
-    final int? clearAt,
-    final bool? oCSAPIRequest,
+    String? statusIcon,
+    String? message,
+    int? clearAt,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -798,7 +794,7 @@ class UserStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -858,7 +854,7 @@ class UserStatusClient {
   /// See:
   ///  * [clearMessageRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UserStatusClearMessageResponseApplicationJson, void>> clearMessage({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = clearMessageRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -883,9 +879,7 @@ class UserStatusClient {
   /// See:
   ///  * [clearMessage] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<UserStatusClearMessageResponseApplicationJson, void> clearMessageRaw({
-    final bool? oCSAPIRequest,
-  }) {
+  DynamiteRawResponse<UserStatusClearMessageResponseApplicationJson, void> clearMessageRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -894,7 +888,7 @@ class UserStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -943,8 +937,8 @@ class UserStatusClient {
   /// See:
   ///  * [revertStatusRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<UserStatusRevertStatusResponseApplicationJson, void>> revertStatus({
-    required final String messageId,
-    final bool? oCSAPIRequest,
+    required String messageId,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = revertStatusRaw(
       messageId: messageId,
@@ -972,8 +966,8 @@ class UserStatusClient {
   ///  * [revertStatus] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<UserStatusRevertStatusResponseApplicationJson, void> revertStatusRaw({
-    required final String messageId,
-    final bool? oCSAPIRequest,
+    required String messageId,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -983,7 +977,7 @@ class UserStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -1033,14 +1027,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1060,14 +1054,14 @@ abstract interface class $PublicInterface {
 }
 
 abstract class Public implements $PublicInterface, Built<Public, PublicBuilder> {
-  factory Public([final void Function(PublicBuilder)? b]) = _$Public;
+  factory Public([void Function(PublicBuilder)? b]) = _$Public;
 
   // coverage:ignore-start
   const Public._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Public.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Public.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1088,14 +1082,14 @@ abstract interface class $Private_1Interface {
 abstract interface class $PrivateInterface implements $PublicInterface, $Private_1Interface {}
 
 abstract class Private implements $PrivateInterface, Built<Private, PrivateBuilder> {
-  factory Private([final void Function(PrivateBuilder)? b]) = _$Private;
+  factory Private([void Function(PrivateBuilder)? b]) = _$Private;
 
   // coverage:ignore-start
   const Private._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Private.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Private.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1116,7 +1110,7 @@ abstract class HeartbeatHeartbeatResponseApplicationJson_Ocs
         $HeartbeatHeartbeatResponseApplicationJson_OcsInterface,
         Built<HeartbeatHeartbeatResponseApplicationJson_Ocs, HeartbeatHeartbeatResponseApplicationJson_OcsBuilder> {
   factory HeartbeatHeartbeatResponseApplicationJson_Ocs([
-    final void Function(HeartbeatHeartbeatResponseApplicationJson_OcsBuilder)? b,
+    void Function(HeartbeatHeartbeatResponseApplicationJson_OcsBuilder)? b,
   ]) = _$HeartbeatHeartbeatResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1124,7 +1118,7 @@ abstract class HeartbeatHeartbeatResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory HeartbeatHeartbeatResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory HeartbeatHeartbeatResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1146,7 +1140,7 @@ abstract class HeartbeatHeartbeatResponseApplicationJson
         $HeartbeatHeartbeatResponseApplicationJsonInterface,
         Built<HeartbeatHeartbeatResponseApplicationJson, HeartbeatHeartbeatResponseApplicationJsonBuilder> {
   factory HeartbeatHeartbeatResponseApplicationJson([
-    final void Function(HeartbeatHeartbeatResponseApplicationJsonBuilder)? b,
+    void Function(HeartbeatHeartbeatResponseApplicationJsonBuilder)? b,
   ]) = _$HeartbeatHeartbeatResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1154,7 +1148,7 @@ abstract class HeartbeatHeartbeatResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory HeartbeatHeartbeatResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory HeartbeatHeartbeatResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1178,7 +1172,7 @@ class ClearAt_Type extends EnumClass {
   static BuiltSet<ClearAt_Type> get values => _$clearAtTypeValues;
   // coverage:ignore-end
 
-  static ClearAt_Type valueOf(final String name) => _$valueOfClearAt_Type(name);
+  static ClearAt_Type valueOf(String name) => _$valueOfClearAt_Type(name);
 
   static Serializer<ClearAt_Type> get serializer => _$clearAtTypeSerializer;
 }
@@ -1194,7 +1188,7 @@ class ClearAtTimeType extends EnumClass {
   static BuiltSet<ClearAtTimeType> get values => _$clearAtTimeTypeValues;
   // coverage:ignore-end
 
-  static ClearAtTimeType valueOf(final String name) => _$valueOfClearAtTimeType(name);
+  static ClearAtTimeType valueOf(String name) => _$valueOfClearAtTimeType(name);
 
   static Serializer<ClearAtTimeType> get serializer => _$clearAtTimeTypeSerializer;
 }
@@ -1206,14 +1200,14 @@ abstract interface class $ClearAtInterface {
 }
 
 abstract class ClearAt implements $ClearAtInterface, Built<ClearAt, ClearAtBuilder> {
-  factory ClearAt([final void Function(ClearAtBuilder)? b]) = _$ClearAt;
+  factory ClearAt([void Function(ClearAtBuilder)? b]) = _$ClearAt;
 
   // coverage:ignore-start
   const ClearAt._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory ClearAt.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory ClearAt.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1223,7 +1217,7 @@ abstract class ClearAt implements $ClearAtInterface, Built<ClearAt, ClearAtBuild
   static Serializer<ClearAt> get serializer => _$clearAtSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final ClearAtBuilder b) {
+  static void _validate(ClearAtBuilder b) {
     b.time?.validateOneOf();
   }
 }
@@ -1238,14 +1232,14 @@ abstract interface class $PredefinedInterface {
 }
 
 abstract class Predefined implements $PredefinedInterface, Built<Predefined, PredefinedBuilder> {
-  factory Predefined([final void Function(PredefinedBuilder)? b]) = _$Predefined;
+  factory Predefined([void Function(PredefinedBuilder)? b]) = _$Predefined;
 
   // coverage:ignore-start
   const Predefined._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Predefined.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Predefined.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1267,7 +1261,7 @@ abstract class PredefinedStatusFindAllResponseApplicationJson_Ocs
         Built<PredefinedStatusFindAllResponseApplicationJson_Ocs,
             PredefinedStatusFindAllResponseApplicationJson_OcsBuilder> {
   factory PredefinedStatusFindAllResponseApplicationJson_Ocs([
-    final void Function(PredefinedStatusFindAllResponseApplicationJson_OcsBuilder)? b,
+    void Function(PredefinedStatusFindAllResponseApplicationJson_OcsBuilder)? b,
   ]) = _$PredefinedStatusFindAllResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1275,7 +1269,7 @@ abstract class PredefinedStatusFindAllResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PredefinedStatusFindAllResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory PredefinedStatusFindAllResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1297,7 +1291,7 @@ abstract class PredefinedStatusFindAllResponseApplicationJson
         $PredefinedStatusFindAllResponseApplicationJsonInterface,
         Built<PredefinedStatusFindAllResponseApplicationJson, PredefinedStatusFindAllResponseApplicationJsonBuilder> {
   factory PredefinedStatusFindAllResponseApplicationJson([
-    final void Function(PredefinedStatusFindAllResponseApplicationJsonBuilder)? b,
+    void Function(PredefinedStatusFindAllResponseApplicationJsonBuilder)? b,
   ]) = _$PredefinedStatusFindAllResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1305,7 +1299,7 @@ abstract class PredefinedStatusFindAllResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory PredefinedStatusFindAllResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory PredefinedStatusFindAllResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1328,7 +1322,7 @@ abstract class StatusesFindAllResponseApplicationJson_Ocs
         $StatusesFindAllResponseApplicationJson_OcsInterface,
         Built<StatusesFindAllResponseApplicationJson_Ocs, StatusesFindAllResponseApplicationJson_OcsBuilder> {
   factory StatusesFindAllResponseApplicationJson_Ocs([
-    final void Function(StatusesFindAllResponseApplicationJson_OcsBuilder)? b,
+    void Function(StatusesFindAllResponseApplicationJson_OcsBuilder)? b,
   ]) = _$StatusesFindAllResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1336,7 +1330,7 @@ abstract class StatusesFindAllResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory StatusesFindAllResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory StatusesFindAllResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1357,16 +1351,15 @@ abstract class StatusesFindAllResponseApplicationJson
     implements
         $StatusesFindAllResponseApplicationJsonInterface,
         Built<StatusesFindAllResponseApplicationJson, StatusesFindAllResponseApplicationJsonBuilder> {
-  factory StatusesFindAllResponseApplicationJson([
-    final void Function(StatusesFindAllResponseApplicationJsonBuilder)? b,
-  ]) = _$StatusesFindAllResponseApplicationJson;
+  factory StatusesFindAllResponseApplicationJson([void Function(StatusesFindAllResponseApplicationJsonBuilder)? b]) =
+      _$StatusesFindAllResponseApplicationJson;
 
   // coverage:ignore-start
   const StatusesFindAllResponseApplicationJson._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory StatusesFindAllResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory StatusesFindAllResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1388,16 +1381,15 @@ abstract class StatusesFindResponseApplicationJson_Ocs
     implements
         $StatusesFindResponseApplicationJson_OcsInterface,
         Built<StatusesFindResponseApplicationJson_Ocs, StatusesFindResponseApplicationJson_OcsBuilder> {
-  factory StatusesFindResponseApplicationJson_Ocs([
-    final void Function(StatusesFindResponseApplicationJson_OcsBuilder)? b,
-  ]) = _$StatusesFindResponseApplicationJson_Ocs;
+  factory StatusesFindResponseApplicationJson_Ocs([void Function(StatusesFindResponseApplicationJson_OcsBuilder)? b]) =
+      _$StatusesFindResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
   const StatusesFindResponseApplicationJson_Ocs._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory StatusesFindResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory StatusesFindResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1418,7 +1410,7 @@ abstract class StatusesFindResponseApplicationJson
     implements
         $StatusesFindResponseApplicationJsonInterface,
         Built<StatusesFindResponseApplicationJson, StatusesFindResponseApplicationJsonBuilder> {
-  factory StatusesFindResponseApplicationJson([final void Function(StatusesFindResponseApplicationJsonBuilder)? b]) =
+  factory StatusesFindResponseApplicationJson([void Function(StatusesFindResponseApplicationJsonBuilder)? b]) =
       _$StatusesFindResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1426,7 +1418,7 @@ abstract class StatusesFindResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory StatusesFindResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory StatusesFindResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1449,7 +1441,7 @@ abstract class UserStatusGetStatusResponseApplicationJson_Ocs
         $UserStatusGetStatusResponseApplicationJson_OcsInterface,
         Built<UserStatusGetStatusResponseApplicationJson_Ocs, UserStatusGetStatusResponseApplicationJson_OcsBuilder> {
   factory UserStatusGetStatusResponseApplicationJson_Ocs([
-    final void Function(UserStatusGetStatusResponseApplicationJson_OcsBuilder)? b,
+    void Function(UserStatusGetStatusResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UserStatusGetStatusResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1457,7 +1449,7 @@ abstract class UserStatusGetStatusResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusGetStatusResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusGetStatusResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1479,7 +1471,7 @@ abstract class UserStatusGetStatusResponseApplicationJson
         $UserStatusGetStatusResponseApplicationJsonInterface,
         Built<UserStatusGetStatusResponseApplicationJson, UserStatusGetStatusResponseApplicationJsonBuilder> {
   factory UserStatusGetStatusResponseApplicationJson([
-    final void Function(UserStatusGetStatusResponseApplicationJsonBuilder)? b,
+    void Function(UserStatusGetStatusResponseApplicationJsonBuilder)? b,
   ]) = _$UserStatusGetStatusResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1487,7 +1479,7 @@ abstract class UserStatusGetStatusResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusGetStatusResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusGetStatusResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1510,7 +1502,7 @@ abstract class UserStatusSetStatusResponseApplicationJson_Ocs
         $UserStatusSetStatusResponseApplicationJson_OcsInterface,
         Built<UserStatusSetStatusResponseApplicationJson_Ocs, UserStatusSetStatusResponseApplicationJson_OcsBuilder> {
   factory UserStatusSetStatusResponseApplicationJson_Ocs([
-    final void Function(UserStatusSetStatusResponseApplicationJson_OcsBuilder)? b,
+    void Function(UserStatusSetStatusResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UserStatusSetStatusResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1518,7 +1510,7 @@ abstract class UserStatusSetStatusResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusSetStatusResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusSetStatusResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1540,7 +1532,7 @@ abstract class UserStatusSetStatusResponseApplicationJson
         $UserStatusSetStatusResponseApplicationJsonInterface,
         Built<UserStatusSetStatusResponseApplicationJson, UserStatusSetStatusResponseApplicationJsonBuilder> {
   factory UserStatusSetStatusResponseApplicationJson([
-    final void Function(UserStatusSetStatusResponseApplicationJsonBuilder)? b,
+    void Function(UserStatusSetStatusResponseApplicationJsonBuilder)? b,
   ]) = _$UserStatusSetStatusResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1548,7 +1540,7 @@ abstract class UserStatusSetStatusResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusSetStatusResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusSetStatusResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1572,7 +1564,7 @@ abstract class UserStatusSetPredefinedMessageResponseApplicationJson_Ocs
         Built<UserStatusSetPredefinedMessageResponseApplicationJson_Ocs,
             UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder> {
   factory UserStatusSetPredefinedMessageResponseApplicationJson_Ocs([
-    final void Function(UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder)? b,
+    void Function(UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UserStatusSetPredefinedMessageResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1580,7 +1572,7 @@ abstract class UserStatusSetPredefinedMessageResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusSetPredefinedMessageResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusSetPredefinedMessageResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1603,7 +1595,7 @@ abstract class UserStatusSetPredefinedMessageResponseApplicationJson
         Built<UserStatusSetPredefinedMessageResponseApplicationJson,
             UserStatusSetPredefinedMessageResponseApplicationJsonBuilder> {
   factory UserStatusSetPredefinedMessageResponseApplicationJson([
-    final void Function(UserStatusSetPredefinedMessageResponseApplicationJsonBuilder)? b,
+    void Function(UserStatusSetPredefinedMessageResponseApplicationJsonBuilder)? b,
   ]) = _$UserStatusSetPredefinedMessageResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1611,7 +1603,7 @@ abstract class UserStatusSetPredefinedMessageResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusSetPredefinedMessageResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusSetPredefinedMessageResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1635,7 +1627,7 @@ abstract class UserStatusSetCustomMessageResponseApplicationJson_Ocs
         Built<UserStatusSetCustomMessageResponseApplicationJson_Ocs,
             UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder> {
   factory UserStatusSetCustomMessageResponseApplicationJson_Ocs([
-    final void Function(UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder)? b,
+    void Function(UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UserStatusSetCustomMessageResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1643,7 +1635,7 @@ abstract class UserStatusSetCustomMessageResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusSetCustomMessageResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusSetCustomMessageResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1666,7 +1658,7 @@ abstract class UserStatusSetCustomMessageResponseApplicationJson
         Built<UserStatusSetCustomMessageResponseApplicationJson,
             UserStatusSetCustomMessageResponseApplicationJsonBuilder> {
   factory UserStatusSetCustomMessageResponseApplicationJson([
-    final void Function(UserStatusSetCustomMessageResponseApplicationJsonBuilder)? b,
+    void Function(UserStatusSetCustomMessageResponseApplicationJsonBuilder)? b,
   ]) = _$UserStatusSetCustomMessageResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1674,7 +1666,7 @@ abstract class UserStatusSetCustomMessageResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusSetCustomMessageResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusSetCustomMessageResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1698,7 +1690,7 @@ abstract class UserStatusClearMessageResponseApplicationJson_Ocs
         Built<UserStatusClearMessageResponseApplicationJson_Ocs,
             UserStatusClearMessageResponseApplicationJson_OcsBuilder> {
   factory UserStatusClearMessageResponseApplicationJson_Ocs([
-    final void Function(UserStatusClearMessageResponseApplicationJson_OcsBuilder)? b,
+    void Function(UserStatusClearMessageResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UserStatusClearMessageResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1706,7 +1698,7 @@ abstract class UserStatusClearMessageResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusClearMessageResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusClearMessageResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1728,7 +1720,7 @@ abstract class UserStatusClearMessageResponseApplicationJson
         $UserStatusClearMessageResponseApplicationJsonInterface,
         Built<UserStatusClearMessageResponseApplicationJson, UserStatusClearMessageResponseApplicationJsonBuilder> {
   factory UserStatusClearMessageResponseApplicationJson([
-    final void Function(UserStatusClearMessageResponseApplicationJsonBuilder)? b,
+    void Function(UserStatusClearMessageResponseApplicationJsonBuilder)? b,
   ]) = _$UserStatusClearMessageResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1736,7 +1728,7 @@ abstract class UserStatusClearMessageResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusClearMessageResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusClearMessageResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1760,7 +1752,7 @@ abstract class UserStatusRevertStatusResponseApplicationJson_Ocs
         Built<UserStatusRevertStatusResponseApplicationJson_Ocs,
             UserStatusRevertStatusResponseApplicationJson_OcsBuilder> {
   factory UserStatusRevertStatusResponseApplicationJson_Ocs([
-    final void Function(UserStatusRevertStatusResponseApplicationJson_OcsBuilder)? b,
+    void Function(UserStatusRevertStatusResponseApplicationJson_OcsBuilder)? b,
   ]) = _$UserStatusRevertStatusResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1768,7 +1760,7 @@ abstract class UserStatusRevertStatusResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusRevertStatusResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusRevertStatusResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1780,7 +1772,7 @@ abstract class UserStatusRevertStatusResponseApplicationJson_Ocs
       _$userStatusRevertStatusResponseApplicationJsonOcsSerializer;
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(final UserStatusRevertStatusResponseApplicationJson_OcsBuilder b) {
+  static void _validate(UserStatusRevertStatusResponseApplicationJson_OcsBuilder b) {
     b.data?.validateOneOf();
   }
 }
@@ -1795,7 +1787,7 @@ abstract class UserStatusRevertStatusResponseApplicationJson
         $UserStatusRevertStatusResponseApplicationJsonInterface,
         Built<UserStatusRevertStatusResponseApplicationJson, UserStatusRevertStatusResponseApplicationJsonBuilder> {
   factory UserStatusRevertStatusResponseApplicationJson([
-    final void Function(UserStatusRevertStatusResponseApplicationJsonBuilder)? b,
+    void Function(UserStatusRevertStatusResponseApplicationJsonBuilder)? b,
   ]) = _$UserStatusRevertStatusResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1803,7 +1795,7 @@ abstract class UserStatusRevertStatusResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory UserStatusRevertStatusResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory UserStatusRevertStatusResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1825,14 +1817,14 @@ abstract interface class $Capabilities_UserStatusInterface {
 
 abstract class Capabilities_UserStatus
     implements $Capabilities_UserStatusInterface, Built<Capabilities_UserStatus, Capabilities_UserStatusBuilder> {
-  factory Capabilities_UserStatus([final void Function(Capabilities_UserStatusBuilder)? b]) = _$Capabilities_UserStatus;
+  factory Capabilities_UserStatus([void Function(Capabilities_UserStatusBuilder)? b]) = _$Capabilities_UserStatus;
 
   // coverage:ignore-start
   const Capabilities_UserStatus._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_UserStatus.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_UserStatus.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1850,14 +1842,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1878,7 +1870,7 @@ extension $ClearAtTimeTypeIntExtension on $ClearAtTimeTypeInt {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$ClearAtTimeTypeInt> get serializer => const _$ClearAtTimeTypeIntSerializer();
-  static $ClearAtTimeTypeInt fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $ClearAtTimeTypeInt fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -1893,9 +1885,9 @@ class _$ClearAtTimeTypeIntSerializer implements PrimitiveSerializer<$ClearAtTime
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $ClearAtTimeTypeInt object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $ClearAtTimeTypeInt object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.clearAtTimeType;
@@ -1912,9 +1904,9 @@ class _$ClearAtTimeTypeIntSerializer implements PrimitiveSerializer<$ClearAtTime
 
   @override
   $ClearAtTimeTypeInt deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     ClearAtTimeType? clearAtTimeType;
     try {
@@ -1936,7 +1928,7 @@ extension $BuiltListPrivateExtension on $BuiltListPrivate {
   void validateOneOf() => dynamite_utils.validateOneOf(_values);
   void validateAnyOf() => dynamite_utils.validateAnyOf(_values);
   static Serializer<$BuiltListPrivate> get serializer => const _$BuiltListPrivateSerializer();
-  static $BuiltListPrivate fromJson(final Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
+  static $BuiltListPrivate fromJson(Object? json) => jsonSerializers.deserializeWith(serializer, json)!;
   Object? toJson() => jsonSerializers.serializeWith(serializer, this);
 }
 
@@ -1951,9 +1943,9 @@ class _$BuiltListPrivateSerializer implements PrimitiveSerializer<$BuiltListPriv
 
   @override
   Object serialize(
-    final Serializers serializers,
-    final $BuiltListPrivate object, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    $BuiltListPrivate object, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     dynamic value;
     value = object.builtListNever;
@@ -1970,9 +1962,9 @@ class _$BuiltListPrivateSerializer implements PrimitiveSerializer<$BuiltListPriv
 
   @override
   $BuiltListPrivate deserialize(
-    final Serializers serializers,
-    final Object data, {
-    final FullType specifiedType = FullType.unspecified,
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
   }) {
     BuiltList<Never>? builtListNever;
     try {

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -28,7 +28,7 @@ class Client extends DynamiteClient {
     super.authentications,
   });
 
-  Client.fromClient(final DynamiteClient client)
+  Client.fromClient(DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -60,8 +60,8 @@ class WeatherStatusClient {
   /// See:
   ///  * [setModeRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<WeatherStatusSetModeResponseApplicationJson, void>> setMode({
-    required final int mode,
-    final bool? oCSAPIRequest,
+    required int mode,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setModeRaw(
       mode: mode,
@@ -89,8 +89,8 @@ class WeatherStatusClient {
   ///  * [setMode] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<WeatherStatusSetModeResponseApplicationJson, void> setModeRaw({
-    required final int mode,
-    final bool? oCSAPIRequest,
+    required int mode,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -100,7 +100,7 @@ class WeatherStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -151,7 +151,7 @@ class WeatherStatusClient {
   /// See:
   ///  * [usePersonalAddressRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<WeatherStatusUsePersonalAddressResponseApplicationJson, void>> usePersonalAddress({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = usePersonalAddressRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -177,7 +177,7 @@ class WeatherStatusClient {
   ///  * [usePersonalAddress] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<WeatherStatusUsePersonalAddressResponseApplicationJson, void> usePersonalAddressRaw({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -187,7 +187,7 @@ class WeatherStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -235,7 +235,7 @@ class WeatherStatusClient {
   /// See:
   ///  * [getLocationRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<WeatherStatusGetLocationResponseApplicationJson, void>> getLocation({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getLocationRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -260,9 +260,7 @@ class WeatherStatusClient {
   /// See:
   ///  * [getLocation] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<WeatherStatusGetLocationResponseApplicationJson, void> getLocationRaw({
-    final bool? oCSAPIRequest,
-  }) {
+  DynamiteRawResponse<WeatherStatusGetLocationResponseApplicationJson, void> getLocationRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -271,7 +269,7 @@ class WeatherStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -322,10 +320,10 @@ class WeatherStatusClient {
   /// See:
   ///  * [setLocationRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<WeatherStatusSetLocationResponseApplicationJson, void>> setLocation({
-    final String? address,
-    final double? lat,
-    final double? lon,
-    final bool? oCSAPIRequest,
+    String? address,
+    double? lat,
+    double? lon,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setLocationRaw(
       address: address,
@@ -357,10 +355,10 @@ class WeatherStatusClient {
   ///  * [setLocation] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<WeatherStatusSetLocationResponseApplicationJson, void> setLocationRaw({
-    final String? address,
-    final double? lat,
-    final double? lon,
-    final bool? oCSAPIRequest,
+    String? address,
+    double? lat,
+    double? lon,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -370,7 +368,7 @@ class WeatherStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -430,7 +428,7 @@ class WeatherStatusClient {
   /// See:
   ///  * [getForecastRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<WeatherStatusGetForecastResponseApplicationJson, void>> getForecast({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getForecastRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -456,9 +454,7 @@ class WeatherStatusClient {
   /// See:
   ///  * [getForecast] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<WeatherStatusGetForecastResponseApplicationJson, void> getForecastRaw({
-    final bool? oCSAPIRequest,
-  }) {
+  DynamiteRawResponse<WeatherStatusGetForecastResponseApplicationJson, void> getForecastRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -467,7 +463,7 @@ class WeatherStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -515,7 +511,7 @@ class WeatherStatusClient {
   /// See:
   ///  * [getFavoritesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<WeatherStatusGetFavoritesResponseApplicationJson, void>> getFavorites({
-    final bool? oCSAPIRequest,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = getFavoritesRaw(
       oCSAPIRequest: oCSAPIRequest,
@@ -540,9 +536,7 @@ class WeatherStatusClient {
   /// See:
   ///  * [getFavorites] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
-  DynamiteRawResponse<WeatherStatusGetFavoritesResponseApplicationJson, void> getFavoritesRaw({
-    final bool? oCSAPIRequest,
-  }) {
+  DynamiteRawResponse<WeatherStatusGetFavoritesResponseApplicationJson, void> getFavoritesRaw({bool? oCSAPIRequest}) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
       'Accept': 'application/json',
@@ -551,7 +545,7 @@ class WeatherStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -600,8 +594,8 @@ class WeatherStatusClient {
   /// See:
   ///  * [setFavoritesRaw] for an experimental operation that returns a [DynamiteRawResponse] that can be serialized.
   Future<DynamiteResponse<WeatherStatusSetFavoritesResponseApplicationJson, void>> setFavorites({
-    required final BuiltList<String> favorites,
-    final bool? oCSAPIRequest,
+    required BuiltList<String> favorites,
+    bool? oCSAPIRequest,
   }) async {
     final rawResponse = setFavoritesRaw(
       favorites: favorites,
@@ -629,8 +623,8 @@ class WeatherStatusClient {
   ///  * [setFavorites] for an operation that returns a [DynamiteResponse] with a stable API.
   @experimental
   DynamiteRawResponse<WeatherStatusSetFavoritesResponseApplicationJson, void> setFavoritesRaw({
-    required final BuiltList<String> favorites,
-    final bool? oCSAPIRequest,
+    required BuiltList<String> favorites,
+    bool? oCSAPIRequest,
   }) {
     final parameters = <String, dynamic>{};
     final headers = <String, String>{
@@ -640,7 +634,7 @@ class WeatherStatusClient {
 
 // coverage:ignore-start
     final authentication = _rootClient.authentications.firstWhereOrNull(
-      (final auth) => switch (auth) {
+      (auth) => switch (auth) {
         DynamiteHttpBearerAuthentication() || DynamiteHttpBasicAuthentication() => true,
         _ => false,
       },
@@ -691,14 +685,14 @@ abstract interface class $OCSMetaInterface {
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
-  factory OCSMeta([final void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
+  factory OCSMeta([void Function(OCSMetaBuilder)? b]) = _$OCSMeta;
 
   // coverage:ignore-start
   const OCSMeta._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory OCSMeta.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory OCSMeta.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -719,7 +713,7 @@ abstract class WeatherStatusSetModeResponseApplicationJson_Ocs_Data
         Built<WeatherStatusSetModeResponseApplicationJson_Ocs_Data,
             WeatherStatusSetModeResponseApplicationJson_Ocs_DataBuilder> {
   factory WeatherStatusSetModeResponseApplicationJson_Ocs_Data([
-    final void Function(WeatherStatusSetModeResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(WeatherStatusSetModeResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$WeatherStatusSetModeResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -727,7 +721,7 @@ abstract class WeatherStatusSetModeResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusSetModeResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusSetModeResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -750,7 +744,7 @@ abstract class WeatherStatusSetModeResponseApplicationJson_Ocs
         $WeatherStatusSetModeResponseApplicationJson_OcsInterface,
         Built<WeatherStatusSetModeResponseApplicationJson_Ocs, WeatherStatusSetModeResponseApplicationJson_OcsBuilder> {
   factory WeatherStatusSetModeResponseApplicationJson_Ocs([
-    final void Function(WeatherStatusSetModeResponseApplicationJson_OcsBuilder)? b,
+    void Function(WeatherStatusSetModeResponseApplicationJson_OcsBuilder)? b,
   ]) = _$WeatherStatusSetModeResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -758,7 +752,7 @@ abstract class WeatherStatusSetModeResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusSetModeResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusSetModeResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -780,7 +774,7 @@ abstract class WeatherStatusSetModeResponseApplicationJson
         $WeatherStatusSetModeResponseApplicationJsonInterface,
         Built<WeatherStatusSetModeResponseApplicationJson, WeatherStatusSetModeResponseApplicationJsonBuilder> {
   factory WeatherStatusSetModeResponseApplicationJson([
-    final void Function(WeatherStatusSetModeResponseApplicationJsonBuilder)? b,
+    void Function(WeatherStatusSetModeResponseApplicationJsonBuilder)? b,
   ]) = _$WeatherStatusSetModeResponseApplicationJson;
 
   // coverage:ignore-start
@@ -788,7 +782,7 @@ abstract class WeatherStatusSetModeResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusSetModeResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusSetModeResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -814,7 +808,7 @@ abstract class WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs_Data
         Built<WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs_Data,
             WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs_DataBuilder> {
   factory WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs_Data([
-    final void Function(WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -822,7 +816,7 @@ abstract class WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -846,7 +840,7 @@ abstract class WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs
         Built<WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs,
             WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder> {
   factory WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs([
-    final void Function(WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder)? b,
+    void Function(WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder)? b,
   ]) = _$WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -854,7 +848,7 @@ abstract class WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -877,7 +871,7 @@ abstract class WeatherStatusUsePersonalAddressResponseApplicationJson
         Built<WeatherStatusUsePersonalAddressResponseApplicationJson,
             WeatherStatusUsePersonalAddressResponseApplicationJsonBuilder> {
   factory WeatherStatusUsePersonalAddressResponseApplicationJson([
-    final void Function(WeatherStatusUsePersonalAddressResponseApplicationJsonBuilder)? b,
+    void Function(WeatherStatusUsePersonalAddressResponseApplicationJsonBuilder)? b,
   ]) = _$WeatherStatusUsePersonalAddressResponseApplicationJson;
 
   // coverage:ignore-start
@@ -885,7 +879,7 @@ abstract class WeatherStatusUsePersonalAddressResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusUsePersonalAddressResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusUsePersonalAddressResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -911,7 +905,7 @@ abstract class WeatherStatusGetLocationResponseApplicationJson_Ocs_Data
         Built<WeatherStatusGetLocationResponseApplicationJson_Ocs_Data,
             WeatherStatusGetLocationResponseApplicationJson_Ocs_DataBuilder> {
   factory WeatherStatusGetLocationResponseApplicationJson_Ocs_Data([
-    final void Function(WeatherStatusGetLocationResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(WeatherStatusGetLocationResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$WeatherStatusGetLocationResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -919,7 +913,7 @@ abstract class WeatherStatusGetLocationResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusGetLocationResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusGetLocationResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -943,7 +937,7 @@ abstract class WeatherStatusGetLocationResponseApplicationJson_Ocs
         Built<WeatherStatusGetLocationResponseApplicationJson_Ocs,
             WeatherStatusGetLocationResponseApplicationJson_OcsBuilder> {
   factory WeatherStatusGetLocationResponseApplicationJson_Ocs([
-    final void Function(WeatherStatusGetLocationResponseApplicationJson_OcsBuilder)? b,
+    void Function(WeatherStatusGetLocationResponseApplicationJson_OcsBuilder)? b,
   ]) = _$WeatherStatusGetLocationResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -951,7 +945,7 @@ abstract class WeatherStatusGetLocationResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusGetLocationResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusGetLocationResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -973,7 +967,7 @@ abstract class WeatherStatusGetLocationResponseApplicationJson
         $WeatherStatusGetLocationResponseApplicationJsonInterface,
         Built<WeatherStatusGetLocationResponseApplicationJson, WeatherStatusGetLocationResponseApplicationJsonBuilder> {
   factory WeatherStatusGetLocationResponseApplicationJson([
-    final void Function(WeatherStatusGetLocationResponseApplicationJsonBuilder)? b,
+    void Function(WeatherStatusGetLocationResponseApplicationJsonBuilder)? b,
   ]) = _$WeatherStatusGetLocationResponseApplicationJson;
 
   // coverage:ignore-start
@@ -981,7 +975,7 @@ abstract class WeatherStatusGetLocationResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusGetLocationResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusGetLocationResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1007,7 +1001,7 @@ abstract class WeatherStatusSetLocationResponseApplicationJson_Ocs_Data
         Built<WeatherStatusSetLocationResponseApplicationJson_Ocs_Data,
             WeatherStatusSetLocationResponseApplicationJson_Ocs_DataBuilder> {
   factory WeatherStatusSetLocationResponseApplicationJson_Ocs_Data([
-    final void Function(WeatherStatusSetLocationResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(WeatherStatusSetLocationResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$WeatherStatusSetLocationResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -1015,7 +1009,7 @@ abstract class WeatherStatusSetLocationResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusSetLocationResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusSetLocationResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1039,7 +1033,7 @@ abstract class WeatherStatusSetLocationResponseApplicationJson_Ocs
         Built<WeatherStatusSetLocationResponseApplicationJson_Ocs,
             WeatherStatusSetLocationResponseApplicationJson_OcsBuilder> {
   factory WeatherStatusSetLocationResponseApplicationJson_Ocs([
-    final void Function(WeatherStatusSetLocationResponseApplicationJson_OcsBuilder)? b,
+    void Function(WeatherStatusSetLocationResponseApplicationJson_OcsBuilder)? b,
   ]) = _$WeatherStatusSetLocationResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1047,7 +1041,7 @@ abstract class WeatherStatusSetLocationResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusSetLocationResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusSetLocationResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1069,7 +1063,7 @@ abstract class WeatherStatusSetLocationResponseApplicationJson
         $WeatherStatusSetLocationResponseApplicationJsonInterface,
         Built<WeatherStatusSetLocationResponseApplicationJson, WeatherStatusSetLocationResponseApplicationJsonBuilder> {
   factory WeatherStatusSetLocationResponseApplicationJson([
-    final void Function(WeatherStatusSetLocationResponseApplicationJsonBuilder)? b,
+    void Function(WeatherStatusSetLocationResponseApplicationJsonBuilder)? b,
   ]) = _$WeatherStatusSetLocationResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1077,7 +1071,7 @@ abstract class WeatherStatusSetLocationResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusSetLocationResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusSetLocationResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1123,7 +1117,7 @@ abstract class Forecast_Data_Instant_Details
     implements
         $Forecast_Data_Instant_DetailsInterface,
         Built<Forecast_Data_Instant_Details, Forecast_Data_Instant_DetailsBuilder> {
-  factory Forecast_Data_Instant_Details([final void Function(Forecast_Data_Instant_DetailsBuilder)? b]) =
+  factory Forecast_Data_Instant_Details([void Function(Forecast_Data_Instant_DetailsBuilder)? b]) =
       _$Forecast_Data_Instant_Details;
 
   // coverage:ignore-start
@@ -1131,7 +1125,7 @@ abstract class Forecast_Data_Instant_Details
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Instant_Details.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Instant_Details.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1149,14 +1143,14 @@ abstract interface class $Forecast_Data_InstantInterface {
 
 abstract class Forecast_Data_Instant
     implements $Forecast_Data_InstantInterface, Built<Forecast_Data_Instant, Forecast_Data_InstantBuilder> {
-  factory Forecast_Data_Instant([final void Function(Forecast_Data_InstantBuilder)? b]) = _$Forecast_Data_Instant;
+  factory Forecast_Data_Instant([void Function(Forecast_Data_InstantBuilder)? b]) = _$Forecast_Data_Instant;
 
   // coverage:ignore-start
   const Forecast_Data_Instant._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Instant.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Instant.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1177,7 +1171,7 @@ abstract class Forecast_Data_Next12Hours_Summary
     implements
         $Forecast_Data_Next12Hours_SummaryInterface,
         Built<Forecast_Data_Next12Hours_Summary, Forecast_Data_Next12Hours_SummaryBuilder> {
-  factory Forecast_Data_Next12Hours_Summary([final void Function(Forecast_Data_Next12Hours_SummaryBuilder)? b]) =
+  factory Forecast_Data_Next12Hours_Summary([void Function(Forecast_Data_Next12Hours_SummaryBuilder)? b]) =
       _$Forecast_Data_Next12Hours_Summary;
 
   // coverage:ignore-start
@@ -1185,7 +1179,7 @@ abstract class Forecast_Data_Next12Hours_Summary
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Next12Hours_Summary.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Next12Hours_Summary.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1206,7 +1200,7 @@ abstract class Forecast_Data_Next12Hours_Details
     implements
         $Forecast_Data_Next12Hours_DetailsInterface,
         Built<Forecast_Data_Next12Hours_Details, Forecast_Data_Next12Hours_DetailsBuilder> {
-  factory Forecast_Data_Next12Hours_Details([final void Function(Forecast_Data_Next12Hours_DetailsBuilder)? b]) =
+  factory Forecast_Data_Next12Hours_Details([void Function(Forecast_Data_Next12Hours_DetailsBuilder)? b]) =
       _$Forecast_Data_Next12Hours_Details;
 
   // coverage:ignore-start
@@ -1214,7 +1208,7 @@ abstract class Forecast_Data_Next12Hours_Details
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Next12Hours_Details.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Next12Hours_Details.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1233,15 +1227,14 @@ abstract interface class $Forecast_Data_Next12HoursInterface {
 
 abstract class Forecast_Data_Next12Hours
     implements $Forecast_Data_Next12HoursInterface, Built<Forecast_Data_Next12Hours, Forecast_Data_Next12HoursBuilder> {
-  factory Forecast_Data_Next12Hours([final void Function(Forecast_Data_Next12HoursBuilder)? b]) =
-      _$Forecast_Data_Next12Hours;
+  factory Forecast_Data_Next12Hours([void Function(Forecast_Data_Next12HoursBuilder)? b]) = _$Forecast_Data_Next12Hours;
 
   // coverage:ignore-start
   const Forecast_Data_Next12Hours._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Next12Hours.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Next12Hours.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1262,7 +1255,7 @@ abstract class Forecast_Data_Next1Hours_Summary
     implements
         $Forecast_Data_Next1Hours_SummaryInterface,
         Built<Forecast_Data_Next1Hours_Summary, Forecast_Data_Next1Hours_SummaryBuilder> {
-  factory Forecast_Data_Next1Hours_Summary([final void Function(Forecast_Data_Next1Hours_SummaryBuilder)? b]) =
+  factory Forecast_Data_Next1Hours_Summary([void Function(Forecast_Data_Next1Hours_SummaryBuilder)? b]) =
       _$Forecast_Data_Next1Hours_Summary;
 
   // coverage:ignore-start
@@ -1270,7 +1263,7 @@ abstract class Forecast_Data_Next1Hours_Summary
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Next1Hours_Summary.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Next1Hours_Summary.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1299,7 +1292,7 @@ abstract class Forecast_Data_Next1Hours_Details
     implements
         $Forecast_Data_Next1Hours_DetailsInterface,
         Built<Forecast_Data_Next1Hours_Details, Forecast_Data_Next1Hours_DetailsBuilder> {
-  factory Forecast_Data_Next1Hours_Details([final void Function(Forecast_Data_Next1Hours_DetailsBuilder)? b]) =
+  factory Forecast_Data_Next1Hours_Details([void Function(Forecast_Data_Next1Hours_DetailsBuilder)? b]) =
       _$Forecast_Data_Next1Hours_Details;
 
   // coverage:ignore-start
@@ -1307,7 +1300,7 @@ abstract class Forecast_Data_Next1Hours_Details
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Next1Hours_Details.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Next1Hours_Details.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1326,15 +1319,14 @@ abstract interface class $Forecast_Data_Next1HoursInterface {
 
 abstract class Forecast_Data_Next1Hours
     implements $Forecast_Data_Next1HoursInterface, Built<Forecast_Data_Next1Hours, Forecast_Data_Next1HoursBuilder> {
-  factory Forecast_Data_Next1Hours([final void Function(Forecast_Data_Next1HoursBuilder)? b]) =
-      _$Forecast_Data_Next1Hours;
+  factory Forecast_Data_Next1Hours([void Function(Forecast_Data_Next1HoursBuilder)? b]) = _$Forecast_Data_Next1Hours;
 
   // coverage:ignore-start
   const Forecast_Data_Next1Hours._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Next1Hours.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Next1Hours.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1355,7 +1347,7 @@ abstract class Forecast_Data_Next6Hours_Summary
     implements
         $Forecast_Data_Next6Hours_SummaryInterface,
         Built<Forecast_Data_Next6Hours_Summary, Forecast_Data_Next6Hours_SummaryBuilder> {
-  factory Forecast_Data_Next6Hours_Summary([final void Function(Forecast_Data_Next6Hours_SummaryBuilder)? b]) =
+  factory Forecast_Data_Next6Hours_Summary([void Function(Forecast_Data_Next6Hours_SummaryBuilder)? b]) =
       _$Forecast_Data_Next6Hours_Summary;
 
   // coverage:ignore-start
@@ -1363,7 +1355,7 @@ abstract class Forecast_Data_Next6Hours_Summary
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Next6Hours_Summary.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Next6Hours_Summary.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1394,7 +1386,7 @@ abstract class Forecast_Data_Next6Hours_Details
     implements
         $Forecast_Data_Next6Hours_DetailsInterface,
         Built<Forecast_Data_Next6Hours_Details, Forecast_Data_Next6Hours_DetailsBuilder> {
-  factory Forecast_Data_Next6Hours_Details([final void Function(Forecast_Data_Next6Hours_DetailsBuilder)? b]) =
+  factory Forecast_Data_Next6Hours_Details([void Function(Forecast_Data_Next6Hours_DetailsBuilder)? b]) =
       _$Forecast_Data_Next6Hours_Details;
 
   // coverage:ignore-start
@@ -1402,7 +1394,7 @@ abstract class Forecast_Data_Next6Hours_Details
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Next6Hours_Details.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Next6Hours_Details.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1421,15 +1413,14 @@ abstract interface class $Forecast_Data_Next6HoursInterface {
 
 abstract class Forecast_Data_Next6Hours
     implements $Forecast_Data_Next6HoursInterface, Built<Forecast_Data_Next6Hours, Forecast_Data_Next6HoursBuilder> {
-  factory Forecast_Data_Next6Hours([final void Function(Forecast_Data_Next6HoursBuilder)? b]) =
-      _$Forecast_Data_Next6Hours;
+  factory Forecast_Data_Next6Hours([void Function(Forecast_Data_Next6HoursBuilder)? b]) = _$Forecast_Data_Next6Hours;
 
   // coverage:ignore-start
   const Forecast_Data_Next6Hours._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data_Next6Hours.fromJson(final Map<String, dynamic> json) =>
+  factory Forecast_Data_Next6Hours.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1452,14 +1443,14 @@ abstract interface class $Forecast_DataInterface {
 }
 
 abstract class Forecast_Data implements $Forecast_DataInterface, Built<Forecast_Data, Forecast_DataBuilder> {
-  factory Forecast_Data([final void Function(Forecast_DataBuilder)? b]) = _$Forecast_Data;
+  factory Forecast_Data([void Function(Forecast_DataBuilder)? b]) = _$Forecast_Data;
 
   // coverage:ignore-start
   const Forecast_Data._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast_Data.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Forecast_Data.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1476,14 +1467,14 @@ abstract interface class $ForecastInterface {
 }
 
 abstract class Forecast implements $ForecastInterface, Built<Forecast, ForecastBuilder> {
-  factory Forecast([final void Function(ForecastBuilder)? b]) = _$Forecast;
+  factory Forecast([void Function(ForecastBuilder)? b]) = _$Forecast;
 
   // coverage:ignore-start
   const Forecast._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Forecast.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Forecast.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start
@@ -1505,7 +1496,7 @@ abstract class WeatherStatusGetForecastResponseApplicationJson_Ocs
         Built<WeatherStatusGetForecastResponseApplicationJson_Ocs,
             WeatherStatusGetForecastResponseApplicationJson_OcsBuilder> {
   factory WeatherStatusGetForecastResponseApplicationJson_Ocs([
-    final void Function(WeatherStatusGetForecastResponseApplicationJson_OcsBuilder)? b,
+    void Function(WeatherStatusGetForecastResponseApplicationJson_OcsBuilder)? b,
   ]) = _$WeatherStatusGetForecastResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1513,7 +1504,7 @@ abstract class WeatherStatusGetForecastResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusGetForecastResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusGetForecastResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1535,7 +1526,7 @@ abstract class WeatherStatusGetForecastResponseApplicationJson
         $WeatherStatusGetForecastResponseApplicationJsonInterface,
         Built<WeatherStatusGetForecastResponseApplicationJson, WeatherStatusGetForecastResponseApplicationJsonBuilder> {
   factory WeatherStatusGetForecastResponseApplicationJson([
-    final void Function(WeatherStatusGetForecastResponseApplicationJsonBuilder)? b,
+    void Function(WeatherStatusGetForecastResponseApplicationJsonBuilder)? b,
   ]) = _$WeatherStatusGetForecastResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1543,7 +1534,7 @@ abstract class WeatherStatusGetForecastResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusGetForecastResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusGetForecastResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1567,7 +1558,7 @@ abstract class WeatherStatusGetFavoritesResponseApplicationJson_Ocs
         Built<WeatherStatusGetFavoritesResponseApplicationJson_Ocs,
             WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder> {
   factory WeatherStatusGetFavoritesResponseApplicationJson_Ocs([
-    final void Function(WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder)? b,
+    void Function(WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$WeatherStatusGetFavoritesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1575,7 +1566,7 @@ abstract class WeatherStatusGetFavoritesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusGetFavoritesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusGetFavoritesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1598,7 +1589,7 @@ abstract class WeatherStatusGetFavoritesResponseApplicationJson
         Built<WeatherStatusGetFavoritesResponseApplicationJson,
             WeatherStatusGetFavoritesResponseApplicationJsonBuilder> {
   factory WeatherStatusGetFavoritesResponseApplicationJson([
-    final void Function(WeatherStatusGetFavoritesResponseApplicationJsonBuilder)? b,
+    void Function(WeatherStatusGetFavoritesResponseApplicationJsonBuilder)? b,
   ]) = _$WeatherStatusGetFavoritesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1606,7 +1597,7 @@ abstract class WeatherStatusGetFavoritesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusGetFavoritesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusGetFavoritesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1629,7 +1620,7 @@ abstract class WeatherStatusSetFavoritesResponseApplicationJson_Ocs_Data
         Built<WeatherStatusSetFavoritesResponseApplicationJson_Ocs_Data,
             WeatherStatusSetFavoritesResponseApplicationJson_Ocs_DataBuilder> {
   factory WeatherStatusSetFavoritesResponseApplicationJson_Ocs_Data([
-    final void Function(WeatherStatusSetFavoritesResponseApplicationJson_Ocs_DataBuilder)? b,
+    void Function(WeatherStatusSetFavoritesResponseApplicationJson_Ocs_DataBuilder)? b,
   ]) = _$WeatherStatusSetFavoritesResponseApplicationJson_Ocs_Data;
 
   // coverage:ignore-start
@@ -1637,7 +1628,7 @@ abstract class WeatherStatusSetFavoritesResponseApplicationJson_Ocs_Data
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusSetFavoritesResponseApplicationJson_Ocs_Data.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusSetFavoritesResponseApplicationJson_Ocs_Data.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1661,7 +1652,7 @@ abstract class WeatherStatusSetFavoritesResponseApplicationJson_Ocs
         Built<WeatherStatusSetFavoritesResponseApplicationJson_Ocs,
             WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder> {
   factory WeatherStatusSetFavoritesResponseApplicationJson_Ocs([
-    final void Function(WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder)? b,
+    void Function(WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder)? b,
   ]) = _$WeatherStatusSetFavoritesResponseApplicationJson_Ocs;
 
   // coverage:ignore-start
@@ -1669,7 +1660,7 @@ abstract class WeatherStatusSetFavoritesResponseApplicationJson_Ocs
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusSetFavoritesResponseApplicationJson_Ocs.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusSetFavoritesResponseApplicationJson_Ocs.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1692,7 +1683,7 @@ abstract class WeatherStatusSetFavoritesResponseApplicationJson
         Built<WeatherStatusSetFavoritesResponseApplicationJson,
             WeatherStatusSetFavoritesResponseApplicationJsonBuilder> {
   factory WeatherStatusSetFavoritesResponseApplicationJson([
-    final void Function(WeatherStatusSetFavoritesResponseApplicationJsonBuilder)? b,
+    void Function(WeatherStatusSetFavoritesResponseApplicationJsonBuilder)? b,
   ]) = _$WeatherStatusSetFavoritesResponseApplicationJson;
 
   // coverage:ignore-start
@@ -1700,7 +1691,7 @@ abstract class WeatherStatusSetFavoritesResponseApplicationJson
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory WeatherStatusSetFavoritesResponseApplicationJson.fromJson(final Map<String, dynamic> json) =>
+  factory WeatherStatusSetFavoritesResponseApplicationJson.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1721,7 +1712,7 @@ abstract class Capabilities_WeatherStatus
     implements
         $Capabilities_WeatherStatusInterface,
         Built<Capabilities_WeatherStatus, Capabilities_WeatherStatusBuilder> {
-  factory Capabilities_WeatherStatus([final void Function(Capabilities_WeatherStatusBuilder)? b]) =
+  factory Capabilities_WeatherStatus([void Function(Capabilities_WeatherStatusBuilder)? b]) =
       _$Capabilities_WeatherStatus;
 
   // coverage:ignore-start
@@ -1729,7 +1720,7 @@ abstract class Capabilities_WeatherStatus
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities_WeatherStatus.fromJson(final Map<String, dynamic> json) =>
+  factory Capabilities_WeatherStatus.fromJson(Map<String, dynamic> json) =>
       jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -1747,14 +1738,14 @@ abstract interface class $CapabilitiesInterface {
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
-  factory Capabilities([final void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
+  factory Capabilities([void Function(CapabilitiesBuilder)? b]) = _$Capabilities;
 
   // coverage:ignore-start
   const Capabilities._();
   // coverage:ignore-end
 
   // coverage:ignore-start
-  factory Capabilities.fromJson(final Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
+  factory Capabilities.fromJson(Map<String, dynamic> json) => jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   // coverage:ignore-start

--- a/packages/nextcloud/lib/src/client.dart
+++ b/packages/nextcloud/lib/src/client.dart
@@ -25,11 +25,11 @@ class NextcloudClient extends DynamiteClient {
   NextcloudClient(
     super.baseURL, {
     this.loginName,
-    final String? password,
-    final String? appPassword,
-    final String? language,
-    final AppType appType = AppType.unknown,
-    final String? userAgentOverride,
+    String? password,
+    String? appPassword,
+    String? language,
+    AppType appType = AppType.unknown,
+    String? userAgentOverride,
     super.httpClient,
     super.cookieJar,
   }) : super(

--- a/packages/nextcloud/lib/src/helpers/common.dart
+++ b/packages/nextcloud/lib/src/helpers/common.dart
@@ -10,7 +10,7 @@ class VersionCheck {
   VersionCheck({
     required this.versions,
     required this.minimumVersion,
-    required final int? maximumMajor,
+    required int? maximumMajor,
   }) : maximumMajor = maximumMajor ?? minimumVersion.major;
 
   /// Current version of the app.

--- a/packages/nextcloud/lib/src/helpers/core.dart
+++ b/packages/nextcloud/lib/src/helpers/core.dart
@@ -14,7 +14,7 @@ extension CoreVersionCheck on core.Client {
   /// Check if the core/Server version is supported by this client
   ///
   /// Also returns the minimum supported version
-  VersionCheck getVersionCheck(final core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data capabilities) {
+  VersionCheck getVersionCheck(core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data capabilities) {
     final version = Version(
       capabilities.version.major,
       capabilities.version.minor,

--- a/packages/nextcloud/lib/src/helpers/news.dart
+++ b/packages/nextcloud/lib/src/helpers/news.dart
@@ -15,7 +15,7 @@ extension NewsVersionCheck on news.Client {
     final response = await getSupportedApiVersions();
     final versions = response.body.apiLevels;
     return VersionCheck(
-      versions: versions?.map((final version) => Version.parse(version.substring(1).replaceAll('-', '.'))).toList(),
+      versions: versions?.map((version) => Version.parse(version.substring(1).replaceAll('-', '.'))).toList(),
       minimumVersion: minVersion,
       maximumMajor: null,
     );

--- a/packages/nextcloud/lib/src/helpers/notes.dart
+++ b/packages/nextcloud/lib/src/helpers/notes.dart
@@ -11,7 +11,7 @@ extension NotesVersionCheck on notes.Client {
   /// Check if the notes app version is supported by this client
   ///
   /// Also returns the supported API version number
-  VersionCheck getVersionCheck(final core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data capabilities) {
+  VersionCheck getVersionCheck(core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data capabilities) {
     final versions = capabilities.capabilities.notesCapabilities?.notes.apiVersion;
     return VersionCheck(
       versions: versions?.map(Version.parse).toList(),

--- a/packages/nextcloud/lib/src/helpers/notifications.dart
+++ b/packages/nextcloud/lib/src/helpers/notifications.dart
@@ -11,7 +11,7 @@ export 'package:crypton/crypton.dart' show RSAKeypair, RSAPrivateKey, RSAPublicK
 part 'notifications.g.dart';
 
 /// Generates the push token hash which is just sha512
-String generatePushTokenHash(final String pushToken) => sha512.convert(utf8.encode(pushToken)).toString();
+String generatePushTokenHash(String pushToken) => sha512.convert(utf8.encode(pushToken)).toString();
 
 @JsonSerializable()
 // ignore: public_member_api_docs
@@ -28,7 +28,7 @@ class DecryptedSubject {
   });
 
   // ignore: public_member_api_docs
-  factory DecryptedSubject.fromJson(final Map<String, dynamic> json) => _$DecryptedSubjectFromJson(json);
+  factory DecryptedSubject.fromJson(Map<String, dynamic> json) => _$DecryptedSubjectFromJson(json);
 
   /// ID if the notification
   final int? nid;
@@ -58,8 +58,8 @@ class DecryptedSubject {
 
 /// Decrypts the subject of a push notification
 DecryptedSubject decryptPushNotificationSubject(
-  final RSAPrivateKey privateKey,
-  final String subject,
+  RSAPrivateKey privateKey,
+  String subject,
 ) =>
     DecryptedSubject.fromJson(
       json.decode(privateKey.decrypt(subject)) as Map<String, dynamic>,

--- a/packages/nextcloud/lib/src/helpers/spreed.dart
+++ b/packages/nextcloud/lib/src/helpers/spreed.dart
@@ -14,7 +14,7 @@ extension SpreedVersionCheck on spreed.Client {
   /// Checks whether the spreed app installed on the server is supported by this client.
   ///
   /// Also returns the supported version number.
-  VersionCheck getVersionCheck(final core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data capabilities) {
+  VersionCheck getVersionCheck(core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data capabilities) {
     final version = capabilities.capabilities.spreedPublicCapabilities?.spreedPublicCapabilities0?.spreed.version;
     return VersionCheck(
       versions: version != null ? [Version.parse(version)] : null,
@@ -51,7 +51,7 @@ enum RoomType {
   int get value => index + 1;
 
   /// Converts the integer [value] representation of a [RoomType] into a [RoomType].
-  static RoomType fromValue(final int value) => RoomType.values[value - 1];
+  static RoomType fromValue(int value) => RoomType.values[value - 1];
 
   /// Whether the room is only with one other user.
   bool get isSingleUser => switch (this) {
@@ -153,7 +153,7 @@ enum ParticipantType {
   int get value => index + 1;
 
   /// Converts the integer [value] representation of a [ParticipantType] into a [ParticipantType].
-  static ParticipantType fromValue(final int value) => ParticipantType.values[value - 1];
+  static ParticipantType fromValue(int value) => ParticipantType.values[value - 1];
 }
 
 /// Attendee permissions.
@@ -222,7 +222,7 @@ enum ParticipantInCallFlag {
 /// See [EnumCollectionBinary.binary] for getting the binary representation of multiple enum values.
 extension EnumByBinary<T extends Enum> on List<T> {
   /// Converts the binary representation of an enum into enum values.
-  Set<T> byBinary(final int value) {
+  Set<T> byBinary(int value) {
     final result = <T>{};
 
     var v = value;
@@ -256,5 +256,5 @@ extension EnumCollectionBinary<T extends Enum> on Set<T> {
   ///
   /// See [EnumBinary.binary] for getting the binary representation of a single enum value.
   /// See [EnumByBinary.byBinary] for converting the binary representation into enum values.
-  int get binary => map((final p) => p.binary).reduce((final a, final b) => a | b);
+  int get binary => map((p) => p.binary).reduce((a, b) => a | b);
 }

--- a/packages/nextcloud/lib/src/webdav/file.dart
+++ b/packages/nextcloud/lib/src/webdav/file.dart
@@ -6,24 +6,21 @@ import 'package:nextcloud/src/webdav/webdav.dart';
 // ignore: public_member_api_docs
 extension WebDavMultistatusFile on WebDavMultistatus {
   /// Convert the [WebDavMultistatus] into a [WebDavFile] for easier handling
-  List<WebDavFile> toWebDavFiles() => responses
-      .where((final response) => response.href != null)
-      .map((final response) => WebDavFile(response: response))
-      .toList();
+  List<WebDavFile> toWebDavFiles() =>
+      responses.where((response) => response.href != null).map((response) => WebDavFile(response: response)).toList();
 }
 
 /// WebDavFile class
 class WebDavFile {
   /// Creates a new WebDavFile object with the given path
   WebDavFile({
-    required final WebDavResponse response,
+    required WebDavResponse response,
   }) : _response = response;
 
   final WebDavResponse _response;
 
   /// Get the props of the file
-  late final WebDavProp props =
-      _response.propstats.singleWhere((final propstat) => propstat.status.contains('200')).prop;
+  late final WebDavProp props = _response.propstats.singleWhere((propstat) => propstat.status.contains('200')).prop;
 
   /// The path of file
   late final PathUri path = () {

--- a/packages/nextcloud/lib/src/webdav/path_uri.dart
+++ b/packages/nextcloud/lib/src/webdav/path_uri.dart
@@ -15,7 +15,7 @@ class PathUri {
   /// Creates a new `PathUri` object by parsing a [path] string.
   ///
   /// An empty [path] is considered to be the current working directory.
-  factory PathUri.parse(final String path) {
+  factory PathUri.parse(String path) {
     final parts = path.split('/');
     if (parts.length == 1 && parts.single.isEmpty) {
       return PathUri(
@@ -27,7 +27,7 @@ class PathUri {
     return PathUri(
       isAbsolute: parts.first.isEmpty,
       isDirectory: parts.last.isEmpty,
-      pathSegments: BuiltList(parts.where((final element) => element.isNotEmpty)),
+      pathSegments: BuiltList(parts.where((element) => element.isNotEmpty)),
     );
   }
 
@@ -77,7 +77,7 @@ class PathUri {
       return PathUri(
         isAbsolute: isAbsolute,
         isDirectory: true,
-        pathSegments: pathSegments.rebuild((final b) => b.removeLast()),
+        pathSegments: pathSegments.rebuild((b) => b.removeLast()),
       );
     }
 
@@ -88,7 +88,7 @@ class PathUri {
   ///
   /// If the current path is not a directory a [StateError] will be thrown.
   /// See [isDirectory] for checking if the current path is a directory.
-  PathUri join(final PathUri other) {
+  PathUri join(PathUri other) {
     if (!isDirectory) {
       throw StateError('$this is not a directory.');
     }
@@ -96,12 +96,12 @@ class PathUri {
     return PathUri(
       isAbsolute: isAbsolute,
       isDirectory: other.isDirectory,
-      pathSegments: pathSegments.rebuild((final b) => b.addAll(other.pathSegments)),
+      pathSegments: pathSegments.rebuild((b) => b.addAll(other.pathSegments)),
     );
   }
 
   /// Renames the last path segment and returns a new path URI.
-  PathUri rename(final String name) {
+  PathUri rename(String name) {
     if (name.contains('/')) {
       throw Exception('Path names must not contain /');
     }
@@ -111,7 +111,7 @@ class PathUri {
       isDirectory: isDirectory,
       pathSegments: pathSegments.isNotEmpty
           ? pathSegments.rebuild(
-              (final b) => b
+              (b) => b
                 ..removeLast()
                 ..add(name),
             )
@@ -120,7 +120,7 @@ class PathUri {
   }
 
   @override
-  bool operator ==(final Object other) =>
+  bool operator ==(Object other) =>
       other is PathUri &&
       isAbsolute == other.isAbsolute &&
       isDirectory == other.isDirectory &&

--- a/packages/nextcloud/lib/src/webdav/props.dart
+++ b/packages/nextcloud/lib/src/webdav/props.dart
@@ -39,33 +39,33 @@ class WebDavPropWithoutValues with _$WebDavPropWithoutValuesXmlSerializableMixin
   });
 
   WebDavPropWithoutValues.fromBools({
-    final bool davgetlastmodified = false,
-    final bool davgetetag = false,
-    final bool davgetcontenttype = false,
-    final bool davgetcontentlength = false,
-    final bool davresourcetype = false,
-    final bool ocid = false,
-    final bool ocfileid = false,
-    final bool ocfavorite = false,
-    final bool occommentshref = false,
-    final bool occommentscount = false,
-    final bool occommentsunread = false,
-    final bool ocdownloadurl = false,
-    final bool ocownerid = false,
-    final bool ocownerdisplayname = false,
-    final bool ocsize = false,
-    final bool ocpermissions = false,
-    final bool ncnote = false,
-    final bool ncdatafingerprint = false,
-    final bool nchaspreview = false,
-    final bool ncmounttype = false,
-    final bool ncisencrypted = false,
-    final bool ncmetadataetag = false,
-    final bool ncuploadtime = false,
-    final bool nccreationtime = false,
-    final bool ncrichworkspace = false,
-    final bool ocssharepermissions = false,
-    final bool ocmsharepermissions = false,
+    bool davgetlastmodified = false,
+    bool davgetetag = false,
+    bool davgetcontenttype = false,
+    bool davgetcontentlength = false,
+    bool davresourcetype = false,
+    bool ocid = false,
+    bool ocfileid = false,
+    bool ocfavorite = false,
+    bool occommentshref = false,
+    bool occommentscount = false,
+    bool occommentsunread = false,
+    bool ocdownloadurl = false,
+    bool ocownerid = false,
+    bool ocownerdisplayname = false,
+    bool ocsize = false,
+    bool ocpermissions = false,
+    bool ncnote = false,
+    bool ncdatafingerprint = false,
+    bool nchaspreview = false,
+    bool ncmounttype = false,
+    bool ncisencrypted = false,
+    bool ncmetadataetag = false,
+    bool ncuploadtime = false,
+    bool nccreationtime = false,
+    bool ncrichworkspace = false,
+    bool ocssharepermissions = false,
+    bool ocmsharepermissions = false,
   })  : davgetlastmodified = davgetlastmodified ? [null] : null,
         davgetetag = davgetetag ? [null] : null,
         davgetcontenttype = davgetcontenttype ? [null] : null,
@@ -94,7 +94,7 @@ class WebDavPropWithoutValues with _$WebDavPropWithoutValuesXmlSerializableMixin
         ocssharepermissions = ocssharepermissions ? [null] : null,
         ocmsharepermissions = ocmsharepermissions ? [null] : null;
 
-  factory WebDavPropWithoutValues.fromXmlElement(final XmlElement element) =>
+  factory WebDavPropWithoutValues.fromXmlElement(XmlElement element) =>
       _$WebDavPropWithoutValuesFromXmlElement(element);
 
   @annotation.XmlElement(
@@ -347,7 +347,7 @@ class WebDavProp with _$WebDavPropXmlSerializableMixin {
     this.ocmsharepermissions,
   });
 
-  factory WebDavProp.fromXmlElement(final XmlElement element) => _$WebDavPropFromXmlElement(element);
+  factory WebDavProp.fromXmlElement(XmlElement element) => _$WebDavPropFromXmlElement(element);
 
   @annotation.XmlElement(
     name: 'getlastmodified',
@@ -572,7 +572,7 @@ class WebDavOcFilterRules with _$WebDavOcFilterRulesXmlSerializableMixin {
     this.ocmsharepermissions,
   });
 
-  factory WebDavOcFilterRules.fromXmlElement(final XmlElement element) => _$WebDavOcFilterRulesFromXmlElement(element);
+  factory WebDavOcFilterRules.fromXmlElement(XmlElement element) => _$WebDavOcFilterRulesFromXmlElement(element);
 
   @annotation.XmlElement(
     name: 'getlastmodified',

--- a/packages/nextcloud/lib/src/webdav/webdav.dart
+++ b/packages/nextcloud/lib/src/webdav/webdav.dart
@@ -32,7 +32,7 @@ class WebDavMultistatus with _$WebDavMultistatusXmlSerializableMixin {
     required this.responses,
   });
 
-  factory WebDavMultistatus.fromXmlElement(final XmlElement element) => _$WebDavMultistatusFromXmlElement(element);
+  factory WebDavMultistatus.fromXmlElement(XmlElement element) => _$WebDavMultistatusFromXmlElement(element);
 
   @annotation.XmlElement(name: 'response', namespace: namespaceDav)
   final List<WebDavResponse> responses;
@@ -46,7 +46,7 @@ class WebDavResponse with _$WebDavResponseXmlSerializableMixin {
     required this.propstats,
   });
 
-  factory WebDavResponse.fromXmlElement(final XmlElement element) => _$WebDavResponseFromXmlElement(element);
+  factory WebDavResponse.fromXmlElement(XmlElement element) => _$WebDavResponseFromXmlElement(element);
 
   @annotation.XmlElement(name: 'href', namespace: namespaceDav)
   final String? href;
@@ -63,7 +63,7 @@ class WebDavPropstat with _$WebDavPropstatXmlSerializableMixin {
     required this.prop,
   });
 
-  factory WebDavPropstat.fromXmlElement(final XmlElement element) => _$WebDavPropstatFromXmlElement(element);
+  factory WebDavPropstat.fromXmlElement(XmlElement element) => _$WebDavPropstatFromXmlElement(element);
 
   @annotation.XmlElement(name: 'status', namespace: namespaceDav)
   final String status;
@@ -94,7 +94,7 @@ class WebDavSet with _$WebDavSetXmlSerializableMixin {
     required this.prop,
   });
 
-  factory WebDavSet.fromXmlElement(final XmlElement element) => _$WebDavSetFromXmlElement(element);
+  factory WebDavSet.fromXmlElement(XmlElement element) => _$WebDavSetFromXmlElement(element);
 
   @annotation.XmlElement(name: 'prop', namespace: namespaceDav)
   final WebDavProp prop; // coverage:ignore-line
@@ -107,7 +107,7 @@ class WebDavRemove with _$WebDavRemoveXmlSerializableMixin {
     required this.prop,
   });
 
-  factory WebDavRemove.fromXmlElement(final XmlElement element) => _$WebDavRemoveFromXmlElement(element);
+  factory WebDavRemove.fromXmlElement(XmlElement element) => _$WebDavRemoveFromXmlElement(element);
 
   @annotation.XmlElement(name: 'prop', namespace: namespaceDav)
   final WebDavPropWithoutValues prop; // coverage:ignore-line
@@ -146,7 +146,7 @@ class WebDavResourcetype with _$WebDavResourcetypeXmlSerializableMixin {
     required this.collection,
   });
 
-  factory WebDavResourcetype.fromXmlElement(final XmlElement element) => _$WebDavResourcetypeFromXmlElement(element);
+  factory WebDavResourcetype.fromXmlElement(XmlElement element) => _$WebDavResourcetypeFromXmlElement(element);
 
   @annotation.XmlElement(name: 'collection', namespace: namespaceDav, isSelfClosing: true, includeIfNull: true)
   final List<String?>? collection;

--- a/packages/nextcloud/test/core_test.dart
+++ b/packages/nextcloud/test/core_test.dart
@@ -9,7 +9,7 @@ void main() {
   presets(
     'server',
     'core',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client;
       setUp(() async {
@@ -148,7 +148,7 @@ void main() {
           await client.core.appPassword.deleteAppPassword();
           await expectLater(
             () => client.core.appPassword.deleteAppPassword(),
-            throwsA(predicate((final e) => (e! as DynamiteApiException).statusCode == 401)),
+            throwsA(predicate((e) => (e! as DynamiteApiException).statusCode == 401)),
           );
         });
       });
@@ -196,7 +196,7 @@ void main() {
 
           await expectLater(
             () => client.core.clientFlowLoginV2.poll(token: response.body.poll.token),
-            throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 404)),
+            throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 404)),
           );
         });
       });

--- a/packages/nextcloud/test/dashboard_test.dart
+++ b/packages/nextcloud/test/dashboard_test.dart
@@ -9,7 +9,7 @@ void main() {
   presets(
     'server',
     'dashboard',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client;
       setUp(() async {

--- a/packages/nextcloud/test/news_test.dart
+++ b/packages/nextcloud/test/news_test.dart
@@ -10,7 +10,7 @@ void main() {
   presets(
     'news',
     'news',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client;
       setUp(() async {
@@ -24,8 +24,7 @@ void main() {
         container.destroy();
       });
 
-      Future<DynamiteResponse<news.ListFeeds, void>> addWikipediaFeed([final int? folderID]) async =>
-          client.news.addFeed(
+      Future<DynamiteResponse<news.ListFeeds, void>> addWikipediaFeed([int? folderID]) async => client.news.addFeed(
             url: 'http://localhost/static/wikipedia.xml',
             folderId: folderID,
           );

--- a/packages/nextcloud/test/notes_test.dart
+++ b/packages/nextcloud/test/notes_test.dart
@@ -9,7 +9,7 @@ void main() {
   presets(
     'notes',
     'notes',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client;
       setUp(() async {
@@ -126,7 +126,7 @@ void main() {
             title: 'c',
             ifMatch: '"${response.body.etag}"',
           ),
-          throwsA(predicate((final e) => (e! as DynamiteApiException).statusCode == 412)),
+          throwsA(predicate((e) => (e! as DynamiteApiException).statusCode == 412)),
         );
       });
 
@@ -161,7 +161,7 @@ void main() {
       test('Update settings', () async {
         var response = await client.notes.updateSettings(
           settings: notes.Settings(
-            (final b) => b
+            (b) => b
               ..notesPath = 'Test Notes'
               ..fileSuffix = '.txt'
               ..noteMode = notes.Settings_NoteMode.preview,

--- a/packages/nextcloud/test/notifications_test.dart
+++ b/packages/nextcloud/test/notifications_test.dart
@@ -10,7 +10,7 @@ void main() {
   presets(
     'server',
     'notifications',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client;
       setUp(() async {

--- a/packages/nextcloud/test/provisioning_api_test.dart
+++ b/packages/nextcloud/test/provisioning_api_test.dart
@@ -8,7 +8,7 @@ void main() {
   presets(
     'server',
     'provisioning_api',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client;
       setUp(() async {

--- a/packages/nextcloud/test/settings_test.dart
+++ b/packages/nextcloud/test/settings_test.dart
@@ -10,7 +10,7 @@ void main() {
   presets(
     'server',
     'settings',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client;
       setUp(() async {

--- a/packages/nextcloud/test/spreed_test.dart
+++ b/packages/nextcloud/test/spreed_test.dart
@@ -13,7 +13,7 @@ void main() {
   presets(
     'spreed',
     'spreed',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client1;
       setUp(() async {
@@ -278,7 +278,7 @@ void main() {
                 .ocs
                 .data!;
             unawaited(
-              Future<void>.delayed(const Duration(seconds: 1)).then((final _) async {
+              Future<void>.delayed(const Duration(seconds: 1)).then((_) async {
                 await client1.spreed.chat.sendMessage(
                   token: room.token,
                   message: '123',
@@ -333,7 +333,7 @@ void main() {
           expect(response.body.ocs.data.helloAuthParams.$10.userid, 'user1');
           expect(response.body.ocs.data.helloAuthParams.$10.ticket, contains(':user1:'));
           expect(
-            response.body.ocs.data.helloAuthParams.$20.token.split('').where((final x) => x == '.'),
+            response.body.ocs.data.helloAuthParams.$20.token.split('').where((x) => x == '.'),
             hasLength(2),
           );
           expect(response.body.ocs.data.stunservers, hasLength(1));

--- a/packages/nextcloud/test/uppush_test.dart
+++ b/packages/nextcloud/test/uppush_test.dart
@@ -8,7 +8,7 @@ void main() {
   presets(
     'uppush',
     'uppush',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client;
       setUp(() async {

--- a/packages/nextcloud/test/user_status_test.dart
+++ b/packages/nextcloud/test/user_status_test.dart
@@ -8,7 +8,7 @@ void main() {
   presets(
     'server',
     'user_status',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client;
       setUp(() async {
@@ -30,30 +30,30 @@ void main() {
           expect(() => response.headers, isA<void>());
 
           expect(response.body.ocs.data, hasLength(5));
-          final responseIDs = response.body.ocs.data.map((final status) => status.id);
+          final responseIDs = response.body.ocs.data.map((status) => status.id);
           expect(expectedStatusIDs.map(responseIDs.contains).contains(false), false);
           for (final status in response.body.ocs.data) {
             expect(status.icon, isNotNull);
             expect(status.message, isNotNull);
           }
 
-          final meeting = response.body.ocs.data.singleWhere((final s) => s.id == 'meeting').clearAt!;
+          final meeting = response.body.ocs.data.singleWhere((s) => s.id == 'meeting').clearAt!;
           expect(meeting.type, user_status.ClearAt_Type.period);
           expect(meeting.time.$int, 3600);
 
-          final commuting = response.body.ocs.data.singleWhere((final s) => s.id == 'commuting').clearAt!;
+          final commuting = response.body.ocs.data.singleWhere((s) => s.id == 'commuting').clearAt!;
           expect(commuting.type, user_status.ClearAt_Type.period);
           expect(commuting.time.$int, 1800);
 
-          final remoteWork = response.body.ocs.data.singleWhere((final s) => s.id == 'remote-work').clearAt!;
+          final remoteWork = response.body.ocs.data.singleWhere((s) => s.id == 'remote-work').clearAt!;
           expect(remoteWork.type, user_status.ClearAt_Type.endOf);
           expect(remoteWork.time.clearAtTimeType, user_status.ClearAtTimeType.day);
 
-          final sickLeave = response.body.ocs.data.singleWhere((final s) => s.id == 'sick-leave').clearAt!;
+          final sickLeave = response.body.ocs.data.singleWhere((s) => s.id == 'sick-leave').clearAt!;
           expect(sickLeave.type, user_status.ClearAt_Type.endOf);
           expect(sickLeave.time.clearAtTimeType, user_status.ClearAtTimeType.day);
 
-          final vacationing = response.body.ocs.data.singleWhere((final s) => s.id == 'vacationing').clearAt;
+          final vacationing = response.body.ocs.data.singleWhere((s) => s.id == 'vacationing').clearAt;
           expect(vacationing, null);
         });
       });

--- a/packages/nextcloud/test/webdav_test.dart
+++ b/packages/nextcloud/test/webdav_test.dart
@@ -138,7 +138,7 @@ void main() {
   presets(
     'server',
     'webdav',
-    (final preset) {
+    (preset) {
       late DockerContainer container;
       late NextcloudClient client;
 
@@ -166,7 +166,7 @@ void main() {
             .responses;
         expect(responses, isNotEmpty);
         final props =
-            responses.singleWhere((final response) => response.href!.endsWith('/Nextcloud.png')).propstats.first.prop;
+            responses.singleWhere((response) => response.href!.endsWith('/Nextcloud.png')).propstats.first.prop;
         expect(props.nchaspreview, isTrue);
         expect(props.davgetcontenttype, 'image/png');
         expect(webdavDateFormat.parseUtc(props.davgetlastmodified!).isBefore(DateTime.now()), isTrue);
@@ -325,8 +325,7 @@ void main() {
         ))
             .responses;
         expect(responses, hasLength(1));
-        final props =
-            responses.singleWhere((final response) => response.href!.endsWith('/test.txt')).propstats.first.prop;
+        final props = responses.singleWhere((response) => response.href!.endsWith('/test.txt')).propstats.first.prop;
         expect(props.ocid, id);
         expect(props.ocfavorite, 1);
       });
@@ -472,7 +471,7 @@ void main() {
             await expectLater(
               () => client.webdav.put(Uint8List(0), PathUri.parse('409me/noparent.txt')),
               // https://github.com/nextcloud/server/issues/39625
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 409)),
+              throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 409)),
             );
           });
 
@@ -486,7 +485,7 @@ void main() {
           test('delete_null', () async {
             await expectLater(
               () => client.webdav.delete(PathUri.parse('test.txt')),
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 404)),
+              throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 404)),
             );
           });
 
@@ -502,7 +501,7 @@ void main() {
 
             await expectLater(
               () => client.webdav.mkcol(PathUri.parse('test')),
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 405)),
+              throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 405)),
             );
           });
 
@@ -516,7 +515,7 @@ void main() {
           test('mkcol_no_parent', () async {
             await expectLater(
               () => client.webdav.mkcol(PathUri.parse('409me/noparent')),
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 409)),
+              throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 409)),
             );
           });
 
@@ -537,7 +536,7 @@ void main() {
 
             await expectLater(
               () => client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst')),
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
+              throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 412)),
             );
 
             final response = await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst'), overwrite: true);
@@ -549,7 +548,7 @@ void main() {
 
             await expectLater(
               () => client.webdav.copy(PathUri.parse('src'), PathUri.parse('nonesuch/dst')),
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 409)),
+              throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 409)),
             );
           });
 
@@ -564,7 +563,7 @@ void main() {
 
             await expectLater(
               () => client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst1')),
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
+              throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 412)),
             );
 
             var response = await client.webdav.copy(PathUri.parse('src'), PathUri.parse('dst2'), overwrite: true);
@@ -594,7 +593,7 @@ void main() {
 
             await expectLater(
               () => client.webdav.move(PathUri.parse('src2.txt'), PathUri.parse('dst.txt')),
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
+              throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 412)),
             );
 
             response = await client.webdav.move(PathUri.parse('src2.txt'), PathUri.parse('dst.txt'), overwrite: true);
@@ -613,7 +612,7 @@ void main() {
 
             await expectLater(
               () => client.webdav.move(PathUri.parse('dst1'), PathUri.parse('dst2')),
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
+              throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 412)),
             );
 
             await client.webdav.move(PathUri.parse('dst2'), PathUri.parse('dst1'), overwrite: true);
@@ -629,7 +628,7 @@ void main() {
 
             await expectLater(
               () => client.webdav.move(PathUri.parse('dst2'), PathUri.parse('noncoll')),
-              throwsA(predicate<DynamiteApiException>((final e) => e.statusCode == 412)),
+              throwsA(predicate<DynamiteApiException>((e) => e.statusCode == 412)),
             );
           });
         });

--- a/packages/nextcloud_test/analysis_options.yaml
+++ b/packages/nextcloud_test/analysis_options.yaml
@@ -1,1 +1,6 @@
 include: package:neon_lints/dart.yaml
+linter:
+  rules:
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false

--- a/packages/sort_box/analysis_options.yaml
+++ b/packages/sort_box/analysis_options.yaml
@@ -1,1 +1,7 @@
 include: package:neon_lints/dart.yaml
+
+linter:
+  rules:
+    # TODO: migrate package to new lint rules
+    prefer_final_parameters: true
+    avoid_final_parameters: false

--- a/packages/sort_box/analysis_options.yaml
+++ b/packages/sort_box/analysis_options.yaml
@@ -1,7 +1,1 @@
 include: package:neon_lints/dart.yaml
-
-linter:
-  rules:
-    # TODO: migrate package to new lint rules
-    prefer_final_parameters: true
-    avoid_final_parameters: false

--- a/packages/sort_box/lib/sort_box.dart
+++ b/packages/sort_box/lib/sort_box.dart
@@ -32,9 +32,9 @@ class SortBox<T extends Enum, R> {
   ///
   /// This function sorts the input in place and a reference to it mutating the provided list.
   List<R> sort(
-    final List<R> input,
-    final Box<T> box, [
-    final Set<Box<T>>? presort,
+    List<R> input,
+    Box<T> box, [
+    Set<Box<T>>? presort,
   ]) {
     if (input.length <= 1) {
       return input;
@@ -46,15 +46,15 @@ class SortBox<T extends Enum, R> {
       ...?_boxes[box.property],
     };
 
-    final sorted = input..sort((final item1, final item2) => _compare(item1, item2, boxes.iterator..moveNext()));
+    final sorted = input..sort((item1, item2) => _compare(item1, item2, boxes.iterator..moveNext()));
 
     return sorted;
   }
 
   int _compare(
-    final R item1,
-    final R item2,
-    final Iterator<Box<T>> iterator,
+    R item1,
+    R item2,
+    Iterator<Box<T>> iterator,
   ) {
     final box = iterator.current;
     final comparableGetter = _properties[box.property]!;

--- a/packages/sort_box/test/sort_box_test.dart
+++ b/packages/sort_box/test/sort_box_test.dart
@@ -25,9 +25,9 @@ class Fruit {
 void main() {
   final sortBox = SortBox<FruitSort, Fruit>(
     {
-      FruitSort.alphabetical: (final fruit) => fruit.name.toLowerCase(),
-      FruitSort.count: (final fruit) => fruit.count,
-      FruitSort.price: (final fruit) => fruit.price!,
+      FruitSort.alphabetical: (fruit) => fruit.name.toLowerCase(),
+      FruitSort.count: (fruit) => fruit.count,
+      FruitSort.price: (fruit) => fruit.price!,
     },
     {
       FruitSort.alphabetical: {


### PR DESCRIPTION
fixes: #1245

This does not migrate all of our packages and I don't see the need to do this any time soon.
For the bigger ones like dynamite or the framework we could also just keep it for ever.