### PR TITLE
fix(neon_framework): Disallow null values in settings

### DIFF
--- a/packages/neon/neon_files/lib/src/options.dart
+++ b/packages/neon/neon_files/lib/src/options.dart
@@ -88,8 +88,8 @@ class FilesOptions extends AppImplementationOptions {
     },
   );
 
-  late final _sizeWarningValues = <int?, LabelBuilder>{
-    null: (context) => FilesLocalizations.of(context).optionsSizeWarningDisabled,
+  late final _sizeWarningValues = <int, LabelBuilder>{
+    0: (context) => FilesLocalizations.of(context).optionsSizeWarningDisabled,
     for (var i in [
       1,
       10,
@@ -105,7 +105,7 @@ class FilesOptions extends AppImplementationOptions {
 
   int _mb(int i) => i * 1024 * 1024;
 
-  late final uploadSizeWarning = SelectOption<int?>(
+  late final uploadSizeWarning = SelectOption<int>(
     storage: storage,
     category: generalCategory,
     key: FilesOptionKeys.uploadSizeWarning,
@@ -114,7 +114,7 @@ class FilesOptions extends AppImplementationOptions {
     values: _sizeWarningValues,
   );
 
-  late final downloadSizeWarning = SelectOption<int?>(
+  late final downloadSizeWarning = SelectOption<int>(
     storage: storage,
     category: generalCategory,
     key: FilesOptionKeys.downloadSizeWarning,

--- a/packages/neon/neon_files/lib/src/widgets/dialog.dart
+++ b/packages/neon/neon_files/lib/src/widgets/dialog.dart
@@ -62,7 +62,7 @@ class _FilesChooseCreateModalState extends State<FilesChooseCreateModal> {
 
   Future<void> upload(File file) async {
     final sizeWarning = widget.bloc.options.uploadSizeWarning.value;
-    if (sizeWarning != null) {
+    if (sizeWarning != 0) {
       final stat = file.statSync();
       if (stat.size > sizeWarning) {
         final result = await showUploadConfirmationDialog(context, sizeWarning, stat.size);

--- a/packages/neon/neon_files/lib/src/widgets/file_list_tile.dart
+++ b/packages/neon/neon_files/lib/src/widgets/file_list_tile.dart
@@ -28,7 +28,7 @@ class FileListTile extends StatelessWidget {
       browserBloc.setPath(details.uri);
     } else if (browserBloc.mode == FilesBrowserMode.browser) {
       final sizeWarning = bloc.options.downloadSizeWarning.value;
-      if (sizeWarning != null && details.size != null && details.size! > sizeWarning) {
+      if (sizeWarning != 0 && details.size != null && details.size! > sizeWarning) {
         final decision = await showDownloadConfirmationDialog(context, sizeWarning, details.size!);
 
         if (!decision) {

--- a/packages/neon_framework/lib/src/blocs/next_push.dart
+++ b/packages/neon_framework/lib/src/blocs/next_push.dart
@@ -45,7 +45,7 @@ class _NextPushBloc extends Bloc implements NextPushBloc {
       if (!globalOptions.pushNotificationsEnabled.enabled || !globalOptions.pushNotificationsEnabled.value) {
         return;
       }
-      if (globalOptions.pushNotificationsDistributor.value != null) {
+      if (globalOptions.pushNotificationsDistributor.value.isNotEmpty) {
         return;
       }
       if (globalOptions.pushNotificationsDistributor.values.containsKey(unifiedPushNextPushID)) {

--- a/packages/neon_framework/lib/src/blocs/push_notifications.dart
+++ b/packages/neon_framework/lib/src/blocs/push_notifications.dart
@@ -102,7 +102,7 @@ class _PushNotificationsBloc extends Bloc implements PushNotificationsBloc {
 
   Future<void> distributorListener() async {
     final distributor = globalOptions.pushNotificationsDistributor.value;
-    final disabled = distributor == null;
+    final disabled = distributor.isEmpty;
     final sameDistributor = distributor == await UnifiedPush.getDistributor();
     final accounts = accountsBloc.accounts.value;
     if (disabled || !sameDistributor) {

--- a/packages/neon_framework/lib/src/settings/models/option.dart
+++ b/packages/neon_framework/lib/src/settings/models/option.dart
@@ -14,7 +14,7 @@ import 'package:rxdart/rxdart.dart';
 /// See:
 ///   * [ToggleOption] for an Option<bool>
 ///   * [SelectOption] for an Option with multiple values
-sealed class Option<T> extends ChangeNotifier implements ValueListenable<T>, Disposable {
+sealed class Option<T extends Object> extends ChangeNotifier implements ValueListenable<T>, Disposable {
   /// Creates an Option
   Option({
     required this.storage,
@@ -151,7 +151,7 @@ sealed class Option<T> extends ChangeNotifier implements ValueListenable<T>, Dis
 /// See:
 ///   * [SelectOption] for an Option with multiple values
 
-class SelectOption<T> extends Option<T> {
+class SelectOption<T extends Object> extends Option<T> {
   /// Creates a SelectOption
   SelectOption({
     required super.storage,
@@ -210,9 +210,7 @@ class SelectOption<T> extends Option<T> {
     if (_values.keys.contains(value)) {
       super.value = value;
 
-      if (value != null) {
-        unawaited(storage.setString(key.value, serialize()!));
-      }
+      unawaited(storage.setString(key.value, serialize()!));
     } else {
       debugPrint('"$value" is not in "${_values.keys.join('", "')}", ignoring');
     }

--- a/packages/neon_framework/lib/src/settings/widgets/option_settings_tile.dart
+++ b/packages/neon_framework/lib/src/settings/widgets/option_settings_tile.dart
@@ -43,7 +43,7 @@ class ToggleSettingsTile extends InputSettingsTile<ToggleOption> {
 }
 
 @internal
-class SelectSettingsTile<T> extends InputSettingsTile<SelectOption<T>> {
+class SelectSettingsTile<T extends Object> extends InputSettingsTile<SelectOption<T>> {
   const SelectSettingsTile({
     required super.option,
     this.immediateSelection = true,
@@ -95,7 +95,7 @@ class SelectSettingsTile<T> extends InputSettingsTile<SelectOption<T>> {
 }
 
 @internal
-class SelectSettingsTileDialog<T> extends StatefulWidget {
+class SelectSettingsTileDialog<T extends Object> extends StatefulWidget {
   const SelectSettingsTileDialog({
     required this.option,
     this.immediateSelection = true,
@@ -110,7 +110,7 @@ class SelectSettingsTileDialog<T> extends StatefulWidget {
   State<SelectSettingsTileDialog<T>> createState() => _SelectSettingsTileDialogState<T>();
 }
 
-class _SelectSettingsTileDialogState<T> extends State<SelectSettingsTileDialog<T>> {
+class _SelectSettingsTileDialogState<T extends Object> extends State<SelectSettingsTileDialog<T>> {
   late T value;
   late SelectOption<T> option = widget.option;
 
@@ -138,8 +138,11 @@ class _SelectSettingsTileDialogState<T> extends State<SelectSettingsTileDialog<T
               value: k,
               groupValue: value,
               onChanged: (value) {
+                if (value == null) {
+                  return;
+                }
                 setState(() {
-                  this.value = value as T;
+                  this.value = value;
                 });
 
                 if (widget.immediateSelection) {
@@ -174,7 +177,7 @@ class _SelectSettingsTileDialogState<T> extends State<SelectSettingsTileDialog<T
 }
 
 @internal
-class SelectSettingsTileScreen<T> extends StatelessWidget {
+class SelectSettingsTileScreen<T extends Object> extends StatelessWidget {
   const SelectSettingsTileScreen({
     required this.option,
     super.key,
@@ -202,7 +205,10 @@ class SelectSettingsTileScreen<T> extends StatelessWidget {
               value: k,
               groupValue: value,
               onChanged: (value) {
-                option.value = value as T;
+                if (value == null) {
+                  return;
+                }
+                option.value = value;
               },
             ),
           ),

--- a/packages/neon_framework/lib/src/utils/account_options.dart
+++ b/packages/neon_framework/lib/src/utils/account_options.dart
@@ -20,7 +20,7 @@ class AccountOptions extends OptionsCollection {
       }
 
       initialApp.values = {
-        null: (context) => NeonLocalizations.of(context).accountOptionsAutomatic,
+        '': (context) => NeonLocalizations.of(context).accountOptionsAutomatic,
       }..addEntries(result.requireData.map((app) => MapEntry(app.id, app.name)));
     });
   }
@@ -34,12 +34,12 @@ class AccountOptions extends OptionsCollection {
 
   /// The initial app to show on app start.
   ///
-  /// Defaults to `null` letting the framework choose one.
-  late final initialApp = SelectOption<String?>(
+  /// Defaults to an empty `String` letting the framework choose one.
+  late final initialApp = SelectOption<String>(
     storage: storage,
     key: AccountOptionKeys.initialApp,
     label: (context) => NeonLocalizations.of(context).accountOptionsInitialApp,
-    defaultValue: null,
+    defaultValue: '',
     values: {},
   );
 }

--- a/packages/neon_framework/lib/src/utils/global_options.dart
+++ b/packages/neon_framework/lib/src/utils/global_options.dart
@@ -175,11 +175,11 @@ class GlobalOptions extends OptionsCollection {
   );
 
   /// The registered distributor for push notifications.
-  late final pushNotificationsDistributor = SelectOption<String?>.depend(
+  late final pushNotificationsDistributor = SelectOption<String>.depend(
     storage: storage,
     key: GlobalOptionKeys.pushNotificationsDistributor,
     label: (context) => NeonLocalizations.of(context).globalOptionsPushNotificationsDistributor,
-    defaultValue: null,
+    defaultValue: '',
     values: {},
     enabled: pushNotificationsEnabled,
   );
@@ -222,11 +222,11 @@ class GlobalOptions extends OptionsCollection {
   );
 
   /// The initial account to use when opening the app.
-  late final initialAccount = SelectOption<String?>(
+  late final initialAccount = SelectOption<String>(
     storage: storage,
     key: GlobalOptionKeys.initialAccount,
     label: (context) => NeonLocalizations.of(context).globalOptionsAccountsInitialAccount,
-    defaultValue: null,
+    defaultValue: '',
     values: {},
   );
 

--- a/packages/neon_framework/test/option_test.dart
+++ b/packages/neon_framework/test/option_test.dart
@@ -177,24 +177,24 @@ void main() {
       expect(option.value, option.defaultValue, reason: 'Should reset the value.');
     });
 
-    test('Serialize null', () {
-      final option = SelectOption<SelectValues?>(
+    test('Serialize', () {
+      final option = SelectOption<SelectValues>(
         storage: storage,
         key: key,
         label: labelBuilder,
-        defaultValue: null,
+        defaultValue: SelectValues.first,
         values: valuesLabel,
       );
 
-      expect(option.serialize(), null, reason: 'Should serialize to null. A string containing "null" is an error');
+      expect(option.serialize(), SelectValues.first.toString(), reason: 'Should serialize to SelectValues.first.');
     });
 
     test('Deserialize', () {
-      final option = SelectOption<SelectValues?>(
+      final option = SelectOption<SelectValues>(
         storage: storage,
         key: key,
         label: labelBuilder,
-        defaultValue: null,
+        defaultValue: SelectValues.first,
         values: valuesLabel,
       );
 
@@ -205,11 +205,11 @@ void main() {
     });
 
     test('Stream', () async {
-      final option = SelectOption<SelectValues?>(
+      final option = SelectOption<SelectValues>(
         storage: storage,
         key: key,
         label: labelBuilder,
-        defaultValue: null,
+        defaultValue: SelectValues.first,
         values: valuesLabel,
       );
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/1494
The problem was the after the dialog closes when selecting a value there is a null check which is necessary to avoid setting the value if the dialog was just canceled. This also meant that any null value that was valid and selected wouldn't be set as the new value. The only way to fix that is to disallow any null value in the settings.