### PR TITLE
fix(tool): Add Husky support for Windows

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-fvm dart run commitlint_cli --edit "$1"
+FLUTTER_SDK="$(pwd)/.fvm/flutter_sdk/bin"
+
+"$FLUTTER_SDK/dart" run commitlint_cli --edit "$1"


### PR DESCRIPTION
Hi guys! When using Husky on Windows, it runs through git bash and does not recognize the `fvm` command.

I tried to fix the problem with this commit