### PR TITLE
chore: Set correct publish_to

### DIFF
--- a/packages/file_icons/pubspec.yaml
+++ b/packages/file_icons/pubspec.yaml
@@ -1,5 +1,6 @@
 name: file_icons
 version: 1.0.0
+publish_to: none
 
 environment:
   sdk: '>=3.1.0 <4.0.0'

--- a/packages/sort_box/pubspec.yaml
+++ b/packages/sort_box/pubspec.yaml
@@ -1,5 +1,6 @@
 name: sort_box
 version: 1.0.0
+publish_to: none
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
Leaves nextcloud, dynamite and dynamite_runtime as non-private packages.