### PR TITLE
refactor: Make bloc implementations private

### DIFF
--- a/packages/neon/neon_dashboard/lib/src/blocs/dashboard.dart
+++ b/packages/neon/neon_dashboard/lib/src/blocs/dashboard.dart
@@ -8,21 +8,20 @@ import 'package:neon_framework/models.dart';
 import 'package:nextcloud/dashboard.dart' as dashboard;
 import 'package:rxdart/rxdart.dart';
 
-/// Events for [DashboardBloc].
-abstract class DashboardBlocEvents {}
+/// Bloc for fetching dashboard widgets and their items.
+sealed class DashboardBloc implements InteractiveBloc {
+  /// Creates a new Dashboard Bloc instance.
+  factory DashboardBloc(final Account account) => _DashboardBloc(account);
 
-/// States for [DashboardBloc].
-abstract class DashboardBlocStates {
   /// Dashboard widgets that are displayed.
   BehaviorSubject<Result<Map<dashboard.Widget, dashboard.WidgetItems?>>> get widgets;
 }
 
-/// Implements the business logic for fetching dashboard widgets and their items.
-class DashboardBloc extends InteractiveBloc implements DashboardBlocEvents, DashboardBlocStates {
-  /// Creates a new Dashboard Bloc instance.
-  ///
-  /// Automatically starts fetching the widgets and their items and refreshes everything every 30 seconds.
-  DashboardBloc(this._account) {
+/// Implementation of [DashboardBloc].
+///
+/// Automatically starts fetching the widgets and their items and refreshes everything every 30 seconds.
+class _DashboardBloc extends InteractiveBloc implements DashboardBloc {
+  _DashboardBloc(this._account) {
     unawaited(refresh());
 
     _timer = TimerBloc().registerTimer(const Duration(seconds: 30), refresh);

--- a/packages/neon/neon_dashboard/test/widget_test.dart
+++ b/packages/neon/neon_dashboard/test/widget_test.dart
@@ -15,6 +15,7 @@ import 'package:neon_framework/widgets.dart';
 import 'package:nextcloud/dashboard.dart' as dashboard;
 import 'package:rxdart/rxdart.dart';
 
+// ignore: subtype_of_sealed_class
 class MockAccountsBloc extends Mock implements AccountsBloc {}
 
 class MockCacheManager extends Mock implements DefaultCacheManager {}

--- a/packages/neon/neon_files/lib/src/blocs/browser.dart
+++ b/packages/neon/neon_files/lib/src/blocs/browser.dart
@@ -7,20 +7,31 @@ import 'package:neon_framework/utils.dart';
 import 'package:nextcloud/webdav.dart';
 import 'package:rxdart/rxdart.dart';
 
-abstract interface class FilesBrowserBlocEvents {
+sealed class FilesBrowserBloc implements InteractiveBloc {
+  factory FilesBrowserBloc(
+    final FilesOptions options,
+    final Account account, {
+    final PathUri? initialPath,
+  }) =>
+      _FilesBrowserBloc(
+        options,
+        account,
+        initialPath: initialPath,
+      );
+
   void setPath(final PathUri uri);
 
   void createFolder(final PathUri uri);
-}
 
-abstract interface class FilesBrowserBlocStates {
   BehaviorSubject<Result<List<WebDavFile>>> get files;
 
   BehaviorSubject<PathUri> get uri;
+
+  FilesOptions get options;
 }
 
-class FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBlocEvents, FilesBrowserBlocStates {
-  FilesBrowserBloc(
+class _FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBloc {
+  _FilesBrowserBloc(
     this.options,
     this.account, {
     final PathUri? initialPath,
@@ -32,6 +43,7 @@ class FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBlocEvents
     unawaited(refresh());
   }
 
+  @override
   final FilesOptions options;
   final Account account;
 

--- a/packages/neon/neon_files/lib/src/blocs/files.dart
+++ b/packages/neon/neon_files/lib/src/blocs/files.dart
@@ -18,7 +18,16 @@ import 'package:rxdart/rxdart.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:universal_io/io.dart';
 
-abstract interface class FilesBlocEvents {
+sealed class FilesBloc implements InteractiveBloc {
+  factory FilesBloc(
+    final FilesOptions options,
+    final Account account,
+  ) =>
+      _FilesBloc(
+        options,
+        account,
+      );
+
   void uploadFile(final PathUri uri, final String localPath);
 
   void syncFile(final PathUri uri);
@@ -38,14 +47,18 @@ abstract interface class FilesBlocEvents {
   void addFavorite(final PathUri uri);
 
   void removeFavorite(final PathUri uri);
-}
 
-abstract interface class FilesBlocStates {
   BehaviorSubject<List<FilesTask>> get tasks;
+
+  FilesOptions get options;
+
+  FilesBrowserBloc get browser;
+
+  FilesBrowserBloc getNewFilesBrowserBloc({final PathUri? initialUri});
 }
 
-class FilesBloc extends InteractiveBloc implements FilesBlocEvents, FilesBlocStates {
-  FilesBloc(
+class _FilesBloc extends InteractiveBloc implements FilesBloc {
+  _FilesBloc(
     this.options,
     this.account,
   ) {
@@ -53,8 +66,10 @@ class FilesBloc extends InteractiveBloc implements FilesBlocEvents, FilesBlocSta
     options.downloadQueueParallelism.addListener(_downloadParallelismListener);
   }
 
+  @override
   final FilesOptions options;
   final Account account;
+  @override
   late final browser = getNewFilesBrowserBloc();
 
   final _uploadQueue = Queue();
@@ -217,6 +232,7 @@ class FilesBloc extends InteractiveBloc implements FilesBlocEvents, FilesBlocSta
     tasks.add(tasks.value..remove(task));
   }
 
+  @override
   FilesBrowserBloc getNewFilesBrowserBloc({
     final PathUri? initialUri,
   }) =>

--- a/packages/neon/neon_news/lib/src/blocs/article.dart
+++ b/packages/neon/neon_news/lib/src/blocs/article.dart
@@ -2,11 +2,23 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:neon_framework/blocs.dart';
+import 'package:neon_framework/models.dart';
 import 'package:neon_news/src/blocs/articles.dart';
 import 'package:nextcloud/news.dart' as news;
 import 'package:rxdart/rxdart.dart';
 
-abstract interface class NewsArticleBlocEvents {
+sealed class NewsArticleBloc implements InteractiveBloc {
+  factory NewsArticleBloc(
+    final NewsArticlesBloc articlesBloc,
+    final Account account,
+    final news.Article article,
+  ) =>
+      _NewsArticleBloc(
+        articlesBloc,
+        account,
+        article,
+      );
+
   void markArticleAsRead();
 
   void markArticleAsUnread();
@@ -14,17 +26,16 @@ abstract interface class NewsArticleBlocEvents {
   void starArticle();
 
   void unstarArticle();
-}
 
-abstract interface class NewsArticleBlocStates {
   BehaviorSubject<bool> get unread;
 
   BehaviorSubject<bool> get starred;
 }
 
-class NewsArticleBloc extends InteractiveBloc implements NewsArticleBlocEvents, NewsArticleBlocStates {
-  NewsArticleBloc(
+class _NewsArticleBloc extends InteractiveBloc implements NewsArticleBloc {
+  _NewsArticleBloc(
     this._newsArticlesBloc,
+    this.account,
     final news.Article article,
   ) {
     _id = article.id;
@@ -33,6 +44,7 @@ class NewsArticleBloc extends InteractiveBloc implements NewsArticleBlocEvents, 
   }
 
   final NewsArticlesBloc _newsArticlesBloc;
+  final Account account;
 
   late final int _id;
 
@@ -50,12 +62,12 @@ class NewsArticleBloc extends InteractiveBloc implements NewsArticleBlocEvents, 
   BehaviorSubject<bool> unread = BehaviorSubject<bool>();
 
   @override
-  void refresh() {}
+  Future<void> refresh() async {}
 
   @override
   void markArticleAsRead() {
     _wrapArticleAction(() async {
-      await _newsArticlesBloc.account.client.news.markArticleAsRead(itemId: _id);
+      await account.client.news.markArticleAsRead(itemId: _id);
       unread.add(false);
     });
   }
@@ -63,7 +75,7 @@ class NewsArticleBloc extends InteractiveBloc implements NewsArticleBlocEvents, 
   @override
   void markArticleAsUnread() {
     _wrapArticleAction(() async {
-      await _newsArticlesBloc.account.client.news.markArticleAsUnread(itemId: _id);
+      await account.client.news.markArticleAsUnread(itemId: _id);
       unread.add(true);
     });
   }
@@ -71,7 +83,7 @@ class NewsArticleBloc extends InteractiveBloc implements NewsArticleBlocEvents, 
   @override
   void starArticle() {
     _wrapArticleAction(() async {
-      await _newsArticlesBloc.account.client.news.starArticle(itemId: _id);
+      await account.client.news.starArticle(itemId: _id);
       starred.add(true);
     });
   }
@@ -79,7 +91,7 @@ class NewsArticleBloc extends InteractiveBloc implements NewsArticleBlocEvents, 
   @override
   void unstarArticle() {
     _wrapArticleAction(() async {
-      await _newsArticlesBloc.account.client.news.unstarArticle(itemId: _id);
+      await account.client.news.unstarArticle(itemId: _id);
       starred.add(false);
     });
   }

--- a/packages/neon/neon_news/lib/src/blocs/articles.dart
+++ b/packages/neon/neon_news/lib/src/blocs/articles.dart
@@ -19,7 +19,22 @@ enum ListType {
   folder,
 }
 
-abstract interface class NewsArticlesBlocEvents {
+sealed class NewsArticlesBloc implements InteractiveBloc {
+  factory NewsArticlesBloc(
+    final NewsBloc newsBloc,
+    final NewsOptions options,
+    final Account account, {
+    final int? id,
+    final ListType? listType,
+  }) =>
+      _NewsArticlesBloc(
+        newsBloc,
+        options,
+        account,
+        id: id,
+        listType: listType,
+      );
+
   void setFilterType(final FilterType type);
 
   void markArticleAsRead(final news.Article article);
@@ -29,15 +44,17 @@ abstract interface class NewsArticlesBlocEvents {
   void starArticle(final news.Article article);
 
   void unstarArticle(final news.Article article);
-}
 
-abstract interface class NewsArticlesBlocStates {
   BehaviorSubject<Result<List<news.Article>>> get articles;
 
   BehaviorSubject<FilterType> get filterType;
+
+  NewsOptions get options;
+
+  ListType? get listType;
 }
 
-class NewsMainArticlesBloc extends NewsArticlesBloc {
+class NewsMainArticlesBloc extends _NewsArticlesBloc {
   NewsMainArticlesBloc(
     super._newsBloc,
     super.options,
@@ -45,8 +62,8 @@ class NewsMainArticlesBloc extends NewsArticlesBloc {
   );
 }
 
-class NewsArticlesBloc extends InteractiveBloc implements NewsArticlesBlocEvents, NewsArticlesBlocStates {
-  NewsArticlesBloc(
+class _NewsArticlesBloc extends InteractiveBloc implements NewsArticlesBloc {
+  _NewsArticlesBloc(
     this._newsBloc,
     this.options,
     this.account, {
@@ -64,9 +81,11 @@ class NewsArticlesBloc extends InteractiveBloc implements NewsArticlesBlocEvents
   }
 
   final NewsBloc _newsBloc;
+  @override
   final NewsOptions options;
   final Account account;
   final int? id;
+  @override
   final ListType? listType;
 
   @override

--- a/packages/neon/neon_news/lib/src/blocs/news.dart
+++ b/packages/neon/neon_news/lib/src/blocs/news.dart
@@ -8,7 +8,16 @@ import 'package:neon_news/src/options.dart';
 import 'package:nextcloud/news.dart' as news;
 import 'package:rxdart/rxdart.dart';
 
-abstract interface class NewsBlocEvents {
+sealed class NewsBloc implements InteractiveBloc {
+  factory NewsBloc(
+    final NewsOptions options,
+    final Account account,
+  ) =>
+      _NewsBloc(
+        options,
+        account,
+      );
+
   void addFeed(final String url, final int? folderId);
 
   void removeFeed(final int feedId);
@@ -26,18 +35,20 @@ abstract interface class NewsBlocEvents {
   void renameFolder(final int folderId, final String name);
 
   void markFolderAsRead(final int folderId);
-}
 
-abstract interface class NewsBlocStates {
   BehaviorSubject<Result<List<news.Folder>>> get folders;
 
   BehaviorSubject<Result<List<news.Feed>>> get feeds;
 
   BehaviorSubject<int> get unreadCounter;
+
+  NewsOptions get options;
+
+  NewsMainArticlesBloc get mainArticlesBloc;
 }
 
-class NewsBloc extends InteractiveBloc implements NewsBlocEvents, NewsBlocStates, NewsMainArticlesBloc {
-  NewsBloc(
+class _NewsBloc extends InteractiveBloc implements NewsBloc, NewsMainArticlesBloc {
+  _NewsBloc(
     this.options,
     this.account,
   ) {
@@ -55,8 +66,8 @@ class NewsBloc extends InteractiveBloc implements NewsBlocEvents, NewsBlocStates
   @override
   final NewsOptions options;
   @override
-  @override
   final Account account;
+  @override
   late final mainArticlesBloc = NewsMainArticlesBloc(
     this,
     options,

--- a/packages/neon/neon_news/lib/src/pages/feed.dart
+++ b/packages/neon/neon_news/lib/src/pages/feed.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:neon_framework/blocs.dart';
+import 'package:neon_framework/utils.dart';
 import 'package:neon_news/src/blocs/articles.dart';
 import 'package:neon_news/src/blocs/news.dart';
 import 'package:neon_news/src/widgets/articles_view.dart';
@@ -25,7 +27,7 @@ class NewsFeedPage extends StatelessWidget {
             bloc: NewsArticlesBloc(
               bloc,
               bloc.options,
-              bloc.account,
+              NeonProvider.of<AccountsBloc>(context).activeAccount.value!,
               id: feed.id,
               listType: ListType.feed,
             ),

--- a/packages/neon/neon_news/lib/src/widgets/articles_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/articles_view.dart
@@ -5,6 +5,7 @@ import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/platform.dart';
 import 'package:neon_framework/sort_box.dart';
 import 'package:neon_framework/theme.dart';
+import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
 import 'package:neon_news/l10n/localizations.dart';
 import 'package:neon_news/src/blocs/article.dart';
@@ -207,12 +208,15 @@ class _NewsArticlesViewState extends State<NewsArticlesView> {
             debugPrint(s.toString());
           }
 
+          final account = NeonProvider.of<AccountsBloc>(context).activeAccount.value!;
+
           if ((viewType == ArticleViewType.direct || article.url == null) && bodyData != null) {
             await Navigator.of(context).push(
               MaterialPageRoute<void>(
                 builder: (final context) => NewsArticlePage(
                   bloc: NewsArticleBloc(
                     widget.bloc,
+                    account,
                     article,
                   ),
                   articlesBloc: widget.bloc,
@@ -230,6 +234,7 @@ class _NewsArticlesViewState extends State<NewsArticlesView> {
                 builder: (final context) => NewsArticlePage(
                   bloc: NewsArticleBloc(
                     widget.bloc,
+                    account,
                     article,
                   ),
                   articlesBloc: widget.bloc,

--- a/packages/neon/neon_news/lib/src/widgets/folder_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/folder_view.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:neon_framework/blocs.dart';
+import 'package:neon_framework/utils.dart';
 import 'package:neon_news/src/blocs/articles.dart';
 import 'package:neon_news/src/blocs/news.dart';
 import 'package:neon_news/src/options.dart';
@@ -53,7 +55,7 @@ class _NewsFolderViewState extends State<NewsFolderView> {
                     bloc: NewsArticlesBloc(
                       widget.bloc,
                       widget.bloc.options,
-                      widget.bloc.account,
+                      NeonProvider.of<AccountsBloc>(context).activeAccount.value!,
                       id: widget.folder.id,
                       listType: ListType.folder,
                     ),

--- a/packages/neon/neon_notes/lib/src/blocs/notes.dart
+++ b/packages/neon/neon_notes/lib/src/blocs/notes.dart
@@ -8,7 +8,16 @@ import 'package:neon_notes/src/options.dart';
 import 'package:nextcloud/notes.dart' as notes;
 import 'package:rxdart/rxdart.dart';
 
-abstract interface class NotesBlocEvents {
+sealed class NotesBloc implements InteractiveBloc {
+  factory NotesBloc(
+    final NotesOptions options,
+    final Account account,
+  ) =>
+      _NotesBloc(
+        options,
+        account,
+      );
+
   void createNote({
     final String title = '',
     final String category = '',
@@ -24,20 +33,21 @@ abstract interface class NotesBlocEvents {
   });
 
   void deleteNote(final int id);
-}
 
-abstract interface class NotesBlocStates {
   BehaviorSubject<Result<List<notes.Note>>> get notesList;
+
+  NotesOptions get options;
 }
 
-class NotesBloc extends InteractiveBloc implements NotesBlocEvents, NotesBlocStates {
-  NotesBloc(
+class _NotesBloc extends InteractiveBloc implements NotesBloc {
+  _NotesBloc(
     this.options,
     this.account,
   ) {
     unawaited(refresh());
   }
 
+  @override
   final NotesOptions options;
   final Account account;
 

--- a/packages/neon/neon_notes/lib/src/widgets/notes_view.dart
+++ b/packages/neon/neon_notes/lib/src/widgets/notes_view.dart
@@ -95,6 +95,7 @@ class NotesView extends StatelessWidget {
               builder: (final context) => NotesNotePage(
                 bloc: NotesNoteBloc(
                   bloc,
+                  NeonProvider.of<AccountsBloc>(context).activeAccount.value!,
                   note,
                 ),
                 notesBloc: bloc,

--- a/packages/neon/neon_notifications/lib/src/blocs/notifications.dart
+++ b/packages/neon/neon_notifications/lib/src/blocs/notifications.dart
@@ -7,21 +7,25 @@ import 'package:neon_notifications/src/options.dart';
 import 'package:nextcloud/notifications.dart' as notifications;
 import 'package:rxdart/rxdart.dart';
 
-abstract interface class NotificationsBlocEvents {
+sealed class NotificationsBloc implements NotificationsBlocInterface, InteractiveBloc {
+  factory NotificationsBloc(
+    final NotificationsOptions options,
+    final Account account,
+  ) =>
+      _NotificationsBloc(options, account);
+
+  @override
   void deleteNotification(final int id);
 
   void deleteAllNotifications();
-}
 
-abstract interface class NotificationsBlocStates {
   BehaviorSubject<Result<List<notifications.Notification>>> get notificationsList;
 
   BehaviorSubject<int> get unreadCounter;
 }
 
-class NotificationsBloc extends InteractiveBloc
-    implements NotificationsBlocInterface, NotificationsBlocEvents, NotificationsBlocStates {
-  NotificationsBloc(
+class _NotificationsBloc extends InteractiveBloc implements NotificationsBlocInterface, NotificationsBloc {
+  _NotificationsBloc(
     this.options,
     this._account,
   ) {
@@ -35,7 +39,6 @@ class NotificationsBloc extends InteractiveBloc
     _timer = TimerBloc().registerTimer(const Duration(seconds: 30), refresh);
   }
 
-  @override
   final NotificationsOptions options;
   final Account _account;
   late final NeonTimer _timer;

--- a/packages/neon/neon_notifications/lib/src/options.dart
+++ b/packages/neon/neon_notifications/lib/src/options.dart
@@ -1,7 +1,6 @@
-import 'package:neon_framework/models.dart';
 import 'package:neon_framework/settings.dart';
 
-class NotificationsOptions extends AppImplementationOptions implements NotificationsOptionsInterface {
+class NotificationsOptions extends AppImplementationOptions {
   NotificationsOptions(super.storage) {
     super.categories = [];
     super.options = [];

--- a/packages/neon/neon_notifications/lib/src/pages/main.dart
+++ b/packages/neon/neon_notifications/lib/src/pages/main.dart
@@ -104,7 +104,7 @@ class _NotificationsMainPageState extends State<NotificationsMainPage> {
         if (app != null) {
           // TODO: use go_router once implemented
           final accountsBloc = NeonProvider.of<AccountsBloc>(context);
-          await accountsBloc.activeAppsBloc.setActiveApp(app.id);
+          accountsBloc.activeAppsBloc.setActiveApp(app.id);
         } else {
           final colorScheme = Theme.of(context).colorScheme;
 

--- a/packages/neon_framework/lib/blocs.dart
+++ b/packages/neon_framework/lib/blocs.dart
@@ -2,4 +2,4 @@ export 'package:neon_framework/src/bloc/bloc.dart';
 export 'package:neon_framework/src/bloc/result.dart';
 // TODO: Remove access to the AccountsBloc. Apps should not need to access this
 export 'package:neon_framework/src/blocs/accounts.dart' show AccountsBloc;
-export 'package:neon_framework/src/blocs/timer.dart' hide TimerBlocEvents, TimerBlocStates;
+export 'package:neon_framework/src/blocs/timer.dart';

--- a/packages/neon_framework/lib/src/app.dart
+++ b/packages/neon_framework/lib/src/app.dart
@@ -245,7 +245,7 @@ class _NeonAppState extends State<NeonApp> with WidgetsBindingObserver, tray.Tra
   }
 
   Future<void> _openAppFromExternal(final Account account, final String id) async {
-    await _accountsBloc.getAppsBlocFor(account).setActiveApp(id);
+    _accountsBloc.getAppsBlocFor(account).setActiveApp(id);
     _navigatorKey.currentState!.popUntil((final route) => route.settings.name == 'home');
     await _showAndRestoreWindow();
   }

--- a/packages/neon_framework/lib/src/bloc/bloc.dart
+++ b/packages/neon_framework/lib/src/bloc/bloc.dart
@@ -35,7 +35,7 @@ abstract class InteractiveBloc extends Bloc {
   /// Refreshes the state of the bloc.
   ///
   /// Commonly involves re-fetching data from the server.
-  FutureOr<void> refresh();
+  Future<void> refresh();
 
   /// Adds an error to the [errors] state.
   @protected

--- a/packages/neon_framework/lib/src/blocs/capabilities.dart
+++ b/packages/neon_framework/lib/src/blocs/capabilities.dart
@@ -9,17 +9,15 @@ import 'package:nextcloud/core.dart' as core;
 import 'package:rxdart/rxdart.dart';
 
 @internal
-abstract interface class CapabilitiesBlocEvents {}
+sealed class CapabilitiesBloc implements InteractiveBloc {
+  /// Creates a new capabilities bloc.
+  factory CapabilitiesBloc(final Account account) => _CapabilitiesBloc(account);
 
-@internal
-abstract interface class CapabilitiesBlocStates {
   BehaviorSubject<Result<core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data>> get capabilities;
 }
 
-@internal
-class CapabilitiesBloc extends InteractiveBloc implements CapabilitiesBlocEvents, CapabilitiesBlocStates {
-  /// Creates a new capabilities bloc.
-  CapabilitiesBloc(
+class _CapabilitiesBloc extends InteractiveBloc implements CapabilitiesBloc {
+  _CapabilitiesBloc(
     this._account,
   ) {
     unawaited(refresh());

--- a/packages/neon_framework/lib/src/blocs/first_launch.dart
+++ b/packages/neon_framework/lib/src/blocs/first_launch.dart
@@ -2,21 +2,23 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 import 'package:neon_framework/src/bloc/bloc.dart';
+import 'package:neon_framework/src/models/disposable.dart';
 import 'package:neon_framework/src/settings/models/storage.dart';
 import 'package:rxdart/rxdart.dart';
 
 @internal
-abstract interface class FirstLaunchBlocEvents {}
+sealed class FirstLaunchBloc implements Disposable {
+  factory FirstLaunchBloc({
+    final bool disabled = false,
+  }) =>
+      _FirstLaunchBloc(disabled: disabled);
 
-@internal
-abstract interface class FirstLaunchBlocStates {
   BehaviorSubject<void> get onFirstLaunch;
 }
 
 @immutable
-@internal
-class FirstLaunchBloc extends Bloc implements FirstLaunchBlocEvents, FirstLaunchBlocStates {
-  FirstLaunchBloc({
+class _FirstLaunchBloc extends Bloc implements FirstLaunchBloc {
+  _FirstLaunchBloc({
     final bool disabled = false,
   }) {
     const storage = SingleValueStorage(StorageKeys.firstLaunch);

--- a/packages/neon_framework/lib/src/blocs/login_check_account.dart
+++ b/packages/neon_framework/lib/src/blocs/login_check_account.dart
@@ -11,18 +11,24 @@ import 'package:nextcloud/provisioning_api.dart' as provisioning_api;
 import 'package:rxdart/rxdart.dart';
 
 @internal
-abstract interface class LoginCheckAccountBlocEvents {}
+sealed class LoginCheckAccountBloc implements InteractiveBloc {
+  factory LoginCheckAccountBloc(
+    final Uri serverURL,
+    final String loginName,
+    final String password,
+  ) =>
+      _LoginCheckAccountBloc(
+        serverURL,
+        loginName,
+        password,
+      );
 
-@internal
-abstract interface class LoginCheckAccountBlocStates {
   /// Contains the account for the user
   BehaviorSubject<Result<Account>> get state;
 }
 
-@internal
-class LoginCheckAccountBloc extends InteractiveBloc
-    implements LoginCheckAccountBlocEvents, LoginCheckAccountBlocStates {
-  LoginCheckAccountBloc(
+class _LoginCheckAccountBloc extends InteractiveBloc implements LoginCheckAccountBloc {
+  _LoginCheckAccountBloc(
     this.serverURL,
     this.loginName,
     this.password,

--- a/packages/neon_framework/lib/src/blocs/login_check_server_status.dart
+++ b/packages/neon_framework/lib/src/blocs/login_check_server_status.dart
@@ -10,18 +10,15 @@ import 'package:nextcloud/nextcloud.dart';
 import 'package:rxdart/rxdart.dart';
 
 @internal
-abstract interface class LoginCheckServerStatusBlocEvents {}
+sealed class LoginCheckServerStatusBloc implements InteractiveBloc {
+  factory LoginCheckServerStatusBloc(final Uri serverURL) => _LoginCheckServerStatusBloc(serverURL);
 
-@internal
-abstract interface class LoginCheckServerStatusBlocStates {
   /// Contains the current server connection state
   BehaviorSubject<Result<core.Status>> get state;
 }
 
-@internal
-class LoginCheckServerStatusBloc extends InteractiveBloc
-    implements LoginCheckServerStatusBlocEvents, LoginCheckServerStatusBlocStates {
-  LoginCheckServerStatusBloc(this.serverURL) {
+class _LoginCheckServerStatusBloc extends InteractiveBloc implements LoginCheckServerStatusBloc {
+  _LoginCheckServerStatusBloc(this.serverURL) {
     unawaited(refresh());
   }
 

--- a/packages/neon_framework/lib/src/blocs/login_flow.dart
+++ b/packages/neon_framework/lib/src/blocs/login_flow.dart
@@ -10,18 +10,16 @@ import 'package:nextcloud/nextcloud.dart';
 import 'package:rxdart/rxdart.dart';
 
 @internal
-abstract interface class LoginFlowBlocEvents {}
+sealed class LoginFlowBloc implements InteractiveBloc {
+  factory LoginFlowBloc(final Uri serverURL) => _LoginFlowBloc(serverURL);
 
-@internal
-abstract interface class LoginFlowBlocStates {
   BehaviorSubject<Result<core.LoginFlowV2>> get init;
 
   Stream<core.LoginFlowV2Credentials> get result;
 }
 
-@internal
-class LoginFlowBloc extends InteractiveBloc implements LoginFlowBlocEvents, LoginFlowBlocStates {
-  LoginFlowBloc(this.serverURL) {
+class _LoginFlowBloc extends InteractiveBloc implements LoginFlowBloc {
+  _LoginFlowBloc(this.serverURL) {
     unawaited(refresh());
   }
 

--- a/packages/neon_framework/lib/src/blocs/next_push.dart
+++ b/packages/neon_framework/lib/src/blocs/next_push.dart
@@ -5,21 +5,29 @@ import 'package:meta/meta.dart';
 import 'package:neon_framework/src/bloc/bloc.dart';
 import 'package:neon_framework/src/blocs/accounts.dart';
 import 'package:neon_framework/src/models/account.dart';
+import 'package:neon_framework/src/models/disposable.dart';
 import 'package:neon_framework/src/utils/global_options.dart';
 import 'package:nextcloud/uppush.dart' as uppush;
 import 'package:rxdart/rxdart.dart';
 
 @internal
-abstract interface class NextPushBlocEvents {}
+sealed class NextPushBloc implements Disposable {
+  factory NextPushBloc(
+    final AccountsBloc accountsBloc,
+    final GlobalOptions globalOptions, {
+    final bool disabled = false,
+  }) =>
+      _NextPushBloc(
+        accountsBloc,
+        globalOptions,
+        disabled: disabled,
+      );
 
-@internal
-abstract interface class NextPushBlocStates {
   BehaviorSubject<void> get onNextPushSupported;
 }
 
-@internal
-class NextPushBloc extends Bloc implements NextPushBlocEvents, NextPushBlocStates {
-  NextPushBloc(
+class _NextPushBloc extends Bloc implements NextPushBloc {
+  _NextPushBloc(
     this._accountsBloc,
     this._globalOptions, {
     final bool disabled = false,

--- a/packages/neon_framework/lib/src/blocs/push_notifications.dart
+++ b/packages/neon_framework/lib/src/blocs/push_notifications.dart
@@ -15,14 +15,19 @@ import 'package:nextcloud/notifications.dart' as notifications;
 import 'package:unifiedpush/unifiedpush.dart';
 
 @internal
-abstract interface class PushNotificationsBlocEvents {}
+sealed class PushNotificationsBloc {
+  factory PushNotificationsBloc(
+    final AccountsBloc accountsBloc,
+    final GlobalOptions globalOptions,
+  ) =>
+      _PushNotificationsBloc(
+        accountsBloc,
+        globalOptions,
+      );
+}
 
-@internal
-abstract interface class PushNotificationsBlocStates {}
-
-@internal
-class PushNotificationsBloc extends Bloc implements PushNotificationsBlocEvents, PushNotificationsBlocStates {
-  PushNotificationsBloc(
+class _PushNotificationsBloc extends Bloc implements PushNotificationsBloc {
+  _PushNotificationsBloc(
     this._accountsBloc,
     this._globalOptions,
   ) {

--- a/packages/neon_framework/lib/src/blocs/timer.dart
+++ b/packages/neon_framework/lib/src/blocs/timer.dart
@@ -6,8 +6,21 @@ import 'dart:ui';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/src/bloc/bloc.dart';
 
-@internal
-abstract interface class TimerBlocEvents {
+sealed class TimerBloc extends Bloc {
+  factory TimerBloc() => instance ??= _TimerBloc._();
+
+  @visibleForTesting
+  factory TimerBloc.mocked(final TimerBloc mock) => instance ??= mock;
+
+  @visibleForTesting
+  static TimerBloc? instance;
+
+  @override
+  void dispose() {
+    TimerBloc.instance?.dispose();
+    TimerBloc.instance = null;
+  }
+
   /// Register a [callback] that will be called periodically.
   /// The time between the executions is defined by the [duration].
   NeonTimer registerTimer(final Duration duration, final VoidCallback callback);
@@ -15,65 +28,55 @@ abstract interface class TimerBlocEvents {
   /// Unregister a timer that has been previously registered with the bloc.
   /// You can also use [NeonTimer.cancel].
   void unregisterTimer(final NeonTimer timer);
-}
 
-@internal
-abstract interface class TimerBlocStates {}
+  @visibleForTesting
+  Map<int, Timer> get timers;
+
+  @visibleForTesting
+  Map<int, Set<VoidCallback>> get callbacks;
+}
 
 /// Execute callbacks at defined periodic intervals.
 /// Components can register their callbacks and everything with the same periodicity will be executed at the same time.
 ///
 /// The [TimerBloc] is a singleton.
 /// Sub-second timers are not supported.
-class TimerBloc extends Bloc implements TimerBlocEvents, TimerBlocStates {
-  factory TimerBloc() => instance ??= TimerBloc._();
+class _TimerBloc implements TimerBloc {
+  _TimerBloc._();
 
-  @visibleForTesting
-  factory TimerBloc.mocked(final TimerBloc mock) => instance ??= mock;
-
-  TimerBloc._();
-
-  @visibleForTesting
-  static TimerBloc? instance;
-
-  final Map<int, Timer> _timers = {};
-  final Map<int, Set<VoidCallback>> _callbacks = {};
-
-  @visibleForTesting
-  Map<int, Timer> get timers => _timers;
-
-  @visibleForTesting
-  Map<int, Set<VoidCallback>> get callbacks => _callbacks;
+  @override
+  final Map<int, Timer> timers = {};
+  @override
+  final Map<int, Set<VoidCallback>> callbacks = {};
 
   @override
   void dispose() {
-    for (final timer in _timers.values) {
+    for (final timer in timers.values) {
       timer.cancel();
     }
-    _timers.clear();
-    _callbacks.clear();
-    TimerBloc.instance = null;
+    timers.clear();
+    callbacks.clear();
   }
 
   @override
   NeonTimer registerTimer(final Duration duration, final VoidCallback callback) {
-    if (_timers[duration.inSeconds] == null) {
-      _timers[duration.inSeconds] = Timer.periodic(duration, (final _) {
-        for (final callback in _callbacks[duration.inSeconds]!) {
+    if (timers[duration.inSeconds] == null) {
+      timers[duration.inSeconds] = Timer.periodic(duration, (final _) {
+        for (final callback in callbacks[duration.inSeconds]!) {
           callback();
         }
       });
-      _callbacks[duration.inSeconds] = {callback};
+      callbacks[duration.inSeconds] = {callback};
     } else {
-      _callbacks[duration.inSeconds]!.add(callback);
+      callbacks[duration.inSeconds]!.add(callback);
     }
     return NeonTimer(duration, callback);
   }
 
   @override
   void unregisterTimer(final NeonTimer timer) {
-    if (_timers[timer.duration.inSeconds] != null) {
-      _callbacks[timer.duration.inSeconds]!.remove(timer.callback);
+    if (timers[timer.duration.inSeconds] != null) {
+      callbacks[timer.duration.inSeconds]!.remove(timer.callback);
     }
   }
 }

--- a/packages/neon_framework/lib/src/blocs/unified_search.dart
+++ b/packages/neon_framework/lib/src/blocs/unified_search.dart
@@ -11,24 +11,29 @@ import 'package:nextcloud/core.dart' as core;
 import 'package:rxdart/rxdart.dart';
 
 @internal
-abstract interface class UnifiedSearchBlocEvents {
+sealed class UnifiedSearchBloc implements InteractiveBloc {
+  factory UnifiedSearchBloc(
+    final AppsBloc appsBloc,
+    final Account account,
+  ) =>
+      _UnifiedSearchBloc(
+        appsBloc,
+        account,
+      );
+
   void search(final String term);
 
   void enable();
 
   void disable();
-}
 
-@internal
-abstract interface class UnifiedSearchBlocStates {
   BehaviorSubject<bool> get enabled;
 
   BehaviorSubject<Result<Map<core.UnifiedSearchProvider, Result<core.UnifiedSearchResult>>?>> get results;
 }
 
-@internal
-class UnifiedSearchBloc extends InteractiveBloc implements UnifiedSearchBlocEvents, UnifiedSearchBlocStates {
-  UnifiedSearchBloc(
+class _UnifiedSearchBloc extends InteractiveBloc implements UnifiedSearchBloc {
+  _UnifiedSearchBloc(
     this._appsBloc,
     this._account,
   ) {

--- a/packages/neon_framework/lib/src/blocs/user_details.dart
+++ b/packages/neon_framework/lib/src/blocs/user_details.dart
@@ -9,16 +9,14 @@ import 'package:nextcloud/provisioning_api.dart' as provisioning_api;
 import 'package:rxdart/rxdart.dart';
 
 @internal
-abstract interface class UserDetailsBlocEvents {}
+sealed class UserDetailsBloc implements InteractiveBloc {
+  factory UserDetailsBloc(final Account account) => _UserDetailsBloc(account);
 
-@internal
-abstract interface class UserDetailsBlocStates {
   BehaviorSubject<Result<provisioning_api.UserDetails>> get userDetails;
 }
 
-@internal
-class UserDetailsBloc extends InteractiveBloc implements UserDetailsBlocEvents, UserDetailsBlocStates {
-  UserDetailsBloc(
+class _UserDetailsBloc extends InteractiveBloc implements UserDetailsBloc {
+  _UserDetailsBloc(
     this._account,
   ) {
     unawaited(refresh());

--- a/packages/neon_framework/lib/src/blocs/user_statuses.dart
+++ b/packages/neon_framework/lib/src/blocs/user_statuses.dart
@@ -7,24 +7,23 @@ import 'package:neon_framework/src/bloc/bloc.dart';
 import 'package:neon_framework/src/bloc/result.dart';
 import 'package:neon_framework/src/blocs/timer.dart';
 import 'package:neon_framework/src/models/account.dart';
+import 'package:neon_framework/src/models/disposable.dart';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/user_status.dart' as user_status;
 import 'package:rxdart/rxdart.dart';
 import 'package:window_manager/window_manager.dart';
 
 @internal
-abstract interface class UserStatusesBlocEvents {
-  void load(final String username, {final bool force = false});
-}
+sealed class UserStatusesBloc implements Disposable {
+  factory UserStatusesBloc(final Account account) => _UserStatusesBloc(account);
 
-@internal
-abstract interface class UserStatusesBlocStates {
+  void load(final String username, {final bool force = false});
+
   BehaviorSubject<Map<String, Result<user_status.$PublicInterface?>>> get statuses;
 }
 
-@internal
-class UserStatusesBloc extends InteractiveBloc implements UserStatusesBlocEvents, UserStatusesBlocStates {
-  UserStatusesBloc(
+class _UserStatusesBloc extends InteractiveBloc implements UserStatusesBloc {
+  _UserStatusesBloc(
     this._account,
   ) {
     unawaited(refresh());

--- a/packages/neon_framework/lib/src/models/notifications_interface.dart
+++ b/packages/neon_framework/lib/src/models/notifications_interface.dart
@@ -7,7 +7,7 @@ import 'package:neon_framework/src/settings/models/options_collection.dart';
 ///
 /// Use this to access the notifications client from other Neon clients.
 abstract interface class NotificationsAppInterface<T extends NotificationsBlocInterface,
-    R extends NotificationsOptionsInterface> extends AppImplementation<T, R> {
+    R extends AppImplementationOptions> extends AppImplementation<T, R> {
   /// Creates a new notifications client.
   NotificationsAppInterface();
 
@@ -18,18 +18,6 @@ abstract interface class NotificationsAppInterface<T extends NotificationsBlocIn
 
 /// The interface of the bloc used by the notifications client.
 abstract interface class NotificationsBlocInterface extends InteractiveBloc {
-  /// Creates a new notifications bloc.
-  NotificationsBlocInterface(this.options);
-
-  /// The options for the notifications client.
-  final NotificationsOptionsInterface options;
-
   /// Deletes the notification with the given [id].
   void deleteNotification(final int id);
-}
-
-/// The interface of the app options used by the notifications client.
-abstract interface class NotificationsOptionsInterface extends AppImplementationOptions {
-  /// Creates the nextcloud app options for the notifications client.
-  NotificationsOptionsInterface(super.storage);
 }

--- a/packages/neon_framework/lib/src/widgets/drawer.dart
+++ b/packages/neon_framework/lib/src/widgets/drawer.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/l10n/localizations.dart';
@@ -88,7 +86,7 @@ class __NeonDrawerState extends State<_NeonDrawer> {
       _activeApp = index;
     });
 
-    unawaited(_appsBloc.setActiveApp(_apps[index].id));
+    _appsBloc.setActiveApp(_apps[index].id);
     //context.goNamed(apps[index].routeName);
   }
 

--- a/packages/neon_framework/lib/src/widgets/user_avatar.dart
+++ b/packages/neon_framework/lib/src/widgets/user_avatar.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:neon_framework/src/bloc/result.dart';
 import 'package:neon_framework/src/blocs/accounts.dart';
@@ -57,7 +55,7 @@ class _UserAvatarState extends State<NeonUserAvatar> {
     super.initState();
 
     if (widget.showStatus) {
-      unawaited(_userStatusBloc.load(widget.username));
+      _userStatusBloc.load(widget.username);
     }
   }
 


### PR DESCRIPTION
Some places accessed parts of Blocs that should have been in the interface. Now it is no longer possible to do that.