### PR TITLE
fix(neon_dashboard): Correctly center statuses in case some are missing

### DIFF
--- a/packages/neon/neon_dashboard/lib/src/pages/main.dart
+++ b/packages/neon/neon_dashboard/lib/src/pages/main.dart
@@ -230,13 +230,7 @@ class DashboardMainPage extends StatelessWidget {
               },
             ),
           ),
-        ]
-            .intersperse(
-              const SizedBox(
-                width: 20,
-              ),
-            )
-            .toList(),
+        ],
       );
 
   Widget _buildStatus({
@@ -245,17 +239,20 @@ class DashboardMainPage extends StatelessWidget {
     required Widget label,
     required VoidCallback onPressed,
   }) =>
-      ActionChip(
-        avatar: icon,
-        label: label,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(50),
-          side: BorderSide(
-            color: Theme.of(context).colorScheme.primary,
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        child: ActionChip(
+          avatar: icon,
+          label: label,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(50),
+            side: BorderSide(
+              color: Theme.of(context).colorScheme.primary,
+            ),
           ),
+          padding: const EdgeInsets.all(15),
+          onPressed: onPressed,
         ),
-        padding: const EdgeInsets.all(15),
-        onPressed: onPressed,
       );
 
   /// Builds the list of messages, [items] and buttons for a [widget].


### PR DESCRIPTION
In case the weather status was disabled a widget would still be returned and the intersperse would insert a spacing. Each status needs to individually add the padding so that it is only there in case it is actually displayed.