### PR TITLE
fix(neon_news): Fix invalid index access

### DIFF
--- a/packages/neon/neon_news/lib/src/widgets/articles_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/articles_view.dart
@@ -63,7 +63,7 @@ class _NewsArticlesViewState extends State<NewsArticlesView> {
                   widget.newsBloc.refresh(),
                 ]);
               },
-              itemCount: feeds.hasData ? sorted.length : null,
+              itemCount: sorted.length,
               itemBuilder: (context, index) {
                 final article = sorted[index];
 


### PR DESCRIPTION
The line `final article = sorted[index];` was failing when opening the articles view initially, because the length was null which lead to an infinite amount of items. The length should always be passed and not conditionally.