### PR TITLE
refactor(neon_framework): Make AppImplementations a BuiltSet

### DIFF
--- a/packages/app/lib/apps.dart
+++ b/packages/app/lib/apps.dart
@@ -1,3 +1,4 @@
+import 'package:built_collection/built_collection.dart';
 import 'package:neon_dashboard/neon_dashboard.dart';
 import 'package:neon_files/neon_files.dart';
 import 'package:neon_framework/models.dart';
@@ -6,10 +7,10 @@ import 'package:neon_notes/neon_notes.dart';
 import 'package:neon_notifications/neon_notifications.dart';
 
 /// The collection of clients enabled for the Neon app.
-final Set<AppImplementation> appImplementations = {
+final BuiltSet<AppImplementation> appImplementations = BuiltSet({
   DashboardApp(),
   FilesApp(),
   NewsApp(),
   NotesApp(),
   NotificationsApp(),
-};
+});

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -58,7 +58,7 @@ packages:
     source: hosted
     version: "1.1.1"
   built_collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   flutter: '>=3.16.0'
 
 dependencies:
+  built_collection: ^5.0.0
   flutter:
     sdk: flutter
   neon_dashboard:

--- a/packages/neon/neon_notifications/lib/src/pages/main.dart
+++ b/packages/neon/neon_notifications/lib/src/pages/main.dart
@@ -65,7 +65,7 @@ class _NotificationsMainPageState extends State<NotificationsMainPage> {
     BuildContext context,
     notifications.Notification notification,
   ) {
-    final app = NeonProvider.of<Iterable<AppImplementation>>(context).tryFind(notification.app);
+    final app = NeonProvider.of<BuiltSet<AppImplementation>>(context).tryFind(notification.app);
 
     return ListTile(
       title: Text(notification.subject),

--- a/packages/neon_framework/lib/neon.dart
+++ b/packages/neon_framework/lib/neon.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:neon_framework/src/app.dart';
@@ -23,7 +24,7 @@ import 'package:provider/provider.dart';
 ///
 /// Optionally provide a [theme] to set the default style.
 Future<void> runNeon({
-  required Set<AppImplementation> appImplementations,
+  required BuiltSet<AppImplementation> appImplementations,
   required NeonTheme theme,
   @visibleForTesting WidgetsBinding? bindingOverride,
   @visibleForTesting Account? account,
@@ -72,7 +73,7 @@ Future<void> runNeon({
         NeonProvider<AccountsBloc>.value(value: accountsBloc),
         NeonProvider<FirstLaunchBloc>.value(value: firstLaunchBloc),
         NeonProvider<NextPushBloc>.value(value: nextPushBloc),
-        Provider<Iterable<AppImplementation>>(
+        Provider<BuiltSet<AppImplementation>>(
           create: (_) => appImplementations,
           dispose: (_, appImplementations) => appImplementations.disposeAll(),
         ),

--- a/packages/neon_framework/lib/src/app.dart
+++ b/packages/neon_framework/lib/src/app.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:collection/collection.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
@@ -55,7 +56,7 @@ class NeonApp extends StatefulWidget {
 class _NeonAppState extends State<NeonApp> with WidgetsBindingObserver, WindowListener {
   final _appRegex = RegExp(r'^app_([a-z]+)$', multiLine: true);
   final _navigatorKey = GlobalKey<NavigatorState>();
-  late final Iterable<AppImplementation> _appImplementations;
+  late final BuiltSet<AppImplementation> _appImplementations;
   late final GlobalOptions _globalOptions;
   late final AccountsBloc _accountsBloc;
   late final _routerDelegate = buildAppRouter(
@@ -67,7 +68,7 @@ class _NeonAppState extends State<NeonApp> with WidgetsBindingObserver, WindowLi
   void initState() {
     super.initState();
 
-    _appImplementations = NeonProvider.of<Iterable<AppImplementation>>(context);
+    _appImplementations = NeonProvider.of<BuiltSet<AppImplementation>>(context);
     _globalOptions = NeonProvider.of<GlobalOptions>(context);
     _accountsBloc = NeonProvider.of<AccountsBloc>(context);
 
@@ -114,7 +115,7 @@ class _NeonAppState extends State<NeonApp> with WidgetsBindingObserver, WindowLi
             return;
           }
 
-          final allAppImplementations = NeonProvider.of<Iterable<AppImplementation>>(context);
+          final allAppImplementations = NeonProvider.of<BuiltSet<AppImplementation>>(context);
           final app = allAppImplementations.tryFind(AppIDs.notifications) as NotificationsAppInterface?;
 
           if (app == null) {
@@ -130,7 +131,7 @@ class _NeonAppState extends State<NeonApp> with WidgetsBindingObserver, WindowLi
           }
           _accountsBloc.setActiveAccount(account);
 
-          final allAppImplementations = NeonProvider.of<Iterable<AppImplementation>>(context);
+          final allAppImplementations = NeonProvider.of<BuiltSet<AppImplementation>>(context);
 
           final notificationsApp = allAppImplementations.tryFind(AppIDs.notifications) as NotificationsAppInterface?;
           if (notificationsApp != null) {

--- a/packages/neon_framework/lib/src/blocs/accounts.dart
+++ b/packages/neon_framework/lib/src/blocs/accounts.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
@@ -29,7 +30,7 @@ abstract interface class AccountsBloc implements Disposable {
   @internal
   factory AccountsBloc(
     GlobalOptions globalOptions,
-    Iterable<AppImplementation> allAppImplementations,
+    BuiltSet<AppImplementation> allAppImplementations,
   ) =>
       _AccountsBloc(
         globalOptions,
@@ -203,7 +204,7 @@ class _AccountsBloc extends Bloc implements AccountsBloc {
   }
 
   final GlobalOptions globalOptions;
-  final Iterable<AppImplementation> allAppImplementations;
+  final BuiltSet<AppImplementation> allAppImplementations;
 
   final accountsOptions = AccountCache<AccountOptions>();
   final appsBlocs = AccountCache<AppsBloc>();

--- a/packages/neon_framework/lib/src/blocs/apps.dart
+++ b/packages/neon_framework/lib/src/blocs/apps.dart
@@ -27,7 +27,7 @@ abstract class AppsBloc implements InteractiveBloc {
     CapabilitiesBloc capabilitiesBloc,
     AccountsBloc accountsBloc,
     Account account,
-    Iterable<AppImplementation> allAppImplementations,
+    BuiltSet<AppImplementation> allAppImplementations,
   ) =>
       _AppsBloc(
         capabilitiesBloc,
@@ -45,7 +45,7 @@ abstract class AppsBloc implements InteractiveBloc {
   /// A collection of clients used in the app drawer.
   ///
   /// It does not contain clients for that are specially handled like for the notifications.
-  BehaviorSubject<Result<Iterable<AppImplementation>>> get appImplementations;
+  BehaviorSubject<Result<BuiltSet<AppImplementation>>> get appImplementations;
 
   /// The interface of the notifications app.
   BehaviorSubject<Result<NotificationsAppInterface?>> get notificationsAppImplementation;
@@ -213,13 +213,13 @@ class _AppsBloc extends InteractiveBloc implements AppsBloc {
     return null;
   }
 
-  Iterable<AppImplementation> filteredAppImplementations(Iterable<String> appIds) =>
-      allAppImplementations.where((a) => appIds.contains(a.id));
+  BuiltSet<AppImplementation> filteredAppImplementations(Iterable<String> appIds) =>
+      BuiltSet(allAppImplementations.where((a) => appIds.contains(a.id)));
 
   final CapabilitiesBloc capabilitiesBloc;
   final AccountsBloc accountsBloc;
   final Account account;
-  final Iterable<AppImplementation> allAppImplementations;
+  final BuiltSet<AppImplementation> allAppImplementations;
   final apps = BehaviorSubject<Result<BuiltList<core.NavigationEntry>>>();
 
   @override
@@ -238,7 +238,7 @@ class _AppsBloc extends InteractiveBloc implements AppsBloc {
   BehaviorSubject<AppImplementation> activeApp = BehaviorSubject();
 
   @override
-  BehaviorSubject<Result<Iterable<AppImplementation<Bloc, AppImplementationOptions>>>> appImplementations =
+  BehaviorSubject<Result<BuiltSet<AppImplementation<Bloc, AppImplementationOptions>>>> appImplementations =
       BehaviorSubject();
 
   @override

--- a/packages/neon_framework/lib/src/pages/home.dart
+++ b/packages/neon_framework/lib/src/pages/home.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/l10n/localizations.dart';
@@ -107,7 +108,7 @@ class _HomePageState extends State<HomePage> {
         if (unifiedSearchEnabledSnapshot.data ?? false) {
           return const NeonUnifiedSearchResults();
         }
-        return ResultBuilder<Iterable<AppImplementation>>.behaviorSubject(
+        return ResultBuilder<BuiltSet<AppImplementation>>.behaviorSubject(
           subject: _appsBloc.appImplementations,
           builder: (context, appImplementations) {
             if (!appImplementations.hasData) {

--- a/packages/neon_framework/lib/src/pages/settings.dart
+++ b/packages/neon_framework/lib/src/pages/settings.dart
@@ -1,3 +1,4 @@
+import 'package:built_collection/built_collection.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -84,7 +85,7 @@ class _SettingsPageState extends State<SettingsPage> {
   Widget build(BuildContext context) {
     final globalOptions = NeonProvider.of<GlobalOptions>(context);
     final accountsBloc = NeonProvider.of<AccountsBloc>(context);
-    final appImplementations = NeonProvider.of<Iterable<AppImplementation>>(context);
+    final appImplementations = NeonProvider.of<BuiltSet<AppImplementation>>(context);
     final branding = Branding.of(context);
 
     final appBar = AppBar(
@@ -415,7 +416,7 @@ class _SettingsPageState extends State<SettingsPage> {
   SettingsExportHelper _buildSettingsExportHelper(BuildContext context) {
     final globalOptions = NeonProvider.of<GlobalOptions>(context);
     final accountsBloc = NeonProvider.of<AccountsBloc>(context);
-    final appImplementations = NeonProvider.of<Iterable<AppImplementation>>(context);
+    final appImplementations = NeonProvider.of<BuiltSet<AppImplementation>>(context);
 
     return SettingsExportHelper(
       exportables: {

--- a/packages/neon_framework/lib/src/router.dart
+++ b/packages/neon_framework/lib/src/router.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -464,7 +465,7 @@ class AppImplementationSettingsRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    final appImplementations = NeonProvider.of<Iterable<AppImplementation>>(context);
+    final appImplementations = NeonProvider.of<BuiltSet<AppImplementation>>(context);
     final appImplementation = appImplementations.tryFind(appid)!;
 
     return AppImplementationSettingsPage(appImplementation: appImplementation);

--- a/packages/neon_framework/lib/src/settings/utils/settings_export_helper.dart
+++ b/packages/neon_framework/lib/src/settings/utils/settings_export_helper.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/src/blocs/accounts.dart';
 import 'package:neon_framework/src/models/account.dart' show Account;
@@ -9,7 +10,6 @@ import 'package:neon_framework/src/models/app_implementation.dart';
 import 'package:neon_framework/src/settings/models/exportable.dart';
 import 'package:neon_framework/src/settings/models/option.dart';
 import 'package:neon_framework/src/storage/keys.dart';
-
 import 'package:neon_framework/src/utils/findable.dart';
 
 /// Helper class to export all [Option]s.
@@ -84,7 +84,7 @@ class AppImplementationsExporter implements Exportable {
   const AppImplementationsExporter(this.appImplementations);
 
   /// List of apps to export.
-  final Iterable<AppImplementation> appImplementations;
+  final BuiltSet<AppImplementation> appImplementations;
 
   /// Key the exported value will be stored at.
   static final _key = StorageKeys.apps.value;

--- a/packages/neon_framework/lib/src/widgets/app_bar.dart
+++ b/packages/neon_framework/lib/src/widgets/app_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/l10n/localizations.dart';
@@ -64,7 +65,7 @@ class _NeonAppBarState extends State<NeonAppBar> {
   }
 
   @override
-  Widget build(BuildContext context) => ResultBuilder<Iterable<AppImplementation>>.behaviorSubject(
+  Widget build(BuildContext context) => ResultBuilder<BuiltSet<AppImplementation>>.behaviorSubject(
         subject: appsBloc.appImplementations,
         builder: (context, appImplementations) => StreamBuilder(
           stream: appsBloc.activeApp,

--- a/packages/neon_framework/test/drawer_test.dart
+++ b/packages/neon_framework/test/drawer_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -36,7 +37,7 @@ void main() {
       ),
     );
 
-    final appImplementations = BehaviorSubject<Result<Iterable<AppImplementation>>>();
+    final appImplementations = BehaviorSubject<Result<BuiltSet<AppImplementation>>>();
     final activeApp = BehaviorSubject<AppImplementation>();
     final appsBloc = MockAppsBloc();
     when(() => appsBloc.activeApp).thenAnswer((_) => activeApp);
@@ -69,7 +70,7 @@ void main() {
     expect(find.byType(NavigationDrawerDestination), findsOne);
 
     activeApp.add(appImplementation);
-    appImplementations.add(Result.success([appImplementation]));
+    appImplementations.add(Result.success(BuiltSet({appImplementation})));
 
     await tester.pumpAndSettle();
 

--- a/packages/neon_framework/test/settings_export_test.dart
+++ b/packages/neon_framework/test/settings_export_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/src/settings/utils/settings_export_helper.dart';
@@ -10,14 +11,14 @@ import 'package:rxdart/rxdart.dart';
 void main() {
   group('Exporter', () {
     test('AccountsBlocExporter', () {
-      var exporter = const AppImplementationsExporter([]);
+      var exporter = AppImplementationsExporter(BuiltSet());
 
       var export = exporter.export();
       expect(Map.fromEntries([export]), {'app': <String, dynamic>{}});
 
       final fakeApp = MockAppImplementation();
       final fakeOptions = MockAppImplementationOptions();
-      exporter = AppImplementationsExporter([fakeApp]);
+      exporter = AppImplementationsExporter(BuiltSet({fakeApp}));
 
       const appValue = MapEntry('appID', 'value');
       const appExport = {


### PR DESCRIPTION
We only accept a Set to begin with, so we can make it a Set everywhere.