### PR TITLE
refactor: Only make bloc factories internal

### DIFF
--- a/packages/neon/neon_dashboard/lib/src/blocs/dashboard.dart
+++ b/packages/neon/neon_dashboard/lib/src/blocs/dashboard.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:built_collection/built_collection.dart';
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:nextcloud/dashboard.dart' as dashboard;
@@ -11,6 +12,7 @@ import 'package:rxdart/rxdart.dart';
 /// Bloc for fetching dashboard widgets and their items.
 sealed class DashboardBloc implements InteractiveBloc {
   /// Creates a new Dashboard Bloc instance.
+  @internal
   factory DashboardBloc(final Account account) => _DashboardBloc(account);
 
   /// Dashboard widgets that are displayed.

--- a/packages/neon/neon_dashboard/pubspec.yaml
+++ b/packages/neon/neon_dashboard/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   go_router: ^13.0.0
+  meta: ^1.0.0
   neon_framework:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/neon/neon_files/lib/src/blocs/browser.dart
+++ b/packages/neon/neon_files/lib/src/blocs/browser.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:neon_files/src/options.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
@@ -8,6 +9,7 @@ import 'package:nextcloud/webdav.dart';
 import 'package:rxdart/rxdart.dart';
 
 sealed class FilesBrowserBloc implements InteractiveBloc {
+  @internal
   factory FilesBrowserBloc(
     final FilesOptions options,
     final Account account, {

--- a/packages/neon/neon_files/lib/src/blocs/files.dart
+++ b/packages/neon/neon_files/lib/src/blocs/files.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:neon_files/l10n/localizations.dart';
 import 'package:neon_files/src/blocs/browser.dart';
 import 'package:neon_files/src/options.dart';
@@ -19,6 +20,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:universal_io/io.dart';
 
 sealed class FilesBloc implements InteractiveBloc {
+  @internal
   factory FilesBloc(
     final FilesOptions options,
     final Account account,

--- a/packages/neon/neon_news/lib/src/blocs/article.dart
+++ b/packages/neon/neon_news/lib/src/blocs/article.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_news/src/blocs/articles.dart';
@@ -8,6 +9,7 @@ import 'package:nextcloud/news.dart' as news;
 import 'package:rxdart/rxdart.dart';
 
 sealed class NewsArticleBloc implements InteractiveBloc {
+  @internal
   factory NewsArticleBloc(
     final NewsArticlesBloc articlesBloc,
     final Account account,

--- a/packages/neon/neon_news/lib/src/blocs/articles.dart
+++ b/packages/neon/neon_news/lib/src/blocs/articles.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/utils.dart';
@@ -20,6 +21,7 @@ enum ListType {
 }
 
 sealed class NewsArticlesBloc implements InteractiveBloc {
+  @internal
   factory NewsArticlesBloc(
     final NewsBloc newsBloc,
     final NewsOptions options,

--- a/packages/neon/neon_news/lib/src/blocs/news.dart
+++ b/packages/neon/neon_news/lib/src/blocs/news.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/utils.dart';
@@ -9,6 +10,7 @@ import 'package:nextcloud/news.dart' as news;
 import 'package:rxdart/rxdart.dart';
 
 sealed class NewsBloc implements InteractiveBloc {
+  @internal
   factory NewsBloc(
     final NewsOptions options,
     final Account account,

--- a/packages/neon/neon_news/pubspec.yaml
+++ b/packages/neon/neon_news/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   go_router: ^13.0.0
   html: ^0.15.0
   intl: ^0.18.0
+  meta: ^1.0.0
   neon_framework:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/neon/neon_notes/lib/src/blocs/note.dart
+++ b/packages/neon/neon_notes/lib/src/blocs/note.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_notes/src/blocs/notes.dart';
@@ -11,6 +12,7 @@ import 'package:queue/queue.dart';
 import 'package:rxdart/rxdart.dart';
 
 sealed class NotesNoteBloc implements InteractiveBloc {
+  @internal
   factory NotesNoteBloc(
     final NotesBloc notesBloc,
     final Account account,

--- a/packages/neon/neon_notes/lib/src/blocs/notes.dart
+++ b/packages/neon/neon_notes/lib/src/blocs/notes.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:built_collection/built_collection.dart';
+import 'package:meta/meta.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/utils.dart';
@@ -9,6 +10,7 @@ import 'package:nextcloud/notes.dart' as notes;
 import 'package:rxdart/rxdart.dart';
 
 sealed class NotesBloc implements InteractiveBloc {
+  @internal
   factory NotesBloc(
     final NotesOptions options,
     final Account account,

--- a/packages/neon/neon_notes/pubspec.yaml
+++ b/packages/neon/neon_notes/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter_material_design_icons: ^1.0.0
   go_router: ^13.0.0
   intl: ^0.18.0
+  meta: ^1.0.0
   neon_framework:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/neon/neon_notifications/lib/src/blocs/notifications.dart
+++ b/packages/neon/neon_notifications/lib/src/blocs/notifications.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/utils.dart';
@@ -8,6 +9,7 @@ import 'package:nextcloud/notifications.dart' as notifications;
 import 'package:rxdart/rxdart.dart';
 
 sealed class NotificationsBloc implements NotificationsBlocInterface, InteractiveBloc {
+  @internal
   factory NotificationsBloc(
     final NotificationsOptions options,
     final Account account,

--- a/packages/neon/neon_notifications/pubspec.yaml
+++ b/packages/neon/neon_notifications/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_material_design_icons: ^1.0.0
   go_router: ^13.0.0
   intl: ^0.18.0
+  meta: ^1.0.0
   neon_framework:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/neon_framework/lib/src/blocs/accounts.dart
+++ b/packages/neon_framework/lib/src/blocs/accounts.dart
@@ -26,6 +26,7 @@ const _keyAccounts = 'accounts';
 /// The Bloc responsible for managing the [Account]s
 @sealed
 abstract interface class AccountsBloc implements Disposable {
+  @internal
   factory AccountsBloc(
     final GlobalOptions globalOptions,
     final Iterable<AppImplementation> allAppImplementations,

--- a/packages/neon_framework/lib/src/blocs/apps.dart
+++ b/packages/neon_framework/lib/src/blocs/apps.dart
@@ -18,8 +18,8 @@ import 'package:provider/provider.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// The Bloc responsible for managing the [AppImplementation]s.
-@internal
 sealed class AppsBloc implements InteractiveBloc {
+  @internal
   factory AppsBloc(
     final CapabilitiesBloc capabilitiesBloc,
     final AccountsBloc accountsBloc,

--- a/packages/neon_framework/lib/src/blocs/capabilities.dart
+++ b/packages/neon_framework/lib/src/blocs/capabilities.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:meta/meta.dart';
@@ -8,9 +10,9 @@ import 'package:neon_framework/src/utils/request_manager.dart';
 import 'package:nextcloud/core.dart' as core;
 import 'package:rxdart/rxdart.dart';
 
-@internal
 sealed class CapabilitiesBloc implements InteractiveBloc {
   /// Creates a new capabilities bloc.
+  @internal
   factory CapabilitiesBloc(final Account account) => _CapabilitiesBloc(account);
 
   BehaviorSubject<Result<core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data>> get capabilities;

--- a/packages/neon_framework/lib/src/blocs/first_launch.dart
+++ b/packages/neon_framework/lib/src/blocs/first_launch.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:meta/meta.dart';
@@ -6,8 +8,8 @@ import 'package:neon_framework/src/models/disposable.dart';
 import 'package:neon_framework/src/settings/models/storage.dart';
 import 'package:rxdart/rxdart.dart';
 
-@internal
 sealed class FirstLaunchBloc implements Disposable {
+  @internal
   factory FirstLaunchBloc({
     final bool disabled = false,
   }) =>

--- a/packages/neon_framework/lib/src/blocs/login_check_account.dart
+++ b/packages/neon_framework/lib/src/blocs/login_check_account.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -10,8 +12,8 @@ import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/provisioning_api.dart' as provisioning_api;
 import 'package:rxdart/rxdart.dart';
 
-@internal
 sealed class LoginCheckAccountBloc implements InteractiveBloc {
+  @internal
   factory LoginCheckAccountBloc(
     final Uri serverURL,
     final String loginName,

--- a/packages/neon_framework/lib/src/blocs/login_check_server_status.dart
+++ b/packages/neon_framework/lib/src/blocs/login_check_server_status.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -9,8 +11,8 @@ import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/nextcloud.dart';
 import 'package:rxdart/rxdart.dart';
 
-@internal
 sealed class LoginCheckServerStatusBloc implements InteractiveBloc {
+  @internal
   factory LoginCheckServerStatusBloc(final Uri serverURL) => _LoginCheckServerStatusBloc(serverURL);
 
   /// Contains the current server connection state

--- a/packages/neon_framework/lib/src/blocs/login_flow.dart
+++ b/packages/neon_framework/lib/src/blocs/login_flow.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -9,8 +11,8 @@ import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/nextcloud.dart';
 import 'package:rxdart/rxdart.dart';
 
-@internal
 sealed class LoginFlowBloc implements InteractiveBloc {
+  @internal
   factory LoginFlowBloc(final Uri serverURL) => _LoginFlowBloc(serverURL);
 
   BehaviorSubject<Result<core.LoginFlowV2>> get init;

--- a/packages/neon_framework/lib/src/blocs/next_push.dart
+++ b/packages/neon_framework/lib/src/blocs/next_push.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -10,8 +12,8 @@ import 'package:neon_framework/src/utils/global_options.dart';
 import 'package:nextcloud/uppush.dart' as uppush;
 import 'package:rxdart/rxdart.dart';
 
-@internal
 sealed class NextPushBloc implements Disposable {
+  @internal
   factory NextPushBloc(
     final AccountsBloc accountsBloc,
     final GlobalOptions globalOptions, {

--- a/packages/neon_framework/lib/src/blocs/push_notifications.dart
+++ b/packages/neon_framework/lib/src/blocs/push_notifications.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 import 'dart:convert';
 
@@ -14,8 +16,8 @@ import 'package:neon_framework/src/utils/push_utils.dart';
 import 'package:nextcloud/notifications.dart' as notifications;
 import 'package:unifiedpush/unifiedpush.dart';
 
-@internal
 sealed class PushNotificationsBloc {
+  @internal
   factory PushNotificationsBloc(
     final AccountsBloc accountsBloc,
     final GlobalOptions globalOptions,

--- a/packages/neon_framework/lib/src/blocs/unified_search.dart
+++ b/packages/neon_framework/lib/src/blocs/unified_search.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:collection/collection.dart';
@@ -10,8 +12,8 @@ import 'package:neon_framework/src/blocs/apps.dart';
 import 'package:nextcloud/core.dart' as core;
 import 'package:rxdart/rxdart.dart';
 
-@internal
 sealed class UnifiedSearchBloc implements InteractiveBloc {
+  @internal
   factory UnifiedSearchBloc(
     final AppsBloc appsBloc,
     final Account account,

--- a/packages/neon_framework/lib/src/blocs/user_details.dart
+++ b/packages/neon_framework/lib/src/blocs/user_details.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:meta/meta.dart';
@@ -8,8 +10,8 @@ import 'package:neon_framework/src/utils/request_manager.dart';
 import 'package:nextcloud/provisioning_api.dart' as provisioning_api;
 import 'package:rxdart/rxdart.dart';
 
-@internal
 sealed class UserDetailsBloc implements InteractiveBloc {
+  @internal
   factory UserDetailsBloc(final Account account) => _UserDetailsBloc(account);
 
   BehaviorSubject<Result<provisioning_api.UserDetails>> get userDetails;

--- a/packages/neon_framework/lib/src/blocs/user_statuses.dart
+++ b/packages/neon_framework/lib/src/blocs/user_statuses.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -13,8 +15,8 @@ import 'package:nextcloud/user_status.dart' as user_status;
 import 'package:rxdart/rxdart.dart';
 import 'package:window_manager/window_manager.dart';
 
-@internal
 sealed class UserStatusesBloc implements Disposable {
+  @internal
   factory UserStatusesBloc(final Account account) => _UserStatusesBloc(account);
 
   void load(final String username, {final bool force = false});


### PR DESCRIPTION
Closes https://github.com/nextcloud/neon/issues/1372

For the neon_* packages this has not effect since they still have the global ignore set (which we should change eventually).