### PR TITLE
chore(app): Update pubspec.lock

### DIFF
--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -236,10 +236,10 @@ packages:
     dependency: transitive
     description:
       name: emoji_picker_flutter
-      sha256: "8506341d62efd116d6fb1481450bffdbac659d3d90d46d9cc610bfae5f33cc54"
+      sha256: "5e9ba37aa2763bb627e8452986bea2e88704f54b90a2fe5aa2b2b20d3102ecdd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.4"
+    version: "2.0.0"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/neon/pull/1557 which was missing this change.