### PR TITLE
fix(nextcloud): Use version range for intl dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,12 @@
   "packageRules": [
     {
       "matchManagers": ["pub"],
+      "matchDepTypes": ["dependencies"],
+      "matchPackageNames": ["intl"],
+      "rangeStrategy": "widen"
+    },
+    {
+      "matchManagers": ["pub"],
       "matchDatasources": ["dart-version", "flutter-version"],
       "matchUpdateTypes": [
         "minor",

--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   crypto: ^3.0.0
   crypton: ^2.0.0
   dynamite_runtime: ^0.1.0
-  intl: ^0.18.0
+  intl: ">=0.17.0 <=0.19.0"
   json_annotation: ^4.8.1
   meta: ^1.0.0
   universal_io: ^2.0.0


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/1445

0.17.0 is the first version that has null-safety, so we can't go lower (although I couldn't find any breaking changes within the last few years).

I had to update the renovate config as version ranges don't play nice with our current dependency update strategy.