### PR TITLE
refactor(neon_framework): Move authorization headers to Account

### DIFF
--- a/packages/neon_framework/lib/src/models/account.dart
+++ b/packages/neon_framework/lib/src/models/account.dart
@@ -117,13 +117,12 @@ class Account implements Credentials, Findable {
   /// Get the necessary `Authorization` headers for a given [uri].
   ///
   /// This method ensures no credentials are sent to the wrong server.
-  Map<String, String> getAuthorizationHeaders(Uri uri) {
-    // Only send the authentication headers when sending the request to the server of the account
-    if (uri.toString().startsWith(serverURL.toString()) && client.authentications.isNotEmpty) {
-      return client.authentications.first.headers;
+  Map<String, String>? getAuthorizationHeaders(Uri uri) {
+    if (uri.toString().startsWith(serverURL.toString())) {
+      return client.authentications.firstOrNull?.headers;
     }
 
-    return <String, String>{};
+    return null;
   }
 
   /// Removes the [serverURL] part from the [uri].

--- a/packages/neon_framework/lib/src/models/account.dart
+++ b/packages/neon_framework/lib/src/models/account.dart
@@ -114,6 +114,18 @@ class Account implements Credentials, Findable {
     return result;
   }
 
+  /// Get the necessary `Authorization` headers for a given [uri].
+  ///
+  /// This method ensures no credentials are sent to the wrong server.
+  Map<String, String> getAuthorizationHeaders(Uri uri) {
+    // Only send the authentication headers when sending the request to the server of the account
+    if (uri.toString().startsWith(serverURL.toString()) && client.authentications.isNotEmpty) {
+      return client.authentications.first.headers;
+    }
+
+    return <String, String>{};
+  }
+
   /// Removes the [serverURL] part from the [uri].
   ///
   /// Should be used when trying to push a [uri] from an API to the router as it might contain the scheme, host and sub path of the instance which will not work with the router.

--- a/packages/neon_framework/lib/src/widgets/image.dart
+++ b/packages/neon_framework/lib/src/widgets/image.dart
@@ -370,18 +370,11 @@ class NeonUrlImage extends StatelessWidget {
         }
 
         final completedUri = account.completeUri(uri);
-        final headers = <String, String>{};
-
-        // Only send the authentication headers when sending the request to the server of the account
-        if (completedUri.toString().startsWith(account.serverURL.toString()) &&
-            account.client.authentications.isNotEmpty) {
-          headers.addAll(account.client.authentications.first.headers);
-        }
 
         final response = await account.client.executeRawRequest(
           'GET',
           completedUri,
-          headers,
+          account.getAuthorizationHeaders(completedUri),
           null,
           const {200, 201},
         );

--- a/packages/neon_framework/test/account_test.dart
+++ b/packages/neon_framework/test/account_test.dart
@@ -62,6 +62,31 @@ void main() {
     }
   });
 
+  test('getAuthorizationHeaders', () {
+    final account = Account(
+      serverURL: Uri.parse('https://example.com:443/test'),
+      username: 'example',
+      password: 'example',
+    );
+
+    for (final (url, shouldHaveHeaders) in [
+      ('https://example.com:443/test/bla.png', true),
+      // Different ports
+      ('https://example.com/test/bla.png', true),
+      ('https://example.com:80/test/bla.png', false),
+      // Different paths
+      ('https://example.com:443/bla.png', false),
+      ('https://example.com:443/123/bla.png', false),
+      // Different protocol
+      ('http://example.com:443/test/bla.png', false),
+      // Different domains
+      ('https://test.example.com:443/test/bla.png', false),
+      ('https://test.com:443/test/bla.png', false),
+    ]) {
+      expect(account.getAuthorizationHeaders(Uri.parse(url)), shouldHaveHeaders ? isNotNull : isNull);
+    }
+  });
+
   group('Account', () {
     final account = Account(
       serverURL: Uri(scheme: 'http', host: 'example.com'),


### PR DESCRIPTION
Closes https://github.com/nextcloud/neon/issues/1462

In the end I needed this change for https://github.com/nextcloud/neon/issues/1125 and this way it was easy to add tests.