### PR TITLE
fix(neon_files): Remove broken sync

### DIFF
--- a/packages/neon/neon_files/lib/l10n/en.arb
+++ b/packages/neon/neon_files/lib/l10n/en.arb
@@ -4,7 +4,6 @@
   "actionRename": "Rename",
   "actionMove": "Move",
   "actionCopy": "Copy",
-  "actionSync": "Sync",
   "actionShare": "Share",
   "errorUnableToOpenFile": "Unable to open the file",
   "general": "General",

--- a/packages/neon/neon_files/lib/l10n/localizations.dart
+++ b/packages/neon/neon_files/lib/l10n/localizations.dart
@@ -113,12 +113,6 @@ abstract class FilesLocalizations {
   /// **'Copy'**
   String get actionCopy;
 
-  /// No description provided for @actionSync.
-  ///
-  /// In en, this message translates to:
-  /// **'Sync'**
-  String get actionSync;
-
   /// No description provided for @actionShare.
   ///
   /// In en, this message translates to:

--- a/packages/neon/neon_files/lib/l10n/localizations_en.dart
+++ b/packages/neon/neon_files/lib/l10n/localizations_en.dart
@@ -17,9 +17,6 @@ class FilesLocalizationsEn extends FilesLocalizations {
   String get actionCopy => 'Copy';
 
   @override
-  String get actionSync => 'Sync';
-
-  @override
   String get actionShare => 'Share';
 
   @override

--- a/packages/neon/neon_files/lib/src/blocs/files.dart
+++ b/packages/neon/neon_files/lib/src/blocs/files.dart
@@ -8,7 +8,6 @@ import 'package:neon_files/src/options.dart';
 import 'package:neon_files/src/utils/task.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
-import 'package:neon_framework/platform.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:nextcloud/webdav.dart';
 import 'package:open_file/open_file.dart';
@@ -31,8 +30,6 @@ sealed class FilesBloc implements InteractiveBloc {
       );
 
   void uploadFile(final PathUri uri, final String localPath);
-
-  void syncFile(final PathUri uri);
 
   void openFile(final PathUri uri, final String etag, final String? mimeType);
 
@@ -166,27 +163,6 @@ class _FilesBloc extends InteractiveBloc implements FilesBloc {
         uri,
         uri.rename(name),
       ),
-    );
-  }
-
-  @override
-  void syncFile(final PathUri uri) {
-    wrapAction(
-      () async {
-        final file = File(
-          p.joinAll([
-            await NeonPlatform.instance.userAccessibleAppDataPath,
-            account.humanReadableID,
-            'files',
-            ...uri.pathSegments,
-          ]),
-        );
-        if (!file.parent.existsSync()) {
-          file.parent.createSync(recursive: true);
-        }
-        await downloadFile(uri, file);
-      },
-      disableTimeout: true,
     );
   }
 

--- a/packages/neon/neon_files/lib/src/widgets/actions.dart
+++ b/packages/neon/neon_files/lib/src/widgets/actions.dart
@@ -18,7 +18,6 @@ class FileActions extends StatelessWidget {
 
   Future<void> onSelected(final BuildContext context, final FilesFileAction action) async {
     final bloc = NeonProvider.of<FilesBloc>(context);
-    final browserBloc = bloc.browser;
     switch (action) {
       case FilesFileAction.share:
         bloc.shareFileNative(details.uri, details.etag!);
@@ -69,19 +68,6 @@ class FileActions extends StatelessWidget {
         if (result != null) {
           bloc.copy(details.uri, result.join(PathUri.parse(details.name)));
         }
-      case FilesFileAction.sync:
-        if (!context.mounted) {
-          return;
-        }
-        final sizeWarning = browserBloc.options.downloadSizeWarning.value;
-        if (sizeWarning != null && details.size != null && details.size! > sizeWarning) {
-          final decision = await showDownloadConfirmationDialog(context, sizeWarning, details.size!);
-
-          if (!decision) {
-            return;
-          }
-        }
-        bloc.syncFile(details.uri);
       case FilesFileAction.delete:
         if (!context.mounted) {
           return;
@@ -110,7 +96,6 @@ class FileActions extends StatelessWidget {
                     : FilesLocalizations.of(context).addToFavorites,
               ),
             ),
-
           PopupMenuItem(
             value: FilesFileAction.details,
             child: Text(FilesLocalizations.of(context).details),
@@ -127,13 +112,6 @@ class FileActions extends StatelessWidget {
             value: FilesFileAction.copy,
             child: Text(FilesLocalizations.of(context).actionCopy),
           ),
-          // TODO: https://github.com/provokateurin/nextcloud-neon/issues/4
-          if (!details.isDirectory)
-            PopupMenuItem(
-              value: FilesFileAction.sync,
-              child: Text(FilesLocalizations.of(context).actionSync),
-            ),
-
           PopupMenuItem(
             value: FilesFileAction.delete,
             child: Text(FilesLocalizations.of(context).actionDelete),
@@ -150,6 +128,5 @@ enum FilesFileAction {
   rename,
   move,
   copy,
-  sync,
   delete,
 }

--- a/packages/neon_framework/lib/src/platform/android.dart
+++ b/packages/neon_framework/lib/src/platform/android.dart
@@ -1,10 +1,6 @@
 import 'package:meta/meta.dart';
 import 'package:neon_framework/src/platform/linux.dart';
 import 'package:neon_framework/src/platform/platform.dart';
-import 'package:neon_framework/src/utils/exceptions.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
-import 'package:permission_handler/permission_handler.dart';
 
 /// Android specific platform information.
 ///
@@ -37,15 +33,6 @@ class AndroidNeonPlatform implements NeonPlatform {
 
   @override
   bool get shouldUseFileDialog => true;
-
-  @override
-  Future<String> get userAccessibleAppDataPath async {
-    if (!await Permission.storage.request().isGranted) {
-      throw const MissingPermissionException(Permission.storage);
-    }
-
-    return p.join((await getExternalStorageDirectory())!.path);
-  }
 
   @override
   void init() {}

--- a/packages/neon_framework/lib/src/platform/linux.dart
+++ b/packages/neon_framework/lib/src/platform/linux.dart
@@ -1,9 +1,7 @@
 import 'package:meta/meta.dart';
 import 'package:neon_framework/src/platform/android.dart';
 import 'package:neon_framework/src/platform/platform.dart';
-import 'package:path/path.dart' as p;
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
-import 'package:universal_io/io.dart';
 
 /// Linux specific platform information.
 ///
@@ -36,9 +34,6 @@ class LinuxNeonPlatform implements NeonPlatform {
 
   @override
   bool get shouldUseFileDialog => false;
-
-  @override
-  String get userAccessibleAppDataPath => p.join(Platform.environment['HOME']!, 'Neon');
 
   @override
   void init() {

--- a/packages/neon_framework/lib/src/platform/platform.dart
+++ b/packages/neon_framework/lib/src/platform/platform.dart
@@ -87,10 +87,6 @@ abstract interface class NeonPlatform {
   /// This is needed to compensate lacking support of `https://pub.dev/packages/file_picker`.
   abstract final bool shouldUseFileDialog;
 
-  /// Returns the path to a directory where the application may access top
-  /// level storage which can also be easily accessed by the user outside of the app.
-  FutureOr<String> get userAccessibleAppDataPath;
-
   /// Initializes this platform.
   FutureOr<void> init();
 }


### PR DESCRIPTION
Closes https://github.com/nextcloud/neon/issues/1251

The sync is not well implemented, a bit broken and incompatible with web. On top of that is it not very useful in the current state. https://github.com/nextcloud/neon/issues/21 will reintroduce syncing but in a better way.