### PR TITLE
fix(neon_framework): fix race condition in request manager when retri…

### DIFF
--- a/packages/neon_framework/lib/src/utils/request_manager.dart
+++ b/packages/neon_framework/lib/src/utils/request_manager.dart
@@ -214,7 +214,8 @@ class RequestManager {
 
         // If the network fetch is faster than fetching the cached value the
         // subject can be closed before emitting.
-        if (subject.value.hasUncachedData) {
+        final value = subject.value;
+        if (value.hasUncachedData && !value.hasError) {
           return true;
         }
 


### PR DESCRIPTION
…eving cached data.

When the connection fails before emitting a cached value we would just emit the current data in an error state instead of the data from cache. Easily reproducible on multiple low end devices.

This should have a unit test but this means adding some for all the request manager (making a draft for now).