### PR TITLE
Fix quick actions not working

### DIFF
--- a/packages/neon_framework/lib/src/blocs/apps.dart
+++ b/packages/neon_framework/lib/src/blocs/apps.dart
@@ -266,7 +266,8 @@ class _AppsBloc extends InteractiveBloc implements AppsBloc {
     final apps = await appImplementations.firstWhere((a) => a.hasData);
     final app = apps.requireData.tryFind(appID);
     if (app != null) {
-      if ((!activeApp.hasValue || !skipAlreadySet) && activeApp.valueOrNull?.id != appID) {
+      if ((!activeApp.hasValue || !skipAlreadySet || apps.requireData.tryFind(activeApp.value.id) == null) &&
+          activeApp.valueOrNull?.id != appID) {
         activeApp.add(app);
       }
     } else {


### PR DESCRIPTION
Fix https://github.com/nextcloud/neon/issues/1454
The problem was that the active app was overridden after it was set by the quick action shortcut.
To prevent it we need to skip setting the active app if there is one already, but that breaks updating the active app in case the current active app is not supported anymore, so I fixed that too.