### PR TITLE
feat(tool,ci): Check for dart:html usage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Find dart:io usage
         run: ./tool/find-dart-io-usage.sh
 
+      - name: Find dart:html usage
+        run: ./tool/find-dart-html-usage.sh
+
       - name: Find relative markdown links
         run: ./tool/find-relative-markdown-links.sh

--- a/tool/find-dart-html-usage.sh
+++ b/tool/find-dart-html-usage.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euxo pipefail
+cd "$(dirname "$0")/.."
+
+dart_html_usage=("$(grep -r packages --include "*\.dart" -e "dart:html" -l | grep -v "/\.dart_tool/" || true)")
+
+if [[ -n "${dart_html_usage[*]}" ]]; then
+  printf "%s\n" "${dart_html_usage[@]}"
+    echo "Use package:universal_html/html.dart instead"
+  exit 1
+fi

--- a/tool/find-dart-io-usage.sh
+++ b/tool/find-dart-io-usage.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 
-dart_io_usage=("$(grep -r packages --include "*\.dart" --exclude "*\.mocks\.dart" -e "dart:io" -l | grep -v "/\.dart_tool/" | grep -v "/bin/" | grep -v "/test_driver/" | grep -v -P "/nextcloud/generate_(exports|props).dart" || true)")
+dart_io_usage=("$(grep -r packages --include "*\.dart" -e "dart:io" -l | grep -v "/\.dart_tool/" | grep -v "/bin/" | grep -v "/test_driver/" | grep -v -P "/nextcloud/generate_(exports|props).dart" || true)")
 
 if [[ -n "${dart_io_usage[*]}" ]]; then
   printf "%s\n" "${dart_io_usage[@]}"

--- a/tool/find-dart-io-usage.sh
+++ b/tool/find-dart-io-usage.sh
@@ -6,5 +6,6 @@ dart_io_usage=("$(grep -r packages --include "*\.dart" -e "dart:io" -l | grep -v
 
 if [[ -n "${dart_io_usage[*]}" ]]; then
   printf "%s\n" "${dart_io_usage[@]}"
+  echo "Use package:universal_io/io.dart instead"
   exit 1
 fi


### PR DESCRIPTION
dart:html is not used yet anywhere, but will be in the future. The proper replacement is universal_html that also allows being compiled on vm.