### PR TITLE
refactor(tool)!: Pin our own version of openapi-extractor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "external/openapi-specification"]
 	path = external/openapi-specification
 	url = https://github.com/OAI/OpenAPI-Specification.git
+[submodule "external/nextcloud-openapi-extractor"]
+	path = external/nextcloud-openapi-extractor
+	url = https://github.com/nextcloud/openapi-extractor.git

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -1747,7 +1747,7 @@ class $GuestAvatarClient {
   Future<_i1.DynamiteResponse<Uint8List, void>> getAvatar({
     required String guestName,
     required String size,
-    int? darkTheme,
+    GuestAvatarGetAvatarDarkTheme? darkTheme,
   }) async {
     final rawResponse = getAvatarRaw(
       guestName: guestName,
@@ -1781,7 +1781,7 @@ class $GuestAvatarClient {
   _i1.DynamiteRawResponse<Uint8List, void> getAvatarRaw({
     required String guestName,
     required String size,
-    int? darkTheme,
+    GuestAvatarGetAvatarDarkTheme? darkTheme,
   }) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{
@@ -1809,7 +1809,8 @@ class $GuestAvatarClient {
     final $size = _$jsonSerializers.serialize(size, specifiedType: const FullType(String));
     _parameters['size'] = $size;
 
-    var $darkTheme = _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(int));
+    var $darkTheme =
+        _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(GuestAvatarGetAvatarDarkTheme));
     $darkTheme ??= 0;
     _parameters['darkTheme'] = $darkTheme;
 
@@ -1954,7 +1955,7 @@ class $NavigationClient {
   /// See:
   ///  * [getAppsNavigationRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<NavigationGetAppsNavigationResponseApplicationJson, void>> getAppsNavigation({
-    int? absolute,
+    NavigationGetAppsNavigationAbsolute? absolute,
     bool? oCSAPIRequest,
   }) async {
     final rawResponse = getAppsNavigationRaw(
@@ -1984,7 +1985,7 @@ class $NavigationClient {
   ///  * [getAppsNavigation] for an operation that returns a `DynamiteResponse` with a stable API.
   @_i4.experimental
   _i1.DynamiteRawResponse<NavigationGetAppsNavigationResponseApplicationJson, void> getAppsNavigationRaw({
-    int? absolute,
+    NavigationGetAppsNavigationAbsolute? absolute,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, dynamic>{};
@@ -2009,7 +2010,8 @@ class $NavigationClient {
     }
 
 // coverage:ignore-end
-    var $absolute = _$jsonSerializers.serialize(absolute, specifiedType: const FullType(int));
+    var $absolute =
+        _$jsonSerializers.serialize(absolute, specifiedType: const FullType(NavigationGetAppsNavigationAbsolute));
     $absolute ??= 0;
     _parameters['absolute'] = $absolute;
 
@@ -2048,7 +2050,7 @@ class $NavigationClient {
   /// See:
   ///  * [getSettingsNavigationRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<NavigationGetSettingsNavigationResponseApplicationJson, void>> getSettingsNavigation({
-    int? absolute,
+    NavigationGetSettingsNavigationAbsolute? absolute,
     bool? oCSAPIRequest,
   }) async {
     final rawResponse = getSettingsNavigationRaw(
@@ -2078,7 +2080,7 @@ class $NavigationClient {
   ///  * [getSettingsNavigation] for an operation that returns a `DynamiteResponse` with a stable API.
   @_i4.experimental
   _i1.DynamiteRawResponse<NavigationGetSettingsNavigationResponseApplicationJson, void> getSettingsNavigationRaw({
-    int? absolute,
+    NavigationGetSettingsNavigationAbsolute? absolute,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, dynamic>{};
@@ -2103,7 +2105,8 @@ class $NavigationClient {
     }
 
 // coverage:ignore-end
-    var $absolute = _$jsonSerializers.serialize(absolute, specifiedType: const FullType(int));
+    var $absolute =
+        _$jsonSerializers.serialize(absolute, specifiedType: const FullType(NavigationGetSettingsNavigationAbsolute));
     $absolute ??= 0;
     _parameters['absolute'] = $absolute;
 
@@ -2319,10 +2322,10 @@ class $PreviewClient {
     int? fileId,
     int? x,
     int? y,
-    int? a,
-    int? forceIcon,
+    PreviewGetPreviewByFileIdA? a,
+    PreviewGetPreviewByFileIdForceIcon? forceIcon,
     String? mode,
-    int? mimeFallback,
+    PreviewGetPreviewByFileIdMimeFallback? mimeFallback,
   }) async {
     final rawResponse = getPreviewByFileIdRaw(
       fileId: fileId,
@@ -2367,10 +2370,10 @@ class $PreviewClient {
     int? fileId,
     int? x,
     int? y,
-    int? a,
-    int? forceIcon,
+    PreviewGetPreviewByFileIdA? a,
+    PreviewGetPreviewByFileIdForceIcon? forceIcon,
     String? mode,
-    int? mimeFallback,
+    PreviewGetPreviewByFileIdMimeFallback? mimeFallback,
   }) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{
@@ -2406,11 +2409,12 @@ class $PreviewClient {
     $y ??= 32;
     _parameters['y'] = $y;
 
-    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(int));
+    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewByFileIdA));
     $a ??= 0;
     _parameters['a'] = $a;
 
-    var $forceIcon = _$jsonSerializers.serialize(forceIcon, specifiedType: const FullType(int));
+    var $forceIcon =
+        _$jsonSerializers.serialize(forceIcon, specifiedType: const FullType(PreviewGetPreviewByFileIdForceIcon));
     $forceIcon ??= 1;
     _parameters['forceIcon'] = $forceIcon;
 
@@ -2418,7 +2422,8 @@ class $PreviewClient {
     $mode ??= 'fill';
     _parameters['mode'] = $mode;
 
-    var $mimeFallback = _$jsonSerializers.serialize(mimeFallback, specifiedType: const FullType(int));
+    var $mimeFallback =
+        _$jsonSerializers.serialize(mimeFallback, specifiedType: const FullType(PreviewGetPreviewByFileIdMimeFallback));
     $mimeFallback ??= 0;
     _parameters['mimeFallback'] = $mimeFallback;
 
@@ -2465,10 +2470,10 @@ class $PreviewClient {
     String? file,
     int? x,
     int? y,
-    int? a,
-    int? forceIcon,
+    PreviewGetPreviewA? a,
+    PreviewGetPreviewForceIcon? forceIcon,
     String? mode,
-    int? mimeFallback,
+    PreviewGetPreviewMimeFallback? mimeFallback,
   }) async {
     final rawResponse = getPreviewRaw(
       file: file,
@@ -2513,10 +2518,10 @@ class $PreviewClient {
     String? file,
     int? x,
     int? y,
-    int? a,
-    int? forceIcon,
+    PreviewGetPreviewA? a,
+    PreviewGetPreviewForceIcon? forceIcon,
     String? mode,
-    int? mimeFallback,
+    PreviewGetPreviewMimeFallback? mimeFallback,
   }) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{
@@ -2552,11 +2557,11 @@ class $PreviewClient {
     $y ??= 32;
     _parameters['y'] = $y;
 
-    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(int));
+    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewA));
     $a ??= 0;
     _parameters['a'] = $a;
 
-    var $forceIcon = _$jsonSerializers.serialize(forceIcon, specifiedType: const FullType(int));
+    var $forceIcon = _$jsonSerializers.serialize(forceIcon, specifiedType: const FullType(PreviewGetPreviewForceIcon));
     $forceIcon ??= 1;
     _parameters['forceIcon'] = $forceIcon;
 
@@ -2564,7 +2569,8 @@ class $PreviewClient {
     $mode ??= 'fill';
     _parameters['mode'] = $mode;
 
-    var $mimeFallback = _$jsonSerializers.serialize(mimeFallback, specifiedType: const FullType(int));
+    var $mimeFallback =
+        _$jsonSerializers.serialize(mimeFallback, specifiedType: const FullType(PreviewGetPreviewMimeFallback));
     $mimeFallback ??= 0;
     _parameters['mimeFallback'] = $mimeFallback;
 
@@ -3006,7 +3012,7 @@ class $ReferenceApiClient {
   ///  * [extractRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<ReferenceApiExtractResponseApplicationJson, void>> extract({
     required String text,
-    int? resolve,
+    ReferenceApiExtractResolve? resolve,
     int? limit,
     bool? oCSAPIRequest,
   }) async {
@@ -3041,7 +3047,7 @@ class $ReferenceApiClient {
   @_i4.experimental
   _i1.DynamiteRawResponse<ReferenceApiExtractResponseApplicationJson, void> extractRaw({
     required String text,
-    int? resolve,
+    ReferenceApiExtractResolve? resolve,
     int? limit,
     bool? oCSAPIRequest,
   }) {
@@ -3070,7 +3076,7 @@ class $ReferenceApiClient {
     final $text = _$jsonSerializers.serialize(text, specifiedType: const FullType(String));
     _parameters['text'] = $text;
 
-    var $resolve = _$jsonSerializers.serialize(resolve, specifiedType: const FullType(int));
+    var $resolve = _$jsonSerializers.serialize(resolve, specifiedType: const FullType(ReferenceApiExtractResolve));
     $resolve ??= 0;
     _parameters['resolve'] = $resolve;
 
@@ -6536,6 +6542,69 @@ abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicati
       _$collaborationResourcesCreateCollectionOnResourceResponseApplicationJsonSerializer;
 }
 
+class GuestAvatarGetAvatarDarkTheme extends EnumClass {
+  const GuestAvatarGetAvatarDarkTheme._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const GuestAvatarGetAvatarDarkTheme $0 = _$guestAvatarGetAvatarDarkTheme$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const GuestAvatarGetAvatarDarkTheme $1 = _$guestAvatarGetAvatarDarkTheme$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<GuestAvatarGetAvatarDarkTheme> get values => _$guestAvatarGetAvatarDarkThemeValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static GuestAvatarGetAvatarDarkTheme valueOf(String name) => _$valueOfGuestAvatarGetAvatarDarkTheme(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for GuestAvatarGetAvatarDarkTheme.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<GuestAvatarGetAvatarDarkTheme> get serializer => const _$GuestAvatarGetAvatarDarkThemeSerializer();
+}
+
+class _$GuestAvatarGetAvatarDarkThemeSerializer implements PrimitiveSerializer<GuestAvatarGetAvatarDarkTheme> {
+  const _$GuestAvatarGetAvatarDarkThemeSerializer();
+
+  static const Map<GuestAvatarGetAvatarDarkTheme, Object> _toWire = <GuestAvatarGetAvatarDarkTheme, Object>{
+    GuestAvatarGetAvatarDarkTheme.$0: 0,
+    GuestAvatarGetAvatarDarkTheme.$1: 1,
+  };
+
+  static const Map<Object, GuestAvatarGetAvatarDarkTheme> _fromWire = <Object, GuestAvatarGetAvatarDarkTheme>{
+    0: GuestAvatarGetAvatarDarkTheme.$0,
+    1: GuestAvatarGetAvatarDarkTheme.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [GuestAvatarGetAvatarDarkTheme];
+
+  @override
+  String get wireName => 'GuestAvatarGetAvatarDarkTheme';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    GuestAvatarGetAvatarDarkTheme object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  GuestAvatarGetAvatarDarkTheme deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 @BuiltValue(instantiable: false)
 abstract interface class $ContactsActionInterface {
   String get title;
@@ -6687,6 +6756,72 @@ abstract class HoverCardGetUserResponseApplicationJson
       _$hoverCardGetUserResponseApplicationJsonSerializer;
 }
 
+class NavigationGetAppsNavigationAbsolute extends EnumClass {
+  const NavigationGetAppsNavigationAbsolute._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const NavigationGetAppsNavigationAbsolute $0 = _$navigationGetAppsNavigationAbsolute$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const NavigationGetAppsNavigationAbsolute $1 = _$navigationGetAppsNavigationAbsolute$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<NavigationGetAppsNavigationAbsolute> get values => _$navigationGetAppsNavigationAbsoluteValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static NavigationGetAppsNavigationAbsolute valueOf(String name) => _$valueOfNavigationGetAppsNavigationAbsolute(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for NavigationGetAppsNavigationAbsolute.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<NavigationGetAppsNavigationAbsolute> get serializer =>
+      const _$NavigationGetAppsNavigationAbsoluteSerializer();
+}
+
+class _$NavigationGetAppsNavigationAbsoluteSerializer
+    implements PrimitiveSerializer<NavigationGetAppsNavigationAbsolute> {
+  const _$NavigationGetAppsNavigationAbsoluteSerializer();
+
+  static const Map<NavigationGetAppsNavigationAbsolute, Object> _toWire = <NavigationGetAppsNavigationAbsolute, Object>{
+    NavigationGetAppsNavigationAbsolute.$0: 0,
+    NavigationGetAppsNavigationAbsolute.$1: 1,
+  };
+
+  static const Map<Object, NavigationGetAppsNavigationAbsolute> _fromWire =
+      <Object, NavigationGetAppsNavigationAbsolute>{
+    0: NavigationGetAppsNavigationAbsolute.$0,
+    1: NavigationGetAppsNavigationAbsolute.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [NavigationGetAppsNavigationAbsolute];
+
+  @override
+  String get wireName => 'NavigationGetAppsNavigationAbsolute';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    NavigationGetAppsNavigationAbsolute object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  NavigationGetAppsNavigationAbsolute deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 typedef NavigationEntry_Order = ({int? $int, String? string});
 
 @BuiltValue(instantiable: false)
@@ -6812,6 +6947,75 @@ abstract class NavigationGetAppsNavigationResponseApplicationJson
       _$navigationGetAppsNavigationResponseApplicationJsonSerializer;
 }
 
+class NavigationGetSettingsNavigationAbsolute extends EnumClass {
+  const NavigationGetSettingsNavigationAbsolute._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const NavigationGetSettingsNavigationAbsolute $0 = _$navigationGetSettingsNavigationAbsolute$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const NavigationGetSettingsNavigationAbsolute $1 = _$navigationGetSettingsNavigationAbsolute$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<NavigationGetSettingsNavigationAbsolute> get values =>
+      _$navigationGetSettingsNavigationAbsoluteValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static NavigationGetSettingsNavigationAbsolute valueOf(String name) =>
+      _$valueOfNavigationGetSettingsNavigationAbsolute(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for NavigationGetSettingsNavigationAbsolute.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<NavigationGetSettingsNavigationAbsolute> get serializer =>
+      const _$NavigationGetSettingsNavigationAbsoluteSerializer();
+}
+
+class _$NavigationGetSettingsNavigationAbsoluteSerializer
+    implements PrimitiveSerializer<NavigationGetSettingsNavigationAbsolute> {
+  const _$NavigationGetSettingsNavigationAbsoluteSerializer();
+
+  static const Map<NavigationGetSettingsNavigationAbsolute, Object> _toWire =
+      <NavigationGetSettingsNavigationAbsolute, Object>{
+    NavigationGetSettingsNavigationAbsolute.$0: 0,
+    NavigationGetSettingsNavigationAbsolute.$1: 1,
+  };
+
+  static const Map<Object, NavigationGetSettingsNavigationAbsolute> _fromWire =
+      <Object, NavigationGetSettingsNavigationAbsolute>{
+    0: NavigationGetSettingsNavigationAbsolute.$0,
+    1: NavigationGetSettingsNavigationAbsolute.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [NavigationGetSettingsNavigationAbsolute];
+
+  @override
+  String get wireName => 'NavigationGetSettingsNavigationAbsolute';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    NavigationGetSettingsNavigationAbsolute object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  NavigationGetSettingsNavigationAbsolute deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 @BuiltValue(instantiable: false)
 abstract interface class $NavigationGetSettingsNavigationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
@@ -6891,10 +7095,74 @@ abstract class NavigationGetSettingsNavigationResponseApplicationJson
       _$navigationGetSettingsNavigationResponseApplicationJsonSerializer;
 }
 
+class OcmOcmDiscoveryHeaders_XNextcloudOcmProviders extends EnumClass {
+  const OcmOcmDiscoveryHeaders_XNextcloudOcmProviders._(super.name);
+
+  /// `true`
+  @BuiltValueEnumConst(wireName: 'true')
+  static const OcmOcmDiscoveryHeaders_XNextcloudOcmProviders $true =
+      _$ocmOcmDiscoveryHeadersXNextcloudOcmProviders$true;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get values =>
+      _$ocmOcmDiscoveryHeadersXNextcloudOcmProvidersValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static OcmOcmDiscoveryHeaders_XNextcloudOcmProviders valueOf(String name) =>
+      _$valueOfOcmOcmDiscoveryHeaders_XNextcloudOcmProviders(name);
+
+  /// Returns the serialized value of this enum value.
+  bool get value => _$jsonSerializers.serializeWith(serializer, this)! as bool;
+
+  /// Serializer for OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get serializer =>
+      const _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer();
+}
+
+class _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer
+    implements PrimitiveSerializer<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> {
+  const _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer();
+
+  static const Map<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders, Object> _toWire =
+      <OcmOcmDiscoveryHeaders_XNextcloudOcmProviders, Object>{
+    OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.$true: true,
+  };
+
+  static const Map<Object, OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> _fromWire =
+      <Object, OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>{
+    true: OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.$true,
+  };
+
+  @override
+  Iterable<Type> get types => const [OcmOcmDiscoveryHeaders_XNextcloudOcmProviders];
+
+  @override
+  String get wireName => 'OcmOcmDiscoveryHeaders_XNextcloudOcmProviders';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    OcmOcmDiscoveryHeaders_XNextcloudOcmProviders object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  OcmOcmDiscoveryHeaders_XNextcloudOcmProviders deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 @BuiltValue(instantiable: false)
 abstract interface class $OcmOcmDiscoveryHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-ocm-providers')
-  Header<bool>? get xNextcloudOcmProviders;
+  Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? get xNextcloudOcmProviders;
 }
 
 abstract class OcmOcmDiscoveryHeaders
@@ -9306,6 +9574,391 @@ abstract class OcsGetCapabilitiesResponseApplicationJson
       _$ocsGetCapabilitiesResponseApplicationJsonSerializer;
 }
 
+class PreviewGetPreviewByFileIdA extends EnumClass {
+  const PreviewGetPreviewByFileIdA._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const PreviewGetPreviewByFileIdA $0 = _$previewGetPreviewByFileIdA$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const PreviewGetPreviewByFileIdA $1 = _$previewGetPreviewByFileIdA$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<PreviewGetPreviewByFileIdA> get values => _$previewGetPreviewByFileIdAValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static PreviewGetPreviewByFileIdA valueOf(String name) => _$valueOfPreviewGetPreviewByFileIdA(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for PreviewGetPreviewByFileIdA.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<PreviewGetPreviewByFileIdA> get serializer => const _$PreviewGetPreviewByFileIdASerializer();
+}
+
+class _$PreviewGetPreviewByFileIdASerializer implements PrimitiveSerializer<PreviewGetPreviewByFileIdA> {
+  const _$PreviewGetPreviewByFileIdASerializer();
+
+  static const Map<PreviewGetPreviewByFileIdA, Object> _toWire = <PreviewGetPreviewByFileIdA, Object>{
+    PreviewGetPreviewByFileIdA.$0: 0,
+    PreviewGetPreviewByFileIdA.$1: 1,
+  };
+
+  static const Map<Object, PreviewGetPreviewByFileIdA> _fromWire = <Object, PreviewGetPreviewByFileIdA>{
+    0: PreviewGetPreviewByFileIdA.$0,
+    1: PreviewGetPreviewByFileIdA.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [PreviewGetPreviewByFileIdA];
+
+  @override
+  String get wireName => 'PreviewGetPreviewByFileIdA';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    PreviewGetPreviewByFileIdA object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  PreviewGetPreviewByFileIdA deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+class PreviewGetPreviewByFileIdForceIcon extends EnumClass {
+  const PreviewGetPreviewByFileIdForceIcon._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const PreviewGetPreviewByFileIdForceIcon $0 = _$previewGetPreviewByFileIdForceIcon$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const PreviewGetPreviewByFileIdForceIcon $1 = _$previewGetPreviewByFileIdForceIcon$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<PreviewGetPreviewByFileIdForceIcon> get values => _$previewGetPreviewByFileIdForceIconValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static PreviewGetPreviewByFileIdForceIcon valueOf(String name) => _$valueOfPreviewGetPreviewByFileIdForceIcon(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for PreviewGetPreviewByFileIdForceIcon.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<PreviewGetPreviewByFileIdForceIcon> get serializer =>
+      const _$PreviewGetPreviewByFileIdForceIconSerializer();
+}
+
+class _$PreviewGetPreviewByFileIdForceIconSerializer
+    implements PrimitiveSerializer<PreviewGetPreviewByFileIdForceIcon> {
+  const _$PreviewGetPreviewByFileIdForceIconSerializer();
+
+  static const Map<PreviewGetPreviewByFileIdForceIcon, Object> _toWire = <PreviewGetPreviewByFileIdForceIcon, Object>{
+    PreviewGetPreviewByFileIdForceIcon.$0: 0,
+    PreviewGetPreviewByFileIdForceIcon.$1: 1,
+  };
+
+  static const Map<Object, PreviewGetPreviewByFileIdForceIcon> _fromWire = <Object, PreviewGetPreviewByFileIdForceIcon>{
+    0: PreviewGetPreviewByFileIdForceIcon.$0,
+    1: PreviewGetPreviewByFileIdForceIcon.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [PreviewGetPreviewByFileIdForceIcon];
+
+  @override
+  String get wireName => 'PreviewGetPreviewByFileIdForceIcon';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    PreviewGetPreviewByFileIdForceIcon object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  PreviewGetPreviewByFileIdForceIcon deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+class PreviewGetPreviewByFileIdMimeFallback extends EnumClass {
+  const PreviewGetPreviewByFileIdMimeFallback._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const PreviewGetPreviewByFileIdMimeFallback $0 = _$previewGetPreviewByFileIdMimeFallback$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const PreviewGetPreviewByFileIdMimeFallback $1 = _$previewGetPreviewByFileIdMimeFallback$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<PreviewGetPreviewByFileIdMimeFallback> get values => _$previewGetPreviewByFileIdMimeFallbackValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static PreviewGetPreviewByFileIdMimeFallback valueOf(String name) =>
+      _$valueOfPreviewGetPreviewByFileIdMimeFallback(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for PreviewGetPreviewByFileIdMimeFallback.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<PreviewGetPreviewByFileIdMimeFallback> get serializer =>
+      const _$PreviewGetPreviewByFileIdMimeFallbackSerializer();
+}
+
+class _$PreviewGetPreviewByFileIdMimeFallbackSerializer
+    implements PrimitiveSerializer<PreviewGetPreviewByFileIdMimeFallback> {
+  const _$PreviewGetPreviewByFileIdMimeFallbackSerializer();
+
+  static const Map<PreviewGetPreviewByFileIdMimeFallback, Object> _toWire =
+      <PreviewGetPreviewByFileIdMimeFallback, Object>{
+    PreviewGetPreviewByFileIdMimeFallback.$0: 0,
+    PreviewGetPreviewByFileIdMimeFallback.$1: 1,
+  };
+
+  static const Map<Object, PreviewGetPreviewByFileIdMimeFallback> _fromWire =
+      <Object, PreviewGetPreviewByFileIdMimeFallback>{
+    0: PreviewGetPreviewByFileIdMimeFallback.$0,
+    1: PreviewGetPreviewByFileIdMimeFallback.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [PreviewGetPreviewByFileIdMimeFallback];
+
+  @override
+  String get wireName => 'PreviewGetPreviewByFileIdMimeFallback';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    PreviewGetPreviewByFileIdMimeFallback object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  PreviewGetPreviewByFileIdMimeFallback deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+class PreviewGetPreviewA extends EnumClass {
+  const PreviewGetPreviewA._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const PreviewGetPreviewA $0 = _$previewGetPreviewA$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const PreviewGetPreviewA $1 = _$previewGetPreviewA$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<PreviewGetPreviewA> get values => _$previewGetPreviewAValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static PreviewGetPreviewA valueOf(String name) => _$valueOfPreviewGetPreviewA(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for PreviewGetPreviewA.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<PreviewGetPreviewA> get serializer => const _$PreviewGetPreviewASerializer();
+}
+
+class _$PreviewGetPreviewASerializer implements PrimitiveSerializer<PreviewGetPreviewA> {
+  const _$PreviewGetPreviewASerializer();
+
+  static const Map<PreviewGetPreviewA, Object> _toWire = <PreviewGetPreviewA, Object>{
+    PreviewGetPreviewA.$0: 0,
+    PreviewGetPreviewA.$1: 1,
+  };
+
+  static const Map<Object, PreviewGetPreviewA> _fromWire = <Object, PreviewGetPreviewA>{
+    0: PreviewGetPreviewA.$0,
+    1: PreviewGetPreviewA.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [PreviewGetPreviewA];
+
+  @override
+  String get wireName => 'PreviewGetPreviewA';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    PreviewGetPreviewA object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  PreviewGetPreviewA deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+class PreviewGetPreviewForceIcon extends EnumClass {
+  const PreviewGetPreviewForceIcon._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const PreviewGetPreviewForceIcon $0 = _$previewGetPreviewForceIcon$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const PreviewGetPreviewForceIcon $1 = _$previewGetPreviewForceIcon$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<PreviewGetPreviewForceIcon> get values => _$previewGetPreviewForceIconValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static PreviewGetPreviewForceIcon valueOf(String name) => _$valueOfPreviewGetPreviewForceIcon(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for PreviewGetPreviewForceIcon.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<PreviewGetPreviewForceIcon> get serializer => const _$PreviewGetPreviewForceIconSerializer();
+}
+
+class _$PreviewGetPreviewForceIconSerializer implements PrimitiveSerializer<PreviewGetPreviewForceIcon> {
+  const _$PreviewGetPreviewForceIconSerializer();
+
+  static const Map<PreviewGetPreviewForceIcon, Object> _toWire = <PreviewGetPreviewForceIcon, Object>{
+    PreviewGetPreviewForceIcon.$0: 0,
+    PreviewGetPreviewForceIcon.$1: 1,
+  };
+
+  static const Map<Object, PreviewGetPreviewForceIcon> _fromWire = <Object, PreviewGetPreviewForceIcon>{
+    0: PreviewGetPreviewForceIcon.$0,
+    1: PreviewGetPreviewForceIcon.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [PreviewGetPreviewForceIcon];
+
+  @override
+  String get wireName => 'PreviewGetPreviewForceIcon';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    PreviewGetPreviewForceIcon object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  PreviewGetPreviewForceIcon deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+class PreviewGetPreviewMimeFallback extends EnumClass {
+  const PreviewGetPreviewMimeFallback._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const PreviewGetPreviewMimeFallback $0 = _$previewGetPreviewMimeFallback$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const PreviewGetPreviewMimeFallback $1 = _$previewGetPreviewMimeFallback$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<PreviewGetPreviewMimeFallback> get values => _$previewGetPreviewMimeFallbackValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static PreviewGetPreviewMimeFallback valueOf(String name) => _$valueOfPreviewGetPreviewMimeFallback(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for PreviewGetPreviewMimeFallback.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<PreviewGetPreviewMimeFallback> get serializer => const _$PreviewGetPreviewMimeFallbackSerializer();
+}
+
+class _$PreviewGetPreviewMimeFallbackSerializer implements PrimitiveSerializer<PreviewGetPreviewMimeFallback> {
+  const _$PreviewGetPreviewMimeFallbackSerializer();
+
+  static const Map<PreviewGetPreviewMimeFallback, Object> _toWire = <PreviewGetPreviewMimeFallback, Object>{
+    PreviewGetPreviewMimeFallback.$0: 0,
+    PreviewGetPreviewMimeFallback.$1: 1,
+  };
+
+  static const Map<Object, PreviewGetPreviewMimeFallback> _fromWire = <Object, PreviewGetPreviewMimeFallback>{
+    0: PreviewGetPreviewMimeFallback.$0,
+    1: PreviewGetPreviewMimeFallback.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [PreviewGetPreviewMimeFallback];
+
+  @override
+  String get wireName => 'PreviewGetPreviewMimeFallback';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    PreviewGetPreviewMimeFallback object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  PreviewGetPreviewMimeFallback deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 @BuiltValue(instantiable: false)
 abstract interface class $ProfileApiSetVisibilityResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
@@ -9649,6 +10302,69 @@ abstract class ReferenceApiResolveResponseApplicationJson
   /// Serializer for ReferenceApiResolveResponseApplicationJson.
   static Serializer<ReferenceApiResolveResponseApplicationJson> get serializer =>
       _$referenceApiResolveResponseApplicationJsonSerializer;
+}
+
+class ReferenceApiExtractResolve extends EnumClass {
+  const ReferenceApiExtractResolve._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ReferenceApiExtractResolve $0 = _$referenceApiExtractResolve$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ReferenceApiExtractResolve $1 = _$referenceApiExtractResolve$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ReferenceApiExtractResolve> get values => _$referenceApiExtractResolveValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ReferenceApiExtractResolve valueOf(String name) => _$valueOfReferenceApiExtractResolve(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ReferenceApiExtractResolve.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ReferenceApiExtractResolve> get serializer => const _$ReferenceApiExtractResolveSerializer();
+}
+
+class _$ReferenceApiExtractResolveSerializer implements PrimitiveSerializer<ReferenceApiExtractResolve> {
+  const _$ReferenceApiExtractResolveSerializer();
+
+  static const Map<ReferenceApiExtractResolve, Object> _toWire = <ReferenceApiExtractResolve, Object>{
+    ReferenceApiExtractResolve.$0: 0,
+    ReferenceApiExtractResolve.$1: 1,
+  };
+
+  static const Map<Object, ReferenceApiExtractResolve> _fromWire = <Object, ReferenceApiExtractResolve>{
+    0: ReferenceApiExtractResolve.$0,
+    1: ReferenceApiExtractResolve.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ReferenceApiExtractResolve];
+
+  @override
+  String get wireName => 'ReferenceApiExtractResolve';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ReferenceApiExtractResolve object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ReferenceApiExtractResolve deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
 }
 
 @BuiltValue(instantiable: false)
@@ -13073,6 +13789,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
         CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder.new,
       )
       ..add(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs.serializer)
+      ..add(GuestAvatarGetAvatarDarkTheme.serializer)
       ..addBuilderFactory(
         const FullType(HoverCardGetUserResponseApplicationJson),
         HoverCardGetUserResponseApplicationJsonBuilder.new,
@@ -13091,6 +13808,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(ContactsAction), ContactsActionBuilder.new)
       ..add(ContactsAction.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(ContactsAction)]), ListBuilder<ContactsAction>.new)
+      ..add(NavigationGetAppsNavigationAbsolute.serializer)
       ..addBuilderFactory(
         const FullType(NavigationGetAppsNavigationResponseApplicationJson),
         NavigationGetAppsNavigationResponseApplicationJsonBuilder.new,
@@ -13105,6 +13823,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(NavigationEntry.serializer)
       ..add($b2c4857c0136baea42828d89c87c757dExtension._serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(NavigationEntry)]), ListBuilder<NavigationEntry>.new)
+      ..add(NavigationGetSettingsNavigationAbsolute.serializer)
       ..addBuilderFactory(
         const FullType(NavigationGetSettingsNavigationResponseApplicationJson),
         NavigationGetSettingsNavigationResponseApplicationJsonBuilder.new,
@@ -13117,7 +13836,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(NavigationGetSettingsNavigationResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(const FullType(OcmOcmDiscoveryHeaders), OcmOcmDiscoveryHeadersBuilder.new)
       ..add(OcmOcmDiscoveryHeaders.serializer)
-      ..addBuilderFactory(const FullType(Header, [FullType(bool)]), HeaderBuilder<bool>.new)
+      ..add(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.serializer)
+      ..addBuilderFactory(
+        const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)]),
+        HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>.new,
+      )
       ..addBuilderFactory(
         const FullType(OcmDiscoveryResponseApplicationJson),
         OcmDiscoveryResponseApplicationJsonBuilder.new,
@@ -13365,6 +14088,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(WeatherStatusCapabilities_WeatherStatus.serializer)
       ..add($3dc1754764311166375258bea55197c8Extension._serializer)
+      ..add(PreviewGetPreviewByFileIdA.serializer)
+      ..add(PreviewGetPreviewByFileIdForceIcon.serializer)
+      ..add(PreviewGetPreviewByFileIdMimeFallback.serializer)
+      ..add(PreviewGetPreviewA.serializer)
+      ..add(PreviewGetPreviewForceIcon.serializer)
+      ..add(PreviewGetPreviewMimeFallback.serializer)
       ..addBuilderFactory(
         const FullType(ProfileApiSetVisibilityResponseApplicationJson),
         ProfileApiSetVisibilityResponseApplicationJsonBuilder.new,
@@ -13411,6 +14140,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(ReferenceApiResolveResponseApplicationJson_Ocs_Data.serializer)
+      ..add(ReferenceApiExtractResolve.serializer)
       ..addBuilderFactory(
         const FullType(ReferenceApiExtractResponseApplicationJson),
         ReferenceApiExtractResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/core.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.g.dart
@@ -6,6 +6,230 @@ part of 'core.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+const GuestAvatarGetAvatarDarkTheme _$guestAvatarGetAvatarDarkTheme$0 = GuestAvatarGetAvatarDarkTheme._('\$0');
+const GuestAvatarGetAvatarDarkTheme _$guestAvatarGetAvatarDarkTheme$1 = GuestAvatarGetAvatarDarkTheme._('\$1');
+
+GuestAvatarGetAvatarDarkTheme _$valueOfGuestAvatarGetAvatarDarkTheme(String name) {
+  switch (name) {
+    case '\$0':
+      return _$guestAvatarGetAvatarDarkTheme$0;
+    case '\$1':
+      return _$guestAvatarGetAvatarDarkTheme$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<GuestAvatarGetAvatarDarkTheme> _$guestAvatarGetAvatarDarkThemeValues =
+    BuiltSet<GuestAvatarGetAvatarDarkTheme>(const <GuestAvatarGetAvatarDarkTheme>[
+  _$guestAvatarGetAvatarDarkTheme$0,
+  _$guestAvatarGetAvatarDarkTheme$1,
+]);
+
+const NavigationGetAppsNavigationAbsolute _$navigationGetAppsNavigationAbsolute$0 =
+    NavigationGetAppsNavigationAbsolute._('\$0');
+const NavigationGetAppsNavigationAbsolute _$navigationGetAppsNavigationAbsolute$1 =
+    NavigationGetAppsNavigationAbsolute._('\$1');
+
+NavigationGetAppsNavigationAbsolute _$valueOfNavigationGetAppsNavigationAbsolute(String name) {
+  switch (name) {
+    case '\$0':
+      return _$navigationGetAppsNavigationAbsolute$0;
+    case '\$1':
+      return _$navigationGetAppsNavigationAbsolute$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<NavigationGetAppsNavigationAbsolute> _$navigationGetAppsNavigationAbsoluteValues =
+    BuiltSet<NavigationGetAppsNavigationAbsolute>(const <NavigationGetAppsNavigationAbsolute>[
+  _$navigationGetAppsNavigationAbsolute$0,
+  _$navigationGetAppsNavigationAbsolute$1,
+]);
+
+const NavigationGetSettingsNavigationAbsolute _$navigationGetSettingsNavigationAbsolute$0 =
+    NavigationGetSettingsNavigationAbsolute._('\$0');
+const NavigationGetSettingsNavigationAbsolute _$navigationGetSettingsNavigationAbsolute$1 =
+    NavigationGetSettingsNavigationAbsolute._('\$1');
+
+NavigationGetSettingsNavigationAbsolute _$valueOfNavigationGetSettingsNavigationAbsolute(String name) {
+  switch (name) {
+    case '\$0':
+      return _$navigationGetSettingsNavigationAbsolute$0;
+    case '\$1':
+      return _$navigationGetSettingsNavigationAbsolute$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<NavigationGetSettingsNavigationAbsolute> _$navigationGetSettingsNavigationAbsoluteValues =
+    BuiltSet<NavigationGetSettingsNavigationAbsolute>(const <NavigationGetSettingsNavigationAbsolute>[
+  _$navigationGetSettingsNavigationAbsolute$0,
+  _$navigationGetSettingsNavigationAbsolute$1,
+]);
+
+const OcmOcmDiscoveryHeaders_XNextcloudOcmProviders _$ocmOcmDiscoveryHeadersXNextcloudOcmProviders$true =
+    OcmOcmDiscoveryHeaders_XNextcloudOcmProviders._('\$true');
+
+OcmOcmDiscoveryHeaders_XNextcloudOcmProviders _$valueOfOcmOcmDiscoveryHeaders_XNextcloudOcmProviders(String name) {
+  switch (name) {
+    case '\$true':
+      return _$ocmOcmDiscoveryHeadersXNextcloudOcmProviders$true;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> _$ocmOcmDiscoveryHeadersXNextcloudOcmProvidersValues =
+    BuiltSet<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>(const <OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>[
+  _$ocmOcmDiscoveryHeadersXNextcloudOcmProviders$true,
+]);
+
+const PreviewGetPreviewByFileIdA _$previewGetPreviewByFileIdA$0 = PreviewGetPreviewByFileIdA._('\$0');
+const PreviewGetPreviewByFileIdA _$previewGetPreviewByFileIdA$1 = PreviewGetPreviewByFileIdA._('\$1');
+
+PreviewGetPreviewByFileIdA _$valueOfPreviewGetPreviewByFileIdA(String name) {
+  switch (name) {
+    case '\$0':
+      return _$previewGetPreviewByFileIdA$0;
+    case '\$1':
+      return _$previewGetPreviewByFileIdA$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<PreviewGetPreviewByFileIdA> _$previewGetPreviewByFileIdAValues =
+    BuiltSet<PreviewGetPreviewByFileIdA>(const <PreviewGetPreviewByFileIdA>[
+  _$previewGetPreviewByFileIdA$0,
+  _$previewGetPreviewByFileIdA$1,
+]);
+
+const PreviewGetPreviewByFileIdForceIcon _$previewGetPreviewByFileIdForceIcon$0 =
+    PreviewGetPreviewByFileIdForceIcon._('\$0');
+const PreviewGetPreviewByFileIdForceIcon _$previewGetPreviewByFileIdForceIcon$1 =
+    PreviewGetPreviewByFileIdForceIcon._('\$1');
+
+PreviewGetPreviewByFileIdForceIcon _$valueOfPreviewGetPreviewByFileIdForceIcon(String name) {
+  switch (name) {
+    case '\$0':
+      return _$previewGetPreviewByFileIdForceIcon$0;
+    case '\$1':
+      return _$previewGetPreviewByFileIdForceIcon$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<PreviewGetPreviewByFileIdForceIcon> _$previewGetPreviewByFileIdForceIconValues =
+    BuiltSet<PreviewGetPreviewByFileIdForceIcon>(const <PreviewGetPreviewByFileIdForceIcon>[
+  _$previewGetPreviewByFileIdForceIcon$0,
+  _$previewGetPreviewByFileIdForceIcon$1,
+]);
+
+const PreviewGetPreviewByFileIdMimeFallback _$previewGetPreviewByFileIdMimeFallback$0 =
+    PreviewGetPreviewByFileIdMimeFallback._('\$0');
+const PreviewGetPreviewByFileIdMimeFallback _$previewGetPreviewByFileIdMimeFallback$1 =
+    PreviewGetPreviewByFileIdMimeFallback._('\$1');
+
+PreviewGetPreviewByFileIdMimeFallback _$valueOfPreviewGetPreviewByFileIdMimeFallback(String name) {
+  switch (name) {
+    case '\$0':
+      return _$previewGetPreviewByFileIdMimeFallback$0;
+    case '\$1':
+      return _$previewGetPreviewByFileIdMimeFallback$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<PreviewGetPreviewByFileIdMimeFallback> _$previewGetPreviewByFileIdMimeFallbackValues =
+    BuiltSet<PreviewGetPreviewByFileIdMimeFallback>(const <PreviewGetPreviewByFileIdMimeFallback>[
+  _$previewGetPreviewByFileIdMimeFallback$0,
+  _$previewGetPreviewByFileIdMimeFallback$1,
+]);
+
+const PreviewGetPreviewA _$previewGetPreviewA$0 = PreviewGetPreviewA._('\$0');
+const PreviewGetPreviewA _$previewGetPreviewA$1 = PreviewGetPreviewA._('\$1');
+
+PreviewGetPreviewA _$valueOfPreviewGetPreviewA(String name) {
+  switch (name) {
+    case '\$0':
+      return _$previewGetPreviewA$0;
+    case '\$1':
+      return _$previewGetPreviewA$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<PreviewGetPreviewA> _$previewGetPreviewAValues = BuiltSet<PreviewGetPreviewA>(const <PreviewGetPreviewA>[
+  _$previewGetPreviewA$0,
+  _$previewGetPreviewA$1,
+]);
+
+const PreviewGetPreviewForceIcon _$previewGetPreviewForceIcon$0 = PreviewGetPreviewForceIcon._('\$0');
+const PreviewGetPreviewForceIcon _$previewGetPreviewForceIcon$1 = PreviewGetPreviewForceIcon._('\$1');
+
+PreviewGetPreviewForceIcon _$valueOfPreviewGetPreviewForceIcon(String name) {
+  switch (name) {
+    case '\$0':
+      return _$previewGetPreviewForceIcon$0;
+    case '\$1':
+      return _$previewGetPreviewForceIcon$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<PreviewGetPreviewForceIcon> _$previewGetPreviewForceIconValues =
+    BuiltSet<PreviewGetPreviewForceIcon>(const <PreviewGetPreviewForceIcon>[
+  _$previewGetPreviewForceIcon$0,
+  _$previewGetPreviewForceIcon$1,
+]);
+
+const PreviewGetPreviewMimeFallback _$previewGetPreviewMimeFallback$0 = PreviewGetPreviewMimeFallback._('\$0');
+const PreviewGetPreviewMimeFallback _$previewGetPreviewMimeFallback$1 = PreviewGetPreviewMimeFallback._('\$1');
+
+PreviewGetPreviewMimeFallback _$valueOfPreviewGetPreviewMimeFallback(String name) {
+  switch (name) {
+    case '\$0':
+      return _$previewGetPreviewMimeFallback$0;
+    case '\$1':
+      return _$previewGetPreviewMimeFallback$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<PreviewGetPreviewMimeFallback> _$previewGetPreviewMimeFallbackValues =
+    BuiltSet<PreviewGetPreviewMimeFallback>(const <PreviewGetPreviewMimeFallback>[
+  _$previewGetPreviewMimeFallback$0,
+  _$previewGetPreviewMimeFallback$1,
+]);
+
+const ReferenceApiExtractResolve _$referenceApiExtractResolve$0 = ReferenceApiExtractResolve._('\$0');
+const ReferenceApiExtractResolve _$referenceApiExtractResolve$1 = ReferenceApiExtractResolve._('\$1');
+
+ReferenceApiExtractResolve _$valueOfReferenceApiExtractResolve(String name) {
+  switch (name) {
+    case '\$0':
+      return _$referenceApiExtractResolve$0;
+    case '\$1':
+      return _$referenceApiExtractResolve$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ReferenceApiExtractResolve> _$referenceApiExtractResolveValues =
+    BuiltSet<ReferenceApiExtractResolve>(const <ReferenceApiExtractResolve>[
+  _$referenceApiExtractResolve$0,
+  _$referenceApiExtractResolve$1,
+]);
+
 const TextProcessingTask_Status _$textProcessingTaskStatus$0 = TextProcessingTask_Status._('\$0');
 const TextProcessingTask_Status _$textProcessingTaskStatus$1 = TextProcessingTask_Status._('\$1');
 const TextProcessingTask_Status _$textProcessingTaskStatus$2 = TextProcessingTask_Status._('\$2');
@@ -2771,7 +2995,8 @@ class _$OcmOcmDiscoveryHeadersSerializer implements StructuredSerializer<OcmOcmD
     if (value != null) {
       result
         ..add('x-nextcloud-ocm-providers')
-        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType(bool)])));
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)])));
     }
     return result;
   }
@@ -2788,8 +3013,9 @@ class _$OcmOcmDiscoveryHeadersSerializer implements StructuredSerializer<OcmOcmD
       final Object? value = iterator.current;
       switch (key) {
         case 'x-nextcloud-ocm-providers':
-          result.xNextcloudOcmProviders.replace(
-              serializers.deserialize(value, specifiedType: const FullType(Header, [FullType(bool)]))! as Header<bool>);
+          result.xNextcloudOcmProviders.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)]))!
+              as Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>);
           break;
       }
     }
@@ -15175,13 +15401,13 @@ class NavigationGetSettingsNavigationResponseApplicationJsonBuilder
 abstract mixin class $OcmOcmDiscoveryHeadersInterfaceBuilder {
   void replace($OcmOcmDiscoveryHeadersInterface other);
   void update(void Function($OcmOcmDiscoveryHeadersInterfaceBuilder) updates);
-  HeaderBuilder<bool> get xNextcloudOcmProviders;
-  set xNextcloudOcmProviders(HeaderBuilder<bool>? xNextcloudOcmProviders);
+  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get xNextcloudOcmProviders;
+  set xNextcloudOcmProviders(HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders);
 }
 
 class _$OcmOcmDiscoveryHeaders extends OcmOcmDiscoveryHeaders {
   @override
-  final Header<bool>? xNextcloudOcmProviders;
+  final Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders;
 
   factory _$OcmOcmDiscoveryHeaders([void Function(OcmOcmDiscoveryHeadersBuilder)? updates]) =>
       (OcmOcmDiscoveryHeadersBuilder()..update(updates))._build();
@@ -15221,9 +15447,11 @@ class OcmOcmDiscoveryHeadersBuilder
     implements Builder<OcmOcmDiscoveryHeaders, OcmOcmDiscoveryHeadersBuilder>, $OcmOcmDiscoveryHeadersInterfaceBuilder {
   _$OcmOcmDiscoveryHeaders? _$v;
 
-  HeaderBuilder<bool>? _xNextcloudOcmProviders;
-  HeaderBuilder<bool> get xNextcloudOcmProviders => _$this._xNextcloudOcmProviders ??= HeaderBuilder<bool>();
-  set xNextcloudOcmProviders(covariant HeaderBuilder<bool>? xNextcloudOcmProviders) =>
+  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? _xNextcloudOcmProviders;
+  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get xNextcloudOcmProviders =>
+      _$this._xNextcloudOcmProviders ??= HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>();
+  set xNextcloudOcmProviders(
+          covariant HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders) =>
       _$this._xNextcloudOcmProviders = xNextcloudOcmProviders;
 
   OcmOcmDiscoveryHeadersBuilder();

--- a/packages/nextcloud/lib/src/api/core.openapi.json
+++ b/packages/nextcloud/lib/src/api/core.openapi.json
@@ -1683,7 +1683,11 @@
             "schema": {
               "type": "integer",
               "nullable": true,
-              "default": 0
+              "default": 0,
+              "enum": [
+                0,
+                1
+              ]
             }
           },
           {
@@ -1865,7 +1869,11 @@
             "description": "Whether to not crop the preview",
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "enum": [
+                0,
+                1
+              ]
             }
           },
           {
@@ -1874,7 +1882,11 @@
             "description": "Force returning an icon",
             "schema": {
               "type": "integer",
-              "default": 1
+              "default": 1,
+              "enum": [
+                0,
+                1
+              ]
             }
           },
           {
@@ -1892,7 +1904,11 @@
             "description": "Whether to fallback to the mime icon if no preview is available",
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "enum": [
+                0,
+                1
+              ]
             }
           }
         ],
@@ -1996,7 +2012,11 @@
             "description": "Whether to not crop the preview",
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "enum": [
+                0,
+                1
+              ]
             }
           },
           {
@@ -2005,7 +2025,11 @@
             "description": "Force returning an icon",
             "schema": {
               "type": "integer",
-              "default": 1
+              "default": 1,
+              "enum": [
+                0,
+                1
+              ]
             }
           },
           {
@@ -2023,7 +2047,11 @@
             "description": "Whether to fallback to the mime icon if no preview is available",
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "enum": [
+                0,
+                1
+              ]
             }
           }
         ],
@@ -2254,7 +2282,10 @@
             "headers": {
               "X-NEXTCLOUD-OCM-PROVIDERS": {
                 "schema": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "enum": [
+                    true
+                  ]
                 }
               }
             },
@@ -2511,7 +2542,11 @@
             "description": "Rewrite URLs to absolute ones",
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "enum": [
+                0,
+                1
+              ]
             }
           },
           {
@@ -2612,7 +2647,11 @@
             "description": "Rewrite URLs to absolute ones",
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "enum": [
+                0,
+                1
+              ]
             }
           },
           {
@@ -4495,7 +4534,11 @@
             "description": "Resolve the references",
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "enum": [
+                0,
+                1
+              ]
             }
           },
           {

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -1012,7 +1012,7 @@ class $TemplateClient {
   ///  * [pathRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<TemplatePathResponseApplicationJson, void>> path({
     String? templatePath,
-    int? copySystemTemplates,
+    TemplatePathCopySystemTemplates? copySystemTemplates,
     bool? oCSAPIRequest,
   }) async {
     final rawResponse = pathRaw(
@@ -1045,7 +1045,7 @@ class $TemplateClient {
   @_i4.experimental
   _i1.DynamiteRawResponse<TemplatePathResponseApplicationJson, void> pathRaw({
     String? templatePath,
-    int? copySystemTemplates,
+    TemplatePathCopySystemTemplates? copySystemTemplates,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, dynamic>{};
@@ -1074,7 +1074,10 @@ class $TemplateClient {
     $templatePath ??= '';
     _parameters['templatePath'] = $templatePath;
 
-    var $copySystemTemplates = _$jsonSerializers.serialize(copySystemTemplates, specifiedType: const FullType(int));
+    var $copySystemTemplates = _$jsonSerializers.serialize(
+      copySystemTemplates,
+      specifiedType: const FullType(TemplatePathCopySystemTemplates),
+    );
     $copySystemTemplates ??= 0;
     _parameters['copySystemTemplates'] = $copySystemTemplates;
 
@@ -2515,6 +2518,70 @@ abstract class TemplateCreateResponseApplicationJson
       _$templateCreateResponseApplicationJsonSerializer;
 }
 
+class TemplatePathCopySystemTemplates extends EnumClass {
+  const TemplatePathCopySystemTemplates._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const TemplatePathCopySystemTemplates $0 = _$templatePathCopySystemTemplates$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const TemplatePathCopySystemTemplates $1 = _$templatePathCopySystemTemplates$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<TemplatePathCopySystemTemplates> get values => _$templatePathCopySystemTemplatesValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static TemplatePathCopySystemTemplates valueOf(String name) => _$valueOfTemplatePathCopySystemTemplates(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for TemplatePathCopySystemTemplates.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<TemplatePathCopySystemTemplates> get serializer =>
+      const _$TemplatePathCopySystemTemplatesSerializer();
+}
+
+class _$TemplatePathCopySystemTemplatesSerializer implements PrimitiveSerializer<TemplatePathCopySystemTemplates> {
+  const _$TemplatePathCopySystemTemplatesSerializer();
+
+  static const Map<TemplatePathCopySystemTemplates, Object> _toWire = <TemplatePathCopySystemTemplates, Object>{
+    TemplatePathCopySystemTemplates.$0: 0,
+    TemplatePathCopySystemTemplates.$1: 1,
+  };
+
+  static const Map<Object, TemplatePathCopySystemTemplates> _fromWire = <Object, TemplatePathCopySystemTemplates>{
+    0: TemplatePathCopySystemTemplates.$0,
+    1: TemplatePathCopySystemTemplates.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [TemplatePathCopySystemTemplates];
+
+  @override
+  String get wireName => 'TemplatePathCopySystemTemplates';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    TemplatePathCopySystemTemplates object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  TemplatePathCopySystemTemplates deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 @BuiltValue(instantiable: false)
 abstract interface class $TemplatePathResponseApplicationJson_Ocs_DataInterface {
   @BuiltValueField(wireName: 'template_path')
@@ -3177,6 +3244,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(TemplateCreateResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(const FullType(TemplateFile), TemplateFileBuilder.new)
       ..add(TemplateFile.serializer)
+      ..add(TemplatePathCopySystemTemplates.serializer)
       ..addBuilderFactory(
         const FullType(TemplatePathResponseApplicationJson),
         TemplatePathResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/files.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.g.dart
@@ -6,6 +6,26 @@ part of 'files.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+const TemplatePathCopySystemTemplates _$templatePathCopySystemTemplates$0 = TemplatePathCopySystemTemplates._('\$0');
+const TemplatePathCopySystemTemplates _$templatePathCopySystemTemplates$1 = TemplatePathCopySystemTemplates._('\$1');
+
+TemplatePathCopySystemTemplates _$valueOfTemplatePathCopySystemTemplates(String name) {
+  switch (name) {
+    case '\$0':
+      return _$templatePathCopySystemTemplates$0;
+    case '\$1':
+      return _$templatePathCopySystemTemplates$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<TemplatePathCopySystemTemplates> _$templatePathCopySystemTemplatesValues =
+    BuiltSet<TemplatePathCopySystemTemplates>(const <TemplatePathCopySystemTemplates>[
+  _$templatePathCopySystemTemplates$0,
+  _$templatePathCopySystemTemplates$1,
+]);
+
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors>
     _$directEditingInfoResponseApplicationJsonOcsDataEditorsSerializer =

--- a/packages/nextcloud/lib/src/api/files.openapi.json
+++ b/packages/nextcloud/lib/src/api/files.openapi.json
@@ -1173,7 +1173,11 @@
                         "description": "Whether to copy the system templates to the template directory",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -255,7 +255,6 @@ class $PublicPreviewClient {
   ///
   /// Parameters:
   ///   * [token] Token of the share.
-  ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
   ///   * 200: Preview returned
@@ -265,13 +264,9 @@ class $PublicPreviewClient {
   ///
   /// See:
   ///  * [directLinkRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i1.DynamiteResponse<Uint8List, void>> directLink({
-    required String token,
-    bool? oCSAPIRequest,
-  }) async {
+  Future<_i1.DynamiteResponse<Uint8List, void>> directLink({required String token}) async {
     final rawResponse = directLinkRaw(
       token: token,
-      oCSAPIRequest: oCSAPIRequest,
     );
 
     return rawResponse.future;
@@ -286,7 +281,6 @@ class $PublicPreviewClient {
   ///
   /// Parameters:
   ///   * [token] Token of the share.
-  ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
   ///   * 200: Preview returned
@@ -297,10 +291,7 @@ class $PublicPreviewClient {
   /// See:
   ///  * [directLink] for an operation that returns a `DynamiteResponse` with a stable API.
   @_i4.experimental
-  _i1.DynamiteRawResponse<Uint8List, void> directLinkRaw({
-    required String token,
-    bool? oCSAPIRequest,
-  }) {
+  _i1.DynamiteRawResponse<Uint8List, void> directLinkRaw({required String token}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{
       'Accept': '*/*',
@@ -323,10 +314,6 @@ class $PublicPreviewClient {
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _parameters['token'] = $token;
-
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path = _i3.UriTemplate('/index.php/s/{token}/preview').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
@@ -354,7 +341,6 @@ class $PublicPreviewClient {
   ///   * [y] Height of the preview. Defaults to `32`.
   ///   * [a] Whether to not crop the preview. Defaults to `0`.
   ///   * [token] Token of the share.
-  ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
   ///   * 200: Preview returned
@@ -369,8 +355,7 @@ class $PublicPreviewClient {
     String? file,
     int? x,
     int? y,
-    int? a,
-    bool? oCSAPIRequest,
+    PublicPreviewGetPreviewA? a,
   }) async {
     final rawResponse = getPreviewRaw(
       token: token,
@@ -378,7 +363,6 @@ class $PublicPreviewClient {
       x: x,
       y: y,
       a: a,
-      oCSAPIRequest: oCSAPIRequest,
     );
 
     return rawResponse.future;
@@ -397,7 +381,6 @@ class $PublicPreviewClient {
   ///   * [y] Height of the preview. Defaults to `32`.
   ///   * [a] Whether to not crop the preview. Defaults to `0`.
   ///   * [token] Token of the share.
-  ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
   ///   * 200: Preview returned
@@ -413,8 +396,7 @@ class $PublicPreviewClient {
     String? file,
     int? x,
     int? y,
-    int? a,
-    bool? oCSAPIRequest,
+    PublicPreviewGetPreviewA? a,
   }) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{
@@ -451,13 +433,9 @@ class $PublicPreviewClient {
     $y ??= 32;
     _parameters['y'] = $y;
 
-    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(int));
+    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PublicPreviewGetPreviewA));
     $a ??= 0;
     _parameters['a'] = $a;
-
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
         _i3.UriTemplate('/index.php/apps/files_sharing/publicpreview/{token}{?file*,x*,y*,a*}').expand(_parameters);
@@ -1650,7 +1628,7 @@ class $ShareapiClient {
   ///  * [getShareRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<ShareapiGetShareResponseApplicationJson, void>> getShare({
     required String id,
-    int? includeTags,
+    ShareapiGetShareIncludeTags? includeTags,
     bool? oCSAPIRequest,
   }) async {
     final rawResponse = getShareRaw(
@@ -1683,7 +1661,7 @@ class $ShareapiClient {
   @_i4.experimental
   _i1.DynamiteRawResponse<ShareapiGetShareResponseApplicationJson, void> getShareRaw({
     required String id,
-    int? includeTags,
+    ShareapiGetShareIncludeTags? includeTags,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, dynamic>{};
@@ -1711,7 +1689,8 @@ class $ShareapiClient {
     final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
     _parameters['id'] = $id;
 
-    var $includeTags = _$jsonSerializers.serialize(includeTags, specifiedType: const FullType(int));
+    var $includeTags =
+        _$jsonSerializers.serialize(includeTags, specifiedType: const FullType(ShareapiGetShareIncludeTags));
     $includeTags ??= 0;
     _parameters['include_tags'] = $includeTags;
 
@@ -2129,7 +2108,7 @@ class $ShareesapiClient {
     int? page,
     int? perPage,
     ShareesapiSearchShareType? shareType,
-    int? lookup,
+    ShareesapiSearchLookup? lookup,
     bool? oCSAPIRequest,
   }) async {
     final rawResponse = searchRaw(
@@ -2174,7 +2153,7 @@ class $ShareesapiClient {
     int? page,
     int? perPage,
     ShareesapiSearchShareType? shareType,
-    int? lookup,
+    ShareesapiSearchLookup? lookup,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, dynamic>{};
@@ -2217,7 +2196,7 @@ class $ShareesapiClient {
     final $shareType = _$jsonSerializers.serialize(shareType, specifiedType: const FullType(ShareesapiSearchShareType));
     _parameters['shareType'] = $shareType;
 
-    var $lookup = _$jsonSerializers.serialize(lookup, specifiedType: const FullType(int));
+    var $lookup = _$jsonSerializers.serialize(lookup, specifiedType: const FullType(ShareesapiSearchLookup));
     $lookup ??= 0;
     _parameters['lookup'] = $lookup;
 
@@ -2595,6 +2574,69 @@ abstract class DeletedShareapiUndeleteResponseApplicationJson
   /// Serializer for DeletedShareapiUndeleteResponseApplicationJson.
   static Serializer<DeletedShareapiUndeleteResponseApplicationJson> get serializer =>
       _$deletedShareapiUndeleteResponseApplicationJsonSerializer;
+}
+
+class PublicPreviewGetPreviewA extends EnumClass {
+  const PublicPreviewGetPreviewA._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const PublicPreviewGetPreviewA $0 = _$publicPreviewGetPreviewA$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const PublicPreviewGetPreviewA $1 = _$publicPreviewGetPreviewA$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<PublicPreviewGetPreviewA> get values => _$publicPreviewGetPreviewAValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static PublicPreviewGetPreviewA valueOf(String name) => _$valueOfPublicPreviewGetPreviewA(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for PublicPreviewGetPreviewA.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<PublicPreviewGetPreviewA> get serializer => const _$PublicPreviewGetPreviewASerializer();
+}
+
+class _$PublicPreviewGetPreviewASerializer implements PrimitiveSerializer<PublicPreviewGetPreviewA> {
+  const _$PublicPreviewGetPreviewASerializer();
+
+  static const Map<PublicPreviewGetPreviewA, Object> _toWire = <PublicPreviewGetPreviewA, Object>{
+    PublicPreviewGetPreviewA.$0: 0,
+    PublicPreviewGetPreviewA.$1: 1,
+  };
+
+  static const Map<Object, PublicPreviewGetPreviewA> _fromWire = <Object, PublicPreviewGetPreviewA>{
+    0: PublicPreviewGetPreviewA.$0,
+    1: PublicPreviewGetPreviewA.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [PublicPreviewGetPreviewA];
+
+  @override
+  String get wireName => 'PublicPreviewGetPreviewA';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    PublicPreviewGetPreviewA object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  PublicPreviewGetPreviewA deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
 }
 
 @BuiltValue(instantiable: false)
@@ -3775,6 +3817,69 @@ abstract class ShareapiPendingSharesResponseApplicationJson
       _$shareapiPendingSharesResponseApplicationJsonSerializer;
 }
 
+class ShareapiGetShareIncludeTags extends EnumClass {
+  const ShareapiGetShareIncludeTags._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ShareapiGetShareIncludeTags $0 = _$shareapiGetShareIncludeTags$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ShareapiGetShareIncludeTags $1 = _$shareapiGetShareIncludeTags$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ShareapiGetShareIncludeTags> get values => _$shareapiGetShareIncludeTagsValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ShareapiGetShareIncludeTags valueOf(String name) => _$valueOfShareapiGetShareIncludeTags(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ShareapiGetShareIncludeTags.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ShareapiGetShareIncludeTags> get serializer => const _$ShareapiGetShareIncludeTagsSerializer();
+}
+
+class _$ShareapiGetShareIncludeTagsSerializer implements PrimitiveSerializer<ShareapiGetShareIncludeTags> {
+  const _$ShareapiGetShareIncludeTagsSerializer();
+
+  static const Map<ShareapiGetShareIncludeTags, Object> _toWire = <ShareapiGetShareIncludeTags, Object>{
+    ShareapiGetShareIncludeTags.$0: 0,
+    ShareapiGetShareIncludeTags.$1: 1,
+  };
+
+  static const Map<Object, ShareapiGetShareIncludeTags> _fromWire = <Object, ShareapiGetShareIncludeTags>{
+    0: ShareapiGetShareIncludeTags.$0,
+    1: ShareapiGetShareIncludeTags.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ShareapiGetShareIncludeTags];
+
+  @override
+  String get wireName => 'ShareapiGetShareIncludeTags';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ShareapiGetShareIncludeTags object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ShareapiGetShareIncludeTags deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiGetShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
@@ -4083,6 +4188,69 @@ abstract class ShareapiAcceptShareResponseApplicationJson
 }
 
 typedef ShareesapiSearchShareType = ({BuiltList<int>? builtListInt, int? $int});
+
+class ShareesapiSearchLookup extends EnumClass {
+  const ShareesapiSearchLookup._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ShareesapiSearchLookup $0 = _$shareesapiSearchLookup$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ShareesapiSearchLookup $1 = _$shareesapiSearchLookup$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ShareesapiSearchLookup> get values => _$shareesapiSearchLookupValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ShareesapiSearchLookup valueOf(String name) => _$valueOfShareesapiSearchLookup(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ShareesapiSearchLookup.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ShareesapiSearchLookup> get serializer => const _$ShareesapiSearchLookupSerializer();
+}
+
+class _$ShareesapiSearchLookupSerializer implements PrimitiveSerializer<ShareesapiSearchLookup> {
+  const _$ShareesapiSearchLookupSerializer();
+
+  static const Map<ShareesapiSearchLookup, Object> _toWire = <ShareesapiSearchLookup, Object>{
+    ShareesapiSearchLookup.$0: 0,
+    ShareesapiSearchLookup.$1: 1,
+  };
+
+  static const Map<Object, ShareesapiSearchLookup> _fromWire = <Object, ShareesapiSearchLookup>{
+    0: ShareesapiSearchLookup.$0,
+    1: ShareesapiSearchLookup.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ShareesapiSearchLookup];
+
+  @override
+  String get wireName => 'ShareesapiSearchLookup';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ShareesapiSearchLookup object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ShareesapiSearchLookup deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareesapiShareesapiSearchHeadersInterface {
@@ -5676,6 +5844,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
         DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder.new,
       )
       ..add(DeletedShareapiUndeleteResponseApplicationJson_Ocs.serializer)
+      ..add(PublicPreviewGetPreviewA.serializer)
       ..addBuilderFactory(
         const FullType(RemoteGetSharesResponseApplicationJson),
         RemoteGetSharesResponseApplicationJsonBuilder.new,
@@ -5799,6 +5968,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ShareapiPendingSharesResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ShareapiPendingSharesResponseApplicationJson_Ocs.serializer)
+      ..add(ShareapiGetShareIncludeTags.serializer)
       ..addBuilderFactory(
         const FullType(ShareapiGetShareResponseApplicationJson),
         ShareapiGetShareResponseApplicationJsonBuilder.new,
@@ -5841,6 +6011,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ShareapiAcceptShareResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]), ListBuilder<int>.new)
       ..add($07eaa0304017ba8abe7f9f20d6a736f3Extension._serializer)
+      ..add(ShareesapiSearchLookup.serializer)
       ..addBuilderFactory(
         const FullType(ShareesapiShareesapiSearchHeaders),
         ShareesapiShareesapiSearchHeadersBuilder.new,

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
@@ -6,6 +6,26 @@ part of 'files_sharing.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+const PublicPreviewGetPreviewA _$publicPreviewGetPreviewA$0 = PublicPreviewGetPreviewA._('\$0');
+const PublicPreviewGetPreviewA _$publicPreviewGetPreviewA$1 = PublicPreviewGetPreviewA._('\$1');
+
+PublicPreviewGetPreviewA _$valueOfPublicPreviewGetPreviewA(String name) {
+  switch (name) {
+    case '\$0':
+      return _$publicPreviewGetPreviewA$0;
+    case '\$1':
+      return _$publicPreviewGetPreviewA$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<PublicPreviewGetPreviewA> _$publicPreviewGetPreviewAValues =
+    BuiltSet<PublicPreviewGetPreviewA>(const <PublicPreviewGetPreviewA>[
+  _$publicPreviewGetPreviewA$0,
+  _$publicPreviewGetPreviewA$1,
+]);
+
 const Share_HideDownload _$shareHideDownload$0 = Share_HideDownload._('\$0');
 const Share_HideDownload _$shareHideDownload$1 = Share_HideDownload._('\$1');
 
@@ -61,6 +81,46 @@ Share_MailSend _$valueOfShare_MailSend(String name) {
 final BuiltSet<Share_MailSend> _$shareMailSendValues = BuiltSet<Share_MailSend>(const <Share_MailSend>[
   _$shareMailSend$0,
   _$shareMailSend$1,
+]);
+
+const ShareapiGetShareIncludeTags _$shareapiGetShareIncludeTags$0 = ShareapiGetShareIncludeTags._('\$0');
+const ShareapiGetShareIncludeTags _$shareapiGetShareIncludeTags$1 = ShareapiGetShareIncludeTags._('\$1');
+
+ShareapiGetShareIncludeTags _$valueOfShareapiGetShareIncludeTags(String name) {
+  switch (name) {
+    case '\$0':
+      return _$shareapiGetShareIncludeTags$0;
+    case '\$1':
+      return _$shareapiGetShareIncludeTags$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ShareapiGetShareIncludeTags> _$shareapiGetShareIncludeTagsValues =
+    BuiltSet<ShareapiGetShareIncludeTags>(const <ShareapiGetShareIncludeTags>[
+  _$shareapiGetShareIncludeTags$0,
+  _$shareapiGetShareIncludeTags$1,
+]);
+
+const ShareesapiSearchLookup _$shareesapiSearchLookup$0 = ShareesapiSearchLookup._('\$0');
+const ShareesapiSearchLookup _$shareesapiSearchLookup$1 = ShareesapiSearchLookup._('\$1');
+
+ShareesapiSearchLookup _$valueOfShareesapiSearchLookup(String name) {
+  switch (name) {
+    case '\$0':
+      return _$shareesapiSearchLookup$0;
+    case '\$1':
+      return _$shareesapiSearchLookup$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ShareesapiSearchLookup> _$shareesapiSearchLookupValues =
+    BuiltSet<ShareesapiSearchLookup>(const <ShareesapiSearchLookup>[
+  _$shareesapiSearchLookup$0,
+  _$shareesapiSearchLookup$1,
 ]);
 
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.json
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.json
@@ -1321,16 +1321,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "name": "OCS-APIRequest",
-                        "in": "header",
-                        "description": "Required to be true for the API request to pass",
-                        "required": true,
-                        "schema": {
-                            "type": "boolean",
-                            "default": true
-                        }
                     }
                 ],
                 "responses": {
@@ -1349,27 +1339,7 @@
                         "description": "Getting preview is not possible",
                         "content": {
                             "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {}
-                                            }
-                                        }
-                                    }
-                                }
+                                "schema": {}
                             }
                         }
                     },
@@ -1377,27 +1347,7 @@
                         "description": "Getting preview is not allowed",
                         "content": {
                             "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {}
-                                            }
-                                        }
-                                    }
-                                }
+                                "schema": {}
                             }
                         }
                     },
@@ -1405,27 +1355,7 @@
                         "description": "Share or preview not found",
                         "content": {
                             "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {}
-                                            }
-                                        }
-                                    }
-                                }
+                                "schema": {}
                             }
                         }
                     }
@@ -1484,7 +1414,11 @@
                         "description": "Whether to not crop the preview",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -1494,16 +1428,6 @@
                         "required": true,
                         "schema": {
                             "type": "string"
-                        }
-                    },
-                    {
-                        "name": "OCS-APIRequest",
-                        "in": "header",
-                        "description": "Required to be true for the API request to pass",
-                        "required": true,
-                        "schema": {
-                            "type": "boolean",
-                            "default": true
                         }
                     }
                 ],
@@ -1523,27 +1447,7 @@
                         "description": "Getting preview is not possible",
                         "content": {
                             "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {}
-                                            }
-                                        }
-                                    }
-                                }
+                                "schema": {}
                             }
                         }
                     },
@@ -1551,27 +1455,7 @@
                         "description": "Getting preview is not allowed",
                         "content": {
                             "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {}
-                                            }
-                                        }
-                                    }
-                                }
+                                "schema": {}
                             }
                         }
                     },
@@ -1579,27 +1463,7 @@
                         "description": "Share or preview not found",
                         "content": {
                             "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {}
-                                            }
-                                        }
-                                    }
-                                }
+                                "schema": {}
                             }
                         }
                     }
@@ -2179,7 +2043,11 @@
                         "description": "Include tags in the share",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -2823,7 +2691,11 @@
                         "description": "If a global lookup should be performed too",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -16,6 +16,7 @@ library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'dart:typed_data';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart' as _i5;
@@ -79,7 +80,7 @@ class $PreviewClient {
     int? fileId,
     int? x,
     int? y,
-    int? a,
+    PreviewGetPreviewA? a,
   }) async {
     final rawResponse = getPreviewRaw(
       fileId: fileId,
@@ -116,7 +117,7 @@ class $PreviewClient {
     int? fileId,
     int? x,
     int? y,
-    int? a,
+    PreviewGetPreviewA? a,
   }) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{
@@ -152,7 +153,7 @@ class $PreviewClient {
     $y ??= 32;
     _parameters['y'] = $y;
 
-    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(int));
+    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewA));
     $a ??= 0;
     _parameters['a'] = $a;
 
@@ -170,6 +171,69 @@ class $PreviewClient {
       serializers: _$jsonSerializers,
     );
   }
+}
+
+class PreviewGetPreviewA extends EnumClass {
+  const PreviewGetPreviewA._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const PreviewGetPreviewA $0 = _$previewGetPreviewA$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const PreviewGetPreviewA $1 = _$previewGetPreviewA$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<PreviewGetPreviewA> get values => _$previewGetPreviewAValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static PreviewGetPreviewA valueOf(String name) => _$valueOfPreviewGetPreviewA(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for PreviewGetPreviewA.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<PreviewGetPreviewA> get serializer => const _$PreviewGetPreviewASerializer();
+}
+
+class _$PreviewGetPreviewASerializer implements PrimitiveSerializer<PreviewGetPreviewA> {
+  const _$PreviewGetPreviewASerializer();
+
+  static const Map<PreviewGetPreviewA, Object> _toWire = <PreviewGetPreviewA, Object>{
+    PreviewGetPreviewA.$0: 0,
+    PreviewGetPreviewA.$1: 1,
+  };
+
+  static const Map<Object, PreviewGetPreviewA> _fromWire = <Object, PreviewGetPreviewA>{
+    0: PreviewGetPreviewA.$0,
+    1: PreviewGetPreviewA.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [PreviewGetPreviewA];
+
+  @override
+  String get wireName => 'PreviewGetPreviewA';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    PreviewGetPreviewA object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  PreviewGetPreviewA deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
 }
 
 @BuiltValue(instantiable: false)
@@ -244,6 +308,7 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 @_i3.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
+      ..add(PreviewGetPreviewA.serializer)
       ..addBuilderFactory(const FullType(Capabilities), CapabilitiesBuilder.new)
       ..add(Capabilities.serializer)
       ..addBuilderFactory(const FullType(Capabilities_Files), Capabilities_FilesBuilder.new)

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.g.dart
@@ -6,6 +6,25 @@ part of 'files_trashbin.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+const PreviewGetPreviewA _$previewGetPreviewA$0 = PreviewGetPreviewA._('\$0');
+const PreviewGetPreviewA _$previewGetPreviewA$1 = PreviewGetPreviewA._('\$1');
+
+PreviewGetPreviewA _$valueOfPreviewGetPreviewA(String name) {
+  switch (name) {
+    case '\$0':
+      return _$previewGetPreviewA$0;
+    case '\$1':
+      return _$previewGetPreviewA$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<PreviewGetPreviewA> _$previewGetPreviewAValues = BuiltSet<PreviewGetPreviewA>(const <PreviewGetPreviewA>[
+  _$previewGetPreviewA$0,
+  _$previewGetPreviewA$1,
+]);
+
 Serializer<Capabilities_Files> _$capabilitiesFilesSerializer = _$Capabilities_FilesSerializer();
 Serializer<Capabilities> _$capabilitiesSerializer = _$CapabilitiesSerializer();
 

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.json
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.json
@@ -95,7 +95,11 @@
                         "description": "Whether to not crop the preview",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     }
                 ],

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -115,7 +115,7 @@ class $AvatarClient {
   ///  * [getAvatarRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<Uint8List, void>> getAvatar({
     required String token,
-    int? darkTheme,
+    AvatarGetAvatarDarkTheme? darkTheme,
     AvatarGetAvatarApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
@@ -150,7 +150,7 @@ class $AvatarClient {
   @_i4.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getAvatarRaw({
     required String token,
-    int? darkTheme,
+    AvatarGetAvatarDarkTheme? darkTheme,
     AvatarGetAvatarApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
@@ -182,7 +182,7 @@ class $AvatarClient {
     );
     _parameters['token'] = $token;
 
-    var $darkTheme = _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(int));
+    var $darkTheme = _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(AvatarGetAvatarDarkTheme));
     $darkTheme ??= 0;
     _parameters['darkTheme'] = $darkTheme;
 
@@ -684,7 +684,7 @@ class $BotClient {
     required String token,
     String? referenceId,
     int? replyTo,
-    int? silent,
+    BotSendMessageSilent? silent,
     BotSendMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
@@ -733,7 +733,7 @@ class $BotClient {
     required String token,
     String? referenceId,
     int? replyTo,
-    int? silent,
+    BotSendMessageSilent? silent,
     BotSendMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
@@ -776,7 +776,7 @@ class $BotClient {
     $replyTo ??= 0;
     _parameters['replyTo'] = $replyTo;
 
-    var $silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(int));
+    var $silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(BotSendMessageSilent));
     $silent ??= 0;
     _parameters['silent'] = $silent;
 
@@ -2826,8 +2826,8 @@ class $CallClient {
     required String token,
     CallJoinCallFlags? flags,
     CallJoinCallForcePermissions? forcePermissions,
-    int? silent,
-    int? recordingConsent,
+    CallJoinCallSilent? silent,
+    CallJoinCallRecordingConsent? recordingConsent,
     CallJoinCallApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
@@ -2872,8 +2872,8 @@ class $CallClient {
     required String token,
     CallJoinCallFlags? flags,
     CallJoinCallForcePermissions? forcePermissions,
-    int? silent,
-    int? recordingConsent,
+    CallJoinCallSilent? silent,
+    CallJoinCallRecordingConsent? recordingConsent,
     CallJoinCallApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
@@ -2912,11 +2912,12 @@ class $CallClient {
         _$jsonSerializers.serialize(forcePermissions, specifiedType: const FullType(CallJoinCallForcePermissions));
     _parameters['forcePermissions'] = $forcePermissions;
 
-    var $silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(int));
+    var $silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(CallJoinCallSilent));
     $silent ??= 0;
     _parameters['silent'] = $silent;
 
-    var $recordingConsent = _$jsonSerializers.serialize(recordingConsent, specifiedType: const FullType(int));
+    var $recordingConsent =
+        _$jsonSerializers.serialize(recordingConsent, specifiedType: const FullType(CallJoinCallRecordingConsent));
     $recordingConsent ??= 0;
     _parameters['recordingConsent'] = $recordingConsent;
 
@@ -2967,7 +2968,7 @@ class $CallClient {
   ///  * [leaveCallRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<CallLeaveCallResponseApplicationJson, void>> leaveCall({
     required String token,
-    int? all,
+    CallLeaveCallAll? all,
     CallLeaveCallApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
@@ -3003,7 +3004,7 @@ class $CallClient {
   @_i4.experimental
   _i1.DynamiteRawResponse<CallLeaveCallResponseApplicationJson, void> leaveCallRaw({
     required String token,
-    int? all,
+    CallLeaveCallAll? all,
     CallLeaveCallApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
@@ -3035,7 +3036,7 @@ class $CallClient {
     );
     _parameters['token'] = $token;
 
-    var $all = _$jsonSerializers.serialize(all, specifiedType: const FullType(int));
+    var $all = _$jsonSerializers.serialize(all, specifiedType: const FullType(CallLeaveCallAll));
     $all ??= 0;
     _parameters['all'] = $all;
 
@@ -3676,7 +3677,7 @@ class $ChatClient {
     String? actorDisplayName,
     String? referenceId,
     int? replyTo,
-    int? silent,
+    ChatSendMessageSilent? silent,
     ChatSendMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
@@ -3728,7 +3729,7 @@ class $ChatClient {
     String? actorDisplayName,
     String? referenceId,
     int? replyTo,
-    int? silent,
+    ChatSendMessageSilent? silent,
     ChatSendMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
@@ -3775,7 +3776,7 @@ class $ChatClient {
     $replyTo ??= 0;
     _parameters['replyTo'] = $replyTo;
 
-    var $silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(int));
+    var $silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(ChatSendMessageSilent));
     $silent ??= 0;
     _parameters['silent'] = $silent;
 
@@ -4777,7 +4778,7 @@ class $ChatClient {
     required String search,
     required String token,
     int? limit,
-    int? includeStatus,
+    ChatMentionsIncludeStatus? includeStatus,
     ChatMentionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
@@ -4818,7 +4819,7 @@ class $ChatClient {
     required String search,
     required String token,
     int? limit,
-    int? includeStatus,
+    ChatMentionsIncludeStatus? includeStatus,
     ChatMentionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
@@ -4857,7 +4858,8 @@ class $ChatClient {
     $limit ??= 20;
     _parameters['limit'] = $limit;
 
-    var $includeStatus = _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(int));
+    var $includeStatus =
+        _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(ChatMentionsIncludeStatus));
     $includeStatus ??= 0;
     _parameters['includeStatus'] = $includeStatus;
 
@@ -6064,7 +6066,7 @@ class $MatterbridgeClient {
   /// See:
   ///  * [editBridgeOfRoomRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void>> editBridgeOfRoom({
-    required int enabled,
+    required MatterbridgeEditBridgeOfRoomEnabled enabled,
     required String token,
     ContentString<BuiltList<BuiltMap<String, JsonObject>>>? parts,
     MatterbridgeEditBridgeOfRoomApiVersion? apiVersion,
@@ -6103,7 +6105,7 @@ class $MatterbridgeClient {
   ///  * [editBridgeOfRoom] for an operation that returns a `DynamiteResponse` with a stable API.
   @_i4.experimental
   _i1.DynamiteRawResponse<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void> editBridgeOfRoomRaw({
-    required int enabled,
+    required MatterbridgeEditBridgeOfRoomEnabled enabled,
     required String token,
     ContentString<BuiltList<BuiltMap<String, JsonObject>>>? parts,
     MatterbridgeEditBridgeOfRoomApiVersion? apiVersion,
@@ -6131,7 +6133,8 @@ class $MatterbridgeClient {
     }
 
 // coverage:ignore-end
-    final $enabled = _$jsonSerializers.serialize(enabled, specifiedType: const FullType(int));
+    final $enabled =
+        _$jsonSerializers.serialize(enabled, specifiedType: const FullType(MatterbridgeEditBridgeOfRoomEnabled));
     _parameters['enabled'] = $enabled;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -8335,7 +8338,7 @@ class $RoomClient {
   ///  * [getRoomsRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders>> getRooms({
     RoomGetRoomsNoStatusUpdate? noStatusUpdate,
-    int? includeStatus,
+    RoomGetRoomsIncludeStatus? includeStatus,
     int? modifiedSince,
     RoomGetRoomsApiVersion? apiVersion,
     bool? oCSAPIRequest,
@@ -8373,7 +8376,7 @@ class $RoomClient {
   @_i4.experimental
   _i1.DynamiteRawResponse<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders> getRoomsRaw({
     RoomGetRoomsNoStatusUpdate? noStatusUpdate,
-    int? includeStatus,
+    RoomGetRoomsIncludeStatus? includeStatus,
     int? modifiedSince,
     RoomGetRoomsApiVersion? apiVersion,
     bool? oCSAPIRequest,
@@ -8405,7 +8408,8 @@ class $RoomClient {
     $noStatusUpdate ??= 0;
     _parameters['noStatusUpdate'] = $noStatusUpdate;
 
-    var $includeStatus = _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(int));
+    var $includeStatus =
+        _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(RoomGetRoomsIncludeStatus));
     $includeStatus ??= 0;
     _parameters['includeStatus'] = $includeStatus;
 
@@ -10091,7 +10095,7 @@ class $RoomClient {
   Future<_i1.DynamiteResponse<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>>
       getParticipants({
     required String token,
-    int? includeStatus,
+    RoomGetParticipantsIncludeStatus? includeStatus,
     RoomGetParticipantsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
@@ -10128,7 +10132,7 @@ class $RoomClient {
   _i1.DynamiteRawResponse<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>
       getParticipantsRaw({
     required String token,
-    int? includeStatus,
+    RoomGetParticipantsIncludeStatus? includeStatus,
     RoomGetParticipantsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
@@ -10160,7 +10164,8 @@ class $RoomClient {
     );
     _parameters['token'] = $token;
 
-    var $includeStatus = _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(int));
+    var $includeStatus =
+        _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(RoomGetParticipantsIncludeStatus));
     $includeStatus ??= 0;
     _parameters['includeStatus'] = $includeStatus;
 
@@ -10342,7 +10347,7 @@ class $RoomClient {
       _i1.DynamiteResponse<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
           RoomRoomGetBreakoutRoomParticipantsHeaders>> getBreakoutRoomParticipants({
     required String token,
-    int? includeStatus,
+    RoomGetBreakoutRoomParticipantsIncludeStatus? includeStatus,
     RoomGetBreakoutRoomParticipantsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
@@ -10380,7 +10385,7 @@ class $RoomClient {
   _i1.DynamiteRawResponse<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
       RoomRoomGetBreakoutRoomParticipantsHeaders> getBreakoutRoomParticipantsRaw({
     required String token,
-    int? includeStatus,
+    RoomGetBreakoutRoomParticipantsIncludeStatus? includeStatus,
     RoomGetBreakoutRoomParticipantsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
@@ -10412,7 +10417,10 @@ class $RoomClient {
     );
     _parameters['token'] = $token;
 
-    var $includeStatus = _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(int));
+    var $includeStatus = _$jsonSerializers.serialize(
+      includeStatus,
+      specifiedType: const FullType(RoomGetBreakoutRoomParticipantsIncludeStatus),
+    );
     $includeStatus ??= 0;
     _parameters['includeStatus'] = $includeStatus;
 
@@ -10980,7 +10988,7 @@ class $RoomClient {
   Future<_i1.DynamiteResponse<RoomJoinRoomResponseApplicationJson, void>> joinRoom({
     required String token,
     String? password,
-    int? force,
+    RoomJoinRoomForce? force,
     RoomJoinRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
@@ -11021,7 +11029,7 @@ class $RoomClient {
   _i1.DynamiteRawResponse<RoomJoinRoomResponseApplicationJson, void> joinRoomRaw({
     required String token,
     String? password,
-    int? force,
+    RoomJoinRoomForce? force,
     RoomJoinRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
@@ -11057,7 +11065,7 @@ class $RoomClient {
     $password ??= '';
     _parameters['password'] = $password;
 
-    var $force = _$jsonSerializers.serialize(force, specifiedType: const FullType(int));
+    var $force = _$jsonSerializers.serialize(force, specifiedType: const FullType(RoomJoinRoomForce));
     $force ??= 1;
     _parameters['force'] = $force;
 
@@ -13487,6 +13495,69 @@ class $TempAvatarClient {
   }
 }
 
+class AvatarGetAvatarDarkTheme extends EnumClass {
+  const AvatarGetAvatarDarkTheme._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const AvatarGetAvatarDarkTheme $0 = _$avatarGetAvatarDarkTheme$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const AvatarGetAvatarDarkTheme $1 = _$avatarGetAvatarDarkTheme$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<AvatarGetAvatarDarkTheme> get values => _$avatarGetAvatarDarkThemeValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static AvatarGetAvatarDarkTheme valueOf(String name) => _$valueOfAvatarGetAvatarDarkTheme(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for AvatarGetAvatarDarkTheme.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<AvatarGetAvatarDarkTheme> get serializer => const _$AvatarGetAvatarDarkThemeSerializer();
+}
+
+class _$AvatarGetAvatarDarkThemeSerializer implements PrimitiveSerializer<AvatarGetAvatarDarkTheme> {
+  const _$AvatarGetAvatarDarkThemeSerializer();
+
+  static const Map<AvatarGetAvatarDarkTheme, Object> _toWire = <AvatarGetAvatarDarkTheme, Object>{
+    AvatarGetAvatarDarkTheme.$0: 0,
+    AvatarGetAvatarDarkTheme.$1: 1,
+  };
+
+  static const Map<Object, AvatarGetAvatarDarkTheme> _fromWire = <Object, AvatarGetAvatarDarkTheme>{
+    0: AvatarGetAvatarDarkTheme.$0,
+    1: AvatarGetAvatarDarkTheme.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [AvatarGetAvatarDarkTheme];
+
+  @override
+  String get wireName => 'AvatarGetAvatarDarkTheme';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    AvatarGetAvatarDarkTheme object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  AvatarGetAvatarDarkTheme deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 class AvatarGetAvatarApiVersion extends EnumClass {
   const AvatarGetAvatarApiVersion._(super.name);
 
@@ -13634,12 +13705,69 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
 }
 
+class ChatMessage_Deleted extends EnumClass {
+  const ChatMessage_Deleted._(super.name);
+
+  /// `true`
+  @BuiltValueEnumConst(wireName: 'true')
+  static const ChatMessage_Deleted $true = _$chatMessageDeleted$true;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ChatMessage_Deleted> get values => _$chatMessageDeletedValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ChatMessage_Deleted valueOf(String name) => _$valueOfChatMessage_Deleted(name);
+
+  /// Returns the serialized value of this enum value.
+  bool get value => _$jsonSerializers.serializeWith(serializer, this)! as bool;
+
+  /// Serializer for ChatMessage_Deleted.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ChatMessage_Deleted> get serializer => const _$ChatMessage_DeletedSerializer();
+}
+
+class _$ChatMessage_DeletedSerializer implements PrimitiveSerializer<ChatMessage_Deleted> {
+  const _$ChatMessage_DeletedSerializer();
+
+  static const Map<ChatMessage_Deleted, Object> _toWire = <ChatMessage_Deleted, Object>{
+    ChatMessage_Deleted.$true: true,
+  };
+
+  static const Map<Object, ChatMessage_Deleted> _fromWire = <Object, ChatMessage_Deleted>{
+    true: ChatMessage_Deleted.$true,
+  };
+
+  @override
+  Iterable<Type> get types => const [ChatMessage_Deleted];
+
+  @override
+  String get wireName => 'ChatMessage_Deleted';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ChatMessage_Deleted object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ChatMessage_Deleted deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 @BuiltValue(instantiable: false)
 abstract interface class $ChatMessageInterface {
   String get actorDisplayName;
   String get actorId;
   String get actorType;
-  bool? get deleted;
+  ChatMessage_Deleted? get deleted;
   int get expirationTimestamp;
   int get id;
   bool get isReplyable;
@@ -14163,6 +14291,69 @@ class _$AvatarGetAvatarDarkApiVersionSerializer implements PrimitiveSerializer<A
 
   @override
   AvatarGetAvatarDarkApiVersion deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+class BotSendMessageSilent extends EnumClass {
+  const BotSendMessageSilent._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const BotSendMessageSilent $0 = _$botSendMessageSilent$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const BotSendMessageSilent $1 = _$botSendMessageSilent$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<BotSendMessageSilent> get values => _$botSendMessageSilentValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static BotSendMessageSilent valueOf(String name) => _$valueOfBotSendMessageSilent(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for BotSendMessageSilent.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<BotSendMessageSilent> get serializer => const _$BotSendMessageSilentSerializer();
+}
+
+class _$BotSendMessageSilentSerializer implements PrimitiveSerializer<BotSendMessageSilent> {
+  const _$BotSendMessageSilentSerializer();
+
+  static const Map<BotSendMessageSilent, Object> _toWire = <BotSendMessageSilent, Object>{
+    BotSendMessageSilent.$0: 0,
+    BotSendMessageSilent.$1: 1,
+  };
+
+  static const Map<Object, BotSendMessageSilent> _fromWire = <Object, BotSendMessageSilent>{
+    0: BotSendMessageSilent.$0,
+    1: BotSendMessageSilent.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [BotSendMessageSilent];
+
+  @override
+  String get wireName => 'BotSendMessageSilent';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    BotSendMessageSilent object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  BotSendMessageSilent deserialize(
     Serializers serializers,
     Object serialized, {
     FullType specifiedType = FullType.unspecified,
@@ -18549,6 +18740,132 @@ class _$CallJoinCallForcePermissionsSerializer implements PrimitiveSerializer<Ca
       _fromWire[serialized]!;
 }
 
+class CallJoinCallSilent extends EnumClass {
+  const CallJoinCallSilent._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const CallJoinCallSilent $0 = _$callJoinCallSilent$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const CallJoinCallSilent $1 = _$callJoinCallSilent$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<CallJoinCallSilent> get values => _$callJoinCallSilentValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static CallJoinCallSilent valueOf(String name) => _$valueOfCallJoinCallSilent(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for CallJoinCallSilent.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<CallJoinCallSilent> get serializer => const _$CallJoinCallSilentSerializer();
+}
+
+class _$CallJoinCallSilentSerializer implements PrimitiveSerializer<CallJoinCallSilent> {
+  const _$CallJoinCallSilentSerializer();
+
+  static const Map<CallJoinCallSilent, Object> _toWire = <CallJoinCallSilent, Object>{
+    CallJoinCallSilent.$0: 0,
+    CallJoinCallSilent.$1: 1,
+  };
+
+  static const Map<Object, CallJoinCallSilent> _fromWire = <Object, CallJoinCallSilent>{
+    0: CallJoinCallSilent.$0,
+    1: CallJoinCallSilent.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [CallJoinCallSilent];
+
+  @override
+  String get wireName => 'CallJoinCallSilent';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    CallJoinCallSilent object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  CallJoinCallSilent deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+class CallJoinCallRecordingConsent extends EnumClass {
+  const CallJoinCallRecordingConsent._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const CallJoinCallRecordingConsent $0 = _$callJoinCallRecordingConsent$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const CallJoinCallRecordingConsent $1 = _$callJoinCallRecordingConsent$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<CallJoinCallRecordingConsent> get values => _$callJoinCallRecordingConsentValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static CallJoinCallRecordingConsent valueOf(String name) => _$valueOfCallJoinCallRecordingConsent(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for CallJoinCallRecordingConsent.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<CallJoinCallRecordingConsent> get serializer => const _$CallJoinCallRecordingConsentSerializer();
+}
+
+class _$CallJoinCallRecordingConsentSerializer implements PrimitiveSerializer<CallJoinCallRecordingConsent> {
+  const _$CallJoinCallRecordingConsentSerializer();
+
+  static const Map<CallJoinCallRecordingConsent, Object> _toWire = <CallJoinCallRecordingConsent, Object>{
+    CallJoinCallRecordingConsent.$0: 0,
+    CallJoinCallRecordingConsent.$1: 1,
+  };
+
+  static const Map<Object, CallJoinCallRecordingConsent> _fromWire = <Object, CallJoinCallRecordingConsent>{
+    0: CallJoinCallRecordingConsent.$0,
+    1: CallJoinCallRecordingConsent.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [CallJoinCallRecordingConsent];
+
+  @override
+  String get wireName => 'CallJoinCallRecordingConsent';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    CallJoinCallRecordingConsent object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  CallJoinCallRecordingConsent deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 class CallJoinCallApiVersion extends EnumClass {
   const CallJoinCallApiVersion._(super.name);
 
@@ -18678,6 +18995,69 @@ abstract class CallJoinCallResponseApplicationJson
   /// Serializer for CallJoinCallResponseApplicationJson.
   static Serializer<CallJoinCallResponseApplicationJson> get serializer =>
       _$callJoinCallResponseApplicationJsonSerializer;
+}
+
+class CallLeaveCallAll extends EnumClass {
+  const CallLeaveCallAll._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const CallLeaveCallAll $0 = _$callLeaveCallAll$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const CallLeaveCallAll $1 = _$callLeaveCallAll$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<CallLeaveCallAll> get values => _$callLeaveCallAllValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static CallLeaveCallAll valueOf(String name) => _$valueOfCallLeaveCallAll(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for CallLeaveCallAll.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<CallLeaveCallAll> get serializer => const _$CallLeaveCallAllSerializer();
+}
+
+class _$CallLeaveCallAllSerializer implements PrimitiveSerializer<CallLeaveCallAll> {
+  const _$CallLeaveCallAllSerializer();
+
+  static const Map<CallLeaveCallAll, Object> _toWire = <CallLeaveCallAll, Object>{
+    CallLeaveCallAll.$0: 0,
+    CallLeaveCallAll.$1: 1,
+  };
+
+  static const Map<Object, CallLeaveCallAll> _fromWire = <Object, CallLeaveCallAll>{
+    0: CallLeaveCallAll.$0,
+    1: CallLeaveCallAll.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [CallLeaveCallAll];
+
+  @override
+  String get wireName => 'CallLeaveCallAll';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    CallLeaveCallAll object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  CallLeaveCallAll deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
 }
 
 class CallLeaveCallApiVersion extends EnumClass {
@@ -19826,6 +20206,69 @@ abstract class ChatReceiveMessagesResponseApplicationJson
   /// Serializer for ChatReceiveMessagesResponseApplicationJson.
   static Serializer<ChatReceiveMessagesResponseApplicationJson> get serializer =>
       _$chatReceiveMessagesResponseApplicationJsonSerializer;
+}
+
+class ChatSendMessageSilent extends EnumClass {
+  const ChatSendMessageSilent._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ChatSendMessageSilent $0 = _$chatSendMessageSilent$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ChatSendMessageSilent $1 = _$chatSendMessageSilent$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ChatSendMessageSilent> get values => _$chatSendMessageSilentValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ChatSendMessageSilent valueOf(String name) => _$valueOfChatSendMessageSilent(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ChatSendMessageSilent.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ChatSendMessageSilent> get serializer => const _$ChatSendMessageSilentSerializer();
+}
+
+class _$ChatSendMessageSilentSerializer implements PrimitiveSerializer<ChatSendMessageSilent> {
+  const _$ChatSendMessageSilentSerializer();
+
+  static const Map<ChatSendMessageSilent, Object> _toWire = <ChatSendMessageSilent, Object>{
+    ChatSendMessageSilent.$0: 0,
+    ChatSendMessageSilent.$1: 1,
+  };
+
+  static const Map<Object, ChatSendMessageSilent> _fromWire = <Object, ChatSendMessageSilent>{
+    0: ChatSendMessageSilent.$0,
+    1: ChatSendMessageSilent.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ChatSendMessageSilent];
+
+  @override
+  String get wireName => 'ChatSendMessageSilent';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ChatSendMessageSilent object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ChatSendMessageSilent deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
 }
 
 class ChatSendMessageApiVersion extends EnumClass {
@@ -21275,6 +21718,69 @@ abstract class ChatMarkUnreadResponseApplicationJson
   /// Serializer for ChatMarkUnreadResponseApplicationJson.
   static Serializer<ChatMarkUnreadResponseApplicationJson> get serializer =>
       _$chatMarkUnreadResponseApplicationJsonSerializer;
+}
+
+class ChatMentionsIncludeStatus extends EnumClass {
+  const ChatMentionsIncludeStatus._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ChatMentionsIncludeStatus $0 = _$chatMentionsIncludeStatus$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ChatMentionsIncludeStatus $1 = _$chatMentionsIncludeStatus$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ChatMentionsIncludeStatus> get values => _$chatMentionsIncludeStatusValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ChatMentionsIncludeStatus valueOf(String name) => _$valueOfChatMentionsIncludeStatus(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ChatMentionsIncludeStatus.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ChatMentionsIncludeStatus> get serializer => const _$ChatMentionsIncludeStatusSerializer();
+}
+
+class _$ChatMentionsIncludeStatusSerializer implements PrimitiveSerializer<ChatMentionsIncludeStatus> {
+  const _$ChatMentionsIncludeStatusSerializer();
+
+  static const Map<ChatMentionsIncludeStatus, Object> _toWire = <ChatMentionsIncludeStatus, Object>{
+    ChatMentionsIncludeStatus.$0: 0,
+    ChatMentionsIncludeStatus.$1: 1,
+  };
+
+  static const Map<Object, ChatMentionsIncludeStatus> _fromWire = <Object, ChatMentionsIncludeStatus>{
+    0: ChatMentionsIncludeStatus.$0,
+    1: ChatMentionsIncludeStatus.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ChatMentionsIncludeStatus];
+
+  @override
+  String get wireName => 'ChatMentionsIncludeStatus';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ChatMentionsIncludeStatus object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ChatMentionsIncludeStatus deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
 }
 
 class ChatMentionsApiVersion extends EnumClass {
@@ -22955,6 +23461,72 @@ abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson
   /// Serializer for MatterbridgeGetBridgeOfRoomResponseApplicationJson.
   static Serializer<MatterbridgeGetBridgeOfRoomResponseApplicationJson> get serializer =>
       _$matterbridgeGetBridgeOfRoomResponseApplicationJsonSerializer;
+}
+
+class MatterbridgeEditBridgeOfRoomEnabled extends EnumClass {
+  const MatterbridgeEditBridgeOfRoomEnabled._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const MatterbridgeEditBridgeOfRoomEnabled $0 = _$matterbridgeEditBridgeOfRoomEnabled$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const MatterbridgeEditBridgeOfRoomEnabled $1 = _$matterbridgeEditBridgeOfRoomEnabled$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<MatterbridgeEditBridgeOfRoomEnabled> get values => _$matterbridgeEditBridgeOfRoomEnabledValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static MatterbridgeEditBridgeOfRoomEnabled valueOf(String name) => _$valueOfMatterbridgeEditBridgeOfRoomEnabled(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for MatterbridgeEditBridgeOfRoomEnabled.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<MatterbridgeEditBridgeOfRoomEnabled> get serializer =>
+      const _$MatterbridgeEditBridgeOfRoomEnabledSerializer();
+}
+
+class _$MatterbridgeEditBridgeOfRoomEnabledSerializer
+    implements PrimitiveSerializer<MatterbridgeEditBridgeOfRoomEnabled> {
+  const _$MatterbridgeEditBridgeOfRoomEnabledSerializer();
+
+  static const Map<MatterbridgeEditBridgeOfRoomEnabled, Object> _toWire = <MatterbridgeEditBridgeOfRoomEnabled, Object>{
+    MatterbridgeEditBridgeOfRoomEnabled.$0: 0,
+    MatterbridgeEditBridgeOfRoomEnabled.$1: 1,
+  };
+
+  static const Map<Object, MatterbridgeEditBridgeOfRoomEnabled> _fromWire =
+      <Object, MatterbridgeEditBridgeOfRoomEnabled>{
+    0: MatterbridgeEditBridgeOfRoomEnabled.$0,
+    1: MatterbridgeEditBridgeOfRoomEnabled.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [MatterbridgeEditBridgeOfRoomEnabled];
+
+  @override
+  String get wireName => 'MatterbridgeEditBridgeOfRoomEnabled';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    MatterbridgeEditBridgeOfRoomEnabled object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  MatterbridgeEditBridgeOfRoomEnabled deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
 }
 
 class MatterbridgeEditBridgeOfRoomApiVersion extends EnumClass {
@@ -25885,6 +26457,69 @@ class _$RoomGetRoomsNoStatusUpdateSerializer implements PrimitiveSerializer<Room
 
   @override
   RoomGetRoomsNoStatusUpdate deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+class RoomGetRoomsIncludeStatus extends EnumClass {
+  const RoomGetRoomsIncludeStatus._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const RoomGetRoomsIncludeStatus $0 = _$roomGetRoomsIncludeStatus$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const RoomGetRoomsIncludeStatus $1 = _$roomGetRoomsIncludeStatus$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomGetRoomsIncludeStatus> get values => _$roomGetRoomsIncludeStatusValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomGetRoomsIncludeStatus valueOf(String name) => _$valueOfRoomGetRoomsIncludeStatus(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for RoomGetRoomsIncludeStatus.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomGetRoomsIncludeStatus> get serializer => const _$RoomGetRoomsIncludeStatusSerializer();
+}
+
+class _$RoomGetRoomsIncludeStatusSerializer implements PrimitiveSerializer<RoomGetRoomsIncludeStatus> {
+  const _$RoomGetRoomsIncludeStatusSerializer();
+
+  static const Map<RoomGetRoomsIncludeStatus, Object> _toWire = <RoomGetRoomsIncludeStatus, Object>{
+    RoomGetRoomsIncludeStatus.$0: 0,
+    RoomGetRoomsIncludeStatus.$1: 1,
+  };
+
+  static const Map<Object, RoomGetRoomsIncludeStatus> _fromWire = <Object, RoomGetRoomsIncludeStatus>{
+    0: RoomGetRoomsIncludeStatus.$0,
+    1: RoomGetRoomsIncludeStatus.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomGetRoomsIncludeStatus];
+
+  @override
+  String get wireName => 'RoomGetRoomsIncludeStatus';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomGetRoomsIncludeStatus object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomGetRoomsIncludeStatus deserialize(
     Serializers serializers,
     Object serialized, {
     FullType specifiedType = FullType.unspecified,
@@ -29779,6 +30414,70 @@ abstract class RoomSetPermissionsResponseApplicationJson
       _$roomSetPermissionsResponseApplicationJsonSerializer;
 }
 
+class RoomGetParticipantsIncludeStatus extends EnumClass {
+  const RoomGetParticipantsIncludeStatus._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const RoomGetParticipantsIncludeStatus $0 = _$roomGetParticipantsIncludeStatus$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const RoomGetParticipantsIncludeStatus $1 = _$roomGetParticipantsIncludeStatus$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomGetParticipantsIncludeStatus> get values => _$roomGetParticipantsIncludeStatusValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomGetParticipantsIncludeStatus valueOf(String name) => _$valueOfRoomGetParticipantsIncludeStatus(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for RoomGetParticipantsIncludeStatus.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomGetParticipantsIncludeStatus> get serializer =>
+      const _$RoomGetParticipantsIncludeStatusSerializer();
+}
+
+class _$RoomGetParticipantsIncludeStatusSerializer implements PrimitiveSerializer<RoomGetParticipantsIncludeStatus> {
+  const _$RoomGetParticipantsIncludeStatusSerializer();
+
+  static const Map<RoomGetParticipantsIncludeStatus, Object> _toWire = <RoomGetParticipantsIncludeStatus, Object>{
+    RoomGetParticipantsIncludeStatus.$0: 0,
+    RoomGetParticipantsIncludeStatus.$1: 1,
+  };
+
+  static const Map<Object, RoomGetParticipantsIncludeStatus> _fromWire = <Object, RoomGetParticipantsIncludeStatus>{
+    0: RoomGetParticipantsIncludeStatus.$0,
+    1: RoomGetParticipantsIncludeStatus.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomGetParticipantsIncludeStatus];
+
+  @override
+  String get wireName => 'RoomGetParticipantsIncludeStatus';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomGetParticipantsIncludeStatus object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomGetParticipantsIncludeStatus deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 class RoomGetParticipantsApiVersion extends EnumClass {
   const RoomGetParticipantsApiVersion._(super.name);
 
@@ -30262,6 +30961,75 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson
   /// Serializer for RoomAddParticipantToRoomResponseApplicationJson.
   static Serializer<RoomAddParticipantToRoomResponseApplicationJson> get serializer =>
       _$roomAddParticipantToRoomResponseApplicationJsonSerializer;
+}
+
+class RoomGetBreakoutRoomParticipantsIncludeStatus extends EnumClass {
+  const RoomGetBreakoutRoomParticipantsIncludeStatus._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const RoomGetBreakoutRoomParticipantsIncludeStatus $0 = _$roomGetBreakoutRoomParticipantsIncludeStatus$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const RoomGetBreakoutRoomParticipantsIncludeStatus $1 = _$roomGetBreakoutRoomParticipantsIncludeStatus$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomGetBreakoutRoomParticipantsIncludeStatus> get values =>
+      _$roomGetBreakoutRoomParticipantsIncludeStatusValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomGetBreakoutRoomParticipantsIncludeStatus valueOf(String name) =>
+      _$valueOfRoomGetBreakoutRoomParticipantsIncludeStatus(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for RoomGetBreakoutRoomParticipantsIncludeStatus.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomGetBreakoutRoomParticipantsIncludeStatus> get serializer =>
+      const _$RoomGetBreakoutRoomParticipantsIncludeStatusSerializer();
+}
+
+class _$RoomGetBreakoutRoomParticipantsIncludeStatusSerializer
+    implements PrimitiveSerializer<RoomGetBreakoutRoomParticipantsIncludeStatus> {
+  const _$RoomGetBreakoutRoomParticipantsIncludeStatusSerializer();
+
+  static const Map<RoomGetBreakoutRoomParticipantsIncludeStatus, Object> _toWire =
+      <RoomGetBreakoutRoomParticipantsIncludeStatus, Object>{
+    RoomGetBreakoutRoomParticipantsIncludeStatus.$0: 0,
+    RoomGetBreakoutRoomParticipantsIncludeStatus.$1: 1,
+  };
+
+  static const Map<Object, RoomGetBreakoutRoomParticipantsIncludeStatus> _fromWire =
+      <Object, RoomGetBreakoutRoomParticipantsIncludeStatus>{
+    0: RoomGetBreakoutRoomParticipantsIncludeStatus.$0,
+    1: RoomGetBreakoutRoomParticipantsIncludeStatus.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomGetBreakoutRoomParticipantsIncludeStatus];
+
+  @override
+  String get wireName => 'RoomGetBreakoutRoomParticipantsIncludeStatus';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomGetBreakoutRoomParticipantsIncludeStatus object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomGetBreakoutRoomParticipantsIncludeStatus deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
 }
 
 class RoomGetBreakoutRoomParticipantsApiVersion extends EnumClass {
@@ -34323,6 +35091,69 @@ abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson
   /// Serializer for RoomSetAllAttendeesPermissionsResponseApplicationJson.
   static Serializer<RoomSetAllAttendeesPermissionsResponseApplicationJson> get serializer =>
       _$roomSetAllAttendeesPermissionsResponseApplicationJsonSerializer;
+}
+
+class RoomJoinRoomForce extends EnumClass {
+  const RoomJoinRoomForce._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const RoomJoinRoomForce $0 = _$roomJoinRoomForce$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const RoomJoinRoomForce $1 = _$roomJoinRoomForce$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomJoinRoomForce> get values => _$roomJoinRoomForceValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomJoinRoomForce valueOf(String name) => _$valueOfRoomJoinRoomForce(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for RoomJoinRoomForce.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomJoinRoomForce> get serializer => const _$RoomJoinRoomForceSerializer();
+}
+
+class _$RoomJoinRoomForceSerializer implements PrimitiveSerializer<RoomJoinRoomForce> {
+  const _$RoomJoinRoomForceSerializer();
+
+  static const Map<RoomJoinRoomForce, Object> _toWire = <RoomJoinRoomForce, Object>{
+    RoomJoinRoomForce.$0: 0,
+    RoomJoinRoomForce.$1: 1,
+  };
+
+  static const Map<Object, RoomJoinRoomForce> _fromWire = <Object, RoomJoinRoomForce>{
+    0: RoomJoinRoomForce.$0,
+    1: RoomJoinRoomForce.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomJoinRoomForce];
+
+  @override
+  String get wireName => 'RoomJoinRoomForce';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomJoinRoomForce object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomJoinRoomForce deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
 }
 
 class RoomJoinRoomApiVersion extends EnumClass {
@@ -38582,6 +39413,7 @@ class _$bc4aac45771b11649d372f39a92b1cf3Serializer implements PrimitiveSerialize
 @_i4.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
+      ..add(AvatarGetAvatarDarkTheme.serializer)
       ..add(AvatarGetAvatarApiVersion.serializer)
       ..add(AvatarUploadAvatarApiVersion.serializer)
       ..addBuilderFactory(
@@ -38600,6 +39432,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(Room.serializer)
       ..addBuilderFactory(const FullType(ChatMessage), ChatMessageBuilder.new)
       ..add(ChatMessage.serializer)
+      ..add(ChatMessage_Deleted.serializer)
       ..addBuilderFactory(
         const FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
         MapBuilder<String, JsonObject>.new,
@@ -38637,6 +39470,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(AvatarEmojiAvatarResponseApplicationJson_Ocs.serializer)
       ..add(AvatarGetAvatarDarkApiVersion.serializer)
+      ..add(BotSendMessageSilent.serializer)
       ..add(BotSendMessageApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(BotSendMessageResponseApplicationJson),
@@ -38845,6 +39679,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(CallUpdateCallFlagsResponseApplicationJson_Ocs.serializer)
       ..add(CallJoinCallFlags.serializer)
       ..add(CallJoinCallForcePermissions.serializer)
+      ..add(CallJoinCallSilent.serializer)
+      ..add(CallJoinCallRecordingConsent.serializer)
       ..add(CallJoinCallApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(CallJoinCallResponseApplicationJson),
@@ -38856,6 +39692,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
         CallJoinCallResponseApplicationJson_OcsBuilder.new,
       )
       ..add(CallJoinCallResponseApplicationJson_Ocs.serializer)
+      ..add(CallLeaveCallAll.serializer)
       ..add(CallLeaveCallApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(CallLeaveCallResponseApplicationJson),
@@ -38934,6 +39771,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
         const FullType(BuiltList, [FullType(ChatMessageWithParent)]),
         ListBuilder<ChatMessageWithParent>.new,
       )
+      ..add(ChatSendMessageSilent.serializer)
       ..add(ChatSendMessageApiVersion.serializer)
       ..addBuilderFactory(const FullType(ChatChatSendMessageHeaders), ChatChatSendMessageHeadersBuilder.new)
       ..add(ChatChatSendMessageHeaders.serializer)
@@ -39047,6 +39885,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ChatMarkUnreadResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ChatMarkUnreadResponseApplicationJson_Ocs.serializer)
+      ..add(ChatMentionsIncludeStatus.serializer)
       ..add(ChatMentionsApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(ChatMentionsResponseApplicationJson),
@@ -39200,6 +40039,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..addBuilderFactory(const FullType(MatterbridgeProcessState), MatterbridgeProcessStateBuilder.new)
       ..add(MatterbridgeProcessState.serializer)
+      ..add(MatterbridgeEditBridgeOfRoomEnabled.serializer)
       ..addBuilderFactory(
         const FullType(ContentString, [
           FullType(BuiltList, [
@@ -39452,6 +40292,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(RecordingShareToChatResponseApplicationJson_Ocs.serializer)
       ..add(RoomGetRoomsNoStatusUpdate.serializer)
+      ..add(RoomGetRoomsIncludeStatus.serializer)
       ..add(RoomGetRoomsApiVersion.serializer)
       ..addBuilderFactory(const FullType(RoomRoomGetRoomsHeaders), RoomRoomGetRoomsHeadersBuilder.new)
       ..add(RoomRoomGetRoomsHeaders.serializer)
@@ -39630,6 +40471,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomSetPermissionsResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomSetPermissionsResponseApplicationJson_Ocs.serializer)
+      ..add(RoomGetParticipantsIncludeStatus.serializer)
       ..add(RoomGetParticipantsApiVersion.serializer)
       ..addBuilderFactory(const FullType(RoomRoomGetParticipantsHeaders), RoomRoomGetParticipantsHeadersBuilder.new)
       ..add(RoomRoomGetParticipantsHeaders.serializer)
@@ -39666,6 +40508,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0.serializer)
       ..add($bd993fb3f40af33e8594d0d698208560Extension._serializer)
+      ..add(RoomGetBreakoutRoomParticipantsIncludeStatus.serializer)
       ..add(RoomGetBreakoutRoomParticipantsApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(RoomRoomGetBreakoutRoomParticipantsHeaders),
@@ -39730,6 +40573,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs.serializer)
+      ..add(RoomJoinRoomForce.serializer)
       ..add(RoomJoinRoomApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(RoomJoinRoomResponseApplicationJson),

--- a/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
@@ -6,6 +6,26 @@ part of 'spreed.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+const AvatarGetAvatarDarkTheme _$avatarGetAvatarDarkTheme$0 = AvatarGetAvatarDarkTheme._('\$0');
+const AvatarGetAvatarDarkTheme _$avatarGetAvatarDarkTheme$1 = AvatarGetAvatarDarkTheme._('\$1');
+
+AvatarGetAvatarDarkTheme _$valueOfAvatarGetAvatarDarkTheme(String name) {
+  switch (name) {
+    case '\$0':
+      return _$avatarGetAvatarDarkTheme$0;
+    case '\$1':
+      return _$avatarGetAvatarDarkTheme$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<AvatarGetAvatarDarkTheme> _$avatarGetAvatarDarkThemeValues =
+    BuiltSet<AvatarGetAvatarDarkTheme>(const <AvatarGetAvatarDarkTheme>[
+  _$avatarGetAvatarDarkTheme$0,
+  _$avatarGetAvatarDarkTheme$1,
+]);
+
 const AvatarGetAvatarApiVersion _$avatarGetAvatarApiVersionV1 = AvatarGetAvatarApiVersion._('v1');
 
 AvatarGetAvatarApiVersion _$valueOfAvatarGetAvatarApiVersion(String name) {
@@ -36,6 +56,22 @@ AvatarUploadAvatarApiVersion _$valueOfAvatarUploadAvatarApiVersion(String name) 
 final BuiltSet<AvatarUploadAvatarApiVersion> _$avatarUploadAvatarApiVersionValues =
     BuiltSet<AvatarUploadAvatarApiVersion>(const <AvatarUploadAvatarApiVersion>[
   _$avatarUploadAvatarApiVersionV1,
+]);
+
+const ChatMessage_Deleted _$chatMessageDeleted$true = ChatMessage_Deleted._('\$true');
+
+ChatMessage_Deleted _$valueOfChatMessage_Deleted(String name) {
+  switch (name) {
+    case '\$true':
+      return _$chatMessageDeleted$true;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ChatMessage_Deleted> _$chatMessageDeletedValues =
+    BuiltSet<ChatMessage_Deleted>(const <ChatMessage_Deleted>[
+  _$chatMessageDeleted$true,
 ]);
 
 const AvatarDeleteAvatarApiVersion _$avatarDeleteAvatarApiVersionV1 = AvatarDeleteAvatarApiVersion._('v1');
@@ -84,6 +120,26 @@ AvatarGetAvatarDarkApiVersion _$valueOfAvatarGetAvatarDarkApiVersion(String name
 final BuiltSet<AvatarGetAvatarDarkApiVersion> _$avatarGetAvatarDarkApiVersionValues =
     BuiltSet<AvatarGetAvatarDarkApiVersion>(const <AvatarGetAvatarDarkApiVersion>[
   _$avatarGetAvatarDarkApiVersionV1,
+]);
+
+const BotSendMessageSilent _$botSendMessageSilent$0 = BotSendMessageSilent._('\$0');
+const BotSendMessageSilent _$botSendMessageSilent$1 = BotSendMessageSilent._('\$1');
+
+BotSendMessageSilent _$valueOfBotSendMessageSilent(String name) {
+  switch (name) {
+    case '\$0':
+      return _$botSendMessageSilent$0;
+    case '\$1':
+      return _$botSendMessageSilent$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<BotSendMessageSilent> _$botSendMessageSilentValues =
+    BuiltSet<BotSendMessageSilent>(const <BotSendMessageSilent>[
+  _$botSendMessageSilent$0,
+  _$botSendMessageSilent$1,
 ]);
 
 const BotSendMessageApiVersion _$botSendMessageApiVersionV1 = BotSendMessageApiVersion._('v1');
@@ -1526,6 +1582,45 @@ final BuiltSet<CallJoinCallForcePermissions> _$callJoinCallForcePermissionsValue
   _$callJoinCallForcePermissions$255,
 ]);
 
+const CallJoinCallSilent _$callJoinCallSilent$0 = CallJoinCallSilent._('\$0');
+const CallJoinCallSilent _$callJoinCallSilent$1 = CallJoinCallSilent._('\$1');
+
+CallJoinCallSilent _$valueOfCallJoinCallSilent(String name) {
+  switch (name) {
+    case '\$0':
+      return _$callJoinCallSilent$0;
+    case '\$1':
+      return _$callJoinCallSilent$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<CallJoinCallSilent> _$callJoinCallSilentValues = BuiltSet<CallJoinCallSilent>(const <CallJoinCallSilent>[
+  _$callJoinCallSilent$0,
+  _$callJoinCallSilent$1,
+]);
+
+const CallJoinCallRecordingConsent _$callJoinCallRecordingConsent$0 = CallJoinCallRecordingConsent._('\$0');
+const CallJoinCallRecordingConsent _$callJoinCallRecordingConsent$1 = CallJoinCallRecordingConsent._('\$1');
+
+CallJoinCallRecordingConsent _$valueOfCallJoinCallRecordingConsent(String name) {
+  switch (name) {
+    case '\$0':
+      return _$callJoinCallRecordingConsent$0;
+    case '\$1':
+      return _$callJoinCallRecordingConsent$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<CallJoinCallRecordingConsent> _$callJoinCallRecordingConsentValues =
+    BuiltSet<CallJoinCallRecordingConsent>(const <CallJoinCallRecordingConsent>[
+  _$callJoinCallRecordingConsent$0,
+  _$callJoinCallRecordingConsent$1,
+]);
+
 const CallJoinCallApiVersion _$callJoinCallApiVersionV4 = CallJoinCallApiVersion._('v4');
 
 CallJoinCallApiVersion _$valueOfCallJoinCallApiVersion(String name) {
@@ -1540,6 +1635,25 @@ CallJoinCallApiVersion _$valueOfCallJoinCallApiVersion(String name) {
 final BuiltSet<CallJoinCallApiVersion> _$callJoinCallApiVersionValues =
     BuiltSet<CallJoinCallApiVersion>(const <CallJoinCallApiVersion>[
   _$callJoinCallApiVersionV4,
+]);
+
+const CallLeaveCallAll _$callLeaveCallAll$0 = CallLeaveCallAll._('\$0');
+const CallLeaveCallAll _$callLeaveCallAll$1 = CallLeaveCallAll._('\$1');
+
+CallLeaveCallAll _$valueOfCallLeaveCallAll(String name) {
+  switch (name) {
+    case '\$0':
+      return _$callLeaveCallAll$0;
+    case '\$1':
+      return _$callLeaveCallAll$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<CallLeaveCallAll> _$callLeaveCallAllValues = BuiltSet<CallLeaveCallAll>(const <CallLeaveCallAll>[
+  _$callLeaveCallAll$0,
+  _$callLeaveCallAll$1,
 ]);
 
 const CallLeaveCallApiVersion _$callLeaveCallApiVersionV4 = CallLeaveCallApiVersion._('v4');
@@ -1731,6 +1845,26 @@ final BuiltSet<ChatReceiveMessagesApiVersion> _$chatReceiveMessagesApiVersionVal
   _$chatReceiveMessagesApiVersionV1,
 ]);
 
+const ChatSendMessageSilent _$chatSendMessageSilent$0 = ChatSendMessageSilent._('\$0');
+const ChatSendMessageSilent _$chatSendMessageSilent$1 = ChatSendMessageSilent._('\$1');
+
+ChatSendMessageSilent _$valueOfChatSendMessageSilent(String name) {
+  switch (name) {
+    case '\$0':
+      return _$chatSendMessageSilent$0;
+    case '\$1':
+      return _$chatSendMessageSilent$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ChatSendMessageSilent> _$chatSendMessageSilentValues =
+    BuiltSet<ChatSendMessageSilent>(const <ChatSendMessageSilent>[
+  _$chatSendMessageSilent$0,
+  _$chatSendMessageSilent$1,
+]);
+
 const ChatSendMessageApiVersion _$chatSendMessageApiVersionV1 = ChatSendMessageApiVersion._('v1');
 
 ChatSendMessageApiVersion _$valueOfChatSendMessageApiVersion(String name) {
@@ -1873,6 +2007,26 @@ ChatMarkUnreadApiVersion _$valueOfChatMarkUnreadApiVersion(String name) {
 final BuiltSet<ChatMarkUnreadApiVersion> _$chatMarkUnreadApiVersionValues =
     BuiltSet<ChatMarkUnreadApiVersion>(const <ChatMarkUnreadApiVersion>[
   _$chatMarkUnreadApiVersionV1,
+]);
+
+const ChatMentionsIncludeStatus _$chatMentionsIncludeStatus$0 = ChatMentionsIncludeStatus._('\$0');
+const ChatMentionsIncludeStatus _$chatMentionsIncludeStatus$1 = ChatMentionsIncludeStatus._('\$1');
+
+ChatMentionsIncludeStatus _$valueOfChatMentionsIncludeStatus(String name) {
+  switch (name) {
+    case '\$0':
+      return _$chatMentionsIncludeStatus$0;
+    case '\$1':
+      return _$chatMentionsIncludeStatus$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ChatMentionsIncludeStatus> _$chatMentionsIncludeStatusValues =
+    BuiltSet<ChatMentionsIncludeStatus>(const <ChatMentionsIncludeStatus>[
+  _$chatMentionsIncludeStatus$0,
+  _$chatMentionsIncludeStatus$1,
 ]);
 
 const ChatMentionsApiVersion _$chatMentionsApiVersionV1 = ChatMentionsApiVersion._('v1');
@@ -2040,6 +2194,28 @@ MatterbridgeGetBridgeOfRoomApiVersion _$valueOfMatterbridgeGetBridgeOfRoomApiVer
 final BuiltSet<MatterbridgeGetBridgeOfRoomApiVersion> _$matterbridgeGetBridgeOfRoomApiVersionValues =
     BuiltSet<MatterbridgeGetBridgeOfRoomApiVersion>(const <MatterbridgeGetBridgeOfRoomApiVersion>[
   _$matterbridgeGetBridgeOfRoomApiVersionV1,
+]);
+
+const MatterbridgeEditBridgeOfRoomEnabled _$matterbridgeEditBridgeOfRoomEnabled$0 =
+    MatterbridgeEditBridgeOfRoomEnabled._('\$0');
+const MatterbridgeEditBridgeOfRoomEnabled _$matterbridgeEditBridgeOfRoomEnabled$1 =
+    MatterbridgeEditBridgeOfRoomEnabled._('\$1');
+
+MatterbridgeEditBridgeOfRoomEnabled _$valueOfMatterbridgeEditBridgeOfRoomEnabled(String name) {
+  switch (name) {
+    case '\$0':
+      return _$matterbridgeEditBridgeOfRoomEnabled$0;
+    case '\$1':
+      return _$matterbridgeEditBridgeOfRoomEnabled$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<MatterbridgeEditBridgeOfRoomEnabled> _$matterbridgeEditBridgeOfRoomEnabledValues =
+    BuiltSet<MatterbridgeEditBridgeOfRoomEnabled>(const <MatterbridgeEditBridgeOfRoomEnabled>[
+  _$matterbridgeEditBridgeOfRoomEnabled$0,
+  _$matterbridgeEditBridgeOfRoomEnabled$1,
 ]);
 
 const MatterbridgeEditBridgeOfRoomApiVersion _$matterbridgeEditBridgeOfRoomApiVersionV1 =
@@ -2394,6 +2570,26 @@ final BuiltSet<RoomGetRoomsNoStatusUpdate> _$roomGetRoomsNoStatusUpdateValues =
     BuiltSet<RoomGetRoomsNoStatusUpdate>(const <RoomGetRoomsNoStatusUpdate>[
   _$roomGetRoomsNoStatusUpdate$0,
   _$roomGetRoomsNoStatusUpdate$1,
+]);
+
+const RoomGetRoomsIncludeStatus _$roomGetRoomsIncludeStatus$0 = RoomGetRoomsIncludeStatus._('\$0');
+const RoomGetRoomsIncludeStatus _$roomGetRoomsIncludeStatus$1 = RoomGetRoomsIncludeStatus._('\$1');
+
+RoomGetRoomsIncludeStatus _$valueOfRoomGetRoomsIncludeStatus(String name) {
+  switch (name) {
+    case '\$0':
+      return _$roomGetRoomsIncludeStatus$0;
+    case '\$1':
+      return _$roomGetRoomsIncludeStatus$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<RoomGetRoomsIncludeStatus> _$roomGetRoomsIncludeStatusValues =
+    BuiltSet<RoomGetRoomsIncludeStatus>(const <RoomGetRoomsIncludeStatus>[
+  _$roomGetRoomsIncludeStatus$0,
+  _$roomGetRoomsIncludeStatus$1,
 ]);
 
 const RoomGetRoomsApiVersion _$roomGetRoomsApiVersionV4 = RoomGetRoomsApiVersion._('v4');
@@ -3737,6 +3933,26 @@ final BuiltSet<RoomSetPermissionsApiVersion> _$roomSetPermissionsApiVersionValue
   _$roomSetPermissionsApiVersionV4,
 ]);
 
+const RoomGetParticipantsIncludeStatus _$roomGetParticipantsIncludeStatus$0 = RoomGetParticipantsIncludeStatus._('\$0');
+const RoomGetParticipantsIncludeStatus _$roomGetParticipantsIncludeStatus$1 = RoomGetParticipantsIncludeStatus._('\$1');
+
+RoomGetParticipantsIncludeStatus _$valueOfRoomGetParticipantsIncludeStatus(String name) {
+  switch (name) {
+    case '\$0':
+      return _$roomGetParticipantsIncludeStatus$0;
+    case '\$1':
+      return _$roomGetParticipantsIncludeStatus$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<RoomGetParticipantsIncludeStatus> _$roomGetParticipantsIncludeStatusValues =
+    BuiltSet<RoomGetParticipantsIncludeStatus>(const <RoomGetParticipantsIncludeStatus>[
+  _$roomGetParticipantsIncludeStatus$0,
+  _$roomGetParticipantsIncludeStatus$1,
+]);
+
 const RoomGetParticipantsApiVersion _$roomGetParticipantsApiVersionV4 = RoomGetParticipantsApiVersion._('v4');
 
 RoomGetParticipantsApiVersion _$valueOfRoomGetParticipantsApiVersion(String name) {
@@ -3809,6 +4025,28 @@ RoomAddParticipantToRoomApiVersion _$valueOfRoomAddParticipantToRoomApiVersion(S
 final BuiltSet<RoomAddParticipantToRoomApiVersion> _$roomAddParticipantToRoomApiVersionValues =
     BuiltSet<RoomAddParticipantToRoomApiVersion>(const <RoomAddParticipantToRoomApiVersion>[
   _$roomAddParticipantToRoomApiVersionV4,
+]);
+
+const RoomGetBreakoutRoomParticipantsIncludeStatus _$roomGetBreakoutRoomParticipantsIncludeStatus$0 =
+    RoomGetBreakoutRoomParticipantsIncludeStatus._('\$0');
+const RoomGetBreakoutRoomParticipantsIncludeStatus _$roomGetBreakoutRoomParticipantsIncludeStatus$1 =
+    RoomGetBreakoutRoomParticipantsIncludeStatus._('\$1');
+
+RoomGetBreakoutRoomParticipantsIncludeStatus _$valueOfRoomGetBreakoutRoomParticipantsIncludeStatus(String name) {
+  switch (name) {
+    case '\$0':
+      return _$roomGetBreakoutRoomParticipantsIncludeStatus$0;
+    case '\$1':
+      return _$roomGetBreakoutRoomParticipantsIncludeStatus$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<RoomGetBreakoutRoomParticipantsIncludeStatus> _$roomGetBreakoutRoomParticipantsIncludeStatusValues =
+    BuiltSet<RoomGetBreakoutRoomParticipantsIncludeStatus>(const <RoomGetBreakoutRoomParticipantsIncludeStatus>[
+  _$roomGetBreakoutRoomParticipantsIncludeStatus$0,
+  _$roomGetBreakoutRoomParticipantsIncludeStatus$1,
 ]);
 
 const RoomGetBreakoutRoomParticipantsApiVersion _$roomGetBreakoutRoomParticipantsApiVersionV4 =
@@ -6533,6 +6771,25 @@ final BuiltSet<RoomSetAllAttendeesPermissionsApiVersion> _$roomSetAllAttendeesPe
   _$roomSetAllAttendeesPermissionsApiVersionV4,
 ]);
 
+const RoomJoinRoomForce _$roomJoinRoomForce$0 = RoomJoinRoomForce._('\$0');
+const RoomJoinRoomForce _$roomJoinRoomForce$1 = RoomJoinRoomForce._('\$1');
+
+RoomJoinRoomForce _$valueOfRoomJoinRoomForce(String name) {
+  switch (name) {
+    case '\$0':
+      return _$roomJoinRoomForce$0;
+    case '\$1':
+      return _$roomJoinRoomForce$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<RoomJoinRoomForce> _$roomJoinRoomForceValues = BuiltSet<RoomJoinRoomForce>(const <RoomJoinRoomForce>[
+  _$roomJoinRoomForce$0,
+  _$roomJoinRoomForce$1,
+]);
+
 const RoomJoinRoomApiVersion _$roomJoinRoomApiVersionV4 = RoomJoinRoomApiVersion._('v4');
 
 RoomJoinRoomApiVersion _$valueOfRoomJoinRoomApiVersion(String name) {
@@ -7669,7 +7926,7 @@ class _$ChatMessageSerializer implements StructuredSerializer<ChatMessage> {
     if (value != null) {
       result
         ..add('deleted')
-        ..add(serializers.serialize(value, specifiedType: const FullType(bool)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(ChatMessage_Deleted)));
     }
     value = object.markdown;
     if (value != null) {
@@ -7701,7 +7958,8 @@ class _$ChatMessageSerializer implements StructuredSerializer<ChatMessage> {
           result.actorType = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'deleted':
-          result.deleted = serializers.deserialize(value, specifiedType: const FullType(bool)) as bool?;
+          result.deleted = serializers.deserialize(value, specifiedType: const FullType(ChatMessage_Deleted))
+              as ChatMessage_Deleted?;
           break;
         case 'expirationTimestamp':
           result.expirationTimestamp = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
@@ -10886,7 +11144,7 @@ class _$ChatMessageWithParentSerializer implements StructuredSerializer<ChatMess
     if (value != null) {
       result
         ..add('deleted')
-        ..add(serializers.serialize(value, specifiedType: const FullType(bool)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(ChatMessage_Deleted)));
     }
     value = object.markdown;
     if (value != null) {
@@ -10922,7 +11180,8 @@ class _$ChatMessageWithParentSerializer implements StructuredSerializer<ChatMess
           result.actorType = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'deleted':
-          result.deleted = serializers.deserialize(value, specifiedType: const FullType(bool)) as bool?;
+          result.deleted = serializers.deserialize(value, specifiedType: const FullType(ChatMessage_Deleted))
+              as ChatMessage_Deleted?;
           break;
         case 'expirationTimestamp':
           result.expirationTimestamp = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
@@ -21408,8 +21667,8 @@ abstract mixin class $ChatMessageInterfaceBuilder {
   String? get actorType;
   set actorType(String? actorType);
 
-  bool? get deleted;
-  set deleted(bool? deleted);
+  ChatMessage_Deleted? get deleted;
+  set deleted(ChatMessage_Deleted? deleted);
 
   int? get expirationTimestamp;
   set expirationTimestamp(int? expirationTimestamp);
@@ -21456,7 +21715,7 @@ class _$ChatMessage extends ChatMessage {
   @override
   final String actorType;
   @override
-  final bool? deleted;
+  final ChatMessage_Deleted? deleted;
   @override
   final int expirationTimestamp;
   @override
@@ -21608,9 +21867,9 @@ class ChatMessageBuilder implements Builder<ChatMessage, ChatMessageBuilder>, $C
   String? get actorType => _$this._actorType;
   set actorType(covariant String? actorType) => _$this._actorType = actorType;
 
-  bool? _deleted;
-  bool? get deleted => _$this._deleted;
-  set deleted(covariant bool? deleted) => _$this._deleted = deleted;
+  ChatMessage_Deleted? _deleted;
+  ChatMessage_Deleted? get deleted => _$this._deleted;
+  set deleted(covariant ChatMessage_Deleted? deleted) => _$this._deleted = deleted;
 
   int? _expirationTimestamp;
   int? get expirationTimestamp => _$this._expirationTimestamp;
@@ -29406,8 +29665,8 @@ abstract mixin class $ChatMessageWithParentInterfaceBuilder implements $ChatMess
   String? get actorType;
   set actorType(covariant String? actorType);
 
-  bool? get deleted;
-  set deleted(covariant bool? deleted);
+  ChatMessage_Deleted? get deleted;
+  set deleted(covariant ChatMessage_Deleted? deleted);
 
   int? get expirationTimestamp;
   set expirationTimestamp(covariant int? expirationTimestamp);
@@ -29456,7 +29715,7 @@ class _$ChatMessageWithParent extends ChatMessageWithParent {
   @override
   final String actorType;
   @override
-  final bool? deleted;
+  final ChatMessage_Deleted? deleted;
   @override
   final int expirationTimestamp;
   @override
@@ -29618,9 +29877,9 @@ class ChatMessageWithParentBuilder
   String? get actorType => _$this._actorType;
   set actorType(covariant String? actorType) => _$this._actorType = actorType;
 
-  bool? _deleted;
-  bool? get deleted => _$this._deleted;
-  set deleted(covariant bool? deleted) => _$this._deleted = deleted;
+  ChatMessage_Deleted? _deleted;
+  ChatMessage_Deleted? get deleted => _$this._deleted;
+  set deleted(covariant ChatMessage_Deleted? deleted) => _$this._deleted = deleted;
 
   int? _expirationTimestamp;
   int? get expirationTimestamp => _$this._expirationTimestamp;

--- a/packages/nextcloud/lib/src/api/spreed.openapi.json
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.json
@@ -207,7 +207,10 @@
                         "type": "string"
                     },
                     "deleted": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "enum": [
+                            true
+                        ]
                     },
                     "expirationTimestamp": {
                         "type": "integer",
@@ -1353,7 +1356,11 @@
                         "description": "Theme used for background",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -1739,7 +1746,11 @@
                         "description": "If sent silent the chat message will not create any notifications",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -4294,7 +4305,11 @@
                         "description": "Join the call silently",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -4303,7 +4318,11 @@
                         "description": "When the user ticked a checkbox and agreed with being recorded (Only needed when the `config => call => recording-consent` capability is set to {@see RecordingService::CONSENT_REQUIRED_YES} or the capability is {@see RecordingService::CONSENT_REQUIRED_OPTIONAL} and the conversation `recordingConsent` value is {@see RecordingService::CONSENT_REQUIRED_YES} )",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -4599,7 +4618,11 @@
                         "description": "whether to also terminate the call for all participants",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -5505,7 +5528,11 @@
                         "description": "If sent silent the chat message will not create any notifications",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -6826,7 +6853,11 @@
                         "description": "Include the user statuses",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -8224,7 +8255,11 @@
                         "description": "If the bridge should be enabled",
                         "required": true,
                         "schema": {
-                            "type": "integer"
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -10938,7 +10973,11 @@
                         "description": "Include the user status",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -13081,7 +13120,11 @@
                         "description": "Include the user statuses",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -13425,7 +13468,11 @@
                         "description": "Include the user statuses",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -14765,7 +14812,11 @@
                         "description": "Create a new session if necessary",
                         "schema": {
                             "type": "integer",
-                            "default": 1
+                            "default": 1,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -352,8 +352,8 @@ class $ThemingClient {
   ///  * [getThemeStylesheetRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<String, void>> getThemeStylesheet({
     required String themeId,
-    int? plain,
-    int? withCustomCss,
+    ThemingGetThemeStylesheetPlain? plain,
+    ThemingGetThemeStylesheetWithCustomCss? withCustomCss,
   }) async {
     final rawResponse = getThemeStylesheetRaw(
       themeId: themeId,
@@ -385,8 +385,8 @@ class $ThemingClient {
   @_i4.experimental
   _i1.DynamiteRawResponse<String, void> getThemeStylesheetRaw({
     required String themeId,
-    int? plain,
-    int? withCustomCss,
+    ThemingGetThemeStylesheetPlain? plain,
+    ThemingGetThemeStylesheetWithCustomCss? withCustomCss,
   }) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{
@@ -411,11 +411,14 @@ class $ThemingClient {
     final $themeId = _$jsonSerializers.serialize(themeId, specifiedType: const FullType(String));
     _parameters['themeId'] = $themeId;
 
-    var $plain = _$jsonSerializers.serialize(plain, specifiedType: const FullType(int));
+    var $plain = _$jsonSerializers.serialize(plain, specifiedType: const FullType(ThemingGetThemeStylesheetPlain));
     $plain ??= 0;
     _parameters['plain'] = $plain;
 
-    var $withCustomCss = _$jsonSerializers.serialize(withCustomCss, specifiedType: const FullType(int));
+    var $withCustomCss = _$jsonSerializers.serialize(
+      withCustomCss,
+      specifiedType: const FullType(ThemingGetThemeStylesheetWithCustomCss),
+    );
     $withCustomCss ??= 0;
     _parameters['withCustomCss'] = $withCustomCss;
 
@@ -453,7 +456,7 @@ class $ThemingClient {
   ///  * [getImageRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
   Future<_i1.DynamiteResponse<Uint8List, void>> getImage({
     required String key,
-    int? useSvg,
+    ThemingGetImageUseSvg? useSvg,
   }) async {
     final rawResponse = getImageRaw(
       key: key,
@@ -484,7 +487,7 @@ class $ThemingClient {
   @_i4.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getImageRaw({
     required String key,
-    int? useSvg,
+    ThemingGetImageUseSvg? useSvg,
   }) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{
@@ -509,7 +512,7 @@ class $ThemingClient {
     final $key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
     _parameters['key'] = $key;
 
-    var $useSvg = _$jsonSerializers.serialize(useSvg, specifiedType: const FullType(int));
+    var $useSvg = _$jsonSerializers.serialize(useSvg, specifiedType: const FullType(ThemingGetImageUseSvg));
     $useSvg ??= 1;
     _parameters['useSvg'] = $useSvg;
 
@@ -617,19 +620,14 @@ class $UserThemeClient {
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
-  ///
   /// Status codes:
   ///   * 200: Background image returned
   ///   * 404: Background image not found
   ///
   /// See:
   ///  * [getBackgroundRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i1.DynamiteResponse<Uint8List, void>> getBackground({bool? oCSAPIRequest}) async {
-    final rawResponse = getBackgroundRaw(
-      oCSAPIRequest: oCSAPIRequest,
-    );
+  Future<_i1.DynamiteResponse<Uint8List, void>> getBackground() async {
+    final rawResponse = getBackgroundRaw();
 
     return rawResponse.future;
   }
@@ -641,9 +639,6 @@ class $UserThemeClient {
   /// Returns a [Future] containing a `DynamiteRawResponse` with the raw `HttpClientResponse` and serialization helpers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
-  ///
   /// Status codes:
   ///   * 200: Background image returned
   ///   * 404: Background image not found
@@ -651,7 +646,7 @@ class $UserThemeClient {
   /// See:
   ///  * [getBackground] for an operation that returns a `DynamiteResponse` with a stable API.
   @_i4.experimental
-  _i1.DynamiteRawResponse<Uint8List, void> getBackgroundRaw({bool? oCSAPIRequest}) {
+  _i1.DynamiteRawResponse<Uint8List, void> getBackgroundRaw() {
     final _headers = <String, String>{
       'Accept': '*/*',
     };
@@ -673,10 +668,6 @@ class $UserThemeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
-
     const _path = '/index.php/apps/theming/background';
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -687,196 +678,6 @@ class $UserThemeClient {
         const {200},
       ),
       bodyType: const FullType(Uint8List),
-      headersType: null,
-      serializers: _$jsonSerializers,
-    );
-  }
-
-  /// Set the background.
-  ///
-  /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
-  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Parameters:
-  ///   * [value] Path of the background image. Defaults to `''`.
-  ///   * [color] Color for the background.
-  ///   * [type] Type of background.
-  ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
-  ///
-  /// Status codes:
-  ///   * 200: Background set successfully
-  ///   * 400: Setting background is not possible
-  ///   * 500
-  ///
-  /// See:
-  ///  * [setBackgroundRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i1.DynamiteResponse<Background, void>> setBackground({
-    required String type,
-    String? value,
-    String? color,
-    bool? oCSAPIRequest,
-  }) async {
-    final rawResponse = setBackgroundRaw(
-      type: type,
-      value: value,
-      color: color,
-      oCSAPIRequest: oCSAPIRequest,
-    );
-
-    return rawResponse.future;
-  }
-
-  /// Set the background.
-  ///
-  /// This method and the response it returns is experimental. The API might change without a major version bump.
-  ///
-  /// Returns a [Future] containing a `DynamiteRawResponse` with the raw `HttpClientResponse` and serialization helpers.
-  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Parameters:
-  ///   * [value] Path of the background image. Defaults to `''`.
-  ///   * [color] Color for the background.
-  ///   * [type] Type of background.
-  ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
-  ///
-  /// Status codes:
-  ///   * 200: Background set successfully
-  ///   * 400: Setting background is not possible
-  ///   * 500
-  ///
-  /// See:
-  ///  * [setBackground] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
-  _i1.DynamiteRawResponse<Background, void> setBackgroundRaw({
-    required String type,
-    String? value,
-    String? color,
-    bool? oCSAPIRequest,
-  }) {
-    final _parameters = <String, dynamic>{};
-    final _headers = <String, String>{
-      'Accept': 'application/json',
-    };
-
-// coverage:ignore-start
-    final authentication = _rootClient.authentications.firstWhereOrNull(
-      (auth) => switch (auth) {
-        _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
-        _ => false,
-      },
-    );
-
-    if (authentication != null) {
-      _headers.addAll(
-        authentication.headers,
-      );
-    } else {
-      throw Exception('Missing authentication for bearer_auth or basic_auth');
-    }
-
-// coverage:ignore-end
-    final $type = _$jsonSerializers.serialize(type, specifiedType: const FullType(String));
-    _parameters['type'] = $type;
-
-    var $value = _$jsonSerializers.serialize(value, specifiedType: const FullType(String));
-    $value ??= '';
-    _parameters['value'] = $value;
-
-    final $color = _$jsonSerializers.serialize(color, specifiedType: const FullType(String));
-    _parameters['color'] = $color;
-
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
-
-    final _path = _i2.UriTemplate('/index.php/apps/theming/background/{type}{?value*,color*}').expand(_parameters);
-    return _i1.DynamiteRawResponse<Background, void>(
-      response: _rootClient.executeRequest(
-        'post',
-        _path,
-        _headers,
-        null,
-        const {200},
-      ),
-      bodyType: const FullType(Background),
-      headersType: null,
-      serializers: _$jsonSerializers,
-    );
-  }
-
-  /// Delete the background.
-  ///
-  /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
-  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Parameters:
-  ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
-  ///
-  /// Status codes:
-  ///   * 200: Background deleted successfully
-  ///
-  /// See:
-  ///  * [deleteBackgroundRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i1.DynamiteResponse<Background, void>> deleteBackground({bool? oCSAPIRequest}) async {
-    final rawResponse = deleteBackgroundRaw(
-      oCSAPIRequest: oCSAPIRequest,
-    );
-
-    return rawResponse.future;
-  }
-
-  /// Delete the background.
-  ///
-  /// This method and the response it returns is experimental. The API might change without a major version bump.
-  ///
-  /// Returns a [Future] containing a `DynamiteRawResponse` with the raw `HttpClientResponse` and serialization helpers.
-  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Parameters:
-  ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
-  ///
-  /// Status codes:
-  ///   * 200: Background deleted successfully
-  ///
-  /// See:
-  ///  * [deleteBackground] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
-  _i1.DynamiteRawResponse<Background, void> deleteBackgroundRaw({bool? oCSAPIRequest}) {
-    final _headers = <String, String>{
-      'Accept': 'application/json',
-    };
-
-// coverage:ignore-start
-    final authentication = _rootClient.authentications.firstWhereOrNull(
-      (auth) => switch (auth) {
-        _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
-        _ => false,
-      },
-    );
-
-    if (authentication != null) {
-      _headers.addAll(
-        authentication.headers,
-      );
-    } else {
-      throw Exception('Missing authentication for bearer_auth or basic_auth');
-    }
-
-// coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
-
-    const _path = '/index.php/apps/theming/background/custom';
-    return _i1.DynamiteRawResponse<Background, void>(
-      response: _rootClient.executeRequest(
-        'delete',
-        _path,
-        _headers,
-        null,
-        const {200},
-      ),
-      bodyType: const FullType(Background),
       headersType: null,
       serializers: _$jsonSerializers,
     );
@@ -1073,6 +874,201 @@ class $UserThemeClient {
   }
 }
 
+class ThemingGetThemeStylesheetPlain extends EnumClass {
+  const ThemingGetThemeStylesheetPlain._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ThemingGetThemeStylesheetPlain $0 = _$themingGetThemeStylesheetPlain$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ThemingGetThemeStylesheetPlain $1 = _$themingGetThemeStylesheetPlain$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ThemingGetThemeStylesheetPlain> get values => _$themingGetThemeStylesheetPlainValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ThemingGetThemeStylesheetPlain valueOf(String name) => _$valueOfThemingGetThemeStylesheetPlain(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ThemingGetThemeStylesheetPlain.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ThemingGetThemeStylesheetPlain> get serializer =>
+      const _$ThemingGetThemeStylesheetPlainSerializer();
+}
+
+class _$ThemingGetThemeStylesheetPlainSerializer implements PrimitiveSerializer<ThemingGetThemeStylesheetPlain> {
+  const _$ThemingGetThemeStylesheetPlainSerializer();
+
+  static const Map<ThemingGetThemeStylesheetPlain, Object> _toWire = <ThemingGetThemeStylesheetPlain, Object>{
+    ThemingGetThemeStylesheetPlain.$0: 0,
+    ThemingGetThemeStylesheetPlain.$1: 1,
+  };
+
+  static const Map<Object, ThemingGetThemeStylesheetPlain> _fromWire = <Object, ThemingGetThemeStylesheetPlain>{
+    0: ThemingGetThemeStylesheetPlain.$0,
+    1: ThemingGetThemeStylesheetPlain.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ThemingGetThemeStylesheetPlain];
+
+  @override
+  String get wireName => 'ThemingGetThemeStylesheetPlain';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ThemingGetThemeStylesheetPlain object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ThemingGetThemeStylesheetPlain deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+class ThemingGetThemeStylesheetWithCustomCss extends EnumClass {
+  const ThemingGetThemeStylesheetWithCustomCss._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ThemingGetThemeStylesheetWithCustomCss $0 = _$themingGetThemeStylesheetWithCustomCss$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ThemingGetThemeStylesheetWithCustomCss $1 = _$themingGetThemeStylesheetWithCustomCss$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ThemingGetThemeStylesheetWithCustomCss> get values => _$themingGetThemeStylesheetWithCustomCssValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ThemingGetThemeStylesheetWithCustomCss valueOf(String name) =>
+      _$valueOfThemingGetThemeStylesheetWithCustomCss(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ThemingGetThemeStylesheetWithCustomCss.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ThemingGetThemeStylesheetWithCustomCss> get serializer =>
+      const _$ThemingGetThemeStylesheetWithCustomCssSerializer();
+}
+
+class _$ThemingGetThemeStylesheetWithCustomCssSerializer
+    implements PrimitiveSerializer<ThemingGetThemeStylesheetWithCustomCss> {
+  const _$ThemingGetThemeStylesheetWithCustomCssSerializer();
+
+  static const Map<ThemingGetThemeStylesheetWithCustomCss, Object> _toWire =
+      <ThemingGetThemeStylesheetWithCustomCss, Object>{
+    ThemingGetThemeStylesheetWithCustomCss.$0: 0,
+    ThemingGetThemeStylesheetWithCustomCss.$1: 1,
+  };
+
+  static const Map<Object, ThemingGetThemeStylesheetWithCustomCss> _fromWire =
+      <Object, ThemingGetThemeStylesheetWithCustomCss>{
+    0: ThemingGetThemeStylesheetWithCustomCss.$0,
+    1: ThemingGetThemeStylesheetWithCustomCss.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ThemingGetThemeStylesheetWithCustomCss];
+
+  @override
+  String get wireName => 'ThemingGetThemeStylesheetWithCustomCss';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ThemingGetThemeStylesheetWithCustomCss object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ThemingGetThemeStylesheetWithCustomCss deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+class ThemingGetImageUseSvg extends EnumClass {
+  const ThemingGetImageUseSvg._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ThemingGetImageUseSvg $0 = _$themingGetImageUseSvg$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ThemingGetImageUseSvg $1 = _$themingGetImageUseSvg$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ThemingGetImageUseSvg> get values => _$themingGetImageUseSvgValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ThemingGetImageUseSvg valueOf(String name) => _$valueOfThemingGetImageUseSvg(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ThemingGetImageUseSvg.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ThemingGetImageUseSvg> get serializer => const _$ThemingGetImageUseSvgSerializer();
+}
+
+class _$ThemingGetImageUseSvgSerializer implements PrimitiveSerializer<ThemingGetImageUseSvg> {
+  const _$ThemingGetImageUseSvgSerializer();
+
+  static const Map<ThemingGetImageUseSvg, Object> _toWire = <ThemingGetImageUseSvg, Object>{
+    ThemingGetImageUseSvg.$0: 0,
+    ThemingGetImageUseSvg.$1: 1,
+  };
+
+  static const Map<Object, ThemingGetImageUseSvg> _fromWire = <Object, ThemingGetImageUseSvg>{
+    0: ThemingGetImageUseSvg.$0,
+    1: ThemingGetImageUseSvg.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ThemingGetImageUseSvg];
+
+  @override
+  String get wireName => 'ThemingGetImageUseSvg';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ThemingGetImageUseSvg object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ThemingGetImageUseSvg deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
 @BuiltValue(instantiable: false)
 abstract interface class $ThemingGetManifestResponseApplicationJson_IconsInterface {
   String get src;
@@ -1169,39 +1165,6 @@ abstract class ThemingGetManifestResponseApplicationJson
   /// Serializer for ThemingGetManifestResponseApplicationJson.
   static Serializer<ThemingGetManifestResponseApplicationJson> get serializer =>
       _$themingGetManifestResponseApplicationJsonSerializer;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $BackgroundInterface {
-  String? get backgroundImage;
-  String get backgroundColor;
-  int get version;
-}
-
-abstract class Background implements $BackgroundInterface, Built<Background, BackgroundBuilder> {
-  /// Creates a new Background object using the builder pattern.
-  factory Background([void Function(BackgroundBuilder)? b]) = _$Background;
-
-  // coverage:ignore-start
-  const Background._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory Background.fromJson(Map<String, dynamic> json) => _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for Background.
-  static Serializer<Background> get serializer => _$backgroundSerializer;
 }
 
 @BuiltValue(instantiable: false)
@@ -1395,6 +1358,39 @@ abstract class UserThemeDisableThemeResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+abstract interface class $BackgroundInterface {
+  String? get backgroundImage;
+  String get backgroundColor;
+  int get version;
+}
+
+abstract class Background implements $BackgroundInterface, Built<Background, BackgroundBuilder> {
+  /// Creates a new Background object using the builder pattern.
+  factory Background([void Function(BackgroundBuilder)? b]) = _$Background;
+
+  // coverage:ignore-start
+  const Background._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory Background.fromJson(Map<String, dynamic> json) => _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for Background.
+  static Serializer<Background> get serializer => _$backgroundSerializer;
+}
+
+@BuiltValue(instantiable: false)
 abstract interface class $PublicCapabilities_ThemingInterface {
   String get name;
   String get url;
@@ -1490,6 +1486,9 @@ abstract class PublicCapabilities
 @_i4.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
+      ..add(ThemingGetThemeStylesheetPlain.serializer)
+      ..add(ThemingGetThemeStylesheetWithCustomCss.serializer)
+      ..add(ThemingGetImageUseSvg.serializer)
       ..addBuilderFactory(
         const FullType(ThemingGetManifestResponseApplicationJson),
         ThemingGetManifestResponseApplicationJsonBuilder.new,
@@ -1504,8 +1503,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
         const FullType(BuiltList, [FullType(ThemingGetManifestResponseApplicationJson_Icons)]),
         ListBuilder<ThemingGetManifestResponseApplicationJson_Icons>.new,
       )
-      ..addBuilderFactory(const FullType(Background), BackgroundBuilder.new)
-      ..add(Background.serializer)
       ..addBuilderFactory(
         const FullType(UserThemeEnableThemeResponseApplicationJson),
         UserThemeEnableThemeResponseApplicationJsonBuilder.new,
@@ -1528,6 +1525,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
         UserThemeDisableThemeResponseApplicationJson_OcsBuilder.new,
       )
       ..add(UserThemeDisableThemeResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(const FullType(Background), BackgroundBuilder.new)
+      ..add(Background.serializer)
       ..addBuilderFactory(const FullType(PublicCapabilities), PublicCapabilitiesBuilder.new)
       ..add(PublicCapabilities.serializer)
       ..addBuilderFactory(const FullType(PublicCapabilities_Theming), PublicCapabilities_ThemingBuilder.new)

--- a/packages/nextcloud/lib/src/api/theming.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.g.dart
@@ -6,11 +6,72 @@ part of 'theming.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+const ThemingGetThemeStylesheetPlain _$themingGetThemeStylesheetPlain$0 = ThemingGetThemeStylesheetPlain._('\$0');
+const ThemingGetThemeStylesheetPlain _$themingGetThemeStylesheetPlain$1 = ThemingGetThemeStylesheetPlain._('\$1');
+
+ThemingGetThemeStylesheetPlain _$valueOfThemingGetThemeStylesheetPlain(String name) {
+  switch (name) {
+    case '\$0':
+      return _$themingGetThemeStylesheetPlain$0;
+    case '\$1':
+      return _$themingGetThemeStylesheetPlain$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ThemingGetThemeStylesheetPlain> _$themingGetThemeStylesheetPlainValues =
+    BuiltSet<ThemingGetThemeStylesheetPlain>(const <ThemingGetThemeStylesheetPlain>[
+  _$themingGetThemeStylesheetPlain$0,
+  _$themingGetThemeStylesheetPlain$1,
+]);
+
+const ThemingGetThemeStylesheetWithCustomCss _$themingGetThemeStylesheetWithCustomCss$0 =
+    ThemingGetThemeStylesheetWithCustomCss._('\$0');
+const ThemingGetThemeStylesheetWithCustomCss _$themingGetThemeStylesheetWithCustomCss$1 =
+    ThemingGetThemeStylesheetWithCustomCss._('\$1');
+
+ThemingGetThemeStylesheetWithCustomCss _$valueOfThemingGetThemeStylesheetWithCustomCss(String name) {
+  switch (name) {
+    case '\$0':
+      return _$themingGetThemeStylesheetWithCustomCss$0;
+    case '\$1':
+      return _$themingGetThemeStylesheetWithCustomCss$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ThemingGetThemeStylesheetWithCustomCss> _$themingGetThemeStylesheetWithCustomCssValues =
+    BuiltSet<ThemingGetThemeStylesheetWithCustomCss>(const <ThemingGetThemeStylesheetWithCustomCss>[
+  _$themingGetThemeStylesheetWithCustomCss$0,
+  _$themingGetThemeStylesheetWithCustomCss$1,
+]);
+
+const ThemingGetImageUseSvg _$themingGetImageUseSvg$0 = ThemingGetImageUseSvg._('\$0');
+const ThemingGetImageUseSvg _$themingGetImageUseSvg$1 = ThemingGetImageUseSvg._('\$1');
+
+ThemingGetImageUseSvg _$valueOfThemingGetImageUseSvg(String name) {
+  switch (name) {
+    case '\$0':
+      return _$themingGetImageUseSvg$0;
+    case '\$1':
+      return _$themingGetImageUseSvg$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ThemingGetImageUseSvg> _$themingGetImageUseSvgValues =
+    BuiltSet<ThemingGetImageUseSvg>(const <ThemingGetImageUseSvg>[
+  _$themingGetImageUseSvg$0,
+  _$themingGetImageUseSvg$1,
+]);
+
 Serializer<ThemingGetManifestResponseApplicationJson_Icons> _$themingGetManifestResponseApplicationJsonIconsSerializer =
     _$ThemingGetManifestResponseApplicationJson_IconsSerializer();
 Serializer<ThemingGetManifestResponseApplicationJson> _$themingGetManifestResponseApplicationJsonSerializer =
     _$ThemingGetManifestResponseApplicationJsonSerializer();
-Serializer<Background> _$backgroundSerializer = _$BackgroundSerializer();
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<UserThemeEnableThemeResponseApplicationJson_Ocs> _$userThemeEnableThemeResponseApplicationJsonOcsSerializer =
     _$UserThemeEnableThemeResponseApplicationJson_OcsSerializer();
@@ -21,6 +82,7 @@ Serializer<UserThemeDisableThemeResponseApplicationJson_Ocs>
     _$UserThemeDisableThemeResponseApplicationJson_OcsSerializer();
 Serializer<UserThemeDisableThemeResponseApplicationJson> _$userThemeDisableThemeResponseApplicationJsonSerializer =
     _$UserThemeDisableThemeResponseApplicationJsonSerializer();
+Serializer<Background> _$backgroundSerializer = _$BackgroundSerializer();
 Serializer<PublicCapabilities_Theming> _$publicCapabilitiesThemingSerializer = _$PublicCapabilities_ThemingSerializer();
 Serializer<PublicCapabilities> _$publicCapabilitiesSerializer = _$PublicCapabilitiesSerializer();
 
@@ -149,58 +211,6 @@ class _$ThemingGetManifestResponseApplicationJsonSerializer
           break;
         case 'display':
           result.display = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
-class _$BackgroundSerializer implements StructuredSerializer<Background> {
-  @override
-  final Iterable<Type> types = const [Background, _$Background];
-  @override
-  final String wireName = 'Background';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, Background object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'backgroundColor',
-      serializers.serialize(object.backgroundColor, specifiedType: const FullType(String)),
-      'version',
-      serializers.serialize(object.version, specifiedType: const FullType(int)),
-    ];
-    Object? value;
-    value = object.backgroundImage;
-    if (value != null) {
-      result
-        ..add('backgroundImage')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    return result;
-  }
-
-  @override
-  Background deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = BackgroundBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'backgroundImage':
-          result.backgroundImage = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-        case 'backgroundColor':
-          result.backgroundColor = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
-          break;
-        case 'version':
-          result.version = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -454,6 +464,58 @@ class _$UserThemeDisableThemeResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(UserThemeDisableThemeResponseApplicationJson_Ocs))!
               as UserThemeDisableThemeResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BackgroundSerializer implements StructuredSerializer<Background> {
+  @override
+  final Iterable<Type> types = const [Background, _$Background];
+  @override
+  final String wireName = 'Background';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Background object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'backgroundColor',
+      serializers.serialize(object.backgroundColor, specifiedType: const FullType(String)),
+      'version',
+      serializers.serialize(object.version, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.backgroundImage;
+    if (value != null) {
+      result
+        ..add('backgroundImage')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  Background deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = BackgroundBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'backgroundImage':
+          result.backgroundImage = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'backgroundColor':
+          result.backgroundColor = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'version':
+          result.version = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -958,122 +1020,6 @@ class ThemingGetManifestResponseApplicationJsonBuilder
       }
       rethrow;
     }
-    replace(_$result);
-    return _$result;
-  }
-}
-
-abstract mixin class $BackgroundInterfaceBuilder {
-  void replace($BackgroundInterface other);
-  void update(void Function($BackgroundInterfaceBuilder) updates);
-  String? get backgroundImage;
-  set backgroundImage(String? backgroundImage);
-
-  String? get backgroundColor;
-  set backgroundColor(String? backgroundColor);
-
-  int? get version;
-  set version(int? version);
-}
-
-class _$Background extends Background {
-  @override
-  final String? backgroundImage;
-  @override
-  final String backgroundColor;
-  @override
-  final int version;
-
-  factory _$Background([void Function(BackgroundBuilder)? updates]) => (BackgroundBuilder()..update(updates))._build();
-
-  _$Background._({this.backgroundImage, required this.backgroundColor, required this.version}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(backgroundColor, r'Background', 'backgroundColor');
-    BuiltValueNullFieldError.checkNotNull(version, r'Background', 'version');
-  }
-
-  @override
-  Background rebuild(void Function(BackgroundBuilder) updates) => (toBuilder()..update(updates)).build();
-
-  @override
-  BackgroundBuilder toBuilder() => BackgroundBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is Background &&
-        backgroundImage == other.backgroundImage &&
-        backgroundColor == other.backgroundColor &&
-        version == other.version;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, backgroundImage.hashCode);
-    _$hash = $jc(_$hash, backgroundColor.hashCode);
-    _$hash = $jc(_$hash, version.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'Background')
-          ..add('backgroundImage', backgroundImage)
-          ..add('backgroundColor', backgroundColor)
-          ..add('version', version))
-        .toString();
-  }
-}
-
-class BackgroundBuilder implements Builder<Background, BackgroundBuilder>, $BackgroundInterfaceBuilder {
-  _$Background? _$v;
-
-  String? _backgroundImage;
-  String? get backgroundImage => _$this._backgroundImage;
-  set backgroundImage(covariant String? backgroundImage) => _$this._backgroundImage = backgroundImage;
-
-  String? _backgroundColor;
-  String? get backgroundColor => _$this._backgroundColor;
-  set backgroundColor(covariant String? backgroundColor) => _$this._backgroundColor = backgroundColor;
-
-  int? _version;
-  int? get version => _$this._version;
-  set version(covariant int? version) => _$this._version = version;
-
-  BackgroundBuilder();
-
-  BackgroundBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _backgroundImage = $v.backgroundImage;
-      _backgroundColor = $v.backgroundColor;
-      _version = $v.version;
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant Background other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$Background;
-  }
-
-  @override
-  void update(void Function(BackgroundBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  Background build() => _build();
-
-  _$Background _build() {
-    final _$result = _$v ??
-        _$Background._(
-            backgroundImage: backgroundImage,
-            backgroundColor: BuiltValueNullFieldError.checkNotNull(backgroundColor, r'Background', 'backgroundColor'),
-            version: BuiltValueNullFieldError.checkNotNull(version, r'Background', 'version'));
     replace(_$result);
     return _$result;
   }
@@ -1671,6 +1617,122 @@ class UserThemeDisableThemeResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $BackgroundInterfaceBuilder {
+  void replace($BackgroundInterface other);
+  void update(void Function($BackgroundInterfaceBuilder) updates);
+  String? get backgroundImage;
+  set backgroundImage(String? backgroundImage);
+
+  String? get backgroundColor;
+  set backgroundColor(String? backgroundColor);
+
+  int? get version;
+  set version(int? version);
+}
+
+class _$Background extends Background {
+  @override
+  final String? backgroundImage;
+  @override
+  final String backgroundColor;
+  @override
+  final int version;
+
+  factory _$Background([void Function(BackgroundBuilder)? updates]) => (BackgroundBuilder()..update(updates))._build();
+
+  _$Background._({this.backgroundImage, required this.backgroundColor, required this.version}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(backgroundColor, r'Background', 'backgroundColor');
+    BuiltValueNullFieldError.checkNotNull(version, r'Background', 'version');
+  }
+
+  @override
+  Background rebuild(void Function(BackgroundBuilder) updates) => (toBuilder()..update(updates)).build();
+
+  @override
+  BackgroundBuilder toBuilder() => BackgroundBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Background &&
+        backgroundImage == other.backgroundImage &&
+        backgroundColor == other.backgroundColor &&
+        version == other.version;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, backgroundImage.hashCode);
+    _$hash = $jc(_$hash, backgroundColor.hashCode);
+    _$hash = $jc(_$hash, version.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Background')
+          ..add('backgroundImage', backgroundImage)
+          ..add('backgroundColor', backgroundColor)
+          ..add('version', version))
+        .toString();
+  }
+}
+
+class BackgroundBuilder implements Builder<Background, BackgroundBuilder>, $BackgroundInterfaceBuilder {
+  _$Background? _$v;
+
+  String? _backgroundImage;
+  String? get backgroundImage => _$this._backgroundImage;
+  set backgroundImage(covariant String? backgroundImage) => _$this._backgroundImage = backgroundImage;
+
+  String? _backgroundColor;
+  String? get backgroundColor => _$this._backgroundColor;
+  set backgroundColor(covariant String? backgroundColor) => _$this._backgroundColor = backgroundColor;
+
+  int? _version;
+  int? get version => _$this._version;
+  set version(covariant int? version) => _$this._version = version;
+
+  BackgroundBuilder();
+
+  BackgroundBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _backgroundImage = $v.backgroundImage;
+      _backgroundColor = $v.backgroundColor;
+      _version = $v.version;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant Background other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$Background;
+  }
+
+  @override
+  void update(void Function(BackgroundBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Background build() => _build();
+
+  _$Background _build() {
+    final _$result = _$v ??
+        _$Background._(
+            backgroundImage: backgroundImage,
+            backgroundColor: BuiltValueNullFieldError.checkNotNull(backgroundColor, r'Background', 'backgroundColor'),
+            version: BuiltValueNullFieldError.checkNotNull(version, r'Background', 'version'));
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/theming.openapi.json
+++ b/packages/nextcloud/lib/src/api/theming.openapi.json
@@ -163,7 +163,11 @@
                         "description": "Let the browser decide the CSS priority",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -172,7 +176,11 @@
                         "description": "Include custom CSS",
                         "schema": {
                             "type": "integer",
-                            "default": 0
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -233,7 +241,11 @@
                         "description": "Return image as SVG",
                         "schema": {
                             "type": "integer",
-                            "default": 1
+                            "default": 1,
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {
@@ -592,18 +604,6 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "OCS-APIRequest",
-                        "in": "header",
-                        "description": "Required to be true for the API request to pass",
-                        "required": true,
-                        "schema": {
-                            "type": "boolean",
-                            "default": true
-                        }
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "Background image returned",
@@ -622,151 +622,6 @@
                             "text/html": {
                                 "schema": {
                                     "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/index.php/apps/theming/background/{type}": {
-            "post": {
-                "operationId": "user_theme-set-background",
-                "summary": "Set the background",
-                "tags": [
-                    "user_theme"
-                ],
-                "security": [
-                    {
-                        "bearer_auth": []
-                    },
-                    {
-                        "basic_auth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "Path of the background image",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "color",
-                        "in": "query",
-                        "description": "Color for the background",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "type",
-                        "in": "path",
-                        "description": "Type of background",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "OCS-APIRequest",
-                        "in": "header",
-                        "description": "Required to be true for the API request to pass",
-                        "required": true,
-                        "schema": {
-                            "type": "boolean",
-                            "default": true
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Background set successfully",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Background"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Setting background is not possible",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/index.php/apps/theming/background/custom": {
-            "delete": {
-                "operationId": "user_theme-delete-background",
-                "summary": "Delete the background",
-                "tags": [
-                    "user_theme"
-                ],
-                "security": [
-                    {
-                        "bearer_auth": []
-                    },
-                    {
-                        "basic_auth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "OCS-APIRequest",
-                        "in": "header",
-                        "description": "Required to be true for the API request to pass",
-                        "required": true,
-                        "schema": {
-                            "type": "boolean",
-                            "default": true
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Background deleted successfully",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Background"
                                 }
                             }
                         }

--- a/tool/generate-specs.sh
+++ b/tool/generate-specs.sh
@@ -8,17 +8,13 @@ mkdir -p /tmp/nextcloud-neon
 function generate_spec() {
     path="$1"
     codename="$2"
-    composer exec generate-spec -- "$path" "../../packages/nextcloud/lib/src/api/$codename.openapi.json" --first-content-type --openapi-version 3.1.0
+    ../nextcloud-openapi-extractor/generate-spec "$path" "../../packages/nextcloud/lib/src/api/$codename.openapi.json" --first-content-type --openapi-version 3.1.0
 }
 
-for dir in external/nextcloud-server external/nextcloud-notifications external/nextcloud-spreed; do
-  (
-    cd "$dir"
-    composer install
-    composer install --no-dev
-    git checkout . # Remove changed files
-  )
-done
+(
+  cd external/nextcloud-openapi-extractor
+  composer install
+)
 
 for path in \
   core \
@@ -64,10 +60,7 @@ for spec in packages/nextcloud/lib/src/api/*.openapi.json; do
   fi
 done
 
-(
-  cd external/nextcloud-server
-  composer exec merge-specs -- --core ../../packages/nextcloud/lib/src/api/core.openapi.json --merged /tmp/nextcloud-neon/merged.json ../../packages/nextcloud/lib/src/api/*.openapi.json --openapi-version 3.1.0
-)
+./external/nextcloud-openapi-extractor/merge-specs --core packages/nextcloud/lib/src/api/core.openapi.json --merged /tmp/nextcloud-neon/merged.json packages/nextcloud/lib/src/api/*.openapi.json --openapi-version 3.1.0
 
 jq \
   -s \


### PR DESCRIPTION
It allows us to get improvements and fixes from openapi-extractor much quicker. This is especially helpful since there are multiple repos we get the specs from and each of those would need to individually update their version.
It was like this some time ago and I removed it to avoid running into compatibility problems, but I don't think any problems will appear in the future, so it should be safe to track our own version again.