### PR TITLE
refactor(neon_framework)!: remove emitEmptyCache option from request manager

### DIFF
--- a/packages/neon/neon_files/lib/src/widgets/browser_view.dart
+++ b/packages/neon/neon_files/lib/src/widgets/browser_view.dart
@@ -64,7 +64,7 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
                   presort: const {
                     (property: FilesSortProperty.isFolder, order: SortBoxOrder.ascending),
                   },
-                  input: filesSnapshot.data,
+                  input: filesSnapshot.data?.sublist(1),
                   builder: (context, sorted) {
                     final uploadingTaskTiles = buildUploadTasks(tasksSnapshot.requireData, sorted);
 

--- a/packages/neon_framework/test/request_manager_test.dart
+++ b/packages/neon_framework/test/request_manager_test.dart
@@ -167,7 +167,6 @@ void main() {
           (deserialized) => utf8.decode(deserialized),
           (cached) => utf8.encode(cached),
           false,
-          false,
           const Duration(milliseconds: 50),
         );
 
@@ -210,7 +209,6 @@ void main() {
           (deserialized) => base64.encode(deserialized),
           (deserialized) => utf8.decode(deserialized),
           (cached) => utf8.encode(cached),
-          false,
           false,
           const Duration(milliseconds: 50),
         );
@@ -388,7 +386,6 @@ void main() {
           (deserialized) => utf8.decode(deserialized),
           (cached) => utf8.encode(cached),
           false,
-          false,
           const Duration(milliseconds: 50),
         );
 
@@ -434,7 +431,6 @@ void main() {
           (deserialized) => base64.encode(deserialized),
           (deserialized) => utf8.decode(deserialized),
           (cached) => utf8.encode(cached),
-          false,
           false,
           const Duration(milliseconds: 50),
         );
@@ -625,7 +621,6 @@ void main() {
           (deserialized) => utf8.decode(deserialized),
           (cached) => utf8.encode(cached),
           false,
-          false,
           const Duration(milliseconds: 50),
         );
 
@@ -678,7 +673,6 @@ void main() {
           (deserialized) => base64.encode(deserialized),
           (deserialized) => utf8.decode(deserialized),
           (cached) => utf8.encode(cached),
-          false,
           false,
           const Duration(milliseconds: 50),
         );


### PR DESCRIPTION
depends on: #1505 
All in all this does improve the performance if an api request fails or completes before the cache has emitted a value.