### PR TITLE
fix(neon_framework): Allow 201 status code when loading images

### DIFF
--- a/packages/neon_framework/lib/src/widgets/image.dart
+++ b/packages/neon_framework/lib/src/widgets/image.dart
@@ -378,7 +378,7 @@ class NeonUrlImage extends StatelessWidget {
           completedUri,
           headers,
           null,
-          const {200},
+          const {200, 201},
         );
 
         return response.stream.bytes;


### PR DESCRIPTION
Some endpoints return 201 which is of course not correct, but this is the only way we can fix it.
Disabling the status code check is not a good idea and allowing all 2xx neither.