### PR TITLE
fix(tool): Fix finding untested Neon APIs

### DIFF
--- a/tool/find-untested-neon-apis.sh
+++ b/tool/find-untested-neon-apis.sh
@@ -3,11 +3,11 @@ set -euxo pipefail
 cd "$(dirname "$0")/.."
 
 function find_apis() {
-    path="$1"
-    grep -r "$path" --include "*\.dart" -e "client\([0-9]\)\?\.[^.]*.[^(]*(" -oh | sed "s/^client\([0-9]\)\?\.//" | sed "s/($//" | sed "s/Raw$//" | grep -v "^executeRawRequest" | sort | uniq
+    # shellcheck disable=SC2068
+    grep -r $@ --include "*\.dart" -e "client\([0-9]\)\?\.[^.]*.[^(]*(" -oh | sed "s/^client\([0-9]\)\?\.//" | sed "s/($//" | sed "s/Raw$//" | grep -v "^executeRawRequest" | sort | uniq
 }
 
-used_apis=("$(find_apis "packages/neon")")
+used_apis=("$(find_apis "packages/neon_framework" "packages/neon/"*)")
 tested_apis=("$(find_apis "packages/nextcloud")")
 
 untested_apis=()


### PR DESCRIPTION
After moving the neon_framework package this script didn't check it any more.
We didn't use any untested APIs since the, but it should have been failing on https://github.com/nextcloud/neon/pull/1486.