### PR TITLE
refactor(dynamite_runtime): stop exporting cookie_jar

### DIFF
--- a/packages/dynamite/dynamite_runtime/lib/http_client.dart
+++ b/packages/dynamite/dynamite_runtime/lib/http_client.dart
@@ -1,6 +1,5 @@
 /// The dynamite client to handle http connections.
 library http_client;
 
-export 'package:cookie_jar/cookie_jar.dart';
 export 'src/dynamite_client.dart';
 export 'src/http_extensions.dart';

--- a/packages/dynamite/dynamite_runtime/test/client_test.dart
+++ b/packages/dynamite/dynamite_runtime/test/client_test.dart
@@ -1,3 +1,4 @@
+import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dynamite_runtime/http_client.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';

--- a/packages/neon_framework/lib/src/models/account.dart
+++ b/packages/neon_framework/lib/src/models/account.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:cookie_jar/cookie_jar.dart';
 import 'package:crypto/crypto.dart';
 import 'package:http/http.dart';
 import 'package:json_annotation/json_annotation.dart';

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   built_collection: ^5.0.0
   collection: ^1.0.0
+  cookie_jar: ^4.0.0
   crypto: ^3.0.0
   cupertino_icons: ^1.0.0
   dynamic_color: ^1.0.0

--- a/packages/nextcloud/lib/nextcloud.dart
+++ b/packages/nextcloud/lib/nextcloud.dart
@@ -1,11 +1,5 @@
 export 'package:dynamite_runtime/http_client.dart'
-    show
-        BytesStreamExtension,
-        CookieJar,
-        DynamiteApiException,
-        DynamiteRawResponse,
-        DynamiteResponse,
-        DynamiteStatusCodeException;
+    show BytesStreamExtension, DynamiteApiException, DynamiteRawResponse, DynamiteResponse, DynamiteStatusCodeException;
 export 'package:dynamite_runtime/models.dart';
 
 export 'ids.dart';

--- a/packages/nextcloud_test/lib/src/test_client.dart
+++ b/packages/nextcloud_test/lib/src/test_client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:cookie_jar/cookie_jar.dart';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud_test/src/docker_container.dart';
 import 'package:nextcloud_test/src/fixtures.dart';

--- a/packages/nextcloud_test/pubspec.yaml
+++ b/packages/nextcloud_test/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 
 dependencies:
   built_collection: ^5.0.0
+  cookie_jar: ^4.0.8
   dynamite_runtime: ^0.1.0
   http: ^1.2.0
   meta: ^1.0.0


### PR DESCRIPTION
…t is persiststent

#1434 for dynamite_runtime
towards:: #1536 

Long term we should use the neon sqflite backend for this (I'll open an issue after this lands).
