### PR TITLE
fix(dynamite): loosen package constraints of pub_semver and pubspec_p…

### DIFF
--- a/packages/dynamite/dynamite/pubspec.yaml
+++ b/packages/dynamite/dynamite/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   intersperse: ^2.0.0
   meta: ^1.0.0
   path: ^1.0.0
-  pub_semver: ^2.1.4
-  pubspec_parse: ^1.2.3
+  pub_semver: ^2.1.0
+  pubspec_parse: ^1.2.0
   uri: ^1.0.0
   version: ^3.0.0
 


### PR DESCRIPTION
…arse

As pointed out in: https://github.com/nextcloud/neon/pull/1337#discussion_r1434782761
In theory we can also make the minor version `0` but these packages rarely see any updates (2.1.0 the one this PR uses for pub_semver got released in september of 2021).