### PR TITLE
fix(nextcloud_test): Sort server versions to correctly get the highest one

### DIFF
--- a/packages/nextcloud_test/bin/generate_presets.dart
+++ b/packages/nextcloud_test/bin/generate_presets.dart
@@ -15,6 +15,7 @@ Future<void> main() async {
   final httpClient = HttpClient();
 
   final serverVersions = await _getServerVersions(httpClient);
+  serverVersions.sort((a, b) => b.compareTo(a));
   final apps = await _getApps(appIDs, httpClient);
 
   for (final app in apps) {


### PR DESCRIPTION
https://github.com/nextcloud/neon/pull/1527#discussion_r1467241825