### PR TITLE
fix(neon_framework): Remove progress indicator height jumping around

### DIFF
--- a/packages/neon_framework/lib/src/widgets/linear_progress_indicator.dart
+++ b/packages/neon_framework/lib/src/widgets/linear_progress_indicator.dart
@@ -28,7 +28,7 @@ class NeonLinearProgressIndicator extends StatelessWidget {
   @override
   Widget build(final BuildContext context) => Container(
         margin: margin,
-        constraints: BoxConstraints.loose(const Size.fromHeight(3)),
+        constraints: BoxConstraints.tight(const Size.fromHeight(3)),
         child: visible
             ? LinearProgressIndicator(
                 color: color,


### PR DESCRIPTION
We always want to display it with the exact height to prevent items in a listview or column from jumping around because of the height difference.