### PR TITLE
refactor(dynamite)!: remove unecessary allOf interfaces

### DIFF
--- a/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
+++ b/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
@@ -332,12 +332,9 @@ abstract class NewPet implements $NewPetInterface, Built<NewPet, NewPetBuilder> 
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $Pet_1Interface {
+abstract interface class $PetInterface implements $NewPetInterface {
   int get id;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $PetInterface implements $NewPetInterface, $Pet_1Interface {}
 
 abstract class Pet implements $PetInterface, Built<Pet, PetBuilder> {
   /// Creates a new Pet object using the builder pattern.

--- a/packages/dynamite/dynamite/example/lib/petstore.openapi.g.dart
+++ b/packages/dynamite/dynamite/example/lib/petstore.openapi.g.dart
@@ -65,10 +65,10 @@ class _$PetSerializer implements StructuredSerializer<Pet> {
   @override
   Iterable<Object?> serialize(Serializers serializers, Pet object, {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'name',
-      serializers.serialize(object.name, specifiedType: const FullType(String)),
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(int)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
     ];
     Object? value;
     value = object.tag;
@@ -91,14 +91,14 @@ class _$PetSerializer implements StructuredSerializer<Pet> {
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
         case 'name':
           result.name = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'tag':
           result.tag = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-        case 'id':
-          result.id = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -245,39 +245,32 @@ class NewPetBuilder implements Builder<NewPet, NewPetBuilder>, $NewPetInterfaceB
   }
 }
 
-abstract mixin class $Pet_1InterfaceBuilder {
-  void replace($Pet_1Interface other);
-  void update(void Function($Pet_1InterfaceBuilder) updates);
-  int? get id;
-  set id(int? id);
-}
-
-abstract mixin class $PetInterfaceBuilder implements $NewPetInterfaceBuilder, $Pet_1InterfaceBuilder {
+abstract mixin class $PetInterfaceBuilder implements $NewPetInterfaceBuilder {
   void replace(covariant $PetInterface other);
   void update(void Function($PetInterfaceBuilder) updates);
+  int? get id;
+  set id(covariant int? id);
+
   String? get name;
   set name(covariant String? name);
 
   String? get tag;
   set tag(covariant String? tag);
-
-  int? get id;
-  set id(covariant int? id);
 }
 
 class _$Pet extends Pet {
   @override
+  final int id;
+  @override
   final String name;
   @override
   final String? tag;
-  @override
-  final int id;
 
   factory _$Pet([void Function(PetBuilder)? updates]) => (PetBuilder()..update(updates))._build();
 
-  _$Pet._({required this.name, this.tag, required this.id}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(name, r'Pet', 'name');
+  _$Pet._({required this.id, required this.name, this.tag}) : super._() {
     BuiltValueNullFieldError.checkNotNull(id, r'Pet', 'id');
+    BuiltValueNullFieldError.checkNotNull(name, r'Pet', 'name');
   }
 
   @override
@@ -289,15 +282,15 @@ class _$Pet extends Pet {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is Pet && name == other.name && tag == other.tag && id == other.id;
+    return other is Pet && id == other.id && name == other.name && tag == other.tag;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, tag.hashCode);
-    _$hash = $jc(_$hash, id.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -305,15 +298,19 @@ class _$Pet extends Pet {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'Pet')
+          ..add('id', id)
           ..add('name', name)
-          ..add('tag', tag)
-          ..add('id', id))
+          ..add('tag', tag))
         .toString();
   }
 }
 
 class PetBuilder implements Builder<Pet, PetBuilder>, $PetInterfaceBuilder {
   _$Pet? _$v;
+
+  int? _id;
+  int? get id => _$this._id;
+  set id(covariant int? id) => _$this._id = id;
 
   String? _name;
   String? get name => _$this._name;
@@ -323,18 +320,14 @@ class PetBuilder implements Builder<Pet, PetBuilder>, $PetInterfaceBuilder {
   String? get tag => _$this._tag;
   set tag(covariant String? tag) => _$this._tag = tag;
 
-  int? _id;
-  int? get id => _$this._id;
-  set id(covariant int? id) => _$this._id = id;
-
   PetBuilder();
 
   PetBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _id = $v.id;
       _name = $v.name;
       _tag = $v.tag;
-      _id = $v.id;
       _$v = null;
     }
     return this;
@@ -357,9 +350,9 @@ class PetBuilder implements Builder<Pet, PetBuilder>, $PetInterfaceBuilder {
   _$Pet _build() {
     final _$result = _$v ??
         _$Pet._(
+            id: BuiltValueNullFieldError.checkNotNull(id, r'Pet', 'id'),
             name: BuiltValueNullFieldError.checkNotNull(name, r'Pet', 'name'),
-            tag: tag,
-            id: BuiltValueNullFieldError.checkNotNull(id, r'Pet', 'id'));
+            tag: tag);
     replace(_$result);
     return _$result;
   }

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_interface.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_interface.dart
@@ -1,64 +1,8 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:code_builder/code_builder.dart';
-import 'package:dynamite/src/builder/resolve_type.dart';
-import 'package:dynamite/src/builder/state.dart';
 import 'package:dynamite/src/helpers/built_value.dart';
 import 'package:dynamite/src/helpers/dart_helpers.dart';
-import 'package:dynamite/src/helpers/dynamite.dart';
-import 'package:dynamite/src/models/openapi.dart' as openapi;
 import 'package:dynamite/src/models/type_result.dart';
-
-TypeResultObject resolveInterface(
-  openapi.OpenAPI spec,
-  State state,
-  String identifier,
-  openapi.Schema schema,
-) {
-  final properties = schema.properties?.entries;
-
-  if (properties == null || properties.isEmpty) {
-    throw StateError('The schema must have a non empty properties field.');
-  }
-
-  final result = TypeResultObject(
-    identifier,
-  );
-
-  if (state.resolvedInterfaces.add(result)) {
-    final $interface = buildInterface(
-      identifier,
-      methods: BuiltList.build((b) {
-        b.addAll(
-          properties.map((property) {
-            final propertyName = property.key;
-            final propertySchema = property.value;
-
-            final result = resolveType(
-              spec,
-              state,
-              '${identifier}_${toDartName(propertyName, uppercaseFirstCharacter: true)}',
-              propertySchema,
-              nullable: isDartParameterNullable(
-                schema.required.contains(propertyName),
-                propertySchema,
-              ),
-            );
-
-            return generateProperty(
-              result,
-              propertyName,
-              propertySchema.formattedDescription,
-            );
-          }),
-        );
-      }),
-    );
-
-    state.output.add($interface);
-  }
-
-  return result;
-}
 
 Method generateProperty(
   TypeResult type,

--- a/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.dart
@@ -16,19 +16,12 @@ import 'package:meta/meta.dart' as _i1;
 part 'all_of.openapi.g.dart';
 
 @BuiltValue(instantiable: false)
-abstract interface class $ObjectAllOf_0Interface {
+abstract interface class $ObjectAllOfInterface {
   @BuiltValueField(wireName: 'attribute1-allOf')
   String get attribute1AllOf;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $ObjectAllOf_1Interface {
   @BuiltValueField(wireName: 'attribute2-allOf')
   String get attribute2AllOf;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $ObjectAllOfInterface implements $ObjectAllOf_0Interface, $ObjectAllOf_1Interface {}
 
 /// All of with objects only.
 abstract class ObjectAllOf implements $ObjectAllOfInterface, Built<ObjectAllOf, ObjectAllOfBuilder> {
@@ -52,13 +45,10 @@ abstract class ObjectAllOf implements $ObjectAllOfInterface, Built<ObjectAllOf, 
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $OneObjectAllOf_0Interface {
+abstract interface class $OneObjectAllOfInterface {
   @BuiltValueField(wireName: 'attribute-allOf')
   String get attributeAllOf;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $OneObjectAllOfInterface implements $OneObjectAllOf_0Interface {}
 
 /// All of with one object value.
 abstract class OneObjectAllOf implements $OneObjectAllOfInterface, Built<OneObjectAllOf, OneObjectAllOfBuilder> {
@@ -111,15 +101,11 @@ abstract class PrimitiveAllOf implements $PrimitiveAllOfInterface, Built<Primiti
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $MixedAllOf_1Interface {
-  @BuiltValueField(wireName: 'attribute-allOf')
-  String get attributeAllOf;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $MixedAllOfInterface implements $MixedAllOf_1Interface {
+abstract interface class $MixedAllOfInterface {
   @BuiltValueField(wireName: 'String')
   String get string;
+  @BuiltValueField(wireName: 'attribute-allOf')
+  String get attributeAllOf;
 }
 
 /// All of with object and primitive value.

--- a/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.g.dart
@@ -217,29 +217,14 @@ class _$OneValueAllOfSerializer implements StructuredSerializer<OneValueAllOf> {
   }
 }
 
-abstract mixin class $ObjectAllOf_0InterfaceBuilder {
-  void replace($ObjectAllOf_0Interface other);
-  void update(void Function($ObjectAllOf_0InterfaceBuilder) updates);
-  String? get attribute1AllOf;
-  set attribute1AllOf(String? attribute1AllOf);
-}
-
-abstract mixin class $ObjectAllOf_1InterfaceBuilder {
-  void replace($ObjectAllOf_1Interface other);
-  void update(void Function($ObjectAllOf_1InterfaceBuilder) updates);
-  String? get attribute2AllOf;
-  set attribute2AllOf(String? attribute2AllOf);
-}
-
-abstract mixin class $ObjectAllOfInterfaceBuilder
-    implements $ObjectAllOf_0InterfaceBuilder, $ObjectAllOf_1InterfaceBuilder {
-  void replace(covariant $ObjectAllOfInterface other);
+abstract mixin class $ObjectAllOfInterfaceBuilder {
+  void replace($ObjectAllOfInterface other);
   void update(void Function($ObjectAllOfInterfaceBuilder) updates);
   String? get attribute1AllOf;
-  set attribute1AllOf(covariant String? attribute1AllOf);
+  set attribute1AllOf(String? attribute1AllOf);
 
   String? get attribute2AllOf;
-  set attribute2AllOf(covariant String? attribute2AllOf);
+  set attribute2AllOf(String? attribute2AllOf);
 }
 
 class _$ObjectAllOf extends ObjectAllOf {
@@ -333,18 +318,11 @@ class ObjectAllOfBuilder implements Builder<ObjectAllOf, ObjectAllOfBuilder>, $O
   }
 }
 
-abstract mixin class $OneObjectAllOf_0InterfaceBuilder {
-  void replace($OneObjectAllOf_0Interface other);
-  void update(void Function($OneObjectAllOf_0InterfaceBuilder) updates);
-  String? get attributeAllOf;
-  set attributeAllOf(String? attributeAllOf);
-}
-
-abstract mixin class $OneObjectAllOfInterfaceBuilder implements $OneObjectAllOf_0InterfaceBuilder {
-  void replace(covariant $OneObjectAllOfInterface other);
+abstract mixin class $OneObjectAllOfInterfaceBuilder {
+  void replace($OneObjectAllOfInterface other);
   void update(void Function($OneObjectAllOfInterfaceBuilder) updates);
   String? get attributeAllOf;
-  set attributeAllOf(covariant String? attributeAllOf);
+  set attributeAllOf(String? attributeAllOf);
 }
 
 class _$OneObjectAllOf extends OneObjectAllOf {
@@ -526,21 +504,14 @@ class PrimitiveAllOfBuilder implements Builder<PrimitiveAllOf, PrimitiveAllOfBui
   }
 }
 
-abstract mixin class $MixedAllOf_1InterfaceBuilder {
-  void replace($MixedAllOf_1Interface other);
-  void update(void Function($MixedAllOf_1InterfaceBuilder) updates);
-  String? get attributeAllOf;
-  set attributeAllOf(String? attributeAllOf);
-}
-
-abstract mixin class $MixedAllOfInterfaceBuilder implements $MixedAllOf_1InterfaceBuilder {
-  void replace(covariant $MixedAllOfInterface other);
+abstract mixin class $MixedAllOfInterfaceBuilder {
+  void replace($MixedAllOfInterface other);
   void update(void Function($MixedAllOfInterfaceBuilder) updates);
   String? get string;
-  set string(covariant String? string);
+  set string(String? string);
 
   String? get attributeAllOf;
-  set attributeAllOf(covariant String? attributeAllOf);
+  set attributeAllOf(String? attributeAllOf);
 }
 
 class _$MixedAllOf extends MixedAllOf {

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
@@ -17,15 +17,11 @@ import 'package:meta/meta.dart' as _i2;
 part 'nested_ofs.openapi.g.dart';
 
 @BuiltValue(instantiable: false)
-abstract interface class $BaseAllOf_1Interface {
-  @BuiltValueField(wireName: 'attribute-allOf')
-  String get attributeAllOf;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $BaseAllOfInterface implements $BaseAllOf_1Interface {
+abstract interface class $BaseAllOfInterface {
   @BuiltValueField(wireName: 'String')
   String get string;
+  @BuiltValueField(wireName: 'attribute-allOf')
+  String get attributeAllOf;
 }
 
 abstract class BaseAllOf implements $BaseAllOfInterface, Built<BaseAllOf, BaseAllOfBuilder> {
@@ -105,17 +101,13 @@ abstract class BaseAnyOf1 implements $BaseAnyOf1Interface, Built<BaseAnyOf1, Bas
 typedef BaseAnyOf = ({BaseAnyOf1? baseAnyOf1, int? $int});
 
 @BuiltValue(instantiable: false)
-abstract interface class $BaseNestedAllOf_3Interface {
-  @BuiltValueField(wireName: 'attribute-nested-allOf')
-  String get attributeNestedAllOf;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $BaseNestedAllOfInterface implements $BaseAllOfInterface, $BaseNestedAllOf_3Interface {
+abstract interface class $BaseNestedAllOfInterface implements $BaseAllOfInterface {
   @BuiltValueField(wireName: 'BaseOneOf')
   BaseOneOf get baseOneOf;
   @BuiltValueField(wireName: 'BaseAnyOf')
   BaseAnyOf get baseAnyOf;
+  @BuiltValueField(wireName: 'attribute-nested-allOf')
+  String get attributeNestedAllOf;
 }
 
 abstract class BaseNestedAllOf implements $BaseNestedAllOfInterface, Built<BaseNestedAllOf, BaseNestedAllOfBuilder> {

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.g.dart
@@ -146,12 +146,12 @@ class _$BaseNestedAllOfSerializer implements StructuredSerializer<BaseNestedAllO
       serializers.serialize(object.baseOneOf, specifiedType: const FullType(BaseOneOf)),
       'BaseAnyOf',
       serializers.serialize(object.baseAnyOf, specifiedType: const FullType(BaseAnyOf)),
+      'attribute-nested-allOf',
+      serializers.serialize(object.attributeNestedAllOf, specifiedType: const FullType(String)),
       'String',
       serializers.serialize(object.string, specifiedType: const FullType(String)),
       'attribute-allOf',
       serializers.serialize(object.attributeAllOf, specifiedType: const FullType(String)),
-      'attribute-nested-allOf',
-      serializers.serialize(object.attributeNestedAllOf, specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -174,15 +174,15 @@ class _$BaseNestedAllOfSerializer implements StructuredSerializer<BaseNestedAllO
         case 'BaseAnyOf':
           result.baseAnyOf = serializers.deserialize(value, specifiedType: const FullType(BaseAnyOf))! as BaseAnyOf;
           break;
+        case 'attribute-nested-allOf':
+          result.attributeNestedAllOf =
+              serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'String':
           result.string = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'attribute-allOf':
           result.attributeAllOf = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'attribute-nested-allOf':
-          result.attributeNestedAllOf =
-              serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -269,21 +269,14 @@ class _$BaseNestedAnyOf3Serializer implements StructuredSerializer<BaseNestedAny
   }
 }
 
-abstract mixin class $BaseAllOf_1InterfaceBuilder {
-  void replace($BaseAllOf_1Interface other);
-  void update(void Function($BaseAllOf_1InterfaceBuilder) updates);
-  String? get attributeAllOf;
-  set attributeAllOf(String? attributeAllOf);
-}
-
-abstract mixin class $BaseAllOfInterfaceBuilder implements $BaseAllOf_1InterfaceBuilder {
-  void replace(covariant $BaseAllOfInterface other);
+abstract mixin class $BaseAllOfInterfaceBuilder {
+  void replace($BaseAllOfInterface other);
   void update(void Function($BaseAllOfInterfaceBuilder) updates);
   String? get string;
-  set string(covariant String? string);
+  set string(String? string);
 
   String? get attributeAllOf;
-  set attributeAllOf(covariant String? attributeAllOf);
+  set attributeAllOf(String? attributeAllOf);
 }
 
 class _$BaseAllOf extends BaseAllOf {
@@ -544,15 +537,7 @@ class BaseAnyOf1Builder implements Builder<BaseAnyOf1, BaseAnyOf1Builder>, $Base
   }
 }
 
-abstract mixin class $BaseNestedAllOf_3InterfaceBuilder {
-  void replace($BaseNestedAllOf_3Interface other);
-  void update(void Function($BaseNestedAllOf_3InterfaceBuilder) updates);
-  String? get attributeNestedAllOf;
-  set attributeNestedAllOf(String? attributeNestedAllOf);
-}
-
-abstract mixin class $BaseNestedAllOfInterfaceBuilder
-    implements $BaseAllOfInterfaceBuilder, $BaseNestedAllOf_3InterfaceBuilder {
+abstract mixin class $BaseNestedAllOfInterfaceBuilder implements $BaseAllOfInterfaceBuilder {
   void replace(covariant $BaseNestedAllOfInterface other);
   void update(void Function($BaseNestedAllOfInterfaceBuilder) updates);
   BaseOneOf? get baseOneOf;
@@ -561,14 +546,14 @@ abstract mixin class $BaseNestedAllOfInterfaceBuilder
   BaseAnyOf? get baseAnyOf;
   set baseAnyOf(covariant BaseAnyOf? baseAnyOf);
 
+  String? get attributeNestedAllOf;
+  set attributeNestedAllOf(covariant String? attributeNestedAllOf);
+
   String? get string;
   set string(covariant String? string);
 
   String? get attributeAllOf;
   set attributeAllOf(covariant String? attributeAllOf);
-
-  String? get attributeNestedAllOf;
-  set attributeNestedAllOf(covariant String? attributeNestedAllOf);
 }
 
 class _$BaseNestedAllOf extends BaseNestedAllOf {
@@ -577,11 +562,11 @@ class _$BaseNestedAllOf extends BaseNestedAllOf {
   @override
   final BaseAnyOf baseAnyOf;
   @override
+  final String attributeNestedAllOf;
+  @override
   final String string;
   @override
   final String attributeAllOf;
-  @override
-  final String attributeNestedAllOf;
 
   factory _$BaseNestedAllOf([void Function(BaseNestedAllOfBuilder)? updates]) =>
       (BaseNestedAllOfBuilder()..update(updates))._build();
@@ -589,15 +574,15 @@ class _$BaseNestedAllOf extends BaseNestedAllOf {
   _$BaseNestedAllOf._(
       {required this.baseOneOf,
       required this.baseAnyOf,
+      required this.attributeNestedAllOf,
       required this.string,
-      required this.attributeAllOf,
-      required this.attributeNestedAllOf})
+      required this.attributeAllOf})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(baseOneOf, r'BaseNestedAllOf', 'baseOneOf');
     BuiltValueNullFieldError.checkNotNull(baseAnyOf, r'BaseNestedAllOf', 'baseAnyOf');
+    BuiltValueNullFieldError.checkNotNull(attributeNestedAllOf, r'BaseNestedAllOf', 'attributeNestedAllOf');
     BuiltValueNullFieldError.checkNotNull(string, r'BaseNestedAllOf', 'string');
     BuiltValueNullFieldError.checkNotNull(attributeAllOf, r'BaseNestedAllOf', 'attributeAllOf');
-    BuiltValueNullFieldError.checkNotNull(attributeNestedAllOf, r'BaseNestedAllOf', 'attributeNestedAllOf');
   }
 
   @override
@@ -613,9 +598,9 @@ class _$BaseNestedAllOf extends BaseNestedAllOf {
     return other is BaseNestedAllOf &&
         baseOneOf == _$dynamicOther.baseOneOf &&
         baseAnyOf == _$dynamicOther.baseAnyOf &&
+        attributeNestedAllOf == other.attributeNestedAllOf &&
         string == other.string &&
-        attributeAllOf == other.attributeAllOf &&
-        attributeNestedAllOf == other.attributeNestedAllOf;
+        attributeAllOf == other.attributeAllOf;
   }
 
   @override
@@ -623,9 +608,9 @@ class _$BaseNestedAllOf extends BaseNestedAllOf {
     var _$hash = 0;
     _$hash = $jc(_$hash, baseOneOf.hashCode);
     _$hash = $jc(_$hash, baseAnyOf.hashCode);
+    _$hash = $jc(_$hash, attributeNestedAllOf.hashCode);
     _$hash = $jc(_$hash, string.hashCode);
     _$hash = $jc(_$hash, attributeAllOf.hashCode);
-    _$hash = $jc(_$hash, attributeNestedAllOf.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -635,9 +620,9 @@ class _$BaseNestedAllOf extends BaseNestedAllOf {
     return (newBuiltValueToStringHelper(r'BaseNestedAllOf')
           ..add('baseOneOf', baseOneOf)
           ..add('baseAnyOf', baseAnyOf)
+          ..add('attributeNestedAllOf', attributeNestedAllOf)
           ..add('string', string)
-          ..add('attributeAllOf', attributeAllOf)
-          ..add('attributeNestedAllOf', attributeNestedAllOf))
+          ..add('attributeAllOf', attributeAllOf))
         .toString();
   }
 }
@@ -654,6 +639,11 @@ class BaseNestedAllOfBuilder
   BaseAnyOf? get baseAnyOf => _$this._baseAnyOf;
   set baseAnyOf(covariant BaseAnyOf? baseAnyOf) => _$this._baseAnyOf = baseAnyOf;
 
+  String? _attributeNestedAllOf;
+  String? get attributeNestedAllOf => _$this._attributeNestedAllOf;
+  set attributeNestedAllOf(covariant String? attributeNestedAllOf) =>
+      _$this._attributeNestedAllOf = attributeNestedAllOf;
+
   String? _string;
   String? get string => _$this._string;
   set string(covariant String? string) => _$this._string = string;
@@ -662,11 +652,6 @@ class BaseNestedAllOfBuilder
   String? get attributeAllOf => _$this._attributeAllOf;
   set attributeAllOf(covariant String? attributeAllOf) => _$this._attributeAllOf = attributeAllOf;
 
-  String? _attributeNestedAllOf;
-  String? get attributeNestedAllOf => _$this._attributeNestedAllOf;
-  set attributeNestedAllOf(covariant String? attributeNestedAllOf) =>
-      _$this._attributeNestedAllOf = attributeNestedAllOf;
-
   BaseNestedAllOfBuilder();
 
   BaseNestedAllOfBuilder get _$this {
@@ -674,9 +659,9 @@ class BaseNestedAllOfBuilder
     if ($v != null) {
       _baseOneOf = $v.baseOneOf;
       _baseAnyOf = $v.baseAnyOf;
+      _attributeNestedAllOf = $v.attributeNestedAllOf;
       _string = $v.string;
       _attributeAllOf = $v.attributeAllOf;
-      _attributeNestedAllOf = $v.attributeNestedAllOf;
       _$v = null;
     }
     return this;
@@ -701,10 +686,11 @@ class BaseNestedAllOfBuilder
         _$BaseNestedAllOf._(
             baseOneOf: BuiltValueNullFieldError.checkNotNull(baseOneOf, r'BaseNestedAllOf', 'baseOneOf'),
             baseAnyOf: BuiltValueNullFieldError.checkNotNull(baseAnyOf, r'BaseNestedAllOf', 'baseAnyOf'),
+            attributeNestedAllOf:
+                BuiltValueNullFieldError.checkNotNull(attributeNestedAllOf, r'BaseNestedAllOf', 'attributeNestedAllOf'),
             string: BuiltValueNullFieldError.checkNotNull(string, r'BaseNestedAllOf', 'string'),
-            attributeAllOf: BuiltValueNullFieldError.checkNotNull(attributeAllOf, r'BaseNestedAllOf', 'attributeAllOf'),
-            attributeNestedAllOf: BuiltValueNullFieldError.checkNotNull(
-                attributeNestedAllOf, r'BaseNestedAllOf', 'attributeNestedAllOf'));
+            attributeAllOf:
+                BuiltValueNullFieldError.checkNotNull(attributeAllOf, r'BaseNestedAllOf', 'attributeAllOf'));
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -760,16 +760,12 @@ abstract class OutOfOfficeDataCommon
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $CurrentOutOfOfficeData_1Interface {
+abstract interface class $CurrentOutOfOfficeDataInterface implements $OutOfOfficeDataCommonInterface {
   String get id;
   int get startDate;
   int get endDate;
   String get shortMessage;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $CurrentOutOfOfficeDataInterface
-    implements $OutOfOfficeDataCommonInterface, $CurrentOutOfOfficeData_1Interface {}
 
 abstract class CurrentOutOfOfficeData
     implements $CurrentOutOfOfficeDataInterface, Built<CurrentOutOfOfficeData, CurrentOutOfOfficeDataBuilder> {
@@ -879,16 +875,12 @@ abstract class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $OutOfOfficeData_1Interface {
+abstract interface class $OutOfOfficeDataInterface implements $OutOfOfficeDataCommonInterface {
   int get id;
   String get firstDay;
   String get lastDay;
   String get status;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $OutOfOfficeDataInterface
-    implements $OutOfOfficeDataCommonInterface, $OutOfOfficeData_1Interface {}
 
 abstract class OutOfOfficeData implements $OutOfOfficeDataInterface, Built<OutOfOfficeData, OutOfOfficeDataBuilder> {
   /// Creates a new OutOfOfficeData object using the builder pattern.

--- a/packages/nextcloud/lib/src/api/dav.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.g.dart
@@ -298,10 +298,6 @@ class _$CurrentOutOfOfficeDataSerializer implements StructuredSerializer<Current
   Iterable<Object?> serialize(Serializers serializers, CurrentOutOfOfficeData object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'userId',
-      serializers.serialize(object.userId, specifiedType: const FullType(String)),
-      'message',
-      serializers.serialize(object.message, specifiedType: const FullType(String)),
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(String)),
       'startDate',
@@ -310,6 +306,10 @@ class _$CurrentOutOfOfficeDataSerializer implements StructuredSerializer<Current
       serializers.serialize(object.endDate, specifiedType: const FullType(int)),
       'shortMessage',
       serializers.serialize(object.shortMessage, specifiedType: const FullType(String)),
+      'userId',
+      serializers.serialize(object.userId, specifiedType: const FullType(String)),
+      'message',
+      serializers.serialize(object.message, specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -326,12 +326,6 @@ class _$CurrentOutOfOfficeDataSerializer implements StructuredSerializer<Current
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'userId':
-          result.userId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'message':
-          result.message = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
         case 'id':
           result.id = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -343,6 +337,12 @@ class _$CurrentOutOfOfficeDataSerializer implements StructuredSerializer<Current
           break;
         case 'shortMessage':
           result.shortMessage = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'userId':
+          result.userId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'message':
+          result.message = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -458,10 +458,6 @@ class _$OutOfOfficeDataSerializer implements StructuredSerializer<OutOfOfficeDat
   Iterable<Object?> serialize(Serializers serializers, OutOfOfficeData object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'userId',
-      serializers.serialize(object.userId, specifiedType: const FullType(String)),
-      'message',
-      serializers.serialize(object.message, specifiedType: const FullType(String)),
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(int)),
       'firstDay',
@@ -470,6 +466,10 @@ class _$OutOfOfficeDataSerializer implements StructuredSerializer<OutOfOfficeDat
       serializers.serialize(object.lastDay, specifiedType: const FullType(String)),
       'status',
       serializers.serialize(object.status, specifiedType: const FullType(String)),
+      'userId',
+      serializers.serialize(object.userId, specifiedType: const FullType(String)),
+      'message',
+      serializers.serialize(object.message, specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -486,12 +486,6 @@ class _$OutOfOfficeDataSerializer implements StructuredSerializer<OutOfOfficeDat
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'userId':
-          result.userId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'message':
-          result.message = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
         case 'id':
           result.id = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
@@ -503,6 +497,12 @@ class _$OutOfOfficeDataSerializer implements StructuredSerializer<OutOfOfficeDat
           break;
         case 'status':
           result.status = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'userId':
+          result.userId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'message':
+          result.message = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -1442,32 +1442,9 @@ class OutOfOfficeDataCommonBuilder
   }
 }
 
-abstract mixin class $CurrentOutOfOfficeData_1InterfaceBuilder {
-  void replace($CurrentOutOfOfficeData_1Interface other);
-  void update(void Function($CurrentOutOfOfficeData_1InterfaceBuilder) updates);
-  String? get id;
-  set id(String? id);
-
-  int? get startDate;
-  set startDate(int? startDate);
-
-  int? get endDate;
-  set endDate(int? endDate);
-
-  String? get shortMessage;
-  set shortMessage(String? shortMessage);
-}
-
-abstract mixin class $CurrentOutOfOfficeDataInterfaceBuilder
-    implements $OutOfOfficeDataCommonInterfaceBuilder, $CurrentOutOfOfficeData_1InterfaceBuilder {
+abstract mixin class $CurrentOutOfOfficeDataInterfaceBuilder implements $OutOfOfficeDataCommonInterfaceBuilder {
   void replace(covariant $CurrentOutOfOfficeDataInterface other);
   void update(void Function($CurrentOutOfOfficeDataInterfaceBuilder) updates);
-  String? get userId;
-  set userId(covariant String? userId);
-
-  String? get message;
-  set message(covariant String? message);
-
   String? get id;
   set id(covariant String? id);
 
@@ -1479,13 +1456,15 @@ abstract mixin class $CurrentOutOfOfficeDataInterfaceBuilder
 
   String? get shortMessage;
   set shortMessage(covariant String? shortMessage);
+
+  String? get userId;
+  set userId(covariant String? userId);
+
+  String? get message;
+  set message(covariant String? message);
 }
 
 class _$CurrentOutOfOfficeData extends CurrentOutOfOfficeData {
-  @override
-  final String userId;
-  @override
-  final String message;
   @override
   final String id;
   @override
@@ -1494,24 +1473,28 @@ class _$CurrentOutOfOfficeData extends CurrentOutOfOfficeData {
   final int endDate;
   @override
   final String shortMessage;
+  @override
+  final String userId;
+  @override
+  final String message;
 
   factory _$CurrentOutOfOfficeData([void Function(CurrentOutOfOfficeDataBuilder)? updates]) =>
       (CurrentOutOfOfficeDataBuilder()..update(updates))._build();
 
   _$CurrentOutOfOfficeData._(
-      {required this.userId,
-      required this.message,
-      required this.id,
+      {required this.id,
       required this.startDate,
       required this.endDate,
-      required this.shortMessage})
+      required this.shortMessage,
+      required this.userId,
+      required this.message})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(userId, r'CurrentOutOfOfficeData', 'userId');
-    BuiltValueNullFieldError.checkNotNull(message, r'CurrentOutOfOfficeData', 'message');
     BuiltValueNullFieldError.checkNotNull(id, r'CurrentOutOfOfficeData', 'id');
     BuiltValueNullFieldError.checkNotNull(startDate, r'CurrentOutOfOfficeData', 'startDate');
     BuiltValueNullFieldError.checkNotNull(endDate, r'CurrentOutOfOfficeData', 'endDate');
     BuiltValueNullFieldError.checkNotNull(shortMessage, r'CurrentOutOfOfficeData', 'shortMessage');
+    BuiltValueNullFieldError.checkNotNull(userId, r'CurrentOutOfOfficeData', 'userId');
+    BuiltValueNullFieldError.checkNotNull(message, r'CurrentOutOfOfficeData', 'message');
   }
 
   @override
@@ -1525,23 +1508,23 @@ class _$CurrentOutOfOfficeData extends CurrentOutOfOfficeData {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is CurrentOutOfOfficeData &&
-        userId == other.userId &&
-        message == other.message &&
         id == other.id &&
         startDate == other.startDate &&
         endDate == other.endDate &&
-        shortMessage == other.shortMessage;
+        shortMessage == other.shortMessage &&
+        userId == other.userId &&
+        message == other.message;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, userId.hashCode);
-    _$hash = $jc(_$hash, message.hashCode);
     _$hash = $jc(_$hash, id.hashCode);
     _$hash = $jc(_$hash, startDate.hashCode);
     _$hash = $jc(_$hash, endDate.hashCode);
     _$hash = $jc(_$hash, shortMessage.hashCode);
+    _$hash = $jc(_$hash, userId.hashCode);
+    _$hash = $jc(_$hash, message.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -1549,12 +1532,12 @@ class _$CurrentOutOfOfficeData extends CurrentOutOfOfficeData {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'CurrentOutOfOfficeData')
-          ..add('userId', userId)
-          ..add('message', message)
           ..add('id', id)
           ..add('startDate', startDate)
           ..add('endDate', endDate)
-          ..add('shortMessage', shortMessage))
+          ..add('shortMessage', shortMessage)
+          ..add('userId', userId)
+          ..add('message', message))
         .toString();
   }
 }
@@ -1562,14 +1545,6 @@ class _$CurrentOutOfOfficeData extends CurrentOutOfOfficeData {
 class CurrentOutOfOfficeDataBuilder
     implements Builder<CurrentOutOfOfficeData, CurrentOutOfOfficeDataBuilder>, $CurrentOutOfOfficeDataInterfaceBuilder {
   _$CurrentOutOfOfficeData? _$v;
-
-  String? _userId;
-  String? get userId => _$this._userId;
-  set userId(covariant String? userId) => _$this._userId = userId;
-
-  String? _message;
-  String? get message => _$this._message;
-  set message(covariant String? message) => _$this._message = message;
 
   String? _id;
   String? get id => _$this._id;
@@ -1587,17 +1562,25 @@ class CurrentOutOfOfficeDataBuilder
   String? get shortMessage => _$this._shortMessage;
   set shortMessage(covariant String? shortMessage) => _$this._shortMessage = shortMessage;
 
+  String? _userId;
+  String? get userId => _$this._userId;
+  set userId(covariant String? userId) => _$this._userId = userId;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(covariant String? message) => _$this._message = message;
+
   CurrentOutOfOfficeDataBuilder();
 
   CurrentOutOfOfficeDataBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _userId = $v.userId;
-      _message = $v.message;
       _id = $v.id;
       _startDate = $v.startDate;
       _endDate = $v.endDate;
       _shortMessage = $v.shortMessage;
+      _userId = $v.userId;
+      _message = $v.message;
       _$v = null;
     }
     return this;
@@ -1620,13 +1603,13 @@ class CurrentOutOfOfficeDataBuilder
   _$CurrentOutOfOfficeData _build() {
     final _$result = _$v ??
         _$CurrentOutOfOfficeData._(
-            userId: BuiltValueNullFieldError.checkNotNull(userId, r'CurrentOutOfOfficeData', 'userId'),
-            message: BuiltValueNullFieldError.checkNotNull(message, r'CurrentOutOfOfficeData', 'message'),
             id: BuiltValueNullFieldError.checkNotNull(id, r'CurrentOutOfOfficeData', 'id'),
             startDate: BuiltValueNullFieldError.checkNotNull(startDate, r'CurrentOutOfOfficeData', 'startDate'),
             endDate: BuiltValueNullFieldError.checkNotNull(endDate, r'CurrentOutOfOfficeData', 'endDate'),
             shortMessage:
-                BuiltValueNullFieldError.checkNotNull(shortMessage, r'CurrentOutOfOfficeData', 'shortMessage'));
+                BuiltValueNullFieldError.checkNotNull(shortMessage, r'CurrentOutOfOfficeData', 'shortMessage'),
+            userId: BuiltValueNullFieldError.checkNotNull(userId, r'CurrentOutOfOfficeData', 'userId'),
+            message: BuiltValueNullFieldError.checkNotNull(message, r'CurrentOutOfOfficeData', 'message'));
     replace(_$result);
     return _$result;
   }
@@ -1868,32 +1851,9 @@ class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $OutOfOfficeData_1InterfaceBuilder {
-  void replace($OutOfOfficeData_1Interface other);
-  void update(void Function($OutOfOfficeData_1InterfaceBuilder) updates);
-  int? get id;
-  set id(int? id);
-
-  String? get firstDay;
-  set firstDay(String? firstDay);
-
-  String? get lastDay;
-  set lastDay(String? lastDay);
-
-  String? get status;
-  set status(String? status);
-}
-
-abstract mixin class $OutOfOfficeDataInterfaceBuilder
-    implements $OutOfOfficeDataCommonInterfaceBuilder, $OutOfOfficeData_1InterfaceBuilder {
+abstract mixin class $OutOfOfficeDataInterfaceBuilder implements $OutOfOfficeDataCommonInterfaceBuilder {
   void replace(covariant $OutOfOfficeDataInterface other);
   void update(void Function($OutOfOfficeDataInterfaceBuilder) updates);
-  String? get userId;
-  set userId(covariant String? userId);
-
-  String? get message;
-  set message(covariant String? message);
-
   int? get id;
   set id(covariant int? id);
 
@@ -1905,13 +1865,15 @@ abstract mixin class $OutOfOfficeDataInterfaceBuilder
 
   String? get status;
   set status(covariant String? status);
+
+  String? get userId;
+  set userId(covariant String? userId);
+
+  String? get message;
+  set message(covariant String? message);
 }
 
 class _$OutOfOfficeData extends OutOfOfficeData {
-  @override
-  final String userId;
-  @override
-  final String message;
   @override
   final int id;
   @override
@@ -1920,24 +1882,28 @@ class _$OutOfOfficeData extends OutOfOfficeData {
   final String lastDay;
   @override
   final String status;
+  @override
+  final String userId;
+  @override
+  final String message;
 
   factory _$OutOfOfficeData([void Function(OutOfOfficeDataBuilder)? updates]) =>
       (OutOfOfficeDataBuilder()..update(updates))._build();
 
   _$OutOfOfficeData._(
-      {required this.userId,
-      required this.message,
-      required this.id,
+      {required this.id,
       required this.firstDay,
       required this.lastDay,
-      required this.status})
+      required this.status,
+      required this.userId,
+      required this.message})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(userId, r'OutOfOfficeData', 'userId');
-    BuiltValueNullFieldError.checkNotNull(message, r'OutOfOfficeData', 'message');
     BuiltValueNullFieldError.checkNotNull(id, r'OutOfOfficeData', 'id');
     BuiltValueNullFieldError.checkNotNull(firstDay, r'OutOfOfficeData', 'firstDay');
     BuiltValueNullFieldError.checkNotNull(lastDay, r'OutOfOfficeData', 'lastDay');
     BuiltValueNullFieldError.checkNotNull(status, r'OutOfOfficeData', 'status');
+    BuiltValueNullFieldError.checkNotNull(userId, r'OutOfOfficeData', 'userId');
+    BuiltValueNullFieldError.checkNotNull(message, r'OutOfOfficeData', 'message');
   }
 
   @override
@@ -1950,23 +1916,23 @@ class _$OutOfOfficeData extends OutOfOfficeData {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is OutOfOfficeData &&
-        userId == other.userId &&
-        message == other.message &&
         id == other.id &&
         firstDay == other.firstDay &&
         lastDay == other.lastDay &&
-        status == other.status;
+        status == other.status &&
+        userId == other.userId &&
+        message == other.message;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, userId.hashCode);
-    _$hash = $jc(_$hash, message.hashCode);
     _$hash = $jc(_$hash, id.hashCode);
     _$hash = $jc(_$hash, firstDay.hashCode);
     _$hash = $jc(_$hash, lastDay.hashCode);
     _$hash = $jc(_$hash, status.hashCode);
+    _$hash = $jc(_$hash, userId.hashCode);
+    _$hash = $jc(_$hash, message.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -1974,12 +1940,12 @@ class _$OutOfOfficeData extends OutOfOfficeData {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'OutOfOfficeData')
-          ..add('userId', userId)
-          ..add('message', message)
           ..add('id', id)
           ..add('firstDay', firstDay)
           ..add('lastDay', lastDay)
-          ..add('status', status))
+          ..add('status', status)
+          ..add('userId', userId)
+          ..add('message', message))
         .toString();
   }
 }
@@ -1987,14 +1953,6 @@ class _$OutOfOfficeData extends OutOfOfficeData {
 class OutOfOfficeDataBuilder
     implements Builder<OutOfOfficeData, OutOfOfficeDataBuilder>, $OutOfOfficeDataInterfaceBuilder {
   _$OutOfOfficeData? _$v;
-
-  String? _userId;
-  String? get userId => _$this._userId;
-  set userId(covariant String? userId) => _$this._userId = userId;
-
-  String? _message;
-  String? get message => _$this._message;
-  set message(covariant String? message) => _$this._message = message;
 
   int? _id;
   int? get id => _$this._id;
@@ -2012,17 +1970,25 @@ class OutOfOfficeDataBuilder
   String? get status => _$this._status;
   set status(covariant String? status) => _$this._status = status;
 
+  String? _userId;
+  String? get userId => _$this._userId;
+  set userId(covariant String? userId) => _$this._userId = userId;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(covariant String? message) => _$this._message = message;
+
   OutOfOfficeDataBuilder();
 
   OutOfOfficeDataBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _userId = $v.userId;
-      _message = $v.message;
       _id = $v.id;
       _firstDay = $v.firstDay;
       _lastDay = $v.lastDay;
       _status = $v.status;
+      _userId = $v.userId;
+      _message = $v.message;
       _$v = null;
     }
     return this;
@@ -2045,12 +2011,12 @@ class OutOfOfficeDataBuilder
   _$OutOfOfficeData _build() {
     final _$result = _$v ??
         _$OutOfOfficeData._(
-            userId: BuiltValueNullFieldError.checkNotNull(userId, r'OutOfOfficeData', 'userId'),
-            message: BuiltValueNullFieldError.checkNotNull(message, r'OutOfOfficeData', 'message'),
             id: BuiltValueNullFieldError.checkNotNull(id, r'OutOfOfficeData', 'id'),
             firstDay: BuiltValueNullFieldError.checkNotNull(firstDay, r'OutOfOfficeData', 'firstDay'),
             lastDay: BuiltValueNullFieldError.checkNotNull(lastDay, r'OutOfOfficeData', 'lastDay'),
-            status: BuiltValueNullFieldError.checkNotNull(status, r'OutOfOfficeData', 'status'));
+            status: BuiltValueNullFieldError.checkNotNull(status, r'OutOfOfficeData', 'status'),
+            userId: BuiltValueNullFieldError.checkNotNull(userId, r'OutOfOfficeData', 'userId'),
+            message: BuiltValueNullFieldError.checkNotNull(message, r'OutOfOfficeData', 'message'));
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -4176,28 +4176,24 @@ abstract class ShareeValue implements $ShareeValueInterface, Built<ShareeValue, 
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeCircle_1_Value_1Interface {
+abstract interface class $ShareeCircle_ValueInterface implements $ShareeValueInterface {
   String get circle;
 }
 
-@BuiltValue(instantiable: false)
-abstract interface class $ShareeCircle_1_ValueInterface
-    implements $ShareeValueInterface, $ShareeCircle_1_Value_1Interface {}
-
-abstract class ShareeCircle_1_Value
-    implements $ShareeCircle_1_ValueInterface, Built<ShareeCircle_1_Value, ShareeCircle_1_ValueBuilder> {
-  /// Creates a new ShareeCircle_1_Value object using the builder pattern.
-  factory ShareeCircle_1_Value([void Function(ShareeCircle_1_ValueBuilder)? b]) = _$ShareeCircle_1_Value;
+abstract class ShareeCircle_Value
+    implements $ShareeCircle_ValueInterface, Built<ShareeCircle_Value, ShareeCircle_ValueBuilder> {
+  /// Creates a new ShareeCircle_Value object using the builder pattern.
+  factory ShareeCircle_Value([void Function(ShareeCircle_ValueBuilder)? b]) = _$ShareeCircle_Value;
 
   // coverage:ignore-start
-  const ShareeCircle_1_Value._();
+  const ShareeCircle_Value._();
   // coverage:ignore-end
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use [toJson] to serialize it back into json.
   // coverage:ignore-start
-  factory ShareeCircle_1_Value.fromJson(Map<String, dynamic> json) =>
+  factory ShareeCircle_Value.fromJson(Map<String, dynamic> json) =>
       _$jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4208,18 +4204,15 @@ abstract class ShareeCircle_1_Value
   Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
 
-  /// Serializer for ShareeCircle_1_Value.
-  static Serializer<ShareeCircle_1_Value> get serializer => _$shareeCircle1ValueSerializer;
+  /// Serializer for ShareeCircle_Value.
+  static Serializer<ShareeCircle_Value> get serializer => _$shareeCircleValueSerializer;
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeCircle_1Interface {
+abstract interface class $ShareeCircleInterface implements $ShareeInterface {
   String get shareWithDescription;
-  ShareeCircle_1_Value get value;
+  ShareeCircle_Value get value;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $ShareeCircleInterface implements $ShareeInterface, $ShareeCircle_1Interface {}
 
 abstract class ShareeCircle implements $ShareeCircleInterface, Built<ShareeCircle, ShareeCircleBuilder> {
   /// Creates a new ShareeCircle object using the builder pattern.
@@ -4248,16 +4241,13 @@ abstract class ShareeCircle implements $ShareeCircleInterface, Built<ShareeCircl
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeEmail_1Interface {
+abstract interface class $ShareeEmailInterface implements $ShareeInterface {
   String get uuid;
   String get name;
   String get type;
   String get shareWithDisplayNameUnique;
   ShareeValue get value;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $ShareeEmailInterface implements $ShareeInterface, $ShareeEmail_1Interface {}
 
 abstract class ShareeEmail implements $ShareeEmailInterface, Built<ShareeEmail, ShareeEmailBuilder> {
   /// Creates a new ShareeEmail object using the builder pattern.
@@ -4286,28 +4276,24 @@ abstract class ShareeEmail implements $ShareeEmailInterface, Built<ShareeEmail, 
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeRemoteGroup_1_Value_1Interface {
+abstract interface class $ShareeRemoteGroup_ValueInterface implements $ShareeValueInterface {
   String get server;
 }
 
-@BuiltValue(instantiable: false)
-abstract interface class $ShareeRemoteGroup_1_ValueInterface
-    implements $ShareeValueInterface, $ShareeRemoteGroup_1_Value_1Interface {}
-
-abstract class ShareeRemoteGroup_1_Value
-    implements $ShareeRemoteGroup_1_ValueInterface, Built<ShareeRemoteGroup_1_Value, ShareeRemoteGroup_1_ValueBuilder> {
-  /// Creates a new ShareeRemoteGroup_1_Value object using the builder pattern.
-  factory ShareeRemoteGroup_1_Value([void Function(ShareeRemoteGroup_1_ValueBuilder)? b]) = _$ShareeRemoteGroup_1_Value;
+abstract class ShareeRemoteGroup_Value
+    implements $ShareeRemoteGroup_ValueInterface, Built<ShareeRemoteGroup_Value, ShareeRemoteGroup_ValueBuilder> {
+  /// Creates a new ShareeRemoteGroup_Value object using the builder pattern.
+  factory ShareeRemoteGroup_Value([void Function(ShareeRemoteGroup_ValueBuilder)? b]) = _$ShareeRemoteGroup_Value;
 
   // coverage:ignore-start
-  const ShareeRemoteGroup_1_Value._();
+  const ShareeRemoteGroup_Value._();
   // coverage:ignore-end
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use [toJson] to serialize it back into json.
   // coverage:ignore-start
-  factory ShareeRemoteGroup_1_Value.fromJson(Map<String, dynamic> json) =>
+  factory ShareeRemoteGroup_Value.fromJson(Map<String, dynamic> json) =>
       _$jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4318,19 +4304,16 @@ abstract class ShareeRemoteGroup_1_Value
   Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
 
-  /// Serializer for ShareeRemoteGroup_1_Value.
-  static Serializer<ShareeRemoteGroup_1_Value> get serializer => _$shareeRemoteGroup1ValueSerializer;
+  /// Serializer for ShareeRemoteGroup_Value.
+  static Serializer<ShareeRemoteGroup_Value> get serializer => _$shareeRemoteGroupValueSerializer;
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeRemoteGroup_1Interface {
+abstract interface class $ShareeRemoteGroupInterface implements $ShareeInterface {
   String get guid;
   String get name;
-  ShareeRemoteGroup_1_Value get value;
+  ShareeRemoteGroup_Value get value;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $ShareeRemoteGroupInterface implements $ShareeInterface, $ShareeRemoteGroup_1Interface {}
 
 abstract class ShareeRemoteGroup
     implements $ShareeRemoteGroupInterface, Built<ShareeRemoteGroup, ShareeRemoteGroupBuilder> {
@@ -4360,28 +4343,24 @@ abstract class ShareeRemoteGroup
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeRemote_1_Value_1Interface {
+abstract interface class $ShareeRemote_ValueInterface implements $ShareeValueInterface {
   String get server;
 }
 
-@BuiltValue(instantiable: false)
-abstract interface class $ShareeRemote_1_ValueInterface
-    implements $ShareeValueInterface, $ShareeRemote_1_Value_1Interface {}
-
-abstract class ShareeRemote_1_Value
-    implements $ShareeRemote_1_ValueInterface, Built<ShareeRemote_1_Value, ShareeRemote_1_ValueBuilder> {
-  /// Creates a new ShareeRemote_1_Value object using the builder pattern.
-  factory ShareeRemote_1_Value([void Function(ShareeRemote_1_ValueBuilder)? b]) = _$ShareeRemote_1_Value;
+abstract class ShareeRemote_Value
+    implements $ShareeRemote_ValueInterface, Built<ShareeRemote_Value, ShareeRemote_ValueBuilder> {
+  /// Creates a new ShareeRemote_Value object using the builder pattern.
+  factory ShareeRemote_Value([void Function(ShareeRemote_ValueBuilder)? b]) = _$ShareeRemote_Value;
 
   // coverage:ignore-start
-  const ShareeRemote_1_Value._();
+  const ShareeRemote_Value._();
   // coverage:ignore-end
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use [toJson] to serialize it back into json.
   // coverage:ignore-start
-  factory ShareeRemote_1_Value.fromJson(Map<String, dynamic> json) =>
+  factory ShareeRemote_Value.fromJson(Map<String, dynamic> json) =>
       _$jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4392,20 +4371,17 @@ abstract class ShareeRemote_1_Value
   Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
 
-  /// Serializer for ShareeRemote_1_Value.
-  static Serializer<ShareeRemote_1_Value> get serializer => _$shareeRemote1ValueSerializer;
+  /// Serializer for ShareeRemote_Value.
+  static Serializer<ShareeRemote_Value> get serializer => _$shareeRemoteValueSerializer;
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeRemote_1Interface {
+abstract interface class $ShareeRemoteInterface implements $ShareeInterface {
   String get uuid;
   String get name;
   String get type;
-  ShareeRemote_1_Value get value;
+  ShareeRemote_Value get value;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $ShareeRemoteInterface implements $ShareeInterface, $ShareeRemote_1Interface {}
 
 abstract class ShareeRemote implements $ShareeRemoteInterface, Built<ShareeRemote, ShareeRemoteBuilder> {
   /// Creates a new ShareeRemote object using the builder pattern.
@@ -4434,28 +4410,27 @@ abstract class ShareeRemote implements $ShareeRemoteInterface, Built<ShareeRemot
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeUser_1_StatusInterface {
+abstract interface class $ShareeUser_StatusInterface {
   String get status;
   String get message;
   String get icon;
   int? get clearAt;
 }
 
-abstract class ShareeUser_1_Status
-    implements $ShareeUser_1_StatusInterface, Built<ShareeUser_1_Status, ShareeUser_1_StatusBuilder> {
-  /// Creates a new ShareeUser_1_Status object using the builder pattern.
-  factory ShareeUser_1_Status([void Function(ShareeUser_1_StatusBuilder)? b]) = _$ShareeUser_1_Status;
+abstract class ShareeUser_Status
+    implements $ShareeUser_StatusInterface, Built<ShareeUser_Status, ShareeUser_StatusBuilder> {
+  /// Creates a new ShareeUser_Status object using the builder pattern.
+  factory ShareeUser_Status([void Function(ShareeUser_StatusBuilder)? b]) = _$ShareeUser_Status;
 
   // coverage:ignore-start
-  const ShareeUser_1_Status._();
+  const ShareeUser_Status._();
   // coverage:ignore-end
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use [toJson] to serialize it back into json.
   // coverage:ignore-start
-  factory ShareeUser_1_Status.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
+  factory ShareeUser_Status.fromJson(Map<String, dynamic> json) => _$jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
   /// Parses this object into a json like map.
@@ -4465,21 +4440,18 @@ abstract class ShareeUser_1_Status
   Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
 
-  /// Serializer for ShareeUser_1_Status.
-  static Serializer<ShareeUser_1_Status> get serializer => _$shareeUser1StatusSerializer;
+  /// Serializer for ShareeUser_Status.
+  static Serializer<ShareeUser_Status> get serializer => _$shareeUserStatusSerializer;
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeUser_1Interface {
+abstract interface class $ShareeUserInterface implements $ShareeInterface {
   String get subline;
   String get icon;
   String get shareWithDisplayNameUnique;
-  ShareeUser_1_Status get status;
+  ShareeUser_Status get status;
   ShareeValue get value;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $ShareeUserInterface implements $ShareeInterface, $ShareeUser_1Interface {}
 
 abstract class ShareeUser implements $ShareeUserInterface, Built<ShareeUser, ShareeUserBuilder> {
   /// Creates a new ShareeUser object using the builder pattern.
@@ -4580,7 +4552,7 @@ abstract class Lookup implements $LookupInterface, Built<Lookup, LookupBuilder> 
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeLookup_1_ExtraInterface {
+abstract interface class $ShareeLookup_ExtraInterface {
   String get federationId;
   Lookup? get name;
   Lookup? get email;
@@ -4595,20 +4567,20 @@ abstract interface class $ShareeLookup_1_ExtraInterface {
   Lookup? get userid;
 }
 
-abstract class ShareeLookup_1_Extra
-    implements $ShareeLookup_1_ExtraInterface, Built<ShareeLookup_1_Extra, ShareeLookup_1_ExtraBuilder> {
-  /// Creates a new ShareeLookup_1_Extra object using the builder pattern.
-  factory ShareeLookup_1_Extra([void Function(ShareeLookup_1_ExtraBuilder)? b]) = _$ShareeLookup_1_Extra;
+abstract class ShareeLookup_Extra
+    implements $ShareeLookup_ExtraInterface, Built<ShareeLookup_Extra, ShareeLookup_ExtraBuilder> {
+  /// Creates a new ShareeLookup_Extra object using the builder pattern.
+  factory ShareeLookup_Extra([void Function(ShareeLookup_ExtraBuilder)? b]) = _$ShareeLookup_Extra;
 
   // coverage:ignore-start
-  const ShareeLookup_1_Extra._();
+  const ShareeLookup_Extra._();
   // coverage:ignore-end
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use [toJson] to serialize it back into json.
   // coverage:ignore-start
-  factory ShareeLookup_1_Extra.fromJson(Map<String, dynamic> json) =>
+  factory ShareeLookup_Extra.fromJson(Map<String, dynamic> json) =>
       _$jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4619,33 +4591,29 @@ abstract class ShareeLookup_1_Extra
   Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
 
-  /// Serializer for ShareeLookup_1_Extra.
-  static Serializer<ShareeLookup_1_Extra> get serializer => _$shareeLookup1ExtraSerializer;
+  /// Serializer for ShareeLookup_Extra.
+  static Serializer<ShareeLookup_Extra> get serializer => _$shareeLookupExtraSerializer;
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeLookup_1_Value_1Interface {
+abstract interface class $ShareeLookup_ValueInterface implements $ShareeValueInterface {
   bool get globalScale;
 }
 
-@BuiltValue(instantiable: false)
-abstract interface class $ShareeLookup_1_ValueInterface
-    implements $ShareeValueInterface, $ShareeLookup_1_Value_1Interface {}
-
-abstract class ShareeLookup_1_Value
-    implements $ShareeLookup_1_ValueInterface, Built<ShareeLookup_1_Value, ShareeLookup_1_ValueBuilder> {
-  /// Creates a new ShareeLookup_1_Value object using the builder pattern.
-  factory ShareeLookup_1_Value([void Function(ShareeLookup_1_ValueBuilder)? b]) = _$ShareeLookup_1_Value;
+abstract class ShareeLookup_Value
+    implements $ShareeLookup_ValueInterface, Built<ShareeLookup_Value, ShareeLookup_ValueBuilder> {
+  /// Creates a new ShareeLookup_Value object using the builder pattern.
+  factory ShareeLookup_Value([void Function(ShareeLookup_ValueBuilder)? b]) = _$ShareeLookup_Value;
 
   // coverage:ignore-start
-  const ShareeLookup_1_Value._();
+  const ShareeLookup_Value._();
   // coverage:ignore-end
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use [toJson] to serialize it back into json.
   // coverage:ignore-start
-  factory ShareeLookup_1_Value.fromJson(Map<String, dynamic> json) =>
+  factory ShareeLookup_Value.fromJson(Map<String, dynamic> json) =>
       _$jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
@@ -4656,18 +4624,15 @@ abstract class ShareeLookup_1_Value
   Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
 
-  /// Serializer for ShareeLookup_1_Value.
-  static Serializer<ShareeLookup_1_Value> get serializer => _$shareeLookup1ValueSerializer;
+  /// Serializer for ShareeLookup_Value.
+  static Serializer<ShareeLookup_Value> get serializer => _$shareeLookupValueSerializer;
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareeLookup_1Interface {
-  ShareeLookup_1_Extra get extra;
-  ShareeLookup_1_Value get value;
+abstract interface class $ShareeLookupInterface implements $ShareeInterface {
+  ShareeLookup_Extra get extra;
+  ShareeLookup_Value get value;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $ShareeLookupInterface implements $ShareeInterface, $ShareeLookup_1Interface {}
 
 abstract class ShareeLookup implements $ShareeLookupInterface, Built<ShareeLookup, ShareeLookupBuilder> {
   /// Creates a new ShareeLookup object using the builder pattern.
@@ -5890,8 +5855,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ShareeCircle.serializer)
       ..addBuilderFactory(const FullType(Sharee), ShareeBuilder.new)
       ..add(Sharee.serializer)
-      ..addBuilderFactory(const FullType(ShareeCircle_1_Value), ShareeCircle_1_ValueBuilder.new)
-      ..add(ShareeCircle_1_Value.serializer)
+      ..addBuilderFactory(const FullType(ShareeCircle_Value), ShareeCircle_ValueBuilder.new)
+      ..add(ShareeCircle_Value.serializer)
       ..addBuilderFactory(const FullType(ShareeValue), ShareeValueBuilder.new)
       ..add(ShareeValue.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(ShareeCircle)]), ListBuilder<ShareeCircle>.new)
@@ -5901,27 +5866,27 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(BuiltList, [FullType(Sharee)]), ListBuilder<Sharee>.new)
       ..addBuilderFactory(const FullType(ShareeRemoteGroup), ShareeRemoteGroupBuilder.new)
       ..add(ShareeRemoteGroup.serializer)
-      ..addBuilderFactory(const FullType(ShareeRemoteGroup_1_Value), ShareeRemoteGroup_1_ValueBuilder.new)
-      ..add(ShareeRemoteGroup_1_Value.serializer)
+      ..addBuilderFactory(const FullType(ShareeRemoteGroup_Value), ShareeRemoteGroup_ValueBuilder.new)
+      ..add(ShareeRemoteGroup_Value.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(ShareeRemoteGroup)]), ListBuilder<ShareeRemoteGroup>.new)
       ..addBuilderFactory(const FullType(ShareeRemote), ShareeRemoteBuilder.new)
       ..add(ShareeRemote.serializer)
-      ..addBuilderFactory(const FullType(ShareeRemote_1_Value), ShareeRemote_1_ValueBuilder.new)
-      ..add(ShareeRemote_1_Value.serializer)
+      ..addBuilderFactory(const FullType(ShareeRemote_Value), ShareeRemote_ValueBuilder.new)
+      ..add(ShareeRemote_Value.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(ShareeRemote)]), ListBuilder<ShareeRemote>.new)
       ..addBuilderFactory(const FullType(ShareeUser), ShareeUserBuilder.new)
       ..add(ShareeUser.serializer)
-      ..addBuilderFactory(const FullType(ShareeUser_1_Status), ShareeUser_1_StatusBuilder.new)
-      ..add(ShareeUser_1_Status.serializer)
+      ..addBuilderFactory(const FullType(ShareeUser_Status), ShareeUser_StatusBuilder.new)
+      ..add(ShareeUser_Status.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(ShareeUser)]), ListBuilder<ShareeUser>.new)
       ..addBuilderFactory(const FullType(ShareeLookup), ShareeLookupBuilder.new)
       ..add(ShareeLookup.serializer)
-      ..addBuilderFactory(const FullType(ShareeLookup_1_Extra), ShareeLookup_1_ExtraBuilder.new)
-      ..add(ShareeLookup_1_Extra.serializer)
+      ..addBuilderFactory(const FullType(ShareeLookup_Extra), ShareeLookup_ExtraBuilder.new)
+      ..add(ShareeLookup_Extra.serializer)
       ..addBuilderFactory(const FullType(Lookup), LookupBuilder.new)
       ..add(Lookup.serializer)
-      ..addBuilderFactory(const FullType(ShareeLookup_1_Value), ShareeLookup_1_ValueBuilder.new)
-      ..add(ShareeLookup_1_Value.serializer)
+      ..addBuilderFactory(const FullType(ShareeLookup_Value), ShareeLookup_ValueBuilder.new)
+      ..add(ShareeLookup_Value.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(ShareeLookup)]), ListBuilder<ShareeLookup>.new)
       ..addBuilderFactory(
         const FullType(ShareesapiFindRecommendedResponseApplicationJson),

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
@@ -141,19 +141,19 @@ Serializer<ShareesapiShareesapiSearchHeaders> _$shareesapiShareesapiSearchHeader
     _$ShareesapiShareesapiSearchHeadersSerializer();
 Serializer<Sharee> _$shareeSerializer = _$ShareeSerializer();
 Serializer<ShareeValue> _$shareeValueSerializer = _$ShareeValueSerializer();
-Serializer<ShareeCircle_1_Value> _$shareeCircle1ValueSerializer = _$ShareeCircle_1_ValueSerializer();
+Serializer<ShareeCircle_Value> _$shareeCircleValueSerializer = _$ShareeCircle_ValueSerializer();
 Serializer<ShareeCircle> _$shareeCircleSerializer = _$ShareeCircleSerializer();
 Serializer<ShareeEmail> _$shareeEmailSerializer = _$ShareeEmailSerializer();
-Serializer<ShareeRemoteGroup_1_Value> _$shareeRemoteGroup1ValueSerializer = _$ShareeRemoteGroup_1_ValueSerializer();
+Serializer<ShareeRemoteGroup_Value> _$shareeRemoteGroupValueSerializer = _$ShareeRemoteGroup_ValueSerializer();
 Serializer<ShareeRemoteGroup> _$shareeRemoteGroupSerializer = _$ShareeRemoteGroupSerializer();
-Serializer<ShareeRemote_1_Value> _$shareeRemote1ValueSerializer = _$ShareeRemote_1_ValueSerializer();
+Serializer<ShareeRemote_Value> _$shareeRemoteValueSerializer = _$ShareeRemote_ValueSerializer();
 Serializer<ShareeRemote> _$shareeRemoteSerializer = _$ShareeRemoteSerializer();
-Serializer<ShareeUser_1_Status> _$shareeUser1StatusSerializer = _$ShareeUser_1_StatusSerializer();
+Serializer<ShareeUser_Status> _$shareeUserStatusSerializer = _$ShareeUser_StatusSerializer();
 Serializer<ShareeUser> _$shareeUserSerializer = _$ShareeUserSerializer();
 Serializer<ShareesSearchResult_Exact> _$shareesSearchResultExactSerializer = _$ShareesSearchResult_ExactSerializer();
 Serializer<Lookup> _$lookupSerializer = _$LookupSerializer();
-Serializer<ShareeLookup_1_Extra> _$shareeLookup1ExtraSerializer = _$ShareeLookup_1_ExtraSerializer();
-Serializer<ShareeLookup_1_Value> _$shareeLookup1ValueSerializer = _$ShareeLookup_1_ValueSerializer();
+Serializer<ShareeLookup_Extra> _$shareeLookupExtraSerializer = _$ShareeLookup_ExtraSerializer();
+Serializer<ShareeLookup_Value> _$shareeLookupValueSerializer = _$ShareeLookup_ValueSerializer();
 Serializer<ShareeLookup> _$shareeLookupSerializer = _$ShareeLookupSerializer();
 Serializer<ShareesSearchResult> _$shareesSearchResultSerializer = _$ShareesSearchResultSerializer();
 Serializer<ShareesapiSearchResponseApplicationJson_Ocs> _$shareesapiSearchResponseApplicationJsonOcsSerializer =
@@ -2617,31 +2617,31 @@ class _$ShareeValueSerializer implements StructuredSerializer<ShareeValue> {
   }
 }
 
-class _$ShareeCircle_1_ValueSerializer implements StructuredSerializer<ShareeCircle_1_Value> {
+class _$ShareeCircle_ValueSerializer implements StructuredSerializer<ShareeCircle_Value> {
   @override
-  final Iterable<Type> types = const [ShareeCircle_1_Value, _$ShareeCircle_1_Value];
+  final Iterable<Type> types = const [ShareeCircle_Value, _$ShareeCircle_Value];
   @override
-  final String wireName = 'ShareeCircle_1_Value';
+  final String wireName = 'ShareeCircle_Value';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ShareeCircle_1_Value object,
+  Iterable<Object?> serialize(Serializers serializers, ShareeCircle_Value object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'circle',
+      serializers.serialize(object.circle, specifiedType: const FullType(String)),
       'shareType',
       serializers.serialize(object.shareType, specifiedType: const FullType(int)),
       'shareWith',
       serializers.serialize(object.shareWith, specifiedType: const FullType(String)),
-      'circle',
-      serializers.serialize(object.circle, specifiedType: const FullType(String)),
     ];
 
     return result;
   }
 
   @override
-  ShareeCircle_1_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ShareeCircle_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ShareeCircle_1_ValueBuilder();
+    final result = ShareeCircle_ValueBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2649,14 +2649,14 @@ class _$ShareeCircle_1_ValueSerializer implements StructuredSerializer<ShareeCir
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'circle':
+          result.circle = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'shareType':
           result.shareType = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
         case 'shareWith':
           result.shareWith = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'circle':
-          result.circle = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -2675,12 +2675,12 @@ class _$ShareeCircleSerializer implements StructuredSerializer<ShareeCircle> {
   Iterable<Object?> serialize(Serializers serializers, ShareeCircle object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'label',
-      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'shareWithDescription',
       serializers.serialize(object.shareWithDescription, specifiedType: const FullType(String)),
       'value',
-      serializers.serialize(object.value, specifiedType: const FullType(ShareeCircle_1_Value)),
+      serializers.serialize(object.value, specifiedType: const FullType(ShareeCircle_Value)),
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
     ];
     Object? value;
     value = object.count;
@@ -2703,19 +2703,19 @@ class _$ShareeCircleSerializer implements StructuredSerializer<ShareeCircle> {
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'count':
-          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
-          break;
-        case 'label':
-          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
         case 'shareWithDescription':
           result.shareWithDescription =
               serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'value':
-          result.value.replace(serializers.deserialize(value, specifiedType: const FullType(ShareeCircle_1_Value))!
-              as ShareeCircle_1_Value);
+          result.value.replace(
+              serializers.deserialize(value, specifiedType: const FullType(ShareeCircle_Value))! as ShareeCircle_Value);
+          break;
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -2734,8 +2734,6 @@ class _$ShareeEmailSerializer implements StructuredSerializer<ShareeEmail> {
   Iterable<Object?> serialize(Serializers serializers, ShareeEmail object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'label',
-      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'uuid',
       serializers.serialize(object.uuid, specifiedType: const FullType(String)),
       'name',
@@ -2746,6 +2744,8 @@ class _$ShareeEmailSerializer implements StructuredSerializer<ShareeEmail> {
       serializers.serialize(object.shareWithDisplayNameUnique, specifiedType: const FullType(String)),
       'value',
       serializers.serialize(object.value, specifiedType: const FullType(ShareeValue)),
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
     ];
     Object? value;
     value = object.count;
@@ -2768,12 +2768,6 @@ class _$ShareeEmailSerializer implements StructuredSerializer<ShareeEmail> {
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'count':
-          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
-          break;
-        case 'label':
-          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
         case 'uuid':
           result.uuid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -2791,6 +2785,12 @@ class _$ShareeEmailSerializer implements StructuredSerializer<ShareeEmail> {
           result.value
               .replace(serializers.deserialize(value, specifiedType: const FullType(ShareeValue))! as ShareeValue);
           break;
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
       }
     }
 
@@ -2798,31 +2798,31 @@ class _$ShareeEmailSerializer implements StructuredSerializer<ShareeEmail> {
   }
 }
 
-class _$ShareeRemoteGroup_1_ValueSerializer implements StructuredSerializer<ShareeRemoteGroup_1_Value> {
+class _$ShareeRemoteGroup_ValueSerializer implements StructuredSerializer<ShareeRemoteGroup_Value> {
   @override
-  final Iterable<Type> types = const [ShareeRemoteGroup_1_Value, _$ShareeRemoteGroup_1_Value];
+  final Iterable<Type> types = const [ShareeRemoteGroup_Value, _$ShareeRemoteGroup_Value];
   @override
-  final String wireName = 'ShareeRemoteGroup_1_Value';
+  final String wireName = 'ShareeRemoteGroup_Value';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ShareeRemoteGroup_1_Value object,
+  Iterable<Object?> serialize(Serializers serializers, ShareeRemoteGroup_Value object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'server',
+      serializers.serialize(object.server, specifiedType: const FullType(String)),
       'shareType',
       serializers.serialize(object.shareType, specifiedType: const FullType(int)),
       'shareWith',
       serializers.serialize(object.shareWith, specifiedType: const FullType(String)),
-      'server',
-      serializers.serialize(object.server, specifiedType: const FullType(String)),
     ];
 
     return result;
   }
 
   @override
-  ShareeRemoteGroup_1_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ShareeRemoteGroup_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ShareeRemoteGroup_1_ValueBuilder();
+    final result = ShareeRemoteGroup_ValueBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2830,14 +2830,14 @@ class _$ShareeRemoteGroup_1_ValueSerializer implements StructuredSerializer<Shar
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'server':
+          result.server = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'shareType':
           result.shareType = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
         case 'shareWith':
           result.shareWith = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'server':
-          result.server = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -2856,14 +2856,14 @@ class _$ShareeRemoteGroupSerializer implements StructuredSerializer<ShareeRemote
   Iterable<Object?> serialize(Serializers serializers, ShareeRemoteGroup object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'label',
-      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'guid',
       serializers.serialize(object.guid, specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
       'value',
-      serializers.serialize(object.value, specifiedType: const FullType(ShareeRemoteGroup_1_Value)),
+      serializers.serialize(object.value, specifiedType: const FullType(ShareeRemoteGroup_Value)),
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
     ];
     Object? value;
     value = object.count;
@@ -2886,12 +2886,6 @@ class _$ShareeRemoteGroupSerializer implements StructuredSerializer<ShareeRemote
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'count':
-          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
-          break;
-        case 'label':
-          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
         case 'guid':
           result.guid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -2899,8 +2893,14 @@ class _$ShareeRemoteGroupSerializer implements StructuredSerializer<ShareeRemote
           result.name = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'value':
-          result.value.replace(serializers.deserialize(value, specifiedType: const FullType(ShareeRemoteGroup_1_Value))!
-              as ShareeRemoteGroup_1_Value);
+          result.value.replace(serializers.deserialize(value, specifiedType: const FullType(ShareeRemoteGroup_Value))!
+              as ShareeRemoteGroup_Value);
+          break;
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -2909,31 +2909,31 @@ class _$ShareeRemoteGroupSerializer implements StructuredSerializer<ShareeRemote
   }
 }
 
-class _$ShareeRemote_1_ValueSerializer implements StructuredSerializer<ShareeRemote_1_Value> {
+class _$ShareeRemote_ValueSerializer implements StructuredSerializer<ShareeRemote_Value> {
   @override
-  final Iterable<Type> types = const [ShareeRemote_1_Value, _$ShareeRemote_1_Value];
+  final Iterable<Type> types = const [ShareeRemote_Value, _$ShareeRemote_Value];
   @override
-  final String wireName = 'ShareeRemote_1_Value';
+  final String wireName = 'ShareeRemote_Value';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ShareeRemote_1_Value object,
+  Iterable<Object?> serialize(Serializers serializers, ShareeRemote_Value object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'server',
+      serializers.serialize(object.server, specifiedType: const FullType(String)),
       'shareType',
       serializers.serialize(object.shareType, specifiedType: const FullType(int)),
       'shareWith',
       serializers.serialize(object.shareWith, specifiedType: const FullType(String)),
-      'server',
-      serializers.serialize(object.server, specifiedType: const FullType(String)),
     ];
 
     return result;
   }
 
   @override
-  ShareeRemote_1_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ShareeRemote_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ShareeRemote_1_ValueBuilder();
+    final result = ShareeRemote_ValueBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2941,14 +2941,14 @@ class _$ShareeRemote_1_ValueSerializer implements StructuredSerializer<ShareeRem
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'server':
+          result.server = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
         case 'shareType':
           result.shareType = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
         case 'shareWith':
           result.shareWith = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'server':
-          result.server = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -2967,8 +2967,6 @@ class _$ShareeRemoteSerializer implements StructuredSerializer<ShareeRemote> {
   Iterable<Object?> serialize(Serializers serializers, ShareeRemote object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'label',
-      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'uuid',
       serializers.serialize(object.uuid, specifiedType: const FullType(String)),
       'name',
@@ -2976,7 +2974,9 @@ class _$ShareeRemoteSerializer implements StructuredSerializer<ShareeRemote> {
       'type',
       serializers.serialize(object.type, specifiedType: const FullType(String)),
       'value',
-      serializers.serialize(object.value, specifiedType: const FullType(ShareeRemote_1_Value)),
+      serializers.serialize(object.value, specifiedType: const FullType(ShareeRemote_Value)),
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
     ];
     Object? value;
     value = object.count;
@@ -2999,12 +2999,6 @@ class _$ShareeRemoteSerializer implements StructuredSerializer<ShareeRemote> {
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'count':
-          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
-          break;
-        case 'label':
-          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
         case 'uuid':
           result.uuid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -3015,8 +3009,14 @@ class _$ShareeRemoteSerializer implements StructuredSerializer<ShareeRemote> {
           result.type = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'value':
-          result.value.replace(serializers.deserialize(value, specifiedType: const FullType(ShareeRemote_1_Value))!
-              as ShareeRemote_1_Value);
+          result.value.replace(
+              serializers.deserialize(value, specifiedType: const FullType(ShareeRemote_Value))! as ShareeRemote_Value);
+          break;
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -3025,14 +3025,14 @@ class _$ShareeRemoteSerializer implements StructuredSerializer<ShareeRemote> {
   }
 }
 
-class _$ShareeUser_1_StatusSerializer implements StructuredSerializer<ShareeUser_1_Status> {
+class _$ShareeUser_StatusSerializer implements StructuredSerializer<ShareeUser_Status> {
   @override
-  final Iterable<Type> types = const [ShareeUser_1_Status, _$ShareeUser_1_Status];
+  final Iterable<Type> types = const [ShareeUser_Status, _$ShareeUser_Status];
   @override
-  final String wireName = 'ShareeUser_1_Status';
+  final String wireName = 'ShareeUser_Status';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ShareeUser_1_Status object,
+  Iterable<Object?> serialize(Serializers serializers, ShareeUser_Status object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'status',
@@ -3053,9 +3053,9 @@ class _$ShareeUser_1_StatusSerializer implements StructuredSerializer<ShareeUser
   }
 
   @override
-  ShareeUser_1_Status deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ShareeUser_Status deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ShareeUser_1_StatusBuilder();
+    final result = ShareeUser_StatusBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -3092,8 +3092,6 @@ class _$ShareeUserSerializer implements StructuredSerializer<ShareeUser> {
   Iterable<Object?> serialize(Serializers serializers, ShareeUser object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'label',
-      serializers.serialize(object.label, specifiedType: const FullType(String)),
       'subline',
       serializers.serialize(object.subline, specifiedType: const FullType(String)),
       'icon',
@@ -3101,9 +3099,11 @@ class _$ShareeUserSerializer implements StructuredSerializer<ShareeUser> {
       'shareWithDisplayNameUnique',
       serializers.serialize(object.shareWithDisplayNameUnique, specifiedType: const FullType(String)),
       'status',
-      serializers.serialize(object.status, specifiedType: const FullType(ShareeUser_1_Status)),
+      serializers.serialize(object.status, specifiedType: const FullType(ShareeUser_Status)),
       'value',
       serializers.serialize(object.value, specifiedType: const FullType(ShareeValue)),
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
     ];
     Object? value;
     value = object.count;
@@ -3126,12 +3126,6 @@ class _$ShareeUserSerializer implements StructuredSerializer<ShareeUser> {
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'count':
-          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
-          break;
-        case 'label':
-          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
         case 'subline':
           result.subline = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -3143,12 +3137,18 @@ class _$ShareeUserSerializer implements StructuredSerializer<ShareeUser> {
               serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'status':
-          result.status.replace(serializers.deserialize(value, specifiedType: const FullType(ShareeUser_1_Status))!
-              as ShareeUser_1_Status);
+          result.status.replace(
+              serializers.deserialize(value, specifiedType: const FullType(ShareeUser_Status))! as ShareeUser_Status);
           break;
         case 'value':
           result.value
               .replace(serializers.deserialize(value, specifiedType: const FullType(ShareeValue))! as ShareeValue);
+          break;
+        case 'count':
+          result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -3275,14 +3275,14 @@ class _$LookupSerializer implements StructuredSerializer<Lookup> {
   }
 }
 
-class _$ShareeLookup_1_ExtraSerializer implements StructuredSerializer<ShareeLookup_1_Extra> {
+class _$ShareeLookup_ExtraSerializer implements StructuredSerializer<ShareeLookup_Extra> {
   @override
-  final Iterable<Type> types = const [ShareeLookup_1_Extra, _$ShareeLookup_1_Extra];
+  final Iterable<Type> types = const [ShareeLookup_Extra, _$ShareeLookup_Extra];
   @override
-  final String wireName = 'ShareeLookup_1_Extra';
+  final String wireName = 'ShareeLookup_Extra';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ShareeLookup_1_Extra object,
+  Iterable<Object?> serialize(Serializers serializers, ShareeLookup_Extra object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       'federationId',
@@ -3347,9 +3347,9 @@ class _$ShareeLookup_1_ExtraSerializer implements StructuredSerializer<ShareeLoo
   }
 
   @override
-  ShareeLookup_1_Extra deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ShareeLookup_Extra deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ShareeLookup_1_ExtraBuilder();
+    final result = ShareeLookup_ExtraBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -3396,31 +3396,31 @@ class _$ShareeLookup_1_ExtraSerializer implements StructuredSerializer<ShareeLoo
   }
 }
 
-class _$ShareeLookup_1_ValueSerializer implements StructuredSerializer<ShareeLookup_1_Value> {
+class _$ShareeLookup_ValueSerializer implements StructuredSerializer<ShareeLookup_Value> {
   @override
-  final Iterable<Type> types = const [ShareeLookup_1_Value, _$ShareeLookup_1_Value];
+  final Iterable<Type> types = const [ShareeLookup_Value, _$ShareeLookup_Value];
   @override
-  final String wireName = 'ShareeLookup_1_Value';
+  final String wireName = 'ShareeLookup_Value';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ShareeLookup_1_Value object,
+  Iterable<Object?> serialize(Serializers serializers, ShareeLookup_Value object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'globalScale',
+      serializers.serialize(object.globalScale, specifiedType: const FullType(bool)),
       'shareType',
       serializers.serialize(object.shareType, specifiedType: const FullType(int)),
       'shareWith',
       serializers.serialize(object.shareWith, specifiedType: const FullType(String)),
-      'globalScale',
-      serializers.serialize(object.globalScale, specifiedType: const FullType(bool)),
     ];
 
     return result;
   }
 
   @override
-  ShareeLookup_1_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ShareeLookup_Value deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ShareeLookup_1_ValueBuilder();
+    final result = ShareeLookup_ValueBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -3428,14 +3428,14 @@ class _$ShareeLookup_1_ValueSerializer implements StructuredSerializer<ShareeLoo
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'globalScale':
+          result.globalScale = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
         case 'shareType':
           result.shareType = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
         case 'shareWith':
           result.shareWith = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'globalScale':
-          result.globalScale = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -3454,12 +3454,12 @@ class _$ShareeLookupSerializer implements StructuredSerializer<ShareeLookup> {
   Iterable<Object?> serialize(Serializers serializers, ShareeLookup object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
+      'extra',
+      serializers.serialize(object.extra, specifiedType: const FullType(ShareeLookup_Extra)),
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(ShareeLookup_Value)),
       'label',
       serializers.serialize(object.label, specifiedType: const FullType(String)),
-      'extra',
-      serializers.serialize(object.extra, specifiedType: const FullType(ShareeLookup_1_Extra)),
-      'value',
-      serializers.serialize(object.value, specifiedType: const FullType(ShareeLookup_1_Value)),
     ];
     Object? value;
     value = object.count;
@@ -3482,19 +3482,19 @@ class _$ShareeLookupSerializer implements StructuredSerializer<ShareeLookup> {
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'extra':
+          result.extra.replace(
+              serializers.deserialize(value, specifiedType: const FullType(ShareeLookup_Extra))! as ShareeLookup_Extra);
+          break;
+        case 'value':
+          result.value.replace(
+              serializers.deserialize(value, specifiedType: const FullType(ShareeLookup_Value))! as ShareeLookup_Value);
+          break;
         case 'count':
           result.count = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
           break;
         case 'label':
           result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'extra':
-          result.extra.replace(serializers.deserialize(value, specifiedType: const FullType(ShareeLookup_1_Extra))!
-              as ShareeLookup_1_Extra);
-          break;
-        case 'value':
-          result.value.replace(serializers.deserialize(value, specifiedType: const FullType(ShareeLookup_1_Value))!
-              as ShareeLookup_1_Value);
           break;
       }
     }
@@ -10591,83 +10591,79 @@ class ShareeValueBuilder implements Builder<ShareeValue, ShareeValueBuilder>, $S
   }
 }
 
-abstract mixin class $ShareeCircle_1_Value_1InterfaceBuilder {
-  void replace($ShareeCircle_1_Value_1Interface other);
-  void update(void Function($ShareeCircle_1_Value_1InterfaceBuilder) updates);
+abstract mixin class $ShareeCircle_ValueInterfaceBuilder implements $ShareeValueInterfaceBuilder {
+  void replace(covariant $ShareeCircle_ValueInterface other);
+  void update(void Function($ShareeCircle_ValueInterfaceBuilder) updates);
   String? get circle;
-  set circle(String? circle);
-}
+  set circle(covariant String? circle);
 
-abstract mixin class $ShareeCircle_1_ValueInterfaceBuilder
-    implements $ShareeValueInterfaceBuilder, $ShareeCircle_1_Value_1InterfaceBuilder {
-  void replace(covariant $ShareeCircle_1_ValueInterface other);
-  void update(void Function($ShareeCircle_1_ValueInterfaceBuilder) updates);
   int? get shareType;
   set shareType(covariant int? shareType);
 
   String? get shareWith;
   set shareWith(covariant String? shareWith);
-
-  String? get circle;
-  set circle(covariant String? circle);
 }
 
-class _$ShareeCircle_1_Value extends ShareeCircle_1_Value {
+class _$ShareeCircle_Value extends ShareeCircle_Value {
+  @override
+  final String circle;
   @override
   final int shareType;
   @override
   final String shareWith;
-  @override
-  final String circle;
 
-  factory _$ShareeCircle_1_Value([void Function(ShareeCircle_1_ValueBuilder)? updates]) =>
-      (ShareeCircle_1_ValueBuilder()..update(updates))._build();
+  factory _$ShareeCircle_Value([void Function(ShareeCircle_ValueBuilder)? updates]) =>
+      (ShareeCircle_ValueBuilder()..update(updates))._build();
 
-  _$ShareeCircle_1_Value._({required this.shareType, required this.shareWith, required this.circle}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeCircle_1_Value', 'shareType');
-    BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeCircle_1_Value', 'shareWith');
-    BuiltValueNullFieldError.checkNotNull(circle, r'ShareeCircle_1_Value', 'circle');
+  _$ShareeCircle_Value._({required this.circle, required this.shareType, required this.shareWith}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(circle, r'ShareeCircle_Value', 'circle');
+    BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeCircle_Value', 'shareType');
+    BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeCircle_Value', 'shareWith');
   }
 
   @override
-  ShareeCircle_1_Value rebuild(void Function(ShareeCircle_1_ValueBuilder) updates) =>
+  ShareeCircle_Value rebuild(void Function(ShareeCircle_ValueBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ShareeCircle_1_ValueBuilder toBuilder() => ShareeCircle_1_ValueBuilder()..replace(this);
+  ShareeCircle_ValueBuilder toBuilder() => ShareeCircle_ValueBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ShareeCircle_1_Value &&
+    return other is ShareeCircle_Value &&
+        circle == other.circle &&
         shareType == other.shareType &&
-        shareWith == other.shareWith &&
-        circle == other.circle;
+        shareWith == other.shareWith;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, circle.hashCode);
     _$hash = $jc(_$hash, shareType.hashCode);
     _$hash = $jc(_$hash, shareWith.hashCode);
-    _$hash = $jc(_$hash, circle.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ShareeCircle_1_Value')
+    return (newBuiltValueToStringHelper(r'ShareeCircle_Value')
+          ..add('circle', circle)
           ..add('shareType', shareType)
-          ..add('shareWith', shareWith)
-          ..add('circle', circle))
+          ..add('shareWith', shareWith))
         .toString();
   }
 }
 
-class ShareeCircle_1_ValueBuilder
-    implements Builder<ShareeCircle_1_Value, ShareeCircle_1_ValueBuilder>, $ShareeCircle_1_ValueInterfaceBuilder {
-  _$ShareeCircle_1_Value? _$v;
+class ShareeCircle_ValueBuilder
+    implements Builder<ShareeCircle_Value, ShareeCircle_ValueBuilder>, $ShareeCircle_ValueInterfaceBuilder {
+  _$ShareeCircle_Value? _$v;
+
+  String? _circle;
+  String? get circle => _$this._circle;
+  set circle(covariant String? circle) => _$this._circle = circle;
 
   int? _shareType;
   int? get shareType => _$this._shareType;
@@ -10677,92 +10673,78 @@ class ShareeCircle_1_ValueBuilder
   String? get shareWith => _$this._shareWith;
   set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
-  String? _circle;
-  String? get circle => _$this._circle;
-  set circle(covariant String? circle) => _$this._circle = circle;
+  ShareeCircle_ValueBuilder();
 
-  ShareeCircle_1_ValueBuilder();
-
-  ShareeCircle_1_ValueBuilder get _$this {
+  ShareeCircle_ValueBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _circle = $v.circle;
       _shareType = $v.shareType;
       _shareWith = $v.shareWith;
-      _circle = $v.circle;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(covariant ShareeCircle_1_Value other) {
+  void replace(covariant ShareeCircle_Value other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ShareeCircle_1_Value;
+    _$v = other as _$ShareeCircle_Value;
   }
 
   @override
-  void update(void Function(ShareeCircle_1_ValueBuilder)? updates) {
+  void update(void Function(ShareeCircle_ValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ShareeCircle_1_Value build() => _build();
+  ShareeCircle_Value build() => _build();
 
-  _$ShareeCircle_1_Value _build() {
+  _$ShareeCircle_Value _build() {
     final _$result = _$v ??
-        _$ShareeCircle_1_Value._(
-            shareType: BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeCircle_1_Value', 'shareType'),
-            shareWith: BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeCircle_1_Value', 'shareWith'),
-            circle: BuiltValueNullFieldError.checkNotNull(circle, r'ShareeCircle_1_Value', 'circle'));
+        _$ShareeCircle_Value._(
+            circle: BuiltValueNullFieldError.checkNotNull(circle, r'ShareeCircle_Value', 'circle'),
+            shareType: BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeCircle_Value', 'shareType'),
+            shareWith: BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeCircle_Value', 'shareWith'));
     replace(_$result);
     return _$result;
   }
 }
 
-abstract mixin class $ShareeCircle_1InterfaceBuilder {
-  void replace($ShareeCircle_1Interface other);
-  void update(void Function($ShareeCircle_1InterfaceBuilder) updates);
-  String? get shareWithDescription;
-  set shareWithDescription(String? shareWithDescription);
-
-  ShareeCircle_1_ValueBuilder get value;
-  set value(ShareeCircle_1_ValueBuilder? value);
-}
-
-abstract mixin class $ShareeCircleInterfaceBuilder implements $ShareeInterfaceBuilder, $ShareeCircle_1InterfaceBuilder {
+abstract mixin class $ShareeCircleInterfaceBuilder implements $ShareeInterfaceBuilder {
   void replace(covariant $ShareeCircleInterface other);
   void update(void Function($ShareeCircleInterfaceBuilder) updates);
+  String? get shareWithDescription;
+  set shareWithDescription(covariant String? shareWithDescription);
+
+  ShareeCircle_ValueBuilder get value;
+  set value(covariant ShareeCircle_ValueBuilder? value);
+
   int? get count;
   set count(covariant int? count);
 
   String? get label;
   set label(covariant String? label);
-
-  String? get shareWithDescription;
-  set shareWithDescription(covariant String? shareWithDescription);
-
-  ShareeCircle_1_ValueBuilder get value;
-  set value(covariant ShareeCircle_1_ValueBuilder? value);
 }
 
 class _$ShareeCircle extends ShareeCircle {
   @override
+  final String shareWithDescription;
+  @override
+  final ShareeCircle_Value value;
+  @override
   final int? count;
   @override
   final String label;
-  @override
-  final String shareWithDescription;
-  @override
-  final ShareeCircle_1_Value value;
 
   factory _$ShareeCircle([void Function(ShareeCircleBuilder)? updates]) =>
       (ShareeCircleBuilder()..update(updates))._build();
 
-  _$ShareeCircle._({this.count, required this.label, required this.shareWithDescription, required this.value})
+  _$ShareeCircle._({required this.shareWithDescription, required this.value, this.count, required this.label})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(label, r'ShareeCircle', 'label');
     BuiltValueNullFieldError.checkNotNull(shareWithDescription, r'ShareeCircle', 'shareWithDescription');
     BuiltValueNullFieldError.checkNotNull(value, r'ShareeCircle', 'value');
+    BuiltValueNullFieldError.checkNotNull(label, r'ShareeCircle', 'label');
   }
 
   @override
@@ -10775,19 +10757,19 @@ class _$ShareeCircle extends ShareeCircle {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is ShareeCircle &&
-        count == other.count &&
-        label == other.label &&
         shareWithDescription == other.shareWithDescription &&
-        value == other.value;
+        value == other.value &&
+        count == other.count &&
+        label == other.label;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, count.hashCode);
-    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jc(_$hash, shareWithDescription.hashCode);
     _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -10795,16 +10777,25 @@ class _$ShareeCircle extends ShareeCircle {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'ShareeCircle')
-          ..add('count', count)
-          ..add('label', label)
           ..add('shareWithDescription', shareWithDescription)
-          ..add('value', value))
+          ..add('value', value)
+          ..add('count', count)
+          ..add('label', label))
         .toString();
   }
 }
 
 class ShareeCircleBuilder implements Builder<ShareeCircle, ShareeCircleBuilder>, $ShareeCircleInterfaceBuilder {
   _$ShareeCircle? _$v;
+
+  String? _shareWithDescription;
+  String? get shareWithDescription => _$this._shareWithDescription;
+  set shareWithDescription(covariant String? shareWithDescription) =>
+      _$this._shareWithDescription = shareWithDescription;
+
+  ShareeCircle_ValueBuilder? _value;
+  ShareeCircle_ValueBuilder get value => _$this._value ??= ShareeCircle_ValueBuilder();
+  set value(covariant ShareeCircle_ValueBuilder? value) => _$this._value = value;
 
   int? _count;
   int? get count => _$this._count;
@@ -10814,24 +10805,15 @@ class ShareeCircleBuilder implements Builder<ShareeCircle, ShareeCircleBuilder>,
   String? get label => _$this._label;
   set label(covariant String? label) => _$this._label = label;
 
-  String? _shareWithDescription;
-  String? get shareWithDescription => _$this._shareWithDescription;
-  set shareWithDescription(covariant String? shareWithDescription) =>
-      _$this._shareWithDescription = shareWithDescription;
-
-  ShareeCircle_1_ValueBuilder? _value;
-  ShareeCircle_1_ValueBuilder get value => _$this._value ??= ShareeCircle_1_ValueBuilder();
-  set value(covariant ShareeCircle_1_ValueBuilder? value) => _$this._value = value;
-
   ShareeCircleBuilder();
 
   ShareeCircleBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _count = $v.count;
-      _label = $v.label;
       _shareWithDescription = $v.shareWithDescription;
       _value = $v.value.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
       _$v = null;
     }
     return this;
@@ -10856,11 +10838,11 @@ class ShareeCircleBuilder implements Builder<ShareeCircle, ShareeCircleBuilder>,
     try {
       _$result = _$v ??
           _$ShareeCircle._(
-              count: count,
-              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeCircle', 'label'),
               shareWithDescription:
                   BuiltValueNullFieldError.checkNotNull(shareWithDescription, r'ShareeCircle', 'shareWithDescription'),
-              value: value.build());
+              value: value.build(),
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeCircle', 'label'));
     } catch (_) {
       late String _$failedField;
       try {
@@ -10876,34 +10858,9 @@ class ShareeCircleBuilder implements Builder<ShareeCircle, ShareeCircleBuilder>,
   }
 }
 
-abstract mixin class $ShareeEmail_1InterfaceBuilder {
-  void replace($ShareeEmail_1Interface other);
-  void update(void Function($ShareeEmail_1InterfaceBuilder) updates);
-  String? get uuid;
-  set uuid(String? uuid);
-
-  String? get name;
-  set name(String? name);
-
-  String? get type;
-  set type(String? type);
-
-  String? get shareWithDisplayNameUnique;
-  set shareWithDisplayNameUnique(String? shareWithDisplayNameUnique);
-
-  ShareeValueBuilder get value;
-  set value(ShareeValueBuilder? value);
-}
-
-abstract mixin class $ShareeEmailInterfaceBuilder implements $ShareeInterfaceBuilder, $ShareeEmail_1InterfaceBuilder {
+abstract mixin class $ShareeEmailInterfaceBuilder implements $ShareeInterfaceBuilder {
   void replace(covariant $ShareeEmailInterface other);
   void update(void Function($ShareeEmailInterfaceBuilder) updates);
-  int? get count;
-  set count(covariant int? count);
-
-  String? get label;
-  set label(covariant String? label);
-
   String? get uuid;
   set uuid(covariant String? uuid);
 
@@ -10918,13 +10875,15 @@ abstract mixin class $ShareeEmailInterfaceBuilder implements $ShareeInterfaceBui
 
   ShareeValueBuilder get value;
   set value(covariant ShareeValueBuilder? value);
+
+  int? get count;
+  set count(covariant int? count);
+
+  String? get label;
+  set label(covariant String? label);
 }
 
 class _$ShareeEmail extends ShareeEmail {
-  @override
-  final int? count;
-  @override
-  final String label;
   @override
   final String uuid;
   @override
@@ -10935,25 +10894,29 @@ class _$ShareeEmail extends ShareeEmail {
   final String shareWithDisplayNameUnique;
   @override
   final ShareeValue value;
+  @override
+  final int? count;
+  @override
+  final String label;
 
   factory _$ShareeEmail([void Function(ShareeEmailBuilder)? updates]) =>
       (ShareeEmailBuilder()..update(updates))._build();
 
   _$ShareeEmail._(
-      {this.count,
-      required this.label,
-      required this.uuid,
+      {required this.uuid,
       required this.name,
       required this.type,
       required this.shareWithDisplayNameUnique,
-      required this.value})
+      required this.value,
+      this.count,
+      required this.label})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(label, r'ShareeEmail', 'label');
     BuiltValueNullFieldError.checkNotNull(uuid, r'ShareeEmail', 'uuid');
     BuiltValueNullFieldError.checkNotNull(name, r'ShareeEmail', 'name');
     BuiltValueNullFieldError.checkNotNull(type, r'ShareeEmail', 'type');
     BuiltValueNullFieldError.checkNotNull(shareWithDisplayNameUnique, r'ShareeEmail', 'shareWithDisplayNameUnique');
     BuiltValueNullFieldError.checkNotNull(value, r'ShareeEmail', 'value');
+    BuiltValueNullFieldError.checkNotNull(label, r'ShareeEmail', 'label');
   }
 
   @override
@@ -10966,25 +10929,25 @@ class _$ShareeEmail extends ShareeEmail {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is ShareeEmail &&
-        count == other.count &&
-        label == other.label &&
         uuid == other.uuid &&
         name == other.name &&
         type == other.type &&
         shareWithDisplayNameUnique == other.shareWithDisplayNameUnique &&
-        value == other.value;
+        value == other.value &&
+        count == other.count &&
+        label == other.label;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, count.hashCode);
-    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jc(_$hash, uuid.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, type.hashCode);
     _$hash = $jc(_$hash, shareWithDisplayNameUnique.hashCode);
     _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -10992,27 +10955,19 @@ class _$ShareeEmail extends ShareeEmail {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'ShareeEmail')
-          ..add('count', count)
-          ..add('label', label)
           ..add('uuid', uuid)
           ..add('name', name)
           ..add('type', type)
           ..add('shareWithDisplayNameUnique', shareWithDisplayNameUnique)
-          ..add('value', value))
+          ..add('value', value)
+          ..add('count', count)
+          ..add('label', label))
         .toString();
   }
 }
 
 class ShareeEmailBuilder implements Builder<ShareeEmail, ShareeEmailBuilder>, $ShareeEmailInterfaceBuilder {
   _$ShareeEmail? _$v;
-
-  int? _count;
-  int? get count => _$this._count;
-  set count(covariant int? count) => _$this._count = count;
-
-  String? _label;
-  String? get label => _$this._label;
-  set label(covariant String? label) => _$this._label = label;
 
   String? _uuid;
   String? get uuid => _$this._uuid;
@@ -11035,18 +10990,26 @@ class ShareeEmailBuilder implements Builder<ShareeEmail, ShareeEmailBuilder>, $S
   ShareeValueBuilder get value => _$this._value ??= ShareeValueBuilder();
   set value(covariant ShareeValueBuilder? value) => _$this._value = value;
 
+  int? _count;
+  int? get count => _$this._count;
+  set count(covariant int? count) => _$this._count = count;
+
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
+
   ShareeEmailBuilder();
 
   ShareeEmailBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _count = $v.count;
-      _label = $v.label;
       _uuid = $v.uuid;
       _name = $v.name;
       _type = $v.type;
       _shareWithDisplayNameUnique = $v.shareWithDisplayNameUnique;
       _value = $v.value.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
       _$v = null;
     }
     return this;
@@ -11071,14 +11034,14 @@ class ShareeEmailBuilder implements Builder<ShareeEmail, ShareeEmailBuilder>, $S
     try {
       _$result = _$v ??
           _$ShareeEmail._(
-              count: count,
-              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeEmail', 'label'),
               uuid: BuiltValueNullFieldError.checkNotNull(uuid, r'ShareeEmail', 'uuid'),
               name: BuiltValueNullFieldError.checkNotNull(name, r'ShareeEmail', 'name'),
               type: BuiltValueNullFieldError.checkNotNull(type, r'ShareeEmail', 'type'),
               shareWithDisplayNameUnique: BuiltValueNullFieldError.checkNotNull(
                   shareWithDisplayNameUnique, r'ShareeEmail', 'shareWithDisplayNameUnique'),
-              value: value.build());
+              value: value.build(),
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeEmail', 'label'));
     } catch (_) {
       late String _$failedField;
       try {
@@ -11094,85 +11057,81 @@ class ShareeEmailBuilder implements Builder<ShareeEmail, ShareeEmailBuilder>, $S
   }
 }
 
-abstract mixin class $ShareeRemoteGroup_1_Value_1InterfaceBuilder {
-  void replace($ShareeRemoteGroup_1_Value_1Interface other);
-  void update(void Function($ShareeRemoteGroup_1_Value_1InterfaceBuilder) updates);
+abstract mixin class $ShareeRemoteGroup_ValueInterfaceBuilder implements $ShareeValueInterfaceBuilder {
+  void replace(covariant $ShareeRemoteGroup_ValueInterface other);
+  void update(void Function($ShareeRemoteGroup_ValueInterfaceBuilder) updates);
   String? get server;
-  set server(String? server);
-}
+  set server(covariant String? server);
 
-abstract mixin class $ShareeRemoteGroup_1_ValueInterfaceBuilder
-    implements $ShareeValueInterfaceBuilder, $ShareeRemoteGroup_1_Value_1InterfaceBuilder {
-  void replace(covariant $ShareeRemoteGroup_1_ValueInterface other);
-  void update(void Function($ShareeRemoteGroup_1_ValueInterfaceBuilder) updates);
   int? get shareType;
   set shareType(covariant int? shareType);
 
   String? get shareWith;
   set shareWith(covariant String? shareWith);
-
-  String? get server;
-  set server(covariant String? server);
 }
 
-class _$ShareeRemoteGroup_1_Value extends ShareeRemoteGroup_1_Value {
+class _$ShareeRemoteGroup_Value extends ShareeRemoteGroup_Value {
+  @override
+  final String server;
   @override
   final int shareType;
   @override
   final String shareWith;
-  @override
-  final String server;
 
-  factory _$ShareeRemoteGroup_1_Value([void Function(ShareeRemoteGroup_1_ValueBuilder)? updates]) =>
-      (ShareeRemoteGroup_1_ValueBuilder()..update(updates))._build();
+  factory _$ShareeRemoteGroup_Value([void Function(ShareeRemoteGroup_ValueBuilder)? updates]) =>
+      (ShareeRemoteGroup_ValueBuilder()..update(updates))._build();
 
-  _$ShareeRemoteGroup_1_Value._({required this.shareType, required this.shareWith, required this.server}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeRemoteGroup_1_Value', 'shareType');
-    BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeRemoteGroup_1_Value', 'shareWith');
-    BuiltValueNullFieldError.checkNotNull(server, r'ShareeRemoteGroup_1_Value', 'server');
+  _$ShareeRemoteGroup_Value._({required this.server, required this.shareType, required this.shareWith}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(server, r'ShareeRemoteGroup_Value', 'server');
+    BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeRemoteGroup_Value', 'shareType');
+    BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeRemoteGroup_Value', 'shareWith');
   }
 
   @override
-  ShareeRemoteGroup_1_Value rebuild(void Function(ShareeRemoteGroup_1_ValueBuilder) updates) =>
+  ShareeRemoteGroup_Value rebuild(void Function(ShareeRemoteGroup_ValueBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ShareeRemoteGroup_1_ValueBuilder toBuilder() => ShareeRemoteGroup_1_ValueBuilder()..replace(this);
+  ShareeRemoteGroup_ValueBuilder toBuilder() => ShareeRemoteGroup_ValueBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ShareeRemoteGroup_1_Value &&
+    return other is ShareeRemoteGroup_Value &&
+        server == other.server &&
         shareType == other.shareType &&
-        shareWith == other.shareWith &&
-        server == other.server;
+        shareWith == other.shareWith;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, server.hashCode);
     _$hash = $jc(_$hash, shareType.hashCode);
     _$hash = $jc(_$hash, shareWith.hashCode);
-    _$hash = $jc(_$hash, server.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ShareeRemoteGroup_1_Value')
+    return (newBuiltValueToStringHelper(r'ShareeRemoteGroup_Value')
+          ..add('server', server)
           ..add('shareType', shareType)
-          ..add('shareWith', shareWith)
-          ..add('server', server))
+          ..add('shareWith', shareWith))
         .toString();
   }
 }
 
-class ShareeRemoteGroup_1_ValueBuilder
+class ShareeRemoteGroup_ValueBuilder
     implements
-        Builder<ShareeRemoteGroup_1_Value, ShareeRemoteGroup_1_ValueBuilder>,
-        $ShareeRemoteGroup_1_ValueInterfaceBuilder {
-  _$ShareeRemoteGroup_1_Value? _$v;
+        Builder<ShareeRemoteGroup_Value, ShareeRemoteGroup_ValueBuilder>,
+        $ShareeRemoteGroup_ValueInterfaceBuilder {
+  _$ShareeRemoteGroup_Value? _$v;
+
+  String? _server;
+  String? get server => _$this._server;
+  set server(covariant String? server) => _$this._server = server;
 
   int? _shareType;
   int? get shareType => _$this._shareType;
@@ -11182,102 +11141,84 @@ class ShareeRemoteGroup_1_ValueBuilder
   String? get shareWith => _$this._shareWith;
   set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
-  String? _server;
-  String? get server => _$this._server;
-  set server(covariant String? server) => _$this._server = server;
+  ShareeRemoteGroup_ValueBuilder();
 
-  ShareeRemoteGroup_1_ValueBuilder();
-
-  ShareeRemoteGroup_1_ValueBuilder get _$this {
+  ShareeRemoteGroup_ValueBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _server = $v.server;
       _shareType = $v.shareType;
       _shareWith = $v.shareWith;
-      _server = $v.server;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(covariant ShareeRemoteGroup_1_Value other) {
+  void replace(covariant ShareeRemoteGroup_Value other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ShareeRemoteGroup_1_Value;
+    _$v = other as _$ShareeRemoteGroup_Value;
   }
 
   @override
-  void update(void Function(ShareeRemoteGroup_1_ValueBuilder)? updates) {
+  void update(void Function(ShareeRemoteGroup_ValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ShareeRemoteGroup_1_Value build() => _build();
+  ShareeRemoteGroup_Value build() => _build();
 
-  _$ShareeRemoteGroup_1_Value _build() {
+  _$ShareeRemoteGroup_Value _build() {
     final _$result = _$v ??
-        _$ShareeRemoteGroup_1_Value._(
-            shareType: BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeRemoteGroup_1_Value', 'shareType'),
-            shareWith: BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeRemoteGroup_1_Value', 'shareWith'),
-            server: BuiltValueNullFieldError.checkNotNull(server, r'ShareeRemoteGroup_1_Value', 'server'));
+        _$ShareeRemoteGroup_Value._(
+            server: BuiltValueNullFieldError.checkNotNull(server, r'ShareeRemoteGroup_Value', 'server'),
+            shareType: BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeRemoteGroup_Value', 'shareType'),
+            shareWith: BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeRemoteGroup_Value', 'shareWith'));
     replace(_$result);
     return _$result;
   }
 }
 
-abstract mixin class $ShareeRemoteGroup_1InterfaceBuilder {
-  void replace($ShareeRemoteGroup_1Interface other);
-  void update(void Function($ShareeRemoteGroup_1InterfaceBuilder) updates);
-  String? get guid;
-  set guid(String? guid);
-
-  String? get name;
-  set name(String? name);
-
-  ShareeRemoteGroup_1_ValueBuilder get value;
-  set value(ShareeRemoteGroup_1_ValueBuilder? value);
-}
-
-abstract mixin class $ShareeRemoteGroupInterfaceBuilder
-    implements $ShareeInterfaceBuilder, $ShareeRemoteGroup_1InterfaceBuilder {
+abstract mixin class $ShareeRemoteGroupInterfaceBuilder implements $ShareeInterfaceBuilder {
   void replace(covariant $ShareeRemoteGroupInterface other);
   void update(void Function($ShareeRemoteGroupInterfaceBuilder) updates);
-  int? get count;
-  set count(covariant int? count);
-
-  String? get label;
-  set label(covariant String? label);
-
   String? get guid;
   set guid(covariant String? guid);
 
   String? get name;
   set name(covariant String? name);
 
-  ShareeRemoteGroup_1_ValueBuilder get value;
-  set value(covariant ShareeRemoteGroup_1_ValueBuilder? value);
+  ShareeRemoteGroup_ValueBuilder get value;
+  set value(covariant ShareeRemoteGroup_ValueBuilder? value);
+
+  int? get count;
+  set count(covariant int? count);
+
+  String? get label;
+  set label(covariant String? label);
 }
 
 class _$ShareeRemoteGroup extends ShareeRemoteGroup {
-  @override
-  final int? count;
-  @override
-  final String label;
   @override
   final String guid;
   @override
   final String name;
   @override
-  final ShareeRemoteGroup_1_Value value;
+  final ShareeRemoteGroup_Value value;
+  @override
+  final int? count;
+  @override
+  final String label;
 
   factory _$ShareeRemoteGroup([void Function(ShareeRemoteGroupBuilder)? updates]) =>
       (ShareeRemoteGroupBuilder()..update(updates))._build();
 
-  _$ShareeRemoteGroup._({this.count, required this.label, required this.guid, required this.name, required this.value})
+  _$ShareeRemoteGroup._({required this.guid, required this.name, required this.value, this.count, required this.label})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(label, r'ShareeRemoteGroup', 'label');
     BuiltValueNullFieldError.checkNotNull(guid, r'ShareeRemoteGroup', 'guid');
     BuiltValueNullFieldError.checkNotNull(name, r'ShareeRemoteGroup', 'name');
     BuiltValueNullFieldError.checkNotNull(value, r'ShareeRemoteGroup', 'value');
+    BuiltValueNullFieldError.checkNotNull(label, r'ShareeRemoteGroup', 'label');
   }
 
   @override
@@ -11290,21 +11231,21 @@ class _$ShareeRemoteGroup extends ShareeRemoteGroup {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is ShareeRemoteGroup &&
-        count == other.count &&
-        label == other.label &&
         guid == other.guid &&
         name == other.name &&
-        value == other.value;
+        value == other.value &&
+        count == other.count &&
+        label == other.label;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, count.hashCode);
-    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jc(_$hash, guid.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -11312,11 +11253,11 @@ class _$ShareeRemoteGroup extends ShareeRemoteGroup {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'ShareeRemoteGroup')
-          ..add('count', count)
-          ..add('label', label)
           ..add('guid', guid)
           ..add('name', name)
-          ..add('value', value))
+          ..add('value', value)
+          ..add('count', count)
+          ..add('label', label))
         .toString();
   }
 }
@@ -11324,14 +11265,6 @@ class _$ShareeRemoteGroup extends ShareeRemoteGroup {
 class ShareeRemoteGroupBuilder
     implements Builder<ShareeRemoteGroup, ShareeRemoteGroupBuilder>, $ShareeRemoteGroupInterfaceBuilder {
   _$ShareeRemoteGroup? _$v;
-
-  int? _count;
-  int? get count => _$this._count;
-  set count(covariant int? count) => _$this._count = count;
-
-  String? _label;
-  String? get label => _$this._label;
-  set label(covariant String? label) => _$this._label = label;
 
   String? _guid;
   String? get guid => _$this._guid;
@@ -11341,20 +11274,28 @@ class ShareeRemoteGroupBuilder
   String? get name => _$this._name;
   set name(covariant String? name) => _$this._name = name;
 
-  ShareeRemoteGroup_1_ValueBuilder? _value;
-  ShareeRemoteGroup_1_ValueBuilder get value => _$this._value ??= ShareeRemoteGroup_1_ValueBuilder();
-  set value(covariant ShareeRemoteGroup_1_ValueBuilder? value) => _$this._value = value;
+  ShareeRemoteGroup_ValueBuilder? _value;
+  ShareeRemoteGroup_ValueBuilder get value => _$this._value ??= ShareeRemoteGroup_ValueBuilder();
+  set value(covariant ShareeRemoteGroup_ValueBuilder? value) => _$this._value = value;
+
+  int? _count;
+  int? get count => _$this._count;
+  set count(covariant int? count) => _$this._count = count;
+
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
 
   ShareeRemoteGroupBuilder();
 
   ShareeRemoteGroupBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _count = $v.count;
-      _label = $v.label;
       _guid = $v.guid;
       _name = $v.name;
       _value = $v.value.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
       _$v = null;
     }
     return this;
@@ -11379,11 +11320,11 @@ class ShareeRemoteGroupBuilder
     try {
       _$result = _$v ??
           _$ShareeRemoteGroup._(
-              count: count,
-              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeRemoteGroup', 'label'),
               guid: BuiltValueNullFieldError.checkNotNull(guid, r'ShareeRemoteGroup', 'guid'),
               name: BuiltValueNullFieldError.checkNotNull(name, r'ShareeRemoteGroup', 'name'),
-              value: value.build());
+              value: value.build(),
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeRemoteGroup', 'label'));
     } catch (_) {
       late String _$failedField;
       try {
@@ -11399,83 +11340,79 @@ class ShareeRemoteGroupBuilder
   }
 }
 
-abstract mixin class $ShareeRemote_1_Value_1InterfaceBuilder {
-  void replace($ShareeRemote_1_Value_1Interface other);
-  void update(void Function($ShareeRemote_1_Value_1InterfaceBuilder) updates);
+abstract mixin class $ShareeRemote_ValueInterfaceBuilder implements $ShareeValueInterfaceBuilder {
+  void replace(covariant $ShareeRemote_ValueInterface other);
+  void update(void Function($ShareeRemote_ValueInterfaceBuilder) updates);
   String? get server;
-  set server(String? server);
-}
+  set server(covariant String? server);
 
-abstract mixin class $ShareeRemote_1_ValueInterfaceBuilder
-    implements $ShareeValueInterfaceBuilder, $ShareeRemote_1_Value_1InterfaceBuilder {
-  void replace(covariant $ShareeRemote_1_ValueInterface other);
-  void update(void Function($ShareeRemote_1_ValueInterfaceBuilder) updates);
   int? get shareType;
   set shareType(covariant int? shareType);
 
   String? get shareWith;
   set shareWith(covariant String? shareWith);
-
-  String? get server;
-  set server(covariant String? server);
 }
 
-class _$ShareeRemote_1_Value extends ShareeRemote_1_Value {
+class _$ShareeRemote_Value extends ShareeRemote_Value {
+  @override
+  final String server;
   @override
   final int shareType;
   @override
   final String shareWith;
-  @override
-  final String server;
 
-  factory _$ShareeRemote_1_Value([void Function(ShareeRemote_1_ValueBuilder)? updates]) =>
-      (ShareeRemote_1_ValueBuilder()..update(updates))._build();
+  factory _$ShareeRemote_Value([void Function(ShareeRemote_ValueBuilder)? updates]) =>
+      (ShareeRemote_ValueBuilder()..update(updates))._build();
 
-  _$ShareeRemote_1_Value._({required this.shareType, required this.shareWith, required this.server}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeRemote_1_Value', 'shareType');
-    BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeRemote_1_Value', 'shareWith');
-    BuiltValueNullFieldError.checkNotNull(server, r'ShareeRemote_1_Value', 'server');
+  _$ShareeRemote_Value._({required this.server, required this.shareType, required this.shareWith}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(server, r'ShareeRemote_Value', 'server');
+    BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeRemote_Value', 'shareType');
+    BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeRemote_Value', 'shareWith');
   }
 
   @override
-  ShareeRemote_1_Value rebuild(void Function(ShareeRemote_1_ValueBuilder) updates) =>
+  ShareeRemote_Value rebuild(void Function(ShareeRemote_ValueBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ShareeRemote_1_ValueBuilder toBuilder() => ShareeRemote_1_ValueBuilder()..replace(this);
+  ShareeRemote_ValueBuilder toBuilder() => ShareeRemote_ValueBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ShareeRemote_1_Value &&
+    return other is ShareeRemote_Value &&
+        server == other.server &&
         shareType == other.shareType &&
-        shareWith == other.shareWith &&
-        server == other.server;
+        shareWith == other.shareWith;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, server.hashCode);
     _$hash = $jc(_$hash, shareType.hashCode);
     _$hash = $jc(_$hash, shareWith.hashCode);
-    _$hash = $jc(_$hash, server.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ShareeRemote_1_Value')
+    return (newBuiltValueToStringHelper(r'ShareeRemote_Value')
+          ..add('server', server)
           ..add('shareType', shareType)
-          ..add('shareWith', shareWith)
-          ..add('server', server))
+          ..add('shareWith', shareWith))
         .toString();
   }
 }
 
-class ShareeRemote_1_ValueBuilder
-    implements Builder<ShareeRemote_1_Value, ShareeRemote_1_ValueBuilder>, $ShareeRemote_1_ValueInterfaceBuilder {
-  _$ShareeRemote_1_Value? _$v;
+class ShareeRemote_ValueBuilder
+    implements Builder<ShareeRemote_Value, ShareeRemote_ValueBuilder>, $ShareeRemote_ValueInterfaceBuilder {
+  _$ShareeRemote_Value? _$v;
+
+  String? _server;
+  String? get server => _$this._server;
+  set server(covariant String? server) => _$this._server = server;
 
   int? _shareType;
   int? get shareType => _$this._shareType;
@@ -11485,73 +11422,47 @@ class ShareeRemote_1_ValueBuilder
   String? get shareWith => _$this._shareWith;
   set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
-  String? _server;
-  String? get server => _$this._server;
-  set server(covariant String? server) => _$this._server = server;
+  ShareeRemote_ValueBuilder();
 
-  ShareeRemote_1_ValueBuilder();
-
-  ShareeRemote_1_ValueBuilder get _$this {
+  ShareeRemote_ValueBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _server = $v.server;
       _shareType = $v.shareType;
       _shareWith = $v.shareWith;
-      _server = $v.server;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(covariant ShareeRemote_1_Value other) {
+  void replace(covariant ShareeRemote_Value other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ShareeRemote_1_Value;
+    _$v = other as _$ShareeRemote_Value;
   }
 
   @override
-  void update(void Function(ShareeRemote_1_ValueBuilder)? updates) {
+  void update(void Function(ShareeRemote_ValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ShareeRemote_1_Value build() => _build();
+  ShareeRemote_Value build() => _build();
 
-  _$ShareeRemote_1_Value _build() {
+  _$ShareeRemote_Value _build() {
     final _$result = _$v ??
-        _$ShareeRemote_1_Value._(
-            shareType: BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeRemote_1_Value', 'shareType'),
-            shareWith: BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeRemote_1_Value', 'shareWith'),
-            server: BuiltValueNullFieldError.checkNotNull(server, r'ShareeRemote_1_Value', 'server'));
+        _$ShareeRemote_Value._(
+            server: BuiltValueNullFieldError.checkNotNull(server, r'ShareeRemote_Value', 'server'),
+            shareType: BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeRemote_Value', 'shareType'),
+            shareWith: BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeRemote_Value', 'shareWith'));
     replace(_$result);
     return _$result;
   }
 }
 
-abstract mixin class $ShareeRemote_1InterfaceBuilder {
-  void replace($ShareeRemote_1Interface other);
-  void update(void Function($ShareeRemote_1InterfaceBuilder) updates);
-  String? get uuid;
-  set uuid(String? uuid);
-
-  String? get name;
-  set name(String? name);
-
-  String? get type;
-  set type(String? type);
-
-  ShareeRemote_1_ValueBuilder get value;
-  set value(ShareeRemote_1_ValueBuilder? value);
-}
-
-abstract mixin class $ShareeRemoteInterfaceBuilder implements $ShareeInterfaceBuilder, $ShareeRemote_1InterfaceBuilder {
+abstract mixin class $ShareeRemoteInterfaceBuilder implements $ShareeInterfaceBuilder {
   void replace(covariant $ShareeRemoteInterface other);
   void update(void Function($ShareeRemoteInterfaceBuilder) updates);
-  int? get count;
-  set count(covariant int? count);
-
-  String? get label;
-  set label(covariant String? label);
-
   String? get uuid;
   set uuid(covariant String? uuid);
 
@@ -11561,15 +11472,17 @@ abstract mixin class $ShareeRemoteInterfaceBuilder implements $ShareeInterfaceBu
   String? get type;
   set type(covariant String? type);
 
-  ShareeRemote_1_ValueBuilder get value;
-  set value(covariant ShareeRemote_1_ValueBuilder? value);
+  ShareeRemote_ValueBuilder get value;
+  set value(covariant ShareeRemote_ValueBuilder? value);
+
+  int? get count;
+  set count(covariant int? count);
+
+  String? get label;
+  set label(covariant String? label);
 }
 
 class _$ShareeRemote extends ShareeRemote {
-  @override
-  final int? count;
-  @override
-  final String label;
   @override
   final String uuid;
   @override
@@ -11577,24 +11490,28 @@ class _$ShareeRemote extends ShareeRemote {
   @override
   final String type;
   @override
-  final ShareeRemote_1_Value value;
+  final ShareeRemote_Value value;
+  @override
+  final int? count;
+  @override
+  final String label;
 
   factory _$ShareeRemote([void Function(ShareeRemoteBuilder)? updates]) =>
       (ShareeRemoteBuilder()..update(updates))._build();
 
   _$ShareeRemote._(
-      {this.count,
-      required this.label,
-      required this.uuid,
+      {required this.uuid,
       required this.name,
       required this.type,
-      required this.value})
+      required this.value,
+      this.count,
+      required this.label})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(label, r'ShareeRemote', 'label');
     BuiltValueNullFieldError.checkNotNull(uuid, r'ShareeRemote', 'uuid');
     BuiltValueNullFieldError.checkNotNull(name, r'ShareeRemote', 'name');
     BuiltValueNullFieldError.checkNotNull(type, r'ShareeRemote', 'type');
     BuiltValueNullFieldError.checkNotNull(value, r'ShareeRemote', 'value');
+    BuiltValueNullFieldError.checkNotNull(label, r'ShareeRemote', 'label');
   }
 
   @override
@@ -11607,23 +11524,23 @@ class _$ShareeRemote extends ShareeRemote {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is ShareeRemote &&
-        count == other.count &&
-        label == other.label &&
         uuid == other.uuid &&
         name == other.name &&
         type == other.type &&
-        value == other.value;
+        value == other.value &&
+        count == other.count &&
+        label == other.label;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, count.hashCode);
-    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jc(_$hash, uuid.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, type.hashCode);
     _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -11631,26 +11548,18 @@ class _$ShareeRemote extends ShareeRemote {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'ShareeRemote')
-          ..add('count', count)
-          ..add('label', label)
           ..add('uuid', uuid)
           ..add('name', name)
           ..add('type', type)
-          ..add('value', value))
+          ..add('value', value)
+          ..add('count', count)
+          ..add('label', label))
         .toString();
   }
 }
 
 class ShareeRemoteBuilder implements Builder<ShareeRemote, ShareeRemoteBuilder>, $ShareeRemoteInterfaceBuilder {
   _$ShareeRemote? _$v;
-
-  int? _count;
-  int? get count => _$this._count;
-  set count(covariant int? count) => _$this._count = count;
-
-  String? _label;
-  String? get label => _$this._label;
-  set label(covariant String? label) => _$this._label = label;
 
   String? _uuid;
   String? get uuid => _$this._uuid;
@@ -11664,21 +11573,29 @@ class ShareeRemoteBuilder implements Builder<ShareeRemote, ShareeRemoteBuilder>,
   String? get type => _$this._type;
   set type(covariant String? type) => _$this._type = type;
 
-  ShareeRemote_1_ValueBuilder? _value;
-  ShareeRemote_1_ValueBuilder get value => _$this._value ??= ShareeRemote_1_ValueBuilder();
-  set value(covariant ShareeRemote_1_ValueBuilder? value) => _$this._value = value;
+  ShareeRemote_ValueBuilder? _value;
+  ShareeRemote_ValueBuilder get value => _$this._value ??= ShareeRemote_ValueBuilder();
+  set value(covariant ShareeRemote_ValueBuilder? value) => _$this._value = value;
+
+  int? _count;
+  int? get count => _$this._count;
+  set count(covariant int? count) => _$this._count = count;
+
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
 
   ShareeRemoteBuilder();
 
   ShareeRemoteBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _count = $v.count;
-      _label = $v.label;
       _uuid = $v.uuid;
       _name = $v.name;
       _type = $v.type;
       _value = $v.value.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
       _$v = null;
     }
     return this;
@@ -11703,12 +11620,12 @@ class ShareeRemoteBuilder implements Builder<ShareeRemote, ShareeRemoteBuilder>,
     try {
       _$result = _$v ??
           _$ShareeRemote._(
-              count: count,
-              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeRemote', 'label'),
               uuid: BuiltValueNullFieldError.checkNotNull(uuid, r'ShareeRemote', 'uuid'),
               name: BuiltValueNullFieldError.checkNotNull(name, r'ShareeRemote', 'name'),
               type: BuiltValueNullFieldError.checkNotNull(type, r'ShareeRemote', 'type'),
-              value: value.build());
+              value: value.build(),
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeRemote', 'label'));
     } catch (_) {
       late String _$failedField;
       try {
@@ -11724,9 +11641,9 @@ class ShareeRemoteBuilder implements Builder<ShareeRemote, ShareeRemoteBuilder>,
   }
 }
 
-abstract mixin class $ShareeUser_1_StatusInterfaceBuilder {
-  void replace($ShareeUser_1_StatusInterface other);
-  void update(void Function($ShareeUser_1_StatusInterfaceBuilder) updates);
+abstract mixin class $ShareeUser_StatusInterfaceBuilder {
+  void replace($ShareeUser_StatusInterface other);
+  void update(void Function($ShareeUser_StatusInterfaceBuilder) updates);
   String? get status;
   set status(String? status);
 
@@ -11740,7 +11657,7 @@ abstract mixin class $ShareeUser_1_StatusInterfaceBuilder {
   set clearAt(int? clearAt);
 }
 
-class _$ShareeUser_1_Status extends ShareeUser_1_Status {
+class _$ShareeUser_Status extends ShareeUser_Status {
   @override
   final String status;
   @override
@@ -11750,26 +11667,25 @@ class _$ShareeUser_1_Status extends ShareeUser_1_Status {
   @override
   final int? clearAt;
 
-  factory _$ShareeUser_1_Status([void Function(ShareeUser_1_StatusBuilder)? updates]) =>
-      (ShareeUser_1_StatusBuilder()..update(updates))._build();
+  factory _$ShareeUser_Status([void Function(ShareeUser_StatusBuilder)? updates]) =>
+      (ShareeUser_StatusBuilder()..update(updates))._build();
 
-  _$ShareeUser_1_Status._({required this.status, required this.message, required this.icon, this.clearAt}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(status, r'ShareeUser_1_Status', 'status');
-    BuiltValueNullFieldError.checkNotNull(message, r'ShareeUser_1_Status', 'message');
-    BuiltValueNullFieldError.checkNotNull(icon, r'ShareeUser_1_Status', 'icon');
+  _$ShareeUser_Status._({required this.status, required this.message, required this.icon, this.clearAt}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(status, r'ShareeUser_Status', 'status');
+    BuiltValueNullFieldError.checkNotNull(message, r'ShareeUser_Status', 'message');
+    BuiltValueNullFieldError.checkNotNull(icon, r'ShareeUser_Status', 'icon');
   }
 
   @override
-  ShareeUser_1_Status rebuild(void Function(ShareeUser_1_StatusBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
+  ShareeUser_Status rebuild(void Function(ShareeUser_StatusBuilder) updates) => (toBuilder()..update(updates)).build();
 
   @override
-  ShareeUser_1_StatusBuilder toBuilder() => ShareeUser_1_StatusBuilder()..replace(this);
+  ShareeUser_StatusBuilder toBuilder() => ShareeUser_StatusBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ShareeUser_1_Status &&
+    return other is ShareeUser_Status &&
         status == other.status &&
         message == other.message &&
         icon == other.icon &&
@@ -11789,7 +11705,7 @@ class _$ShareeUser_1_Status extends ShareeUser_1_Status {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ShareeUser_1_Status')
+    return (newBuiltValueToStringHelper(r'ShareeUser_Status')
           ..add('status', status)
           ..add('message', message)
           ..add('icon', icon)
@@ -11798,9 +11714,9 @@ class _$ShareeUser_1_Status extends ShareeUser_1_Status {
   }
 }
 
-class ShareeUser_1_StatusBuilder
-    implements Builder<ShareeUser_1_Status, ShareeUser_1_StatusBuilder>, $ShareeUser_1_StatusInterfaceBuilder {
-  _$ShareeUser_1_Status? _$v;
+class ShareeUser_StatusBuilder
+    implements Builder<ShareeUser_Status, ShareeUser_StatusBuilder>, $ShareeUser_StatusInterfaceBuilder {
+  _$ShareeUser_Status? _$v;
 
   String? _status;
   String? get status => _$this._status;
@@ -11818,9 +11734,9 @@ class ShareeUser_1_StatusBuilder
   int? get clearAt => _$this._clearAt;
   set clearAt(covariant int? clearAt) => _$this._clearAt = clearAt;
 
-  ShareeUser_1_StatusBuilder();
+  ShareeUser_StatusBuilder();
 
-  ShareeUser_1_StatusBuilder get _$this {
+  ShareeUser_StatusBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _status = $v.status;
@@ -11833,59 +11749,34 @@ class ShareeUser_1_StatusBuilder
   }
 
   @override
-  void replace(covariant ShareeUser_1_Status other) {
+  void replace(covariant ShareeUser_Status other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ShareeUser_1_Status;
+    _$v = other as _$ShareeUser_Status;
   }
 
   @override
-  void update(void Function(ShareeUser_1_StatusBuilder)? updates) {
+  void update(void Function(ShareeUser_StatusBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ShareeUser_1_Status build() => _build();
+  ShareeUser_Status build() => _build();
 
-  _$ShareeUser_1_Status _build() {
+  _$ShareeUser_Status _build() {
     final _$result = _$v ??
-        _$ShareeUser_1_Status._(
-            status: BuiltValueNullFieldError.checkNotNull(status, r'ShareeUser_1_Status', 'status'),
-            message: BuiltValueNullFieldError.checkNotNull(message, r'ShareeUser_1_Status', 'message'),
-            icon: BuiltValueNullFieldError.checkNotNull(icon, r'ShareeUser_1_Status', 'icon'),
+        _$ShareeUser_Status._(
+            status: BuiltValueNullFieldError.checkNotNull(status, r'ShareeUser_Status', 'status'),
+            message: BuiltValueNullFieldError.checkNotNull(message, r'ShareeUser_Status', 'message'),
+            icon: BuiltValueNullFieldError.checkNotNull(icon, r'ShareeUser_Status', 'icon'),
             clearAt: clearAt);
     replace(_$result);
     return _$result;
   }
 }
 
-abstract mixin class $ShareeUser_1InterfaceBuilder {
-  void replace($ShareeUser_1Interface other);
-  void update(void Function($ShareeUser_1InterfaceBuilder) updates);
-  String? get subline;
-  set subline(String? subline);
-
-  String? get icon;
-  set icon(String? icon);
-
-  String? get shareWithDisplayNameUnique;
-  set shareWithDisplayNameUnique(String? shareWithDisplayNameUnique);
-
-  ShareeUser_1_StatusBuilder get status;
-  set status(ShareeUser_1_StatusBuilder? status);
-
-  ShareeValueBuilder get value;
-  set value(ShareeValueBuilder? value);
-}
-
-abstract mixin class $ShareeUserInterfaceBuilder implements $ShareeInterfaceBuilder, $ShareeUser_1InterfaceBuilder {
+abstract mixin class $ShareeUserInterfaceBuilder implements $ShareeInterfaceBuilder {
   void replace(covariant $ShareeUserInterface other);
   void update(void Function($ShareeUserInterfaceBuilder) updates);
-  int? get count;
-  set count(covariant int? count);
-
-  String? get label;
-  set label(covariant String? label);
-
   String? get subline;
   set subline(covariant String? subline);
 
@@ -11895,18 +11786,20 @@ abstract mixin class $ShareeUserInterfaceBuilder implements $ShareeInterfaceBuil
   String? get shareWithDisplayNameUnique;
   set shareWithDisplayNameUnique(covariant String? shareWithDisplayNameUnique);
 
-  ShareeUser_1_StatusBuilder get status;
-  set status(covariant ShareeUser_1_StatusBuilder? status);
+  ShareeUser_StatusBuilder get status;
+  set status(covariant ShareeUser_StatusBuilder? status);
 
   ShareeValueBuilder get value;
   set value(covariant ShareeValueBuilder? value);
+
+  int? get count;
+  set count(covariant int? count);
+
+  String? get label;
+  set label(covariant String? label);
 }
 
 class _$ShareeUser extends ShareeUser {
-  @override
-  final int? count;
-  @override
-  final String label;
   @override
   final String subline;
   @override
@@ -11914,27 +11807,31 @@ class _$ShareeUser extends ShareeUser {
   @override
   final String shareWithDisplayNameUnique;
   @override
-  final ShareeUser_1_Status status;
+  final ShareeUser_Status status;
   @override
   final ShareeValue value;
+  @override
+  final int? count;
+  @override
+  final String label;
 
   factory _$ShareeUser([void Function(ShareeUserBuilder)? updates]) => (ShareeUserBuilder()..update(updates))._build();
 
   _$ShareeUser._(
-      {this.count,
-      required this.label,
-      required this.subline,
+      {required this.subline,
       required this.icon,
       required this.shareWithDisplayNameUnique,
       required this.status,
-      required this.value})
+      required this.value,
+      this.count,
+      required this.label})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(label, r'ShareeUser', 'label');
     BuiltValueNullFieldError.checkNotNull(subline, r'ShareeUser', 'subline');
     BuiltValueNullFieldError.checkNotNull(icon, r'ShareeUser', 'icon');
     BuiltValueNullFieldError.checkNotNull(shareWithDisplayNameUnique, r'ShareeUser', 'shareWithDisplayNameUnique');
     BuiltValueNullFieldError.checkNotNull(status, r'ShareeUser', 'status');
     BuiltValueNullFieldError.checkNotNull(value, r'ShareeUser', 'value');
+    BuiltValueNullFieldError.checkNotNull(label, r'ShareeUser', 'label');
   }
 
   @override
@@ -11947,25 +11844,25 @@ class _$ShareeUser extends ShareeUser {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is ShareeUser &&
-        count == other.count &&
-        label == other.label &&
         subline == other.subline &&
         icon == other.icon &&
         shareWithDisplayNameUnique == other.shareWithDisplayNameUnique &&
         status == other.status &&
-        value == other.value;
+        value == other.value &&
+        count == other.count &&
+        label == other.label;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, count.hashCode);
-    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jc(_$hash, subline.hashCode);
     _$hash = $jc(_$hash, icon.hashCode);
     _$hash = $jc(_$hash, shareWithDisplayNameUnique.hashCode);
     _$hash = $jc(_$hash, status.hashCode);
     _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -11973,27 +11870,19 @@ class _$ShareeUser extends ShareeUser {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'ShareeUser')
-          ..add('count', count)
-          ..add('label', label)
           ..add('subline', subline)
           ..add('icon', icon)
           ..add('shareWithDisplayNameUnique', shareWithDisplayNameUnique)
           ..add('status', status)
-          ..add('value', value))
+          ..add('value', value)
+          ..add('count', count)
+          ..add('label', label))
         .toString();
   }
 }
 
 class ShareeUserBuilder implements Builder<ShareeUser, ShareeUserBuilder>, $ShareeUserInterfaceBuilder {
   _$ShareeUser? _$v;
-
-  int? _count;
-  int? get count => _$this._count;
-  set count(covariant int? count) => _$this._count = count;
-
-  String? _label;
-  String? get label => _$this._label;
-  set label(covariant String? label) => _$this._label = label;
 
   String? _subline;
   String? get subline => _$this._subline;
@@ -12008,26 +11897,34 @@ class ShareeUserBuilder implements Builder<ShareeUser, ShareeUserBuilder>, $Shar
   set shareWithDisplayNameUnique(covariant String? shareWithDisplayNameUnique) =>
       _$this._shareWithDisplayNameUnique = shareWithDisplayNameUnique;
 
-  ShareeUser_1_StatusBuilder? _status;
-  ShareeUser_1_StatusBuilder get status => _$this._status ??= ShareeUser_1_StatusBuilder();
-  set status(covariant ShareeUser_1_StatusBuilder? status) => _$this._status = status;
+  ShareeUser_StatusBuilder? _status;
+  ShareeUser_StatusBuilder get status => _$this._status ??= ShareeUser_StatusBuilder();
+  set status(covariant ShareeUser_StatusBuilder? status) => _$this._status = status;
 
   ShareeValueBuilder? _value;
   ShareeValueBuilder get value => _$this._value ??= ShareeValueBuilder();
   set value(covariant ShareeValueBuilder? value) => _$this._value = value;
+
+  int? _count;
+  int? get count => _$this._count;
+  set count(covariant int? count) => _$this._count = count;
+
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
 
   ShareeUserBuilder();
 
   ShareeUserBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _count = $v.count;
-      _label = $v.label;
       _subline = $v.subline;
       _icon = $v.icon;
       _shareWithDisplayNameUnique = $v.shareWithDisplayNameUnique;
       _status = $v.status.toBuilder();
       _value = $v.value.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
       _$v = null;
     }
     return this;
@@ -12052,14 +11949,14 @@ class ShareeUserBuilder implements Builder<ShareeUser, ShareeUserBuilder>, $Shar
     try {
       _$result = _$v ??
           _$ShareeUser._(
-              count: count,
-              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeUser', 'label'),
               subline: BuiltValueNullFieldError.checkNotNull(subline, r'ShareeUser', 'subline'),
               icon: BuiltValueNullFieldError.checkNotNull(icon, r'ShareeUser', 'icon'),
               shareWithDisplayNameUnique: BuiltValueNullFieldError.checkNotNull(
                   shareWithDisplayNameUnique, r'ShareeUser', 'shareWithDisplayNameUnique'),
               status: status.build(),
-              value: value.build());
+              value: value.build(),
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeUser', 'label'));
     } catch (_) {
       late String _$failedField;
       try {
@@ -12391,9 +12288,9 @@ class LookupBuilder implements Builder<Lookup, LookupBuilder>, $LookupInterfaceB
   }
 }
 
-abstract mixin class $ShareeLookup_1_ExtraInterfaceBuilder {
-  void replace($ShareeLookup_1_ExtraInterface other);
-  void update(void Function($ShareeLookup_1_ExtraInterfaceBuilder) updates);
+abstract mixin class $ShareeLookup_ExtraInterfaceBuilder {
+  void replace($ShareeLookup_ExtraInterface other);
+  void update(void Function($ShareeLookup_ExtraInterfaceBuilder) updates);
   String? get federationId;
   set federationId(String? federationId);
 
@@ -12425,7 +12322,7 @@ abstract mixin class $ShareeLookup_1_ExtraInterfaceBuilder {
   set userid(LookupBuilder? userid);
 }
 
-class _$ShareeLookup_1_Extra extends ShareeLookup_1_Extra {
+class _$ShareeLookup_Extra extends ShareeLookup_Extra {
   @override
   final String federationId;
   @override
@@ -12447,10 +12344,10 @@ class _$ShareeLookup_1_Extra extends ShareeLookup_1_Extra {
   @override
   final Lookup? userid;
 
-  factory _$ShareeLookup_1_Extra([void Function(ShareeLookup_1_ExtraBuilder)? updates]) =>
-      (ShareeLookup_1_ExtraBuilder()..update(updates))._build();
+  factory _$ShareeLookup_Extra([void Function(ShareeLookup_ExtraBuilder)? updates]) =>
+      (ShareeLookup_ExtraBuilder()..update(updates))._build();
 
-  _$ShareeLookup_1_Extra._(
+  _$ShareeLookup_Extra._(
       {required this.federationId,
       this.name,
       this.email,
@@ -12462,20 +12359,20 @@ class _$ShareeLookup_1_Extra extends ShareeLookup_1_Extra {
       this.websiteSignature,
       this.userid})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(federationId, r'ShareeLookup_1_Extra', 'federationId');
+    BuiltValueNullFieldError.checkNotNull(federationId, r'ShareeLookup_Extra', 'federationId');
   }
 
   @override
-  ShareeLookup_1_Extra rebuild(void Function(ShareeLookup_1_ExtraBuilder) updates) =>
+  ShareeLookup_Extra rebuild(void Function(ShareeLookup_ExtraBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ShareeLookup_1_ExtraBuilder toBuilder() => ShareeLookup_1_ExtraBuilder()..replace(this);
+  ShareeLookup_ExtraBuilder toBuilder() => ShareeLookup_ExtraBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ShareeLookup_1_Extra &&
+    return other is ShareeLookup_Extra &&
         federationId == other.federationId &&
         name == other.name &&
         email == other.email &&
@@ -12507,7 +12404,7 @@ class _$ShareeLookup_1_Extra extends ShareeLookup_1_Extra {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ShareeLookup_1_Extra')
+    return (newBuiltValueToStringHelper(r'ShareeLookup_Extra')
           ..add('federationId', federationId)
           ..add('name', name)
           ..add('email', email)
@@ -12522,9 +12419,9 @@ class _$ShareeLookup_1_Extra extends ShareeLookup_1_Extra {
   }
 }
 
-class ShareeLookup_1_ExtraBuilder
-    implements Builder<ShareeLookup_1_Extra, ShareeLookup_1_ExtraBuilder>, $ShareeLookup_1_ExtraInterfaceBuilder {
-  _$ShareeLookup_1_Extra? _$v;
+class ShareeLookup_ExtraBuilder
+    implements Builder<ShareeLookup_Extra, ShareeLookup_ExtraBuilder>, $ShareeLookup_ExtraInterfaceBuilder {
+  _$ShareeLookup_Extra? _$v;
 
   String? _federationId;
   String? get federationId => _$this._federationId;
@@ -12566,9 +12463,9 @@ class ShareeLookup_1_ExtraBuilder
   LookupBuilder get userid => _$this._userid ??= LookupBuilder();
   set userid(covariant LookupBuilder? userid) => _$this._userid = userid;
 
-  ShareeLookup_1_ExtraBuilder();
+  ShareeLookup_ExtraBuilder();
 
-  ShareeLookup_1_ExtraBuilder get _$this {
+  ShareeLookup_ExtraBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _federationId = $v.federationId;
@@ -12587,26 +12484,25 @@ class ShareeLookup_1_ExtraBuilder
   }
 
   @override
-  void replace(covariant ShareeLookup_1_Extra other) {
+  void replace(covariant ShareeLookup_Extra other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ShareeLookup_1_Extra;
+    _$v = other as _$ShareeLookup_Extra;
   }
 
   @override
-  void update(void Function(ShareeLookup_1_ExtraBuilder)? updates) {
+  void update(void Function(ShareeLookup_ExtraBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ShareeLookup_1_Extra build() => _build();
+  ShareeLookup_Extra build() => _build();
 
-  _$ShareeLookup_1_Extra _build() {
-    _$ShareeLookup_1_Extra _$result;
+  _$ShareeLookup_Extra _build() {
+    _$ShareeLookup_Extra _$result;
     try {
       _$result = _$v ??
-          _$ShareeLookup_1_Extra._(
-              federationId:
-                  BuiltValueNullFieldError.checkNotNull(federationId, r'ShareeLookup_1_Extra', 'federationId'),
+          _$ShareeLookup_Extra._(
+              federationId: BuiltValueNullFieldError.checkNotNull(federationId, r'ShareeLookup_Extra', 'federationId'),
               name: _name?.build(),
               email: _email?.build(),
               address: _address?.build(),
@@ -12638,7 +12534,7 @@ class ShareeLookup_1_ExtraBuilder
         _$failedField = 'userid';
         _userid?.build();
       } catch (e) {
-        throw BuiltValueNestedFieldError(r'ShareeLookup_1_Extra', _$failedField, e.toString());
+        throw BuiltValueNestedFieldError(r'ShareeLookup_Extra', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -12647,83 +12543,79 @@ class ShareeLookup_1_ExtraBuilder
   }
 }
 
-abstract mixin class $ShareeLookup_1_Value_1InterfaceBuilder {
-  void replace($ShareeLookup_1_Value_1Interface other);
-  void update(void Function($ShareeLookup_1_Value_1InterfaceBuilder) updates);
+abstract mixin class $ShareeLookup_ValueInterfaceBuilder implements $ShareeValueInterfaceBuilder {
+  void replace(covariant $ShareeLookup_ValueInterface other);
+  void update(void Function($ShareeLookup_ValueInterfaceBuilder) updates);
   bool? get globalScale;
-  set globalScale(bool? globalScale);
-}
+  set globalScale(covariant bool? globalScale);
 
-abstract mixin class $ShareeLookup_1_ValueInterfaceBuilder
-    implements $ShareeValueInterfaceBuilder, $ShareeLookup_1_Value_1InterfaceBuilder {
-  void replace(covariant $ShareeLookup_1_ValueInterface other);
-  void update(void Function($ShareeLookup_1_ValueInterfaceBuilder) updates);
   int? get shareType;
   set shareType(covariant int? shareType);
 
   String? get shareWith;
   set shareWith(covariant String? shareWith);
-
-  bool? get globalScale;
-  set globalScale(covariant bool? globalScale);
 }
 
-class _$ShareeLookup_1_Value extends ShareeLookup_1_Value {
+class _$ShareeLookup_Value extends ShareeLookup_Value {
+  @override
+  final bool globalScale;
   @override
   final int shareType;
   @override
   final String shareWith;
-  @override
-  final bool globalScale;
 
-  factory _$ShareeLookup_1_Value([void Function(ShareeLookup_1_ValueBuilder)? updates]) =>
-      (ShareeLookup_1_ValueBuilder()..update(updates))._build();
+  factory _$ShareeLookup_Value([void Function(ShareeLookup_ValueBuilder)? updates]) =>
+      (ShareeLookup_ValueBuilder()..update(updates))._build();
 
-  _$ShareeLookup_1_Value._({required this.shareType, required this.shareWith, required this.globalScale}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeLookup_1_Value', 'shareType');
-    BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeLookup_1_Value', 'shareWith');
-    BuiltValueNullFieldError.checkNotNull(globalScale, r'ShareeLookup_1_Value', 'globalScale');
+  _$ShareeLookup_Value._({required this.globalScale, required this.shareType, required this.shareWith}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(globalScale, r'ShareeLookup_Value', 'globalScale');
+    BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeLookup_Value', 'shareType');
+    BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeLookup_Value', 'shareWith');
   }
 
   @override
-  ShareeLookup_1_Value rebuild(void Function(ShareeLookup_1_ValueBuilder) updates) =>
+  ShareeLookup_Value rebuild(void Function(ShareeLookup_ValueBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ShareeLookup_1_ValueBuilder toBuilder() => ShareeLookup_1_ValueBuilder()..replace(this);
+  ShareeLookup_ValueBuilder toBuilder() => ShareeLookup_ValueBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ShareeLookup_1_Value &&
+    return other is ShareeLookup_Value &&
+        globalScale == other.globalScale &&
         shareType == other.shareType &&
-        shareWith == other.shareWith &&
-        globalScale == other.globalScale;
+        shareWith == other.shareWith;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, globalScale.hashCode);
     _$hash = $jc(_$hash, shareType.hashCode);
     _$hash = $jc(_$hash, shareWith.hashCode);
-    _$hash = $jc(_$hash, globalScale.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ShareeLookup_1_Value')
+    return (newBuiltValueToStringHelper(r'ShareeLookup_Value')
+          ..add('globalScale', globalScale)
           ..add('shareType', shareType)
-          ..add('shareWith', shareWith)
-          ..add('globalScale', globalScale))
+          ..add('shareWith', shareWith))
         .toString();
   }
 }
 
-class ShareeLookup_1_ValueBuilder
-    implements Builder<ShareeLookup_1_Value, ShareeLookup_1_ValueBuilder>, $ShareeLookup_1_ValueInterfaceBuilder {
-  _$ShareeLookup_1_Value? _$v;
+class ShareeLookup_ValueBuilder
+    implements Builder<ShareeLookup_Value, ShareeLookup_ValueBuilder>, $ShareeLookup_ValueInterfaceBuilder {
+  _$ShareeLookup_Value? _$v;
+
+  bool? _globalScale;
+  bool? get globalScale => _$this._globalScale;
+  set globalScale(covariant bool? globalScale) => _$this._globalScale = globalScale;
 
   int? _shareType;
   int? get shareType => _$this._shareType;
@@ -12733,91 +12625,77 @@ class ShareeLookup_1_ValueBuilder
   String? get shareWith => _$this._shareWith;
   set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
-  bool? _globalScale;
-  bool? get globalScale => _$this._globalScale;
-  set globalScale(covariant bool? globalScale) => _$this._globalScale = globalScale;
+  ShareeLookup_ValueBuilder();
 
-  ShareeLookup_1_ValueBuilder();
-
-  ShareeLookup_1_ValueBuilder get _$this {
+  ShareeLookup_ValueBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _globalScale = $v.globalScale;
       _shareType = $v.shareType;
       _shareWith = $v.shareWith;
-      _globalScale = $v.globalScale;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(covariant ShareeLookup_1_Value other) {
+  void replace(covariant ShareeLookup_Value other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ShareeLookup_1_Value;
+    _$v = other as _$ShareeLookup_Value;
   }
 
   @override
-  void update(void Function(ShareeLookup_1_ValueBuilder)? updates) {
+  void update(void Function(ShareeLookup_ValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ShareeLookup_1_Value build() => _build();
+  ShareeLookup_Value build() => _build();
 
-  _$ShareeLookup_1_Value _build() {
+  _$ShareeLookup_Value _build() {
     final _$result = _$v ??
-        _$ShareeLookup_1_Value._(
-            shareType: BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeLookup_1_Value', 'shareType'),
-            shareWith: BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeLookup_1_Value', 'shareWith'),
-            globalScale: BuiltValueNullFieldError.checkNotNull(globalScale, r'ShareeLookup_1_Value', 'globalScale'));
+        _$ShareeLookup_Value._(
+            globalScale: BuiltValueNullFieldError.checkNotNull(globalScale, r'ShareeLookup_Value', 'globalScale'),
+            shareType: BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeLookup_Value', 'shareType'),
+            shareWith: BuiltValueNullFieldError.checkNotNull(shareWith, r'ShareeLookup_Value', 'shareWith'));
     replace(_$result);
     return _$result;
   }
 }
 
-abstract mixin class $ShareeLookup_1InterfaceBuilder {
-  void replace($ShareeLookup_1Interface other);
-  void update(void Function($ShareeLookup_1InterfaceBuilder) updates);
-  ShareeLookup_1_ExtraBuilder get extra;
-  set extra(ShareeLookup_1_ExtraBuilder? extra);
-
-  ShareeLookup_1_ValueBuilder get value;
-  set value(ShareeLookup_1_ValueBuilder? value);
-}
-
-abstract mixin class $ShareeLookupInterfaceBuilder implements $ShareeInterfaceBuilder, $ShareeLookup_1InterfaceBuilder {
+abstract mixin class $ShareeLookupInterfaceBuilder implements $ShareeInterfaceBuilder {
   void replace(covariant $ShareeLookupInterface other);
   void update(void Function($ShareeLookupInterfaceBuilder) updates);
+  ShareeLookup_ExtraBuilder get extra;
+  set extra(covariant ShareeLookup_ExtraBuilder? extra);
+
+  ShareeLookup_ValueBuilder get value;
+  set value(covariant ShareeLookup_ValueBuilder? value);
+
   int? get count;
   set count(covariant int? count);
 
   String? get label;
   set label(covariant String? label);
-
-  ShareeLookup_1_ExtraBuilder get extra;
-  set extra(covariant ShareeLookup_1_ExtraBuilder? extra);
-
-  ShareeLookup_1_ValueBuilder get value;
-  set value(covariant ShareeLookup_1_ValueBuilder? value);
 }
 
 class _$ShareeLookup extends ShareeLookup {
   @override
+  final ShareeLookup_Extra extra;
+  @override
+  final ShareeLookup_Value value;
+  @override
   final int? count;
   @override
   final String label;
-  @override
-  final ShareeLookup_1_Extra extra;
-  @override
-  final ShareeLookup_1_Value value;
 
   factory _$ShareeLookup([void Function(ShareeLookupBuilder)? updates]) =>
       (ShareeLookupBuilder()..update(updates))._build();
 
-  _$ShareeLookup._({this.count, required this.label, required this.extra, required this.value}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(label, r'ShareeLookup', 'label');
+  _$ShareeLookup._({required this.extra, required this.value, this.count, required this.label}) : super._() {
     BuiltValueNullFieldError.checkNotNull(extra, r'ShareeLookup', 'extra');
     BuiltValueNullFieldError.checkNotNull(value, r'ShareeLookup', 'value');
+    BuiltValueNullFieldError.checkNotNull(label, r'ShareeLookup', 'label');
   }
 
   @override
@@ -12830,19 +12708,19 @@ class _$ShareeLookup extends ShareeLookup {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is ShareeLookup &&
-        count == other.count &&
-        label == other.label &&
         extra == other.extra &&
-        value == other.value;
+        value == other.value &&
+        count == other.count &&
+        label == other.label;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, count.hashCode);
-    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jc(_$hash, extra.hashCode);
     _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, count.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -12850,16 +12728,24 @@ class _$ShareeLookup extends ShareeLookup {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'ShareeLookup')
-          ..add('count', count)
-          ..add('label', label)
           ..add('extra', extra)
-          ..add('value', value))
+          ..add('value', value)
+          ..add('count', count)
+          ..add('label', label))
         .toString();
   }
 }
 
 class ShareeLookupBuilder implements Builder<ShareeLookup, ShareeLookupBuilder>, $ShareeLookupInterfaceBuilder {
   _$ShareeLookup? _$v;
+
+  ShareeLookup_ExtraBuilder? _extra;
+  ShareeLookup_ExtraBuilder get extra => _$this._extra ??= ShareeLookup_ExtraBuilder();
+  set extra(covariant ShareeLookup_ExtraBuilder? extra) => _$this._extra = extra;
+
+  ShareeLookup_ValueBuilder? _value;
+  ShareeLookup_ValueBuilder get value => _$this._value ??= ShareeLookup_ValueBuilder();
+  set value(covariant ShareeLookup_ValueBuilder? value) => _$this._value = value;
 
   int? _count;
   int? get count => _$this._count;
@@ -12869,23 +12755,15 @@ class ShareeLookupBuilder implements Builder<ShareeLookup, ShareeLookupBuilder>,
   String? get label => _$this._label;
   set label(covariant String? label) => _$this._label = label;
 
-  ShareeLookup_1_ExtraBuilder? _extra;
-  ShareeLookup_1_ExtraBuilder get extra => _$this._extra ??= ShareeLookup_1_ExtraBuilder();
-  set extra(covariant ShareeLookup_1_ExtraBuilder? extra) => _$this._extra = extra;
-
-  ShareeLookup_1_ValueBuilder? _value;
-  ShareeLookup_1_ValueBuilder get value => _$this._value ??= ShareeLookup_1_ValueBuilder();
-  set value(covariant ShareeLookup_1_ValueBuilder? value) => _$this._value = value;
-
   ShareeLookupBuilder();
 
   ShareeLookupBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _count = $v.count;
-      _label = $v.label;
       _extra = $v.extra.toBuilder();
       _value = $v.value.toBuilder();
+      _count = $v.count;
+      _label = $v.label;
       _$v = null;
     }
     return this;
@@ -12910,10 +12788,10 @@ class ShareeLookupBuilder implements Builder<ShareeLookup, ShareeLookupBuilder>,
     try {
       _$result = _$v ??
           _$ShareeLookup._(
-              count: count,
-              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeLookup', 'label'),
               extra: extra.build(),
-              value: value.build());
+              value: value.build(),
+              count: count,
+              label: BuiltValueNullFieldError.checkNotNull(label, r'ShareeLookup', 'label'));
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -14647,7 +14647,7 @@ abstract class Bot implements $BotInterface, Built<Bot, BotBuilder> {
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $BotWithDetails_1Interface {
+abstract interface class $BotWithDetailsInterface implements $BotInterface {
   @BuiltValueField(wireName: 'error_count')
   int get errorCount;
   int get features;
@@ -14659,9 +14659,6 @@ abstract interface class $BotWithDetails_1Interface {
   @BuiltValueField(wireName: 'url_hash')
   String get urlHash;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $BotWithDetailsInterface implements $BotInterface, $BotWithDetails_1Interface {}
 
 abstract class BotWithDetails implements $BotWithDetailsInterface, Built<BotWithDetails, BotWithDetailsBuilder> {
   /// Creates a new BotWithDetails object using the builder pattern.
@@ -19713,13 +19710,9 @@ abstract class ChatChatReceiveMessagesHeaders
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ChatMessageWithParent_1Interface {
+abstract interface class $ChatMessageWithParentInterface implements $ChatMessageInterface {
   ChatMessage? get parent;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $ChatMessageWithParentInterface
-    implements $ChatMessageInterface, $ChatMessageWithParent_1Interface {}
 
 abstract class ChatMessageWithParent
     implements $ChatMessageWithParentInterface, Built<ChatMessageWithParent, ChatMessageWithParentBuilder> {
@@ -37690,13 +37683,9 @@ abstract class TempAvatarDeleteAvatarResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $BotWithDetailsAndSecret_1Interface {
+abstract interface class $BotWithDetailsAndSecretInterface implements $BotWithDetailsInterface {
   String get secret;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $BotWithDetailsAndSecretInterface
-    implements $BotWithDetailsInterface, $BotWithDetailsAndSecret_1Interface {}
 
 abstract class BotWithDetailsAndSecret
     implements $BotWithDetailsAndSecretInterface, Built<BotWithDetailsAndSecret, BotWithDetailsAndSecretBuilder> {

--- a/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
@@ -8684,12 +8684,6 @@ class _$BotWithDetailsSerializer implements StructuredSerializer<BotWithDetails>
   Iterable<Object?> serialize(Serializers serializers, BotWithDetails object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'id',
-      serializers.serialize(object.id, specifiedType: const FullType(int)),
-      'name',
-      serializers.serialize(object.name, specifiedType: const FullType(String)),
-      'state',
-      serializers.serialize(object.state, specifiedType: const FullType(int)),
       'error_count',
       serializers.serialize(object.errorCount, specifiedType: const FullType(int)),
       'features',
@@ -8702,6 +8696,12 @@ class _$BotWithDetailsSerializer implements StructuredSerializer<BotWithDetails>
       serializers.serialize(object.url, specifiedType: const FullType(String)),
       'url_hash',
       serializers.serialize(object.urlHash, specifiedType: const FullType(String)),
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(int)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'state',
+      serializers.serialize(object.state, specifiedType: const FullType(int)),
     ];
     Object? value;
     value = object.description;
@@ -8724,18 +8724,6 @@ class _$BotWithDetailsSerializer implements StructuredSerializer<BotWithDetails>
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'description':
-          result.description = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-        case 'id':
-          result.id = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
-          break;
-        case 'name':
-          result.name = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'state':
-          result.state = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
-          break;
         case 'error_count':
           result.errorCount = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
@@ -8753,6 +8741,18 @@ class _$BotWithDetailsSerializer implements StructuredSerializer<BotWithDetails>
           break;
         case 'url_hash':
           result.urlHash = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'description':
+          result.description = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'id':
+          result.id = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'state':
+          result.state = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -10876,6 +10876,12 @@ class _$ChatMessageWithParentSerializer implements StructuredSerializer<ChatMess
       serializers.serialize(object.token, specifiedType: const FullType(String)),
     ];
     Object? value;
+    value = object.parent;
+    if (value != null) {
+      result
+        ..add('parent')
+        ..add(serializers.serialize(value, specifiedType: const FullType(ChatMessage)));
+    }
     value = object.deleted;
     if (value != null) {
       result
@@ -10887,12 +10893,6 @@ class _$ChatMessageWithParentSerializer implements StructuredSerializer<ChatMess
       result
         ..add('markdown')
         ..add(serializers.serialize(value, specifiedType: const FullType(bool)));
-    }
-    value = object.parent;
-    if (value != null) {
-      result
-        ..add('parent')
-        ..add(serializers.serialize(value, specifiedType: const FullType(ChatMessage)));
     }
     return result;
   }
@@ -10908,6 +10908,10 @@ class _$ChatMessageWithParentSerializer implements StructuredSerializer<ChatMess
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'parent':
+          result.parent
+              .replace(serializers.deserialize(value, specifiedType: const FullType(ChatMessage))! as ChatMessage);
+          break;
         case 'actorDisplayName':
           result.actorDisplayName = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -10960,10 +10964,6 @@ class _$ChatMessageWithParentSerializer implements StructuredSerializer<ChatMess
           break;
         case 'token':
           result.token = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'parent':
-          result.parent
-              .replace(serializers.deserialize(value, specifiedType: const FullType(ChatMessage))! as ChatMessage);
           break;
       }
     }
@@ -20562,12 +20562,8 @@ class _$BotWithDetailsAndSecretSerializer implements StructuredSerializer<BotWit
   Iterable<Object?> serialize(Serializers serializers, BotWithDetailsAndSecret object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'id',
-      serializers.serialize(object.id, specifiedType: const FullType(int)),
-      'name',
-      serializers.serialize(object.name, specifiedType: const FullType(String)),
-      'state',
-      serializers.serialize(object.state, specifiedType: const FullType(int)),
+      'secret',
+      serializers.serialize(object.secret, specifiedType: const FullType(String)),
       'error_count',
       serializers.serialize(object.errorCount, specifiedType: const FullType(int)),
       'features',
@@ -20580,8 +20576,12 @@ class _$BotWithDetailsAndSecretSerializer implements StructuredSerializer<BotWit
       serializers.serialize(object.url, specifiedType: const FullType(String)),
       'url_hash',
       serializers.serialize(object.urlHash, specifiedType: const FullType(String)),
-      'secret',
-      serializers.serialize(object.secret, specifiedType: const FullType(String)),
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(int)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'state',
+      serializers.serialize(object.state, specifiedType: const FullType(int)),
     ];
     Object? value;
     value = object.description;
@@ -20604,17 +20604,8 @@ class _$BotWithDetailsAndSecretSerializer implements StructuredSerializer<BotWit
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'description':
-          result.description = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-        case 'id':
-          result.id = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
-          break;
-        case 'name':
-          result.name = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'state':
-          result.state = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+        case 'secret':
+          result.secret = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'error_count':
           result.errorCount = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
@@ -20634,8 +20625,17 @@ class _$BotWithDetailsAndSecretSerializer implements StructuredSerializer<BotWit
         case 'url_hash':
           result.urlHash = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
-        case 'secret':
-          result.secret = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+        case 'description':
+          result.description = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'id':
+          result.id = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'state':
+          result.state = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -24143,44 +24143,9 @@ class BotBuilder implements Builder<Bot, BotBuilder>, $BotInterfaceBuilder {
   }
 }
 
-abstract mixin class $BotWithDetails_1InterfaceBuilder {
-  void replace($BotWithDetails_1Interface other);
-  void update(void Function($BotWithDetails_1InterfaceBuilder) updates);
-  int? get errorCount;
-  set errorCount(int? errorCount);
-
-  int? get features;
-  set features(int? features);
-
-  int? get lastErrorDate;
-  set lastErrorDate(int? lastErrorDate);
-
-  String? get lastErrorMessage;
-  set lastErrorMessage(String? lastErrorMessage);
-
-  String? get url;
-  set url(String? url);
-
-  String? get urlHash;
-  set urlHash(String? urlHash);
-}
-
-abstract mixin class $BotWithDetailsInterfaceBuilder
-    implements $BotInterfaceBuilder, $BotWithDetails_1InterfaceBuilder {
+abstract mixin class $BotWithDetailsInterfaceBuilder implements $BotInterfaceBuilder {
   void replace(covariant $BotWithDetailsInterface other);
   void update(void Function($BotWithDetailsInterfaceBuilder) updates);
-  String? get description;
-  set description(covariant String? description);
-
-  int? get id;
-  set id(covariant int? id);
-
-  String? get name;
-  set name(covariant String? name);
-
-  int? get state;
-  set state(covariant int? state);
-
   int? get errorCount;
   set errorCount(covariant int? errorCount);
 
@@ -24198,17 +24163,21 @@ abstract mixin class $BotWithDetailsInterfaceBuilder
 
   String? get urlHash;
   set urlHash(covariant String? urlHash);
+
+  String? get description;
+  set description(covariant String? description);
+
+  int? get id;
+  set id(covariant int? id);
+
+  String? get name;
+  set name(covariant String? name);
+
+  int? get state;
+  set state(covariant int? state);
 }
 
 class _$BotWithDetails extends BotWithDetails {
-  @override
-  final String? description;
-  @override
-  final int id;
-  @override
-  final String name;
-  @override
-  final int state;
   @override
   final int errorCount;
   @override
@@ -24221,31 +24190,39 @@ class _$BotWithDetails extends BotWithDetails {
   final String url;
   @override
   final String urlHash;
+  @override
+  final String? description;
+  @override
+  final int id;
+  @override
+  final String name;
+  @override
+  final int state;
 
   factory _$BotWithDetails([void Function(BotWithDetailsBuilder)? updates]) =>
       (BotWithDetailsBuilder()..update(updates))._build();
 
   _$BotWithDetails._(
-      {this.description,
-      required this.id,
-      required this.name,
-      required this.state,
-      required this.errorCount,
+      {required this.errorCount,
       required this.features,
       required this.lastErrorDate,
       required this.lastErrorMessage,
       required this.url,
-      required this.urlHash})
+      required this.urlHash,
+      this.description,
+      required this.id,
+      required this.name,
+      required this.state})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(id, r'BotWithDetails', 'id');
-    BuiltValueNullFieldError.checkNotNull(name, r'BotWithDetails', 'name');
-    BuiltValueNullFieldError.checkNotNull(state, r'BotWithDetails', 'state');
     BuiltValueNullFieldError.checkNotNull(errorCount, r'BotWithDetails', 'errorCount');
     BuiltValueNullFieldError.checkNotNull(features, r'BotWithDetails', 'features');
     BuiltValueNullFieldError.checkNotNull(lastErrorDate, r'BotWithDetails', 'lastErrorDate');
     BuiltValueNullFieldError.checkNotNull(lastErrorMessage, r'BotWithDetails', 'lastErrorMessage');
     BuiltValueNullFieldError.checkNotNull(url, r'BotWithDetails', 'url');
     BuiltValueNullFieldError.checkNotNull(urlHash, r'BotWithDetails', 'urlHash');
+    BuiltValueNullFieldError.checkNotNull(id, r'BotWithDetails', 'id');
+    BuiltValueNullFieldError.checkNotNull(name, r'BotWithDetails', 'name');
+    BuiltValueNullFieldError.checkNotNull(state, r'BotWithDetails', 'state');
   }
 
   @override
@@ -24258,31 +24235,31 @@ class _$BotWithDetails extends BotWithDetails {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is BotWithDetails &&
-        description == other.description &&
-        id == other.id &&
-        name == other.name &&
-        state == other.state &&
         errorCount == other.errorCount &&
         features == other.features &&
         lastErrorDate == other.lastErrorDate &&
         lastErrorMessage == other.lastErrorMessage &&
         url == other.url &&
-        urlHash == other.urlHash;
+        urlHash == other.urlHash &&
+        description == other.description &&
+        id == other.id &&
+        name == other.name &&
+        state == other.state;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, description.hashCode);
-    _$hash = $jc(_$hash, id.hashCode);
-    _$hash = $jc(_$hash, name.hashCode);
-    _$hash = $jc(_$hash, state.hashCode);
     _$hash = $jc(_$hash, errorCount.hashCode);
     _$hash = $jc(_$hash, features.hashCode);
     _$hash = $jc(_$hash, lastErrorDate.hashCode);
     _$hash = $jc(_$hash, lastErrorMessage.hashCode);
     _$hash = $jc(_$hash, url.hashCode);
     _$hash = $jc(_$hash, urlHash.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, state.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -24290,38 +24267,22 @@ class _$BotWithDetails extends BotWithDetails {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'BotWithDetails')
-          ..add('description', description)
-          ..add('id', id)
-          ..add('name', name)
-          ..add('state', state)
           ..add('errorCount', errorCount)
           ..add('features', features)
           ..add('lastErrorDate', lastErrorDate)
           ..add('lastErrorMessage', lastErrorMessage)
           ..add('url', url)
-          ..add('urlHash', urlHash))
+          ..add('urlHash', urlHash)
+          ..add('description', description)
+          ..add('id', id)
+          ..add('name', name)
+          ..add('state', state))
         .toString();
   }
 }
 
 class BotWithDetailsBuilder implements Builder<BotWithDetails, BotWithDetailsBuilder>, $BotWithDetailsInterfaceBuilder {
   _$BotWithDetails? _$v;
-
-  String? _description;
-  String? get description => _$this._description;
-  set description(covariant String? description) => _$this._description = description;
-
-  int? _id;
-  int? get id => _$this._id;
-  set id(covariant int? id) => _$this._id = id;
-
-  String? _name;
-  String? get name => _$this._name;
-  set name(covariant String? name) => _$this._name = name;
-
-  int? _state;
-  int? get state => _$this._state;
-  set state(covariant int? state) => _$this._state = state;
 
   int? _errorCount;
   int? get errorCount => _$this._errorCount;
@@ -24347,21 +24308,37 @@ class BotWithDetailsBuilder implements Builder<BotWithDetails, BotWithDetailsBui
   String? get urlHash => _$this._urlHash;
   set urlHash(covariant String? urlHash) => _$this._urlHash = urlHash;
 
+  String? _description;
+  String? get description => _$this._description;
+  set description(covariant String? description) => _$this._description = description;
+
+  int? _id;
+  int? get id => _$this._id;
+  set id(covariant int? id) => _$this._id = id;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  int? _state;
+  int? get state => _$this._state;
+  set state(covariant int? state) => _$this._state = state;
+
   BotWithDetailsBuilder();
 
   BotWithDetailsBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _description = $v.description;
-      _id = $v.id;
-      _name = $v.name;
-      _state = $v.state;
       _errorCount = $v.errorCount;
       _features = $v.features;
       _lastErrorDate = $v.lastErrorDate;
       _lastErrorMessage = $v.lastErrorMessage;
       _url = $v.url;
       _urlHash = $v.urlHash;
+      _description = $v.description;
+      _id = $v.id;
+      _name = $v.name;
+      _state = $v.state;
       _$v = null;
     }
     return this;
@@ -24384,17 +24361,17 @@ class BotWithDetailsBuilder implements Builder<BotWithDetails, BotWithDetailsBui
   _$BotWithDetails _build() {
     final _$result = _$v ??
         _$BotWithDetails._(
-            description: description,
-            id: BuiltValueNullFieldError.checkNotNull(id, r'BotWithDetails', 'id'),
-            name: BuiltValueNullFieldError.checkNotNull(name, r'BotWithDetails', 'name'),
-            state: BuiltValueNullFieldError.checkNotNull(state, r'BotWithDetails', 'state'),
             errorCount: BuiltValueNullFieldError.checkNotNull(errorCount, r'BotWithDetails', 'errorCount'),
             features: BuiltValueNullFieldError.checkNotNull(features, r'BotWithDetails', 'features'),
             lastErrorDate: BuiltValueNullFieldError.checkNotNull(lastErrorDate, r'BotWithDetails', 'lastErrorDate'),
             lastErrorMessage:
                 BuiltValueNullFieldError.checkNotNull(lastErrorMessage, r'BotWithDetails', 'lastErrorMessage'),
             url: BuiltValueNullFieldError.checkNotNull(url, r'BotWithDetails', 'url'),
-            urlHash: BuiltValueNullFieldError.checkNotNull(urlHash, r'BotWithDetails', 'urlHash'));
+            urlHash: BuiltValueNullFieldError.checkNotNull(urlHash, r'BotWithDetails', 'urlHash'),
+            description: description,
+            id: BuiltValueNullFieldError.checkNotNull(id, r'BotWithDetails', 'id'),
+            name: BuiltValueNullFieldError.checkNotNull(name, r'BotWithDetails', 'name'),
+            state: BuiltValueNullFieldError.checkNotNull(state, r'BotWithDetails', 'state'));
     replace(_$result);
     return _$result;
   }
@@ -29414,17 +29391,12 @@ class ChatChatReceiveMessagesHeadersBuilder
   }
 }
 
-abstract mixin class $ChatMessageWithParent_1InterfaceBuilder {
-  void replace($ChatMessageWithParent_1Interface other);
-  void update(void Function($ChatMessageWithParent_1InterfaceBuilder) updates);
-  ChatMessageBuilder get parent;
-  set parent(ChatMessageBuilder? parent);
-}
-
-abstract mixin class $ChatMessageWithParentInterfaceBuilder
-    implements $ChatMessageInterfaceBuilder, $ChatMessageWithParent_1InterfaceBuilder {
+abstract mixin class $ChatMessageWithParentInterfaceBuilder implements $ChatMessageInterfaceBuilder {
   void replace(covariant $ChatMessageWithParentInterface other);
   void update(void Function($ChatMessageWithParentInterfaceBuilder) updates);
+  ChatMessageBuilder get parent;
+  set parent(covariant ChatMessageBuilder? parent);
+
   String? get actorDisplayName;
   set actorDisplayName(covariant String? actorDisplayName);
 
@@ -29472,12 +29444,11 @@ abstract mixin class $ChatMessageWithParentInterfaceBuilder
 
   String? get token;
   set token(covariant String? token);
-
-  ChatMessageBuilder get parent;
-  set parent(covariant ChatMessageBuilder? parent);
 }
 
 class _$ChatMessageWithParent extends ChatMessageWithParent {
+  @override
+  final ChatMessage? parent;
   @override
   final String actorDisplayName;
   @override
@@ -29510,14 +29481,13 @@ class _$ChatMessageWithParent extends ChatMessageWithParent {
   final int timestamp;
   @override
   final String token;
-  @override
-  final ChatMessage? parent;
 
   factory _$ChatMessageWithParent([void Function(ChatMessageWithParentBuilder)? updates]) =>
       (ChatMessageWithParentBuilder()..update(updates))._build();
 
   _$ChatMessageWithParent._(
-      {required this.actorDisplayName,
+      {this.parent,
+      required this.actorDisplayName,
       required this.actorId,
       required this.actorType,
       this.deleted,
@@ -29532,8 +29502,7 @@ class _$ChatMessageWithParent extends ChatMessageWithParent {
       required this.referenceId,
       required this.systemMessage,
       required this.timestamp,
-      required this.token,
-      this.parent})
+      required this.token})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(actorDisplayName, r'ChatMessageWithParent', 'actorDisplayName');
     BuiltValueNullFieldError.checkNotNull(actorId, r'ChatMessageWithParent', 'actorId');
@@ -29562,6 +29531,7 @@ class _$ChatMessageWithParent extends ChatMessageWithParent {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is ChatMessageWithParent &&
+        parent == other.parent &&
         actorDisplayName == other.actorDisplayName &&
         actorId == other.actorId &&
         actorType == other.actorType &&
@@ -29577,13 +29547,13 @@ class _$ChatMessageWithParent extends ChatMessageWithParent {
         referenceId == other.referenceId &&
         systemMessage == other.systemMessage &&
         timestamp == other.timestamp &&
-        token == other.token &&
-        parent == other.parent;
+        token == other.token;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, parent.hashCode);
     _$hash = $jc(_$hash, actorDisplayName.hashCode);
     _$hash = $jc(_$hash, actorId.hashCode);
     _$hash = $jc(_$hash, actorType.hashCode);
@@ -29600,7 +29570,6 @@ class _$ChatMessageWithParent extends ChatMessageWithParent {
     _$hash = $jc(_$hash, systemMessage.hashCode);
     _$hash = $jc(_$hash, timestamp.hashCode);
     _$hash = $jc(_$hash, token.hashCode);
-    _$hash = $jc(_$hash, parent.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -29608,6 +29577,7 @@ class _$ChatMessageWithParent extends ChatMessageWithParent {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'ChatMessageWithParent')
+          ..add('parent', parent)
           ..add('actorDisplayName', actorDisplayName)
           ..add('actorId', actorId)
           ..add('actorType', actorType)
@@ -29623,8 +29593,7 @@ class _$ChatMessageWithParent extends ChatMessageWithParent {
           ..add('referenceId', referenceId)
           ..add('systemMessage', systemMessage)
           ..add('timestamp', timestamp)
-          ..add('token', token)
-          ..add('parent', parent))
+          ..add('token', token))
         .toString();
   }
 }
@@ -29632,6 +29601,10 @@ class _$ChatMessageWithParent extends ChatMessageWithParent {
 class ChatMessageWithParentBuilder
     implements Builder<ChatMessageWithParent, ChatMessageWithParentBuilder>, $ChatMessageWithParentInterfaceBuilder {
   _$ChatMessageWithParent? _$v;
+
+  ChatMessageBuilder? _parent;
+  ChatMessageBuilder get parent => _$this._parent ??= ChatMessageBuilder();
+  set parent(covariant ChatMessageBuilder? parent) => _$this._parent = parent;
 
   String? _actorDisplayName;
   String? get actorDisplayName => _$this._actorDisplayName;
@@ -29699,15 +29672,12 @@ class ChatMessageWithParentBuilder
   String? get token => _$this._token;
   set token(covariant String? token) => _$this._token = token;
 
-  ChatMessageBuilder? _parent;
-  ChatMessageBuilder get parent => _$this._parent ??= ChatMessageBuilder();
-  set parent(covariant ChatMessageBuilder? parent) => _$this._parent = parent;
-
   ChatMessageWithParentBuilder();
 
   ChatMessageWithParentBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _parent = $v.parent?.toBuilder();
       _actorDisplayName = $v.actorDisplayName;
       _actorId = $v.actorId;
       _actorType = $v.actorType;
@@ -29724,7 +29694,6 @@ class ChatMessageWithParentBuilder
       _systemMessage = $v.systemMessage;
       _timestamp = $v.timestamp;
       _token = $v.token;
-      _parent = $v.parent?.toBuilder();
       _$v = null;
     }
     return this;
@@ -29749,6 +29718,7 @@ class ChatMessageWithParentBuilder
     try {
       _$result = _$v ??
           _$ChatMessageWithParent._(
+              parent: _parent?.build(),
               actorDisplayName:
                   BuiltValueNullFieldError.checkNotNull(actorDisplayName, r'ChatMessageWithParent', 'actorDisplayName'),
               actorId: BuiltValueNullFieldError.checkNotNull(actorId, r'ChatMessageWithParent', 'actorId'),
@@ -29767,19 +29737,18 @@ class ChatMessageWithParentBuilder
               systemMessage:
                   BuiltValueNullFieldError.checkNotNull(systemMessage, r'ChatMessageWithParent', 'systemMessage'),
               timestamp: BuiltValueNullFieldError.checkNotNull(timestamp, r'ChatMessageWithParent', 'timestamp'),
-              token: BuiltValueNullFieldError.checkNotNull(token, r'ChatMessageWithParent', 'token'),
-              parent: _parent?.build());
+              token: BuiltValueNullFieldError.checkNotNull(token, r'ChatMessageWithParent', 'token'));
     } catch (_) {
       late String _$failedField;
       try {
+        _$failedField = 'parent';
+        _parent?.build();
+
         _$failedField = 'messageParameters';
         messageParameters.build();
 
         _$failedField = 'reactions';
         reactions.build();
-
-        _$failedField = 'parent';
-        _parent?.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'ChatMessageWithParent', _$failedField, e.toString());
       }
@@ -53128,28 +53097,11 @@ class TempAvatarDeleteAvatarResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $BotWithDetailsAndSecret_1InterfaceBuilder {
-  void replace($BotWithDetailsAndSecret_1Interface other);
-  void update(void Function($BotWithDetailsAndSecret_1InterfaceBuilder) updates);
-  String? get secret;
-  set secret(String? secret);
-}
-
-abstract mixin class $BotWithDetailsAndSecretInterfaceBuilder
-    implements $BotWithDetailsInterfaceBuilder, $BotWithDetailsAndSecret_1InterfaceBuilder {
+abstract mixin class $BotWithDetailsAndSecretInterfaceBuilder implements $BotWithDetailsInterfaceBuilder {
   void replace(covariant $BotWithDetailsAndSecretInterface other);
   void update(void Function($BotWithDetailsAndSecretInterfaceBuilder) updates);
-  String? get description;
-  set description(covariant String? description);
-
-  int? get id;
-  set id(covariant int? id);
-
-  String? get name;
-  set name(covariant String? name);
-
-  int? get state;
-  set state(covariant int? state);
+  String? get secret;
+  set secret(covariant String? secret);
 
   int? get errorCount;
   set errorCount(covariant int? errorCount);
@@ -53169,19 +53121,22 @@ abstract mixin class $BotWithDetailsAndSecretInterfaceBuilder
   String? get urlHash;
   set urlHash(covariant String? urlHash);
 
-  String? get secret;
-  set secret(covariant String? secret);
+  String? get description;
+  set description(covariant String? description);
+
+  int? get id;
+  set id(covariant int? id);
+
+  String? get name;
+  set name(covariant String? name);
+
+  int? get state;
+  set state(covariant int? state);
 }
 
 class _$BotWithDetailsAndSecret extends BotWithDetailsAndSecret {
   @override
-  final String? description;
-  @override
-  final int id;
-  @override
-  final String name;
-  @override
-  final int state;
+  final String secret;
   @override
   final int errorCount;
   @override
@@ -53195,34 +53150,40 @@ class _$BotWithDetailsAndSecret extends BotWithDetailsAndSecret {
   @override
   final String urlHash;
   @override
-  final String secret;
+  final String? description;
+  @override
+  final int id;
+  @override
+  final String name;
+  @override
+  final int state;
 
   factory _$BotWithDetailsAndSecret([void Function(BotWithDetailsAndSecretBuilder)? updates]) =>
       (BotWithDetailsAndSecretBuilder()..update(updates))._build();
 
   _$BotWithDetailsAndSecret._(
-      {this.description,
-      required this.id,
-      required this.name,
-      required this.state,
+      {required this.secret,
       required this.errorCount,
       required this.features,
       required this.lastErrorDate,
       required this.lastErrorMessage,
       required this.url,
       required this.urlHash,
-      required this.secret})
+      this.description,
+      required this.id,
+      required this.name,
+      required this.state})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(id, r'BotWithDetailsAndSecret', 'id');
-    BuiltValueNullFieldError.checkNotNull(name, r'BotWithDetailsAndSecret', 'name');
-    BuiltValueNullFieldError.checkNotNull(state, r'BotWithDetailsAndSecret', 'state');
+    BuiltValueNullFieldError.checkNotNull(secret, r'BotWithDetailsAndSecret', 'secret');
     BuiltValueNullFieldError.checkNotNull(errorCount, r'BotWithDetailsAndSecret', 'errorCount');
     BuiltValueNullFieldError.checkNotNull(features, r'BotWithDetailsAndSecret', 'features');
     BuiltValueNullFieldError.checkNotNull(lastErrorDate, r'BotWithDetailsAndSecret', 'lastErrorDate');
     BuiltValueNullFieldError.checkNotNull(lastErrorMessage, r'BotWithDetailsAndSecret', 'lastErrorMessage');
     BuiltValueNullFieldError.checkNotNull(url, r'BotWithDetailsAndSecret', 'url');
     BuiltValueNullFieldError.checkNotNull(urlHash, r'BotWithDetailsAndSecret', 'urlHash');
-    BuiltValueNullFieldError.checkNotNull(secret, r'BotWithDetailsAndSecret', 'secret');
+    BuiltValueNullFieldError.checkNotNull(id, r'BotWithDetailsAndSecret', 'id');
+    BuiltValueNullFieldError.checkNotNull(name, r'BotWithDetailsAndSecret', 'name');
+    BuiltValueNullFieldError.checkNotNull(state, r'BotWithDetailsAndSecret', 'state');
   }
 
   @override
@@ -53236,33 +53197,33 @@ class _$BotWithDetailsAndSecret extends BotWithDetailsAndSecret {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is BotWithDetailsAndSecret &&
-        description == other.description &&
-        id == other.id &&
-        name == other.name &&
-        state == other.state &&
+        secret == other.secret &&
         errorCount == other.errorCount &&
         features == other.features &&
         lastErrorDate == other.lastErrorDate &&
         lastErrorMessage == other.lastErrorMessage &&
         url == other.url &&
         urlHash == other.urlHash &&
-        secret == other.secret;
+        description == other.description &&
+        id == other.id &&
+        name == other.name &&
+        state == other.state;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, description.hashCode);
-    _$hash = $jc(_$hash, id.hashCode);
-    _$hash = $jc(_$hash, name.hashCode);
-    _$hash = $jc(_$hash, state.hashCode);
+    _$hash = $jc(_$hash, secret.hashCode);
     _$hash = $jc(_$hash, errorCount.hashCode);
     _$hash = $jc(_$hash, features.hashCode);
     _$hash = $jc(_$hash, lastErrorDate.hashCode);
     _$hash = $jc(_$hash, lastErrorMessage.hashCode);
     _$hash = $jc(_$hash, url.hashCode);
     _$hash = $jc(_$hash, urlHash.hashCode);
-    _$hash = $jc(_$hash, secret.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, state.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -53270,17 +53231,17 @@ class _$BotWithDetailsAndSecret extends BotWithDetailsAndSecret {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'BotWithDetailsAndSecret')
-          ..add('description', description)
-          ..add('id', id)
-          ..add('name', name)
-          ..add('state', state)
+          ..add('secret', secret)
           ..add('errorCount', errorCount)
           ..add('features', features)
           ..add('lastErrorDate', lastErrorDate)
           ..add('lastErrorMessage', lastErrorMessage)
           ..add('url', url)
           ..add('urlHash', urlHash)
-          ..add('secret', secret))
+          ..add('description', description)
+          ..add('id', id)
+          ..add('name', name)
+          ..add('state', state))
         .toString();
   }
 }
@@ -53291,21 +53252,9 @@ class BotWithDetailsAndSecretBuilder
         $BotWithDetailsAndSecretInterfaceBuilder {
   _$BotWithDetailsAndSecret? _$v;
 
-  String? _description;
-  String? get description => _$this._description;
-  set description(covariant String? description) => _$this._description = description;
-
-  int? _id;
-  int? get id => _$this._id;
-  set id(covariant int? id) => _$this._id = id;
-
-  String? _name;
-  String? get name => _$this._name;
-  set name(covariant String? name) => _$this._name = name;
-
-  int? _state;
-  int? get state => _$this._state;
-  set state(covariant int? state) => _$this._state = state;
+  String? _secret;
+  String? get secret => _$this._secret;
+  set secret(covariant String? secret) => _$this._secret = secret;
 
   int? _errorCount;
   int? get errorCount => _$this._errorCount;
@@ -53331,26 +53280,38 @@ class BotWithDetailsAndSecretBuilder
   String? get urlHash => _$this._urlHash;
   set urlHash(covariant String? urlHash) => _$this._urlHash = urlHash;
 
-  String? _secret;
-  String? get secret => _$this._secret;
-  set secret(covariant String? secret) => _$this._secret = secret;
+  String? _description;
+  String? get description => _$this._description;
+  set description(covariant String? description) => _$this._description = description;
+
+  int? _id;
+  int? get id => _$this._id;
+  set id(covariant int? id) => _$this._id = id;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  int? _state;
+  int? get state => _$this._state;
+  set state(covariant int? state) => _$this._state = state;
 
   BotWithDetailsAndSecretBuilder();
 
   BotWithDetailsAndSecretBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _description = $v.description;
-      _id = $v.id;
-      _name = $v.name;
-      _state = $v.state;
+      _secret = $v.secret;
       _errorCount = $v.errorCount;
       _features = $v.features;
       _lastErrorDate = $v.lastErrorDate;
       _lastErrorMessage = $v.lastErrorMessage;
       _url = $v.url;
       _urlHash = $v.urlHash;
-      _secret = $v.secret;
+      _description = $v.description;
+      _id = $v.id;
+      _name = $v.name;
+      _state = $v.state;
       _$v = null;
     }
     return this;
@@ -53373,10 +53334,7 @@ class BotWithDetailsAndSecretBuilder
   _$BotWithDetailsAndSecret _build() {
     final _$result = _$v ??
         _$BotWithDetailsAndSecret._(
-            description: description,
-            id: BuiltValueNullFieldError.checkNotNull(id, r'BotWithDetailsAndSecret', 'id'),
-            name: BuiltValueNullFieldError.checkNotNull(name, r'BotWithDetailsAndSecret', 'name'),
-            state: BuiltValueNullFieldError.checkNotNull(state, r'BotWithDetailsAndSecret', 'state'),
+            secret: BuiltValueNullFieldError.checkNotNull(secret, r'BotWithDetailsAndSecret', 'secret'),
             errorCount: BuiltValueNullFieldError.checkNotNull(errorCount, r'BotWithDetailsAndSecret', 'errorCount'),
             features: BuiltValueNullFieldError.checkNotNull(features, r'BotWithDetailsAndSecret', 'features'),
             lastErrorDate:
@@ -53385,7 +53343,10 @@ class BotWithDetailsAndSecretBuilder
                 BuiltValueNullFieldError.checkNotNull(lastErrorMessage, r'BotWithDetailsAndSecret', 'lastErrorMessage'),
             url: BuiltValueNullFieldError.checkNotNull(url, r'BotWithDetailsAndSecret', 'url'),
             urlHash: BuiltValueNullFieldError.checkNotNull(urlHash, r'BotWithDetailsAndSecret', 'urlHash'),
-            secret: BuiltValueNullFieldError.checkNotNull(secret, r'BotWithDetailsAndSecret', 'secret'));
+            description: description,
+            id: BuiltValueNullFieldError.checkNotNull(id, r'BotWithDetailsAndSecret', 'id'),
+            name: BuiltValueNullFieldError.checkNotNull(name, r'BotWithDetailsAndSecret', 'name'),
+            state: BuiltValueNullFieldError.checkNotNull(state, r'BotWithDetailsAndSecret', 'state'));
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -1080,14 +1080,11 @@ abstract class Public implements $PublicInterface, Built<Public, PublicBuilder> 
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $Private_1Interface {
+abstract interface class $PrivateInterface implements $PublicInterface {
   String? get messageId;
   bool get messageIsPredefined;
   bool get statusIsUserDefined;
 }
-
-@BuiltValue(instantiable: false)
-abstract interface class $PrivateInterface implements $PublicInterface, $Private_1Interface {}
 
 abstract class Private implements $PrivateInterface, Built<Private, PrivateBuilder> {
   /// Creates a new Private object using the builder pattern.

--- a/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
@@ -248,16 +248,22 @@ class _$PrivateSerializer implements StructuredSerializer<Private> {
   Iterable<Object?> serialize(Serializers serializers, Private object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'userId',
-      serializers.serialize(object.userId, specifiedType: const FullType(String)),
-      'status',
-      serializers.serialize(object.status, specifiedType: const FullType(String)),
       'messageIsPredefined',
       serializers.serialize(object.messageIsPredefined, specifiedType: const FullType(bool)),
       'statusIsUserDefined',
       serializers.serialize(object.statusIsUserDefined, specifiedType: const FullType(bool)),
+      'userId',
+      serializers.serialize(object.userId, specifiedType: const FullType(String)),
+      'status',
+      serializers.serialize(object.status, specifiedType: const FullType(String)),
     ];
     Object? value;
+    value = object.messageId;
+    if (value != null) {
+      result
+        ..add('messageId')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
     value = object.message;
     if (value != null) {
       result
@@ -276,12 +282,6 @@ class _$PrivateSerializer implements StructuredSerializer<Private> {
         ..add('clearAt')
         ..add(serializers.serialize(value, specifiedType: const FullType(int)));
     }
-    value = object.messageId;
-    if (value != null) {
-      result
-        ..add('messageId')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
     return result;
   }
 
@@ -296,6 +296,15 @@ class _$PrivateSerializer implements StructuredSerializer<Private> {
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
+        case 'messageId':
+          result.messageId = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'messageIsPredefined':
+          result.messageIsPredefined = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'statusIsUserDefined':
+          result.statusIsUserDefined = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
         case 'userId':
           result.userId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
@@ -310,15 +319,6 @@ class _$PrivateSerializer implements StructuredSerializer<Private> {
           break;
         case 'status':
           result.status = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'messageId':
-          result.messageId = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-        case 'messageIsPredefined':
-          result.messageIsPredefined = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
-          break;
-        case 'statusIsUserDefined':
-          result.statusIsUserDefined = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -1733,22 +1733,18 @@ class PublicBuilder implements Builder<Public, PublicBuilder>, $PublicInterfaceB
   }
 }
 
-abstract mixin class $Private_1InterfaceBuilder {
-  void replace($Private_1Interface other);
-  void update(void Function($Private_1InterfaceBuilder) updates);
-  String? get messageId;
-  set messageId(String? messageId);
-
-  bool? get messageIsPredefined;
-  set messageIsPredefined(bool? messageIsPredefined);
-
-  bool? get statusIsUserDefined;
-  set statusIsUserDefined(bool? statusIsUserDefined);
-}
-
-abstract mixin class $PrivateInterfaceBuilder implements $PublicInterfaceBuilder, $Private_1InterfaceBuilder {
+abstract mixin class $PrivateInterfaceBuilder implements $PublicInterfaceBuilder {
   void replace(covariant $PrivateInterface other);
   void update(void Function($PrivateInterfaceBuilder) updates);
+  String? get messageId;
+  set messageId(covariant String? messageId);
+
+  bool? get messageIsPredefined;
+  set messageIsPredefined(covariant bool? messageIsPredefined);
+
+  bool? get statusIsUserDefined;
+  set statusIsUserDefined(covariant bool? statusIsUserDefined);
+
   String? get userId;
   set userId(covariant String? userId);
 
@@ -1763,18 +1759,15 @@ abstract mixin class $PrivateInterfaceBuilder implements $PublicInterfaceBuilder
 
   String? get status;
   set status(covariant String? status);
-
-  String? get messageId;
-  set messageId(covariant String? messageId);
-
-  bool? get messageIsPredefined;
-  set messageIsPredefined(covariant bool? messageIsPredefined);
-
-  bool? get statusIsUserDefined;
-  set statusIsUserDefined(covariant bool? statusIsUserDefined);
 }
 
 class _$Private extends Private {
+  @override
+  final String? messageId;
+  @override
+  final bool messageIsPredefined;
+  @override
+  final bool statusIsUserDefined;
   @override
   final String userId;
   @override
@@ -1785,29 +1778,23 @@ class _$Private extends Private {
   final int? clearAt;
   @override
   final String status;
-  @override
-  final String? messageId;
-  @override
-  final bool messageIsPredefined;
-  @override
-  final bool statusIsUserDefined;
 
   factory _$Private([void Function(PrivateBuilder)? updates]) => (PrivateBuilder()..update(updates))._build();
 
   _$Private._(
-      {required this.userId,
+      {this.messageId,
+      required this.messageIsPredefined,
+      required this.statusIsUserDefined,
+      required this.userId,
       this.message,
       this.icon,
       this.clearAt,
-      required this.status,
-      this.messageId,
-      required this.messageIsPredefined,
-      required this.statusIsUserDefined})
+      required this.status})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(userId, r'Private', 'userId');
-    BuiltValueNullFieldError.checkNotNull(status, r'Private', 'status');
     BuiltValueNullFieldError.checkNotNull(messageIsPredefined, r'Private', 'messageIsPredefined');
     BuiltValueNullFieldError.checkNotNull(statusIsUserDefined, r'Private', 'statusIsUserDefined');
+    BuiltValueNullFieldError.checkNotNull(userId, r'Private', 'userId');
+    BuiltValueNullFieldError.checkNotNull(status, r'Private', 'status');
   }
 
   @override
@@ -1820,27 +1807,27 @@ class _$Private extends Private {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is Private &&
+        messageId == other.messageId &&
+        messageIsPredefined == other.messageIsPredefined &&
+        statusIsUserDefined == other.statusIsUserDefined &&
         userId == other.userId &&
         message == other.message &&
         icon == other.icon &&
         clearAt == other.clearAt &&
-        status == other.status &&
-        messageId == other.messageId &&
-        messageIsPredefined == other.messageIsPredefined &&
-        statusIsUserDefined == other.statusIsUserDefined;
+        status == other.status;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, messageId.hashCode);
+    _$hash = $jc(_$hash, messageIsPredefined.hashCode);
+    _$hash = $jc(_$hash, statusIsUserDefined.hashCode);
     _$hash = $jc(_$hash, userId.hashCode);
     _$hash = $jc(_$hash, message.hashCode);
     _$hash = $jc(_$hash, icon.hashCode);
     _$hash = $jc(_$hash, clearAt.hashCode);
     _$hash = $jc(_$hash, status.hashCode);
-    _$hash = $jc(_$hash, messageId.hashCode);
-    _$hash = $jc(_$hash, messageIsPredefined.hashCode);
-    _$hash = $jc(_$hash, statusIsUserDefined.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -1848,20 +1835,32 @@ class _$Private extends Private {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'Private')
+          ..add('messageId', messageId)
+          ..add('messageIsPredefined', messageIsPredefined)
+          ..add('statusIsUserDefined', statusIsUserDefined)
           ..add('userId', userId)
           ..add('message', message)
           ..add('icon', icon)
           ..add('clearAt', clearAt)
-          ..add('status', status)
-          ..add('messageId', messageId)
-          ..add('messageIsPredefined', messageIsPredefined)
-          ..add('statusIsUserDefined', statusIsUserDefined))
+          ..add('status', status))
         .toString();
   }
 }
 
 class PrivateBuilder implements Builder<Private, PrivateBuilder>, $PrivateInterfaceBuilder {
   _$Private? _$v;
+
+  String? _messageId;
+  String? get messageId => _$this._messageId;
+  set messageId(covariant String? messageId) => _$this._messageId = messageId;
+
+  bool? _messageIsPredefined;
+  bool? get messageIsPredefined => _$this._messageIsPredefined;
+  set messageIsPredefined(covariant bool? messageIsPredefined) => _$this._messageIsPredefined = messageIsPredefined;
+
+  bool? _statusIsUserDefined;
+  bool? get statusIsUserDefined => _$this._statusIsUserDefined;
+  set statusIsUserDefined(covariant bool? statusIsUserDefined) => _$this._statusIsUserDefined = statusIsUserDefined;
 
   String? _userId;
   String? get userId => _$this._userId;
@@ -1883,31 +1882,19 @@ class PrivateBuilder implements Builder<Private, PrivateBuilder>, $PrivateInterf
   String? get status => _$this._status;
   set status(covariant String? status) => _$this._status = status;
 
-  String? _messageId;
-  String? get messageId => _$this._messageId;
-  set messageId(covariant String? messageId) => _$this._messageId = messageId;
-
-  bool? _messageIsPredefined;
-  bool? get messageIsPredefined => _$this._messageIsPredefined;
-  set messageIsPredefined(covariant bool? messageIsPredefined) => _$this._messageIsPredefined = messageIsPredefined;
-
-  bool? _statusIsUserDefined;
-  bool? get statusIsUserDefined => _$this._statusIsUserDefined;
-  set statusIsUserDefined(covariant bool? statusIsUserDefined) => _$this._statusIsUserDefined = statusIsUserDefined;
-
   PrivateBuilder();
 
   PrivateBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _messageId = $v.messageId;
+      _messageIsPredefined = $v.messageIsPredefined;
+      _statusIsUserDefined = $v.statusIsUserDefined;
       _userId = $v.userId;
       _message = $v.message;
       _icon = $v.icon;
       _clearAt = $v.clearAt;
       _status = $v.status;
-      _messageId = $v.messageId;
-      _messageIsPredefined = $v.messageIsPredefined;
-      _statusIsUserDefined = $v.statusIsUserDefined;
       _$v = null;
     }
     return this;
@@ -1930,16 +1917,16 @@ class PrivateBuilder implements Builder<Private, PrivateBuilder>, $PrivateInterf
   _$Private _build() {
     final _$result = _$v ??
         _$Private._(
-            userId: BuiltValueNullFieldError.checkNotNull(userId, r'Private', 'userId'),
-            message: message,
-            icon: icon,
-            clearAt: clearAt,
-            status: BuiltValueNullFieldError.checkNotNull(status, r'Private', 'status'),
             messageId: messageId,
             messageIsPredefined:
                 BuiltValueNullFieldError.checkNotNull(messageIsPredefined, r'Private', 'messageIsPredefined'),
             statusIsUserDefined:
-                BuiltValueNullFieldError.checkNotNull(statusIsUserDefined, r'Private', 'statusIsUserDefined'));
+                BuiltValueNullFieldError.checkNotNull(statusIsUserDefined, r'Private', 'statusIsUserDefined'),
+            userId: BuiltValueNullFieldError.checkNotNull(userId, r'Private', 'userId'),
+            message: message,
+            icon: icon,
+            clearAt: clearAt,
+            status: BuiltValueNullFieldError.checkNotNull(status, r'Private', 'status'));
     replace(_$result);
     return _$result;
   }


### PR DESCRIPTION
Cleaner code and allows us to easily document all generated interfaces.
This is breaking (also for NC)