### PR TITLE
refactor(neon_framework): Allow omitting sign in relative time

### DIFF
--- a/packages/neon_framework/lib/src/utils/relative_time.dart
+++ b/packages/neon_framework/lib/src/utils/relative_time.dart
@@ -7,11 +7,17 @@ extension RelativeTimeFormatDateTime on DateTime {
   /// Format the relative time between this and [to].
   ///
   /// If [to] is unspecified [DateTime.now] will be used.
+  /// Set [includeSign] to skip the parts that tell if the difference is into the future or into the past.
+  /// It should only be used if it is already clear from the context if it is about the future or the past.
   String formatRelative(
-    NeonLocalizations localizations, [
+    NeonLocalizations localizations, {
+    bool includeSign = true,
     DateTime? to,
-  ]) =>
-      toLocal().difference(to ?? DateTime.now()).formatRelative(localizations);
+  }) =>
+      toLocal().difference(to ?? DateTime.now()).formatRelative(
+            localizations,
+            includeSign: includeSign,
+          );
 }
 
 /// Extension for formatting difference of a [Duration].
@@ -19,7 +25,12 @@ extension RelativeTimeFormatDateTime on DateTime {
 extension RelativeTimeFormatDuration on Duration {
   /// Format the relative time.
   ///
-  String formatRelative(NeonLocalizations localizations) {
+  /// Set [includeSign] to skip the parts that tell if the difference is into the future or into the past.
+  /// It should only be used if it is already clear from the context if it is about the future or the past.
+  String formatRelative(
+    NeonLocalizations localizations, {
+    bool includeSign = true,
+  }) {
     final normalizedDuration = isNegative ? Duration(microseconds: -inMicroseconds) : this;
     if (normalizedDuration.inMinutes < 1) {
       return localizations.relativeTimeNow;
@@ -34,6 +45,10 @@ extension RelativeTimeFormatDuration on Duration {
       time = localizations.relativeTimeDays(normalizedDuration.inDays);
     } else {
       time = localizations.relativeTimeYears(normalizedDuration.inDays ~/ 365);
+    }
+
+    if (!includeSign) {
+      return time;
     }
 
     if (isNegative) {

--- a/packages/neon_framework/test/relative_time_test.dart
+++ b/packages/neon_framework/test/relative_time_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_redundant_argument_values
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:neon_framework/l10n/localizations_en.dart';
 import 'package:neon_framework/src/utils/relative_time.dart';
@@ -5,34 +7,35 @@ import 'package:neon_framework/src/utils/relative_time.dart';
 void main() {
   final localizations = NeonLocalizationsEn();
 
-  final durations = <Duration, String>{
-    const Duration(days: 730): 'in 2 years',
-    const Duration(days: 729): 'in 1 year',
-    const Duration(days: 365): 'in 1 year',
-    const Duration(days: 364): 'in 364 days',
-    const Duration(days: 1): 'in 1 day',
-    const Duration(hours: 23): 'in 23 hours',
-    const Duration(hours: 1): 'in 1 hour',
-    const Duration(minutes: 59): 'in 59 minutes',
-    const Duration(minutes: 1): 'in 1 minute',
-    const Duration(seconds: 59): 'now',
-    const Duration(seconds: 1): 'now',
-    const Duration(seconds: -1): 'now',
-    const Duration(seconds: -59): 'now',
-    const Duration(minutes: -1): '1 minute ago',
-    const Duration(minutes: -59): '59 minutes ago',
-    const Duration(hours: -1): '1 hour ago',
-    const Duration(hours: -23): '23 hours ago',
-    const Duration(days: -1): '1 day ago',
-    const Duration(days: -364): '364 days ago',
-    const Duration(days: -365): '1 year ago',
-    const Duration(days: -729): '1 year ago',
-    const Duration(days: -730): '2 years ago',
+  final durations = <Duration, (String, String)>{
+    const Duration(days: 730): ('2 years', 'in 2 years'),
+    const Duration(days: 729): ('1 year', 'in 1 year'),
+    const Duration(days: 365): ('1 year', 'in 1 year'),
+    const Duration(days: 364): ('364 days', 'in 364 days'),
+    const Duration(days: 1): ('1 day', 'in 1 day'),
+    const Duration(hours: 23): ('23 hours', 'in 23 hours'),
+    const Duration(hours: 1): ('1 hour', 'in 1 hour'),
+    const Duration(minutes: 59): ('59 minutes', 'in 59 minutes'),
+    const Duration(minutes: 1): ('1 minute', 'in 1 minute'),
+    const Duration(seconds: 59): ('now', 'now'),
+    const Duration(seconds: 1): ('now', 'now'),
+    const Duration(seconds: -1): ('now', 'now'),
+    const Duration(seconds: -59): ('now', 'now'),
+    const Duration(minutes: -1): ('1 minute', '1 minute ago'),
+    const Duration(minutes: -59): ('59 minutes', '59 minutes ago'),
+    const Duration(hours: -1): ('1 hour', '1 hour ago'),
+    const Duration(hours: -23): ('23 hours', '23 hours ago'),
+    const Duration(days: -1): ('1 day', '1 day ago'),
+    const Duration(days: -364): ('364 days', '364 days ago'),
+    const Duration(days: -365): ('1 year', '1 year ago'),
+    const Duration(days: -729): ('1 year', '1 year ago'),
+    const Duration(days: -730): ('2 years', '2 years ago'),
   };
 
   test('Duration', () {
     for (final entry in durations.entries) {
-      expect(entry.key.formatRelative(localizations), entry.value);
+      expect(entry.key.formatRelative(localizations, includeSign: false), entry.value.$1);
+      expect(entry.key.formatRelative(localizations, includeSign: true), entry.value.$2);
     }
   });
 
@@ -42,7 +45,8 @@ void main() {
     expect(base.formatRelative(localizations), 'now');
 
     for (final entry in durations.entries) {
-      expect(base.add(entry.key).formatRelative(localizations, base), entry.value);
+      expect(base.add(entry.key).formatRelative(localizations, to: base, includeSign: false), entry.value.$1);
+      expect(base.add(entry.key).formatRelative(localizations, to: base, includeSign: true), entry.value.$2);
     }
   });
 }


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/neon/pull/1378 and added a test.