### PR TITLE
fix(ci): Limit intl range updates to nextcloud package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,8 +13,7 @@
   },
   "packageRules": [
     {
-      "matchManagers": ["pub"],
-      "matchDepTypes": ["dependencies"],
+      "matchFileNames": ["packages/nextcloud/**"],
       "matchPackageNames": ["intl"],
       "rangeStrategy": "widen"
     },


### PR DESCRIPTION
Fixes the wrong bumps from https://github.com/nextcloud/neon/pull/1347 introduced by https://github.com/nextcloud/neon/pull/1446

(I tested this locally and it works)