### PR TITLE
fix(neon_framework): Fix settings page height

### DIFF
--- a/packages/neon_framework/lib/src/theme/dialog.dart
+++ b/packages/neon_framework/lib/src/theme/dialog.dart
@@ -14,7 +14,6 @@ class NeonDialogTheme {
     this.constraints = const BoxConstraints(
       minWidth: 280,
       maxWidth: 560,
-      maxHeight: 560 * 1.5,
     ),
     this.padding = const EdgeInsets.all(24),
   });

--- a/packages/neon_framework/lib/src/widgets/dialog.dart
+++ b/packages/neon_framework/lib/src/widgets/dialog.dart
@@ -537,10 +537,12 @@ class NeonEmojiPickerDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final constraints = NeonDialogTheme.of(context).constraints;
 
     return NeonDialog(
       content: SizedBox(
-        width: NeonDialogTheme.of(context).constraints.maxWidth,
+        width: constraints.maxWidth,
+        height: constraints.maxWidth * 1.5,
         child: EmojiPicker(
           config: Config(
             emojiSizeMax: 25,


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/1478
The height constraint should have never been there. In the emoji picker dialog we still need it.