### PR TITLE
feat(neon_framework): add testing library to consolidate mocks and ot…

### DIFF
--- a/packages/neon/neon_dashboard/test/widget_test.dart
+++ b/packages/neon/neon_dashboard/test/widget_test.dart
@@ -11,14 +11,12 @@ import 'package:neon_dashboard/src/widgets/widget_button.dart';
 import 'package:neon_dashboard/src/widgets/widget_item.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
+import 'package:neon_framework/testing.dart';
 import 'package:neon_framework/theme.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
 import 'package:nextcloud/dashboard.dart' as dashboard;
 import 'package:rxdart/rxdart.dart';
-
-// ignore: subtype_of_sealed_class
-class MockAccountsBloc extends Mock implements AccountsBloc {}
 
 class MockCacheManager extends Mock implements DefaultCacheManager {}
 
@@ -37,7 +35,7 @@ Widget wrapWidget(AccountsBloc accountsBloc, Widget child) => MaterialApp(
 void main() {
   NeonCachedImage.cacheManager = MockCacheManager();
 
-  final accountsBloc = MockAccountsBloc();
+  final accountsBloc = AccountsBlocMock();
   when(() => accountsBloc.activeAccount).thenAnswer(
     (invocation) => BehaviorSubject.seeded(
       Account(

--- a/packages/neon_framework/lib/src/testing/mocks.dart
+++ b/packages/neon_framework/lib/src/testing/mocks.dart
@@ -1,0 +1,52 @@
+// ignore_for_file: avoid_implementing_value_types, public_member_api_docs, missing_override_of_must_be_overridden
+
+import 'dart:async';
+
+// ignore: depend_on_referenced_packages
+import 'package:mocktail/mocktail.dart';
+import 'package:neon_framework/blocs.dart';
+import 'package:neon_framework/models.dart';
+import 'package:neon_framework/platform.dart';
+import 'package:neon_framework/settings.dart';
+import 'package:neon_framework/src/blocs/apps.dart';
+import 'package:neon_framework/src/blocs/capabilities.dart';
+import 'package:neon_framework/src/models/disposable.dart';
+import 'package:neon_framework/src/settings/models/exportable.dart';
+import 'package:neon_framework/src/settings/models/storage.dart';
+import 'package:neon_framework/src/utils/account_options.dart';
+import 'package:neon_framework/src/utils/request_manager.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AccountMock extends Mock implements Account {}
+
+class AppImplementationMock extends Mock implements AppImplementation {}
+
+class AccountsBlocMock extends Mock implements AccountsBloc {}
+
+class MockNeonPlatform extends Mock implements NeonPlatform {}
+
+class DisposableMock extends Mock implements Disposable {}
+
+class MockUserStatusBloc extends Mock implements UserStatusBloc {}
+
+class MockAppsBloc extends Mock implements AppsBloc {}
+
+class MockCapabilitiesBloc extends Mock implements CapabilitiesBloc {}
+
+class MockStorage extends Mock implements SettingsStorage {}
+
+class AccountOptionsMock extends Mock implements AccountOptions {}
+
+class ExporterMock extends Mock implements Exportable {}
+
+class OptionMock extends Mock implements ToggleOption {}
+
+class AppImplementationOptionsMock extends Mock implements AppImplementationOptions {}
+
+class MockedCache extends Mock implements Cache {}
+
+class SharedPreferencesMock extends Mock implements SharedPreferences {}
+
+class MockCallbackFunction<T> extends Mock {
+  FutureOr<T> call();
+}

--- a/packages/neon_framework/lib/src/testing/utils.dart
+++ b/packages/neon_framework/lib/src/testing/utils.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:neon_framework/src/theme/theme.dart';
+import 'package:neon_framework/utils.dart';
+
+/// An application used in testing that wraps it's children in a configured
+/// `MaterialApp`.
+class TestApp extends StatelessWidget {
+  /// Creates a new TestApp to wrap a child in a `MaterialApp`.
+  const TestApp({
+    this.child,
+    this.platform = TargetPlatform.android,
+    this.locale = const Locale('en'),
+    this.wrapMaterial = true,
+    super.key,
+  });
+
+  /// The widget below this widget in the tree.
+  ///
+  /// {@macro flutter.widgets.ProxyWidget.child}
+  final Widget? child;
+
+  /// The platform to use for the apps theme.
+  final TargetPlatform platform;
+
+  /// Whether to wrap the child in a `Material` widget.
+  ///
+  /// Most widgets require a `Material` ancestor so the child will be wrapped
+  /// in one if the [platform] is not a cupertino one.
+  /// In golden tests it is encouraged to be disabled when possible to avoid
+  /// changes and background colors.
+  ///
+  /// Defaults to `true`.
+  final bool wrapMaterial;
+
+  /// {@macro flutter.widgets.widgetsApp.locale}
+  final Locale locale;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = AppTheme.test(platform: platform);
+
+    var child = this.child;
+    if (wrapMaterial && platform != TargetPlatform.iOS && platform != TargetPlatform.macOS) {
+      child = Material(child: child);
+    }
+
+    return MaterialApp(
+      theme: theme.lightTheme,
+      localizationsDelegates: NeonLocalizations.localizationsDelegates,
+      supportedLocales: NeonLocalizations.supportedLocales,
+      locale: locale,
+      home: child,
+    );
+  }
+}

--- a/packages/neon_framework/lib/testing.dart
+++ b/packages/neon_framework/lib/testing.dart
@@ -1,0 +1,11 @@
+/// Neon testing library.
+///
+/// Contains helper methods, widgets and mocks used throughout the Neon apps.
+/// The mocking library [mocktail](https://pub.dev/packages/mocktail) is used.
+@visibleForTesting
+library;
+
+import 'package:flutter/material.dart';
+
+export 'package:neon_framework/src/testing/mocks.dart';
+export 'package:neon_framework/src/testing/utils.dart';

--- a/packages/neon_framework/test/account_cache_test.dart
+++ b/packages/neon_framework/test/account_cache_test.dart
@@ -1,13 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:neon_framework/models.dart';
 import 'package:neon_framework/src/models/account_cache.dart';
-import 'package:neon_framework/src/models/disposable.dart';
-
-class DisposableMock extends Mock implements Disposable {}
-
-// ignore: avoid_implementing_value_types
-class AccountMock extends Mock implements Account {}
+import 'package:neon_framework/testing.dart';
 
 void main() {
   final disposable0 = DisposableMock();

--- a/packages/neon_framework/test/app_implementation_test.dart
+++ b/packages/neon_framework/test/app_implementation_test.dart
@@ -1,10 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:neon_framework/src/models/app_implementation.dart';
+import 'package:neon_framework/src/testing/mocks.dart';
 import 'package:neon_framework/src/utils/findable.dart';
-
-// ignore: missing_override_of_must_be_overridden, avoid_implementing_value_types
-class AppImplementationMock extends Mock implements AppImplementation {}
 
 void main() {
   group('group name', () {

--- a/packages/neon_framework/test/dialog_test.dart
+++ b/packages/neon_framework/test/dialog_test.dart
@@ -4,34 +4,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/l10n/localizations_en.dart';
-import 'package:neon_framework/models.dart';
-import 'package:neon_framework/src/theme/theme.dart';
 import 'package:neon_framework/src/widgets/dialog.dart';
-import 'package:neon_framework/theme.dart';
+import 'package:neon_framework/testing.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:nextcloud/user_status.dart' as user_status;
 import 'package:rxdart/rxdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
-// ignore: avoid_implementing_value_types
-class MockAccount extends Mock implements Account {}
-
-class MockAccountsBloc extends Mock implements AccountsBloc {}
-
-class MockUserStatusBloc extends Mock implements UserStatusBloc {}
-
-Widget wrapDialog(Widget dialog, [TargetPlatform platform = TargetPlatform.android]) {
-  final theme = AppTheme.test(platform: platform);
-  const locale = Locale('en');
-
-  return MaterialApp(
-    theme: theme.lightTheme,
-    localizationsDelegates: NeonLocalizations.localizationsDelegates,
-    supportedLocales: NeonLocalizations.supportedLocales,
-    locale: locale,
-    home: dialog,
-  );
-}
 
 void main() {
   group('dialog', () {
@@ -39,7 +17,7 @@ void main() {
       testWidgets('NeonConfirmationDialog widget', (widgetTester) async {
         const title = 'My Title';
         var dialog = const NeonConfirmationDialog(title: title);
-        await widgetTester.pumpWidget(wrapDialog(dialog));
+        await widgetTester.pumpWidget(TestApp(child: dialog));
 
         expect(find.text(title), findsOneWidget);
         expect(find.byType(NeonDialogAction), findsExactly(2));
@@ -53,7 +31,7 @@ void main() {
           isDestructive: false,
         );
 
-        await widgetTester.pumpWidget(wrapDialog(dialog));
+        await widgetTester.pumpWidget(TestApp(child: dialog));
 
         expect(find.byType(NeonDialogAction), findsExactly(2));
         expect(find.byType(OutlinedButton), findsExactly(2));
@@ -69,7 +47,7 @@ void main() {
           confirmAction: confirmAction,
           declineAction: declineAction,
         );
-        await widgetTester.pumpWidget(wrapDialog(dialog));
+        await widgetTester.pumpWidget(TestApp(child: dialog));
 
         expect(find.byIcon(Icons.error), findsOneWidget);
         expect(find.byKey(const Key('content')), findsOneWidget);
@@ -79,7 +57,7 @@ void main() {
 
       testWidgets('NeonConfirmationDialog actions', (widgetTester) async {
         const title = 'My Title';
-        await widgetTester.pumpWidget(wrapDialog(const Placeholder()));
+        await widgetTester.pumpWidget(const TestApp(child: Placeholder()));
         final context = widgetTester.element(find.byType(Placeholder));
 
         // confirm
@@ -107,7 +85,7 @@ void main() {
         const title = 'My Title';
         const value = 'My value';
         const dialog = NeonRenameDialog(title: title, value: value);
-        await widgetTester.pumpWidget(wrapDialog(dialog));
+        await widgetTester.pumpWidget(const TestApp(child: dialog));
 
         expect(find.text(title), findsExactly(2), reason: 'The title is also used for the confirmation button');
         expect(find.text(value), findsOneWidget);
@@ -117,7 +95,7 @@ void main() {
       testWidgets('NeonRenameDialog actions', (widgetTester) async {
         const title = 'My Title';
         const value = 'My value';
-        await widgetTester.pumpWidget(wrapDialog(const Placeholder()));
+        await widgetTester.pumpWidget(const TestApp(child: Placeholder()));
         final context = widgetTester.element(find.byType(Placeholder));
 
         // Equal value should not submit
@@ -152,7 +130,7 @@ void main() {
         const title = 'My Title';
         const content = 'My content';
         var dialog = const NeonErrorDialog(content: content, title: title);
-        await widgetTester.pumpWidget(wrapDialog(dialog));
+        await widgetTester.pumpWidget(TestApp(child: dialog));
 
         expect(find.byIcon(Icons.error), findsOneWidget);
         expect(find.text(title), findsOneWidget);
@@ -160,14 +138,14 @@ void main() {
         expect(find.byType(NeonDialogAction), findsOneWidget);
 
         dialog = const NeonErrorDialog(content: content);
-        await widgetTester.pumpWidget(wrapDialog(dialog));
+        await widgetTester.pumpWidget(TestApp(child: dialog));
 
         expect(find.text(NeonLocalizationsEn().errorDialog), findsOneWidget);
       });
 
       testWidgets('NeonErrorDialog actions', (widgetTester) async {
         const content = 'My content';
-        await widgetTester.pumpWidget(wrapDialog(const Placeholder()));
+        await widgetTester.pumpWidget(const TestApp(child: Placeholder()));
         final context = widgetTester.element(find.byType(Placeholder));
 
         final result = showErrorDialog(context: context, message: content);
@@ -179,7 +157,7 @@ void main() {
 
     testWidgets('UnimplementedDialog', (widgetTester) async {
       const title = 'My Title';
-      await widgetTester.pumpWidget(wrapDialog(const Placeholder()));
+      await widgetTester.pumpWidget(const TestApp(child: Placeholder()));
       final context = widgetTester.element(find.byType(Placeholder));
 
       final result = showUnimplementedDialog(context: context, title: title);
@@ -192,7 +170,7 @@ void main() {
       var dialog = const NeonDialog(
         actions: [],
       );
-      await widgetTester.pumpWidget(wrapDialog(dialog, TargetPlatform.macOS));
+      await widgetTester.pumpWidget(TestApp(platform: TargetPlatform.macOS, child: dialog));
       expect(
         find.byType(NeonDialogAction),
         findsOneWidget,
@@ -203,31 +181,15 @@ void main() {
         automaticallyShowCancel: false,
         actions: [],
       );
-      await widgetTester.pumpWidget(wrapDialog(dialog, TargetPlatform.macOS));
+      await widgetTester.pumpWidget(TestApp(platform: TargetPlatform.macOS, child: dialog));
       expect(find.byType(NeonDialogAction), findsNothing);
     });
 
     testWidgets('NeonEmojiPickerDialog', (tester) async {
       SharedPreferences.setMockInitialValues({});
 
-      await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: NeonLocalizations.localizationsDelegates,
-          supportedLocales: NeonLocalizations.supportedLocales,
-          theme: ThemeData(
-            extensions: const [
-              NeonTheme(
-                branding: Branding(
-                  name: '',
-                  logo: SizedBox.shrink(),
-                ),
-              ),
-            ],
-          ),
-          home: const SizedBox.shrink(),
-        ),
-      );
-      final BuildContext context = tester.element(find.byType(SizedBox));
+      await tester.pumpWidget(const TestApp(child: Placeholder()));
+      final BuildContext context = tester.element(find.byType(Placeholder));
 
       final future = showDialog<String>(
         context: context,
@@ -301,13 +263,14 @@ void main() {
       when(() => userStatusBloc.status).thenAnswer((_) => status);
       when(() => userStatusBloc.predefinedStatuses).thenAnswer((_) => predefinedStatuses);
 
-      final account = MockAccount();
-      final accountsBloc = MockAccountsBloc();
+      final account = AccountMock();
+      final accountsBloc = AccountsBlocMock();
       when(() => accountsBloc.getUserStatusBlocFor(account)).thenReturn(userStatusBloc);
 
       await tester.pumpWidget(
-        wrapDialog(
-          NeonProvider<AccountsBloc>(
+        TestApp(
+          wrapMaterial: false,
+          child: NeonProvider<AccountsBloc>(
             create: (_) => accountsBloc,
             child: NeonUserStatusDialog(
               account: account,

--- a/packages/neon_framework/test/disposable_test.dart
+++ b/packages/neon_framework/test/disposable_test.dart
@@ -1,8 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/src/models/disposable.dart';
-
-class DisposableMock extends Mock implements Disposable {}
+import 'package:neon_framework/testing.dart';
 
 void main() {
   test('Disposable extensions', () {

--- a/packages/neon_framework/test/drawer_test.dart
+++ b/packages/neon_framework/test/drawer_test.dart
@@ -6,23 +6,13 @@ import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/l10n/localizations.dart';
 import 'package:neon_framework/src/bloc/result.dart';
 import 'package:neon_framework/src/blocs/accounts.dart';
-import 'package:neon_framework/src/blocs/apps.dart';
-import 'package:neon_framework/src/blocs/capabilities.dart';
 import 'package:neon_framework/src/models/app_implementation.dart';
 import 'package:neon_framework/src/utils/provider.dart';
 import 'package:neon_framework/src/widgets/drawer.dart';
 import 'package:neon_framework/src/widgets/drawer_destination.dart';
+import 'package:neon_framework/testing.dart';
 import 'package:nextcloud/core.dart' as core;
 import 'package:rxdart/rxdart.dart';
-
-class MockAccountsBloc extends Mock implements AccountsBloc {}
-
-class MockAppsBloc extends Mock implements AppsBloc {}
-
-class MockCapabilitiesBloc extends Mock implements CapabilitiesBloc {}
-
-// ignore: missing_override_of_must_be_overridden, avoid_implementing_value_types
-class MockAppImplementation extends Mock implements AppImplementation {}
 
 class BuildContextFake extends Fake implements BuildContext {}
 
@@ -32,7 +22,7 @@ void main() {
   });
 
   testWidgets('Drawer', (tester) async {
-    final appImplementation = MockAppImplementation();
+    final appImplementation = AppImplementationMock();
     when(() => appImplementation.id).thenReturn('id');
     when(() => appImplementation.destination(any())).thenReturn(
       NeonNavigationDestination(
@@ -57,7 +47,7 @@ void main() {
     final capabilitiesBloc = MockCapabilitiesBloc();
     when(() => capabilitiesBloc.capabilities).thenAnswer((_) => capabilities);
 
-    final accountsBloc = MockAccountsBloc();
+    final accountsBloc = AccountsBlocMock();
     when(() => accountsBloc.activeAppsBloc).thenReturn(appsBloc);
     when(() => accountsBloc.activeCapabilitiesBloc).thenReturn(capabilitiesBloc);
 

--- a/packages/neon_framework/test/nextcloud_logo_test.dart
+++ b/packages/neon_framework/test/nextcloud_logo_test.dart
@@ -1,29 +1,14 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:neon_framework/l10n/localizations.dart';
 import 'package:neon_framework/l10n/localizations_en.dart';
-import 'package:neon_framework/src/theme/theme.dart';
 import 'package:neon_framework/src/widgets/nextcloud_logo.dart';
+import 'package:neon_framework/testing.dart';
 import 'package:vector_graphics/vector_graphics.dart';
-
-Widget wrapWidget(Widget dialog, [TargetPlatform platform = TargetPlatform.android]) {
-  final theme = AppTheme.test(platform: platform);
-  const locale = Locale('en');
-
-  return MaterialApp(
-    theme: theme.lightTheme,
-    localizationsDelegates: NeonLocalizations.localizationsDelegates,
-    supportedLocales: NeonLocalizations.supportedLocales,
-    locale: locale,
-    home: dialog,
-  );
-}
 
 void main() {
   testWidgets('NextcloudLogo', (widgetTester) async {
     const widget = NextcloudLogo();
 
-    await widgetTester.pumpWidget(wrapWidget(widget));
+    await widgetTester.pumpWidget(const TestApp(wrapMaterial: false, child: widget));
     expect(find.byType(VectorGraphic), findsOneWidget);
     expect(find.bySemanticsLabel(NeonLocalizationsEn().nextcloudLogo), findsOneWidget);
 

--- a/packages/neon_framework/test/option_test.dart
+++ b/packages/neon_framework/test/option_test.dart
@@ -1,18 +1,11 @@
-// ignore_for_file: discarded_futures
-
-import 'dart:async';
+// ignore_for_file: discarded_futures, inference_failure_on_instance_creation
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/src/settings/models/option.dart';
 import 'package:neon_framework/src/settings/models/storage.dart';
-
-class MockStorage extends Mock implements SettingsStorage {}
-
-class MockCallbackFunction extends Mock {
-  FutureOr<void> call();
-}
+import 'package:neon_framework/testing.dart';
 
 enum StorageKey implements Storable {
   key._('storage-key');

--- a/packages/neon_framework/test/options_collection_test.dart
+++ b/packages/neon_framework/test/options_collection_test.dart
@@ -2,9 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/settings.dart';
 import 'package:neon_framework/src/settings/models/storage.dart';
-
-// ignore: missing_override_of_must_be_overridden
-class OptionMock extends Mock implements ToggleOption {}
+import 'package:neon_framework/testing.dart';
 
 class Collection extends AppImplementationOptions {
   Collection(List<Option<Object>> options) : super(const AppStorage(StorageKeys.apps)) {

--- a/packages/neon_framework/test/request_manager_test.dart
+++ b/packages/neon_framework/test/request_manager_test.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: unnecessary_lambdas
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
@@ -7,25 +5,16 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:neon_framework/models.dart';
 import 'package:neon_framework/src/bloc/result.dart';
 import 'package:neon_framework/src/utils/request_manager.dart';
+import 'package:neon_framework/testing.dart';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:rxdart/rxdart.dart';
-
-// ignore: avoid_implementing_value_types
-class MockAccount extends Mock implements Account {}
-
-class MockCallbackFunction<T> extends Mock {
-  FutureOr<T> call();
-}
-
-class MockedCache extends Mock implements Cache {}
 
 String base64String(String value) => base64.encode(utf8.encode(value));
 
 void main() {
-  final account = MockAccount();
+  final account = AccountMock();
   when(() => account.id).thenReturn('clientID');
 
   tearDown(() {

--- a/packages/neon_framework/test/server_icon_test.dart
+++ b/packages/neon_framework/test/server_icon_test.dart
@@ -1,30 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:neon_framework/src/theme/theme.dart';
 import 'package:neon_framework/src/widgets/server_icon.dart';
+import 'package:neon_framework/testing.dart';
 import 'package:vector_graphics/vector_graphics.dart';
-
-Widget wrapWidget(Widget widget, [TargetPlatform platform = TargetPlatform.android]) {
-  final theme = AppTheme.test(platform: platform);
-
-  return MaterialApp(
-    theme: theme.lightTheme,
-    home: widget,
-  );
-}
 
 void main() {
   testWidgets('NeonServerIcon', (widgetTester) async {
     var widget = const NeonServerIcon(icon: 'icon-logo-dark');
 
-    await widgetTester.pumpWidget(wrapWidget(widget));
+    await widgetTester.pumpWidget(TestApp(wrapMaterial: false, child: widget));
     expect(find.byType(VectorGraphic), findsOneWidget);
 
     widget = const NeonServerIcon(
       icon: 'icon-logo-dark',
       colorFilter: ColorFilter.mode(Colors.orange, BlendMode.srcIn),
     );
-    await widgetTester.pumpWidget(wrapWidget(widget));
+    await widgetTester.pumpWidget(TestApp(wrapMaterial: false, child: widget));
 
     await expectLater(find.byType(VectorGraphic), matchesGoldenFile('goldens/neon_server_icon_nextcloud_logo.png'));
   });

--- a/packages/neon_framework/test/settings_export_test.dart
+++ b/packages/neon_framework/test/settings_export_test.dart
@@ -3,28 +3,9 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:neon_framework/src/blocs/accounts.dart';
-import 'package:neon_framework/src/models/account.dart';
-import 'package:neon_framework/src/models/app_implementation.dart';
-import 'package:neon_framework/src/settings/models/exportable.dart';
-import 'package:neon_framework/src/settings/models/options_collection.dart';
 import 'package:neon_framework/src/settings/utils/settings_export_helper.dart';
-import 'package:neon_framework/src/utils/account_options.dart';
+import 'package:neon_framework/testing.dart';
 import 'package:rxdart/rxdart.dart';
-
-// ignore: missing_override_of_must_be_overridden, avoid_implementing_value_types
-class FakeAppImplementation extends Mock implements AppImplementation {}
-
-class AppImplementationOptionsMock extends Mock implements AppImplementationOptions {}
-
-class AccountsBlocMock extends Mock implements AccountsBloc {}
-
-// ignore: avoid_implementing_value_types
-class FakeAccount extends Mock implements Account {}
-
-class AccountOptionsMock extends Mock implements AccountOptions {}
-
-class ExporterMock extends Mock implements Exportable {}
 
 void main() {
   group('Exporter', () {
@@ -34,7 +15,7 @@ void main() {
       var export = exporter.export();
       expect(Map.fromEntries([export]), {'app': <String, dynamic>{}});
 
-      final fakeApp = FakeAppImplementation();
+      final fakeApp = AppImplementationMock();
       final fakeOptions = AppImplementationOptionsMock();
       exporter = AppImplementationsExporter([fakeApp]);
 
@@ -67,7 +48,7 @@ void main() {
       var export = exporter.export();
       expect(Map.fromEntries([export]), {'accounts': <String, dynamic>{}});
 
-      final fakeAccount = FakeAccount();
+      final fakeAccount = AccountMock();
       final fakeOptions = AccountOptionsMock();
       when(() => bloc.accounts).thenAnswer((_) => BehaviorSubject.seeded([fakeAccount]));
       when(() => bloc.getOptionsFor(fakeAccount)).thenReturn(fakeOptions);

--- a/packages/neon_framework/test/settings_test.dart
+++ b/packages/neon_framework/test/settings_test.dart
@@ -3,14 +3,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:neon_framework/l10n/localizations.dart';
 import 'package:neon_framework/src/settings/models/option.dart';
 import 'package:neon_framework/src/settings/models/storage.dart';
 import 'package:neon_framework/src/settings/widgets/option_settings_tile.dart';
-import 'package:neon_framework/src/theme/theme.dart';
-
-// ignore: missing_override_of_must_be_overridden
-class MockStorage extends Mock implements SettingsStorage {}
+import 'package:neon_framework/testing.dart';
 
 enum StorageKey implements Storable {
   key._('storage-key');
@@ -25,19 +21,6 @@ enum SelectValues {
   first,
   second,
   third,
-}
-
-Widget wrapWidget(Widget widget, [TargetPlatform platform = TargetPlatform.android]) {
-  final theme = AppTheme.test(platform: platform);
-  const locale = Locale('en');
-
-  return MaterialApp(
-    theme: theme.lightTheme,
-    localizationsDelegates: NeonLocalizations.localizationsDelegates,
-    supportedLocales: NeonLocalizations.supportedLocales,
-    locale: locale,
-    home: Material(child: widget),
-  );
 }
 
 void main() {
@@ -59,7 +42,7 @@ void main() {
         defaultValue: true,
       );
 
-      final widget = wrapWidget(OptionSettingsTile(option: option));
+      final widget = TestApp(child: OptionSettingsTile(option: option));
       await widgetTester.pumpWidget(widget);
 
       expect(find.text('label'), findsOneWidget);
@@ -91,7 +74,7 @@ void main() {
       });
 
       testWidgets('ToggleOption material', (widgetTester) async {
-        final widget = wrapWidget(OptionSettingsTile(option: option));
+        final widget = TestApp(child: OptionSettingsTile(option: option));
         await widgetTester.pumpWidget(widget);
 
         expect(find.text('label'), findsOneWidget);
@@ -116,7 +99,7 @@ void main() {
       });
 
       testWidgets('ToggleOption cupertino', (widgetTester) async {
-        final widget = wrapWidget(OptionSettingsTile(option: option), TargetPlatform.macOS);
+        final widget = TestApp(platform: TargetPlatform.macOS, child: OptionSettingsTile(option: option));
         await widgetTester.pumpWidget(widget);
 
         expect(find.text('label'), findsOneWidget);

--- a/packages/neon_framework/test/storage_test.dart
+++ b/packages/neon_framework/test/storage_test.dart
@@ -1,9 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/src/settings/models/storage.dart';
+import 'package:neon_framework/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
-class SharedPreferencesMock extends Mock implements SharedPreferences {}
 
 void main() {
   test('NeonStorage', () async {

--- a/packages/neon_framework/test/stream_listenable_test.dart
+++ b/packages/neon_framework/test/stream_listenable_test.dart
@@ -3,17 +3,14 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/src/utils/stream_listenable.dart';
+import 'package:neon_framework/testing.dart';
 import 'package:rxdart/rxdart.dart';
-
-class MockCallbackFunction extends Mock {
-  FutureOr<void> call();
-}
 
 void main() {
   group('StreamListenable', () {
     test('stream', () async {
       final stream = BehaviorSubject<bool>();
-      final callback = MockCallbackFunction();
+      final callback = MockCallbackFunction<void>();
 
       StreamListenable(stream).addListener(callback.call);
 
@@ -33,7 +30,7 @@ void main() {
     test('multiStream', () async {
       final stream = BehaviorSubject<bool>();
       final stream2 = BehaviorSubject<int>();
-      final callback = MockCallbackFunction();
+      final callback = MockCallbackFunction<void>();
 
       StreamListenable.multiListenable({
         stream,

--- a/packages/neon_framework/test/user_status_bloc_test.dart
+++ b/packages/neon_framework/test/user_status_bloc_test.dart
@@ -7,10 +7,9 @@ import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/platform.dart';
 import 'package:neon_framework/src/models/account.dart';
+import 'package:neon_framework/testing.dart';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/user_status.dart' as user_status;
-
-class MockNeonPlatform extends Mock implements NeonPlatform {}
 
 Account mockUserStatusAccount() {
   var messageIsPredefined = false;

--- a/packages/neon_framework/test/validation_tile_test.dart
+++ b/packages/neon_framework/test/validation_tile_test.dart
@@ -1,47 +1,28 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:neon_framework/l10n/localizations.dart';
-import 'package:neon_framework/src/theme/theme.dart';
 import 'package:neon_framework/src/widgets/validation_tile.dart';
-
-Widget wrapWidget(Widget widget, [TargetPlatform platform = TargetPlatform.android]) {
-  final theme = AppTheme.test(platform: platform);
-  const locale = Locale('en');
-
-  var child = widget;
-  if (platform != TargetPlatform.iOS && platform != TargetPlatform.macOS) {
-    child = Material(child: child);
-  }
-
-  return MaterialApp(
-    theme: theme.lightTheme,
-    localizationsDelegates: NeonLocalizations.localizationsDelegates,
-    supportedLocales: NeonLocalizations.supportedLocales,
-    locale: locale,
-    home: child,
-  );
-}
+import 'package:neon_framework/testing.dart';
 
 void main() {
   group('NeonValidationTile', () {
     testWidgets('NeonValidationTile material', (widgetTester) async {
       var widget = const NeonValidationTile(title: 'title', state: ValidationState.loading);
-      await widgetTester.pumpWidget(wrapWidget(widget));
+      await widgetTester.pumpWidget(TestApp(child: widget));
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
       // We do not change the theme throughout the test so getting once is enough.
       final theme = (widgetTester.firstWidget(find.byType(Theme)) as Theme).data;
 
       widget = const NeonValidationTile(title: 'title', state: ValidationState.failure);
-      await widgetTester.pumpWidget(wrapWidget(widget));
+      await widgetTester.pumpWidget(TestApp(child: widget));
       var iconFinder = find.byIcon(Icons.error_outline);
       expect(iconFinder, findsOneWidget);
       var icon = widgetTester.firstWidget(iconFinder) as Icon;
       expect(icon.color, theme.colorScheme.error);
 
       widget = const NeonValidationTile(title: 'title', state: ValidationState.canceled);
-      await widgetTester.pumpWidget(wrapWidget(widget));
+      await widgetTester.pumpWidget(TestApp(child: widget));
       iconFinder = find.byIcon(Icons.cancel_outlined);
       expect(iconFinder, findsOneWidget);
       icon = widgetTester.firstWidget(iconFinder) as Icon;
@@ -50,7 +31,7 @@ void main() {
       expect(text.style?.color, theme.disabledColor);
 
       widget = const NeonValidationTile(title: 'title', state: ValidationState.success);
-      await widgetTester.pumpWidget(wrapWidget(widget));
+      await widgetTester.pumpWidget(TestApp(child: widget));
       iconFinder = find.byIcon(Icons.check_circle);
       expect(iconFinder, findsOneWidget);
       icon = widgetTester.firstWidget(iconFinder) as Icon;
@@ -60,7 +41,7 @@ void main() {
     testWidgets('NeonValidationTile cupertino', (widgetTester) async {
       const widget = NeonValidationTile(title: 'title', state: ValidationState.canceled);
 
-      await widgetTester.pumpWidget(wrapWidget(widget, TargetPlatform.macOS));
+      await widgetTester.pumpWidget(const TestApp(platform: TargetPlatform.macOS, child: widget));
       expect(find.byType(CupertinoListTile), findsOneWidget);
     });
   });


### PR DESCRIPTION
…her common testing infrastructure

solves: #1520
The dashboard tests still have a custom `wrapWidget` but chaning it does also change the goldens (which I try to avoid) and something with the NeonCachedImage was throwing so I left it for now.