### PR TITLE
fix(app): Increase Android minSdkVersion to 24 to fix debug builds

### DIFF
--- a/packages/app/android/app/build.gradle
+++ b/packages/app/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
         applicationId "de.provokateurin.neon"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
With any version lower than 24 we can't build the app in debug mode (release mode works though :woman_shrugging:).
This means only support Android 7.0+ which is ok IMO because it was released in 2016.