### PR TITLE
fix(ci): Let renovate update dependencies with zero as major version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,7 @@
         "minor",
         "patch"
       ],
+      "matchCurrentVersion": "!/^0/",
       "excludeDepNames": [
         "app",
         "dynamite_end_to_end_test",
@@ -35,6 +36,15 @@
         "neon_lints",
         "nextcloud_test"
       ],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["pub"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "matchCurrentVersion": "/^0/",
       "enabled": false
     },
     {


### PR DESCRIPTION
The second rule is there to still disable patch updates.
I checked locally and it correctly generates a pr for the intl package which pana complained about in the nextcloud package.