### PR TITLE
chore: Add license to root directory

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+assets/AGPL-3.0.txt


### PR DESCRIPTION
Without it GH complains we have no license set. I set it to AGPL-3.0 because most of the code is licensed under that license with a few exceptions.