### PR TITLE
fix(neon_framework): Skip displaying user status icon if offline

### DIFF
--- a/packages/neon_framework/lib/src/widgets/user_avatar.dart
+++ b/packages/neon_framework/lib/src/widgets/user_avatar.dart
@@ -129,7 +129,10 @@ class _UserAvatarState extends State<NeonUserAvatar> {
         ),
       );
     } else if (result.hasData) {
-      child = NeonServerIcon(icon: 'user-status-${result.data!.status}');
+      final type = result.data!.status;
+      if (type != 'offline') {
+        child = NeonServerIcon(icon: 'user-status-$type');
+      }
     }
 
     return SizedBox.square(


### PR DESCRIPTION
If the user status was set to offline and error was thrown because there is no icon for offline and it shouldn't be shown anyway.