### PR TITLE
chore: update built_value to 8.9.0

### DIFF
--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: c9aabae0718ec394e5bc3c7272e6bb0dc0b32201a08fe185ec1d8401d3e39309
+      sha256: a3ec2e0f967bc47f69f95009bb93db936288d61d5343b9436e378b28a2f830c6
       url: "https://pub.dev"
     source: hosted
-    version: "8.8.1"
+    version: "8.9.0"
   camera:
     dependency: transitive
     description:

--- a/packages/dynamite/dynamite/example/pubspec.yaml
+++ b/packages/dynamite/dynamite/example/pubspec.yaml
@@ -8,14 +8,14 @@ environment:
 
 dependencies:
   built_collection: ^5.0.0
-  built_value: ^8.0.1
+  built_value: ^8.9.0
   dynamite_runtime: ^0.1.0
   meta: ^1.0.0
   uri: ^1.0.0
 
 dev_dependencies:
   build_runner: ^2.4.8
-  built_value_generator: ^8.8.1
+  built_value_generator: ^8.9.0
   dynamite: ^0.1.0
   neon_lints:
     git:

--- a/packages/dynamite/dynamite/lib/src/helpers/version_checker.dart
+++ b/packages/dynamite/dynamite/lib/src/helpers/version_checker.dart
@@ -4,7 +4,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 
 final dependencies = {
   'built_collection': Version.parse('5.0.0'),
-  'built_value': Version.parse('8.0.0'),
+  'built_value': Version.parse('8.9.0'),
   'collection': Version.parse('1.0.0'),
   'dynamite_runtime': Version.parse('0.1.0'),
   'http': Version.parse('1.2.0'),
@@ -13,7 +13,7 @@ final dependencies = {
 };
 
 final devDependencies = {
-  'built_value_generator': Version.parse('8.8.1'),
+  'built_value_generator': Version.parse('8.9.0'),
 };
 
 /// Checks whether the correct version of the dependencies are present in the pubspec.yaml file.

--- a/packages/dynamite/dynamite/pubspec.yaml
+++ b/packages/dynamite/dynamite/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   build: ^2.0.0
   built_collection: ^5.0.0
-  built_value: ^8.0.1
+  built_value: ^8.9.0
   checked_yaml: ^2.0.0
   code_builder: ^4.10.0
   collection: ^1.0.0
@@ -31,7 +31,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  built_value_generator: ^8.8.1
+  built_value_generator: ^8.9.0
   neon_lints:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/dynamite/dynamite_end_to_end_test/pubspec.yaml
+++ b/packages/dynamite/dynamite_end_to_end_test/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   built_collection: ^5.0.0
-  built_value: ^8.0.0
+  built_value: ^8.9.0
   collection: ^1.0.0
   dynamite_runtime: ^0.1.0
   http: ^1.2.0
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  built_value_generator: ^8.8.1
+  built_value_generator: ^8.9.0
   dynamite: ^0.1.0
   neon_lints:
     git:

--- a/packages/dynamite/dynamite_runtime/pubspec.yaml
+++ b/packages/dynamite/dynamite_runtime/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   built_collection: ^5.0.0
-  built_value: ^8.0.1
+  built_value: ^8.9.0
   collection: ^1.0.0
   cookie_jar: ^4.0.7
   http: ^1.2.0
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  built_value_generator: ^8.8.1
+  built_value_generator: ^8.9.0
   neon_lints:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   built_collection: ^5.0.0
-  built_value: ^8.0.0
+  built_value: ^8.9.0
   collection: ^1.0.0
   crypto: ^3.0.0
   crypton: ^2.0.0
@@ -30,7 +30,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  built_value_generator: ^8.8.1
+  built_value_generator: ^8.9.0
   coverage: ^1.7.2
   dynamite: ^0.1.0
   json_serializable: ^6.7.1


### PR DESCRIPTION
Looks like renovate has beaten me by a few minutes.
This replaces: #1509