### PR TITLE
feat(neon_framework)!: encrypt storages as sqlcypher databases

### DIFF
--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -9,6 +9,7 @@ persistences
 playstore
 postmarket
 provokateurin
+sqlcipher
 subroutes
 uncategorized
 upsert

--- a/packages/app/linux/CMakeLists.txt
+++ b/packages/app/linux/CMakeLists.txt
@@ -2,6 +2,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(runner LANGUAGES CXX)
 
+# SQLCipher do not bundle openssl
+# https://github.com/simolus3/sqlite3.dart/issues/186
+set(OPENSSL_USE_STATIC_LIBS OFF)
+
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
 set(BINARY_NAME "nextcloud-neon")

--- a/packages/app/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/app/linux/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <dynamic_color/dynamic_color_plugin.h>
 #include <emoji_picker_flutter/emoji_picker_flutter_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
@@ -23,6 +24,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
   screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);

--- a/packages/app/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/app/linux/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
+#include <sqlcipher_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
@@ -30,6 +31,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
   screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);
+  g_autoptr(FlPluginRegistrar) sqlcipher_flutter_libs_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
+  sqlite3_flutter_libs_plugin_register_with_registrar(sqlcipher_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/packages/app/linux/flutter/generated_plugins.cmake
+++ b/packages/app/linux/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   flutter_secure_storage_linux
   screen_retriever
+  sqlcipher_flutter_libs
   url_launcher_linux
   window_manager
 )

--- a/packages/app/linux/flutter/generated_plugins.cmake
+++ b/packages/app/linux/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
   emoji_picker_flutter
   file_selector_linux
+  flutter_secure_storage_linux
   screen_retriever
   url_launcher_linux
   window_manager

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -217,14 +217,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.3"
-  dev_build:
-    dependency: transitive
-    description:
-      name: dev_build
-      sha256: e5d575f3de4b0e5f004e065e1e2d98fa012d634b61b5855216b5698ed7f1e443
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.16.4+3"
   dynamic_color:
     dependency: transitive
     description:
@@ -972,22 +964,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.7.4"
-  pool:
-    dependency: transitive
-    description:
-      name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.5.1"
-  process_run:
-    dependency: transitive
-    description:
-      name: process_run
-      sha256: cad2c57a34f8313a4182e34e31e0b2f12972eef3d0930cdc7ab3240bb8cad380
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.14.1+3"
   provider:
     dependency: transitive
     description:
@@ -1184,14 +1160,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
-  sqflite:
-    dependency: transitive
-    description:
-      name: sqflite
-      sha256: a9016f495c927cb90557c909ff26a6d92d9bd54fc42ba92e19d4e79d61e798c6
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.2"
   sqflite_common:
     dependency: transitive
     description:
@@ -1208,14 +1176,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2+1"
-  sqflite_common_ffi_web:
+  sqlcipher_flutter_libs:
     dependency: transitive
     description:
-      name: sqflite_common_ffi_web
-      sha256: "0c2921454d2e4a227675fb952be9fef916cf65fb9e9b606b54cfdf080d3e9450"
+      name: sqlcipher_flutter_libs
+      sha256: "60fe3444ff5b1b298a9ca3003c6c7f1f7ee4c90aa6035a8647f3aeaf05a073e2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2+3"
+    version: "0.6.1"
   sqlite3:
     dependency: transitive
     description:

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -417,6 +417,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.17"
+  flutter_secure_storage:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage
+      sha256: ffdbb60130e4665d2af814a0267c481bcf522c41ae2e43caf69fa0146876d685
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: "3d5032e314774ee0e1a7d0a9f5e2793486f0dff2dd9ef5a23f4e3fb2a0ae6a9e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: bd33935b4b628abd0b86c8ca20655c5b36275c3a3f5194769a7b3f37c905369c
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: "0d4d3a5dd4db28c96ae414d7ba3b8422fd735a8255642774803b2532c9a61d7e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "30f84f102df9dcdaa2241866a958c2ec976902ebdaa8883fbfe525f1f2f3cf20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: "5809c66f9dd3b4b93b0a6e2e8561539405322ee767ac2f64d084e2ab5429d108"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_svg:
     dependency: transitive
     description:
@@ -459,6 +507,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.2.0"
+  hex:
+    dependency: transitive
+    description:
+      name: hex
+      sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   html:
     dependency: transitive
     description:

--- a/packages/neon_framework/lib/src/platform/android.dart
+++ b/packages/neon_framework/lib/src/platform/android.dart
@@ -3,6 +3,9 @@ import 'dart:typed_data';
 import 'package:flutter_file_dialog/flutter_file_dialog.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/src/platform/platform.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:sqlcipher_flutter_libs/sqlcipher_flutter_libs.dart';
+import 'package:sqlite3/open.dart' as sqlite3;
 
 /// Android specific platform information.
 ///
@@ -41,7 +44,13 @@ class AndroidNeonPlatform implements NeonPlatform {
   bool get canUsePaths => true;
 
   @override
-  void init() {}
+  void init() {
+    databaseFactory = createDatabaseFactoryFfi(ffiInit: _ffiInit);
+  }
+
+  static void _ffiInit() {
+    sqlite3.open.overrideFor(sqlite3.OperatingSystem.android, openCipherOnAndroid);
+  }
 
   @override
   Future<void> saveFileWithPickDialog(String fileName, String mimeType, Uint8List data) async {

--- a/packages/neon_framework/lib/src/platform/linux.dart
+++ b/packages/neon_framework/lib/src/platform/linux.dart
@@ -44,8 +44,7 @@ class LinuxNeonPlatform implements NeonPlatform {
 
   @override
   void init() {
-    sqfliteFfiInit();
-    databaseFactory = databaseFactoryFfi;
+    databaseFactory = createDatabaseFactoryFfi();
   }
 
   @override

--- a/packages/neon_framework/lib/src/platform/web.dart
+++ b/packages/neon_framework/lib/src/platform/web.dart
@@ -4,8 +4,6 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:neon_framework/src/platform/platform.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
-import 'package:sqflite_common_ffi_web/sqflite_ffi_web.dart';
 import 'package:web/web.dart';
 
 @immutable
@@ -39,9 +37,7 @@ class WebNeonPlatform implements NeonPlatform {
   bool get canUsePaths => false;
 
   @override
-  FutureOr<void> init() {
-    databaseFactory = databaseFactoryFfiWeb;
-  }
+  void init() {}
 
   @override
   Future<String?> saveFileWithPickDialog(String fileName, String mimeType, Uint8List data) async {

--- a/packages/neon_framework/lib/src/storage/keys.dart
+++ b/packages/neon_framework/lib/src/storage/keys.dart
@@ -9,6 +9,12 @@ abstract interface class Storable {
   String get value;
 }
 
+/// Mixin class that uses the `name` of an `Enum` as the storage key.
+mixin StorableEnum on Enum implements Storable {
+  @override
+  String get value => name;
+}
+
 /// Unique storage keys.
 ///
 /// Required by the users of the `NeonStorage` storage backend.

--- a/packages/neon_framework/lib/src/storage/secure_persistence.dart
+++ b/packages/neon_framework/lib/src/storage/secure_persistence.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show PlatformException;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:meta/meta.dart' show internal;
+import 'package:neon_framework/src/storage/persistence.dart';
+
+/// An FlutterSecureStorage backed persistence persisting values encrypted at rest.
+@immutable
+@internal
+final class SecurePersistence implements Persistence<String> {
+  /// Creates a new secure storage.
+  const SecurePersistence();
+
+  static const FlutterSecureStorage _storage = FlutterSecureStorage();
+
+  @override
+  Future<bool> clear() async {
+    try {
+      await _storage.deleteAll();
+    } on PlatformException catch (e) {
+      debugPrint(e.toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  Future<bool> remove(String key) async {
+    try {
+      await _storage.delete(key: key);
+    } on PlatformException catch (e) {
+      debugPrint(e.toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  Future<bool> setValue(String key, String value) async {
+    try {
+      await _storage.write(key: key, value: value);
+    } on PlatformException catch (e) {
+      debugPrint(e.toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  Future<bool> containsKey(String key) async {
+    try {
+      final result = await _storage.containsKey(key: key);
+      return result;
+    } on PlatformException catch (e) {
+      debugPrint(e.toString());
+    }
+
+    return false;
+  }
+
+  @override
+  Future<String?> getValue(String key) async {
+    try {
+      final value = await _storage.read(key: key);
+      return value;
+    } on PlatformException catch (e) {
+      debugPrint(e.toString());
+    }
+
+    return null;
+  }
+}

--- a/packages/neon_framework/lib/src/storage/secure_storage.dart
+++ b/packages/neon_framework/lib/src/storage/secure_storage.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/foundation.dart';
+import 'package:hex/hex.dart';
+import 'package:meta/meta.dart' show internal;
+import 'package:neon_framework/src/storage/keys.dart';
+import 'package:neon_framework/src/storage/persistence.dart';
+import 'package:neon_framework/src/storage/secure_persistence.dart';
+import 'package:neon_framework/src/utils/rng.dart';
+
+/// Storable keys for the [SecureStorage].
+@internal
+enum SecureStorageKeys with StorableEnum implements Storable {
+  /// Ued to store the encryption key for the `StorageManager`.
+  encryption;
+}
+
+/// Storage to persist data encrypted on the device.
+@internal
+abstract interface class SecureStorage {
+  /// Reads the hex encoded encryption key from storage if available.
+  ///
+  /// If no key has been saved yet a new cryptographically secure 256bit key
+  /// is generated and saved.
+  Future<String> get encryptionKey;
+}
+
+/// Default SecureStorage implementation.
+///
+/// Leverages the `https://pub.dev/packages/flutter_secure_storage` to persist
+/// values encrypted on the device.
+///
+/// Performance might be slow for big data so it is recommended to only store
+/// encryption keys and persist the encrypted separately.
+@immutable
+@internal
+final class NeonSecureStorage implements SecureStorage {
+  /// Creates a new secure storage.
+  const NeonSecureStorage([this.persistence = const SecurePersistence()]);
+
+  @protected
+  final Persistence<String> persistence;
+
+  @override
+  Future<String> get encryptionKey async {
+    final key = SecureStorageKeys.encryption.value;
+    var value = await persistence.getValue(key);
+
+    if (value != null) {
+      return value;
+    }
+
+    value ??= HEX.encode(const CryptoRNG().generate());
+    await persistence.setValue(key, value);
+
+    return value;
+  }
+}

--- a/packages/neon_framework/lib/src/storage/sqlite_persistence.dart
+++ b/packages/neon_framework/lib/src/storage/sqlite_persistence.dart
@@ -1,0 +1,213 @@
+// ignore_for_file: cascade_invocations
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart' show internal;
+import 'package:neon_framework/src/storage/persistence.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+/// An SQLite backed cached persistence for preferences.
+///
+/// There is only one cache backing all `SQLitePersistence` instances.
+/// Use the [prefix] to separate different storages.
+/// Keys within a storage must be unique.
+///
+/// The persistence must be initialized with by calling `SQLitePersistence().init()`
+/// and awaiting it's completion. If it has not yet initialized a `StateError`
+/// will be thrown.
+@internal
+final class SQLitePersistence extends CachedPersistence {
+  /// Creates a new sqlite persistence.
+  SQLitePersistence({this.prefix = ''});
+
+  /// The prefix of this persistence.
+  ///
+  /// Keys within it must be unique.
+  final String prefix;
+
+  @override
+  Map<String, Object> get cache => globalCache[prefix] ??= {};
+
+  @visibleForTesting
+  static final Map<String, Map<String, Object>> globalCache = {};
+
+  @visibleForTesting
+  static Database? database;
+
+  /// Initializes all persistences by setting up the backing SQLite database
+  /// and priming the global cache.
+  ///
+  /// This must be called and completed before any sqlite persistence.
+  static Future<void> init(String encryptionKey) async {
+    if (database != null) {
+      return;
+    }
+
+    final appDir = await getApplicationSupportDirectory();
+    database = await openDatabase(
+      p.join(appDir.path, 'preferences.db'),
+      version: 1,
+      onConfigure: (db) async {
+        final cipherVersion = await db.rawQuery('PRAGMA cipher_version');
+        if (cipherVersion.isEmpty) {
+          // Make sure that we're actually using SQLCipher, since the pragma used to encrypt
+          // databases just fails silently with regular sqlite3 (meaning that we'd accidentally
+          // use plaintext databases).
+          throw StateError('SQLCipher library is not available, please check your dependencies!');
+        }
+
+        // Set the encryption key for the database
+        await db.execute("PRAGMA KEY=\"x'$encryptionKey'\"");
+      },
+      onCreate: onCreate,
+    );
+
+    await getAll();
+  }
+
+  @visibleForTesting
+  static Future<void> onCreate(Database db, int version) async {
+    await db.execute('''
+CREATE TABLE "preferences" (
+	"prefix"	TEXT NOT NULL,
+	"key"	TEXT NOT NULL,
+	"value"	TEXT NOT NULL,
+	PRIMARY KEY("prefix","key"),
+	UNIQUE("key","prefix")
+);
+''');
+  }
+
+  static Database get _requireDatabase {
+    if (database == null) {
+      throw StateError(
+        'Persistence has not been set up yet. Please make sure SQLitePersistence.init() has been called before and completed.',
+      );
+    }
+
+    return database!;
+  }
+
+  @visibleForTesting
+  static Future<void> getAll() async {
+    try {
+      final results = await _requireDatabase.rawQuery('SELECT * FROM preferences');
+
+      globalCache.clear();
+      for (final result in results) {
+        final prefix = result['prefix']! as String;
+        final key = result['key']! as String;
+        final value = result['value']! as String;
+
+        final cache = globalCache[prefix] ??= {};
+        cache[key] = _decode(value) as Object;
+      }
+    } on DatabaseException catch (e) {
+      debugPrint(e.toString());
+    }
+  }
+
+  @override
+  Future<bool> clear() async {
+    try {
+      await _requireDatabase.rawDelete('DELETE FROM preferences WHERE prefix = ?', [prefix]);
+      cache.clear();
+    } on DatabaseException catch (e) {
+      debugPrint(e.toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  Future<void> reload() async {
+    try {
+      final fromSystem = <String, Object>{};
+
+      final results = await _requireDatabase.rawQuery('SELECT key, value FROM preferences WHERE prefix = ?', [prefix]);
+      for (final result in results) {
+        final key = result['key']! as String;
+        final value = result['value']! as String;
+
+        fromSystem[key] = _decode(value) as Object;
+      }
+
+      cache.clear();
+      cache.addAll(fromSystem);
+    } on DatabaseException catch (e) {
+      debugPrint(e.toString());
+    }
+  }
+
+  @override
+  Future<bool> remove(String key) async {
+    cache.remove(key);
+
+    try {
+      await _requireDatabase.rawDelete('DELETE FROM preferences WHERE prefix = ? AND key = ?', [prefix, key]);
+    } on DatabaseException catch (e) {
+      debugPrint(e.toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  Future<bool> setValue(String key, Object value) async {
+    cache[key] = value;
+
+    final serialized = _encode(value);
+
+    try {
+      await _requireDatabase.execute(
+        '''
+INSERT INTO preferences (prefix, key, value)
+VALUES (?, ?, ?)
+ON CONFLICT (prefix, key) DO UPDATE 
+SET value = excluded.value
+''',
+        [prefix, key, serialized],
+      );
+    } on DatabaseException catch (e) {
+      debugPrint(e.toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  static dynamic _decode(String source) => jsonDecode(
+        source,
+        reviver: (key, value) {
+          switch (value) {
+            case List():
+              return BuiltList<dynamic>.from(value);
+            case Map():
+              return BuiltMap<dynamic, dynamic>.from(value);
+            case _:
+              return value;
+          }
+        },
+      );
+
+  static String _encode(Object? object) => jsonEncode(
+        object,
+        toEncodable: (nonEncodable) {
+          switch (nonEncodable) {
+            case BuiltList():
+              return nonEncodable.toList();
+            case BuiltMap():
+              return nonEncodable.toMap();
+            case _:
+              return nonEncodable;
+          }
+        },
+      );
+}

--- a/packages/neon_framework/lib/src/testing/mocks.dart
+++ b/packages/neon_framework/lib/src/testing/mocks.dart
@@ -51,7 +51,9 @@ class MockNeonStorage extends Mock implements NeonStorage {
   }
 }
 
-class MockPersistence extends Mock implements CachedPersistence {}
+class MockCachedPersistence<T extends Object> extends Mock implements CachedPersistence<T> {}
+
+class MockPersistence<T extends Object> extends Mock implements Persistence<T> {}
 
 class MockSettingsStore extends Mock implements SettingsStore {}
 

--- a/packages/neon_framework/lib/src/utils/rng.dart
+++ b/packages/neon_framework/lib/src/utils/rng.dart
@@ -1,0 +1,32 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+/// Cryptographically secure random number generator.
+///
+/// Copied from `https://github.com/daegalus/dart-uuid/blob/4.3.3/lib/rng.dart`.
+class CryptoRNG {
+  /// Creates a new secure random number generator.
+  const CryptoRNG();
+
+  static final _secureRandom = math.Random.secure();
+
+  /// Generates a unmodifiable list with [length] random bytes.
+  ///
+  /// Length must be a positive multiple of `4`.
+  Uint8List generate([int length = 32]) {
+    if (length < 0 || length % 4 != 0) {
+      throw ArgumentError.value(length, 'length', 'must be a positive multiple of 4.');
+    }
+
+    final b = Uint8List(length);
+    for (var i = 0; i < length; i += 4) {
+      final k = _secureRandom.nextInt(math.pow(2, 32) as int);
+      b[i] = k;
+      b[i + 1] = k >> 8;
+      b[i + 2] = k >> 16;
+      b[i + 3] = k >> 24;
+    }
+
+    return b.asUnmodifiableView();
+  }
+}

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.1.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
   flutter: '>=3.13.0'
 
 dependencies:
@@ -26,9 +26,11 @@ dependencies:
     sdk: flutter
   flutter_material_design_icons: ^1.0.0
   flutter_native_splash: ^2.0.0
+  flutter_secure_storage: ^9.0.0
   flutter_svg: ^2.0.0
   flutter_zxing: ^1.0.0
   go_router: ^13.0.0
+  hex: ^0.2.0
   http: ^1.0.0
   image: ^4.0.0
   intersperse: ^2.0.0

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -51,9 +51,9 @@ dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/sort_box
-  sqflite: ^2.3.0
-  sqflite_common_ffi: ^2.3.2
-  sqflite_common_ffi_web: ^0.4.2+3
+  sqflite_common_ffi: ^2.2.8-2
+  sqlcipher_flutter_libs: ^0.6.1
+  sqlite3: ^2.3.0
   unifiedpush: ^5.0.0
   unifiedpush_android: ^2.0.0
   universal_io: ^2.0.0

--- a/packages/neon_framework/test/persistence_test.dart
+++ b/packages/neon_framework/test/persistence_test.dart
@@ -1,7 +1,9 @@
 // ignore_for_file: unnecessary_lambdas
 
 import 'package:built_collection/built_collection.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:neon_framework/src/storage/secure_persistence.dart';
 import 'package:neon_framework/src/storage/shared_preferences_persistence.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
@@ -148,6 +150,32 @@ void main() {
         await persistence.reload();
         expect(persistence.containsKey('key'), isTrue);
       });
+    });
+
+    test('FlutterSecureStorage', () async {
+      FlutterSecureStorage.setMockInitialValues({
+        'key2': 'value2',
+      });
+
+      const persistence = SecurePersistence();
+
+      dynamic result = await persistence.containsKey('key');
+      expect(result, isFalse);
+
+      result = await persistence.setValue('key', 'value');
+      expect(result, isTrue);
+      result = await persistence.getValue('key');
+      expect(result, equals('value'));
+
+      result = await persistence.remove('key');
+      expect(result, isTrue);
+      result = await persistence.containsKey('key');
+      expect(result, isFalse);
+
+      result = await persistence.clear();
+      expect(result, isTrue);
+      result = await persistence.containsKey('key2');
+      expect(result, isFalse);
     });
   });
 }

--- a/packages/neon_framework/test/rng_test.dart
+++ b/packages/neon_framework/test/rng_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neon_framework/src/utils/rng.dart';
+
+void main() {
+  group('CryptoRNG', () {
+    const rng = CryptoRNG();
+
+    test('lengths', () {
+      expect(() => rng.generate(-1), throwsA(isA<ArgumentError>()));
+      expect(() => rng.generate(5), throwsA(isA<ArgumentError>()));
+
+      expect(rng.generate(0), hasLength(0));
+      expect(rng.generate(4), hasLength(4));
+    });
+
+    test('not equal', () {
+      expect(rng.generate(), isNot(equals(rng.generate())));
+    });
+
+    test('unmodifiable', () {
+      final random = rng.generate(4);
+
+      expect(() => random[2] = 5, throwsA(isA<Error>()));
+    });
+  });
+}


### PR DESCRIPTION
fixes: #1538, #1280

While sqlcipher supports migrating unencrypted databases I did not consider it in the scope of this PR.
We would need to create a ne db file and then migrate ...
Please make sure to remove the old cache as the DB might otherwise throw.
I also suggest cleaning your build cache with something like `melos exec flutter clean` as otherwise cmake might fail.

 I've tested it on both linux and android but only verified on linux that the db is actually encrypted.