### PR TITLE
fix(neon_framework): warning in the dialog unit tests 

### DIFF
--- a/packages/neon_framework/test/dialog_test.dart
+++ b/packages/neon_framework/test/dialog_test.dart
@@ -128,7 +128,6 @@ void main() {
         await widgetTester.pumpAndSettle();
         await widgetTester.enterText(find.byType(TextFormField), 'My new value');
         await widgetTester.testTextInput.receiveAction(TextInputAction.done);
-        await widgetTester.tap(find.byType(NeonDialogAction));
         expect(await result, equals('My new value'));
       });
     });


### PR DESCRIPTION
When hitting enter on the keyboard the dialog should (and does) automatically submit the result and pop.
We do not need to tap the save action anymore. Doing so produces a warning that the save action is no longer present on the screen.