### PR TITLE
refactor: Remove unnecessary generic type arguments

### DIFF
--- a/packages/neon/neon_dashboard/lib/src/blocs/dashboard.dart
+++ b/packages/neon/neon_dashboard/lib/src/blocs/dashboard.dart
@@ -47,7 +47,7 @@ class _DashboardBloc extends InteractiveBloc implements DashboardBloc {
         }
       }
 
-      await Future.wait<void>([
+      await Future.wait([
         if (v1WidgetIDs.isNotEmpty)
           RequestManager.instance.wrapNextcloud(
             account: account,
@@ -85,10 +85,10 @@ class _DashboardBloc extends InteractiveBloc implements DashboardBloc {
   static const int maxItems = 7;
 
   @override
-  final widgets = BehaviorSubject<Result<BuiltList<dashboard.Widget>>>();
+  final widgets = BehaviorSubject();
 
   @override
-  final items = BehaviorSubject<Result<BuiltMap<String, dashboard.WidgetItems>>>();
+  final items = BehaviorSubject();
 
   @override
   void dispose() {

--- a/packages/neon/neon_dashboard/test/widget_test.dart
+++ b/packages/neon/neon_dashboard/test/widget_test.dart
@@ -21,7 +21,7 @@ Widget wrapWidget(AccountsBloc accountsBloc, Widget child) => MaterialApp(
       supportedLocales: DashboardLocalizations.supportedLocales,
       home: Scaffold(
         backgroundColor: Colors.transparent,
-        body: NeonProvider<AccountsBloc>.value(
+        body: NeonProvider.value(
           value: accountsBloc,
           child: child,
         ),

--- a/packages/neon/neon_files/lib/src/blocs/browser.dart
+++ b/packages/neon/neon_files/lib/src/blocs/browser.dart
@@ -87,14 +87,14 @@ class _FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBloc {
   }
 
   @override
-  BehaviorSubject<Result<List<WebDavFile>>> files = BehaviorSubject<Result<List<WebDavFile>>>();
+  final files = BehaviorSubject();
 
   @override
-  BehaviorSubject<PathUri> uri = BehaviorSubject.seeded(PathUri.cwd());
+  final uri = BehaviorSubject.seeded(PathUri.cwd());
 
   @override
   Future<void> refresh() async {
-    await RequestManager.instance.wrapWebDav<List<WebDavFile>>(
+    await RequestManager.instance.wrapWebDav(
       account: account,
       cacheKey: 'files-${uri.value.path}',
       subject: files,

--- a/packages/neon/neon_files/lib/src/blocs/files.dart
+++ b/packages/neon/neon_files/lib/src/blocs/files.dart
@@ -87,7 +87,7 @@ class _FilesBloc extends InteractiveBloc implements FilesBloc {
   }
 
   @override
-  BehaviorSubject<List<FilesTask>> tasks = BehaviorSubject<List<FilesTask>>.seeded([]);
+  final tasks = BehaviorSubject.seeded([]);
 
   @override
   void addFavorite(PathUri uri) {

--- a/packages/neon/neon_files/lib/src/widgets/actions.dart
+++ b/packages/neon/neon_files/lib/src/widgets/actions.dart
@@ -80,7 +80,7 @@ class FileActions extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) => PopupMenuButton<FilesFileAction>(
+  Widget build(BuildContext context) => PopupMenuButton(
         itemBuilder: (context) => [
           if (!details.isDirectory && NeonPlatform.instance.canUseSharing)
             PopupMenuItem(

--- a/packages/neon/neon_files/lib/src/widgets/browser_view.dart
+++ b/packages/neon/neon_files/lib/src/widgets/browser_view.dart
@@ -38,11 +38,11 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
   }
 
   @override
-  Widget build(BuildContext context) => ResultBuilder<List<WebDavFile>>.behaviorSubject(
+  Widget build(BuildContext context) => ResultBuilder.behaviorSubject(
         subject: widget.bloc.files,
-        builder: (context, filesSnapshot) => StreamBuilder<PathUri>(
+        builder: (context, filesSnapshot) => StreamBuilder(
           stream: widget.bloc.uri,
-          builder: (context, uriSnapshot) => StreamBuilder<List<FilesTask>>(
+          builder: (context, uriSnapshot) => StreamBuilder(
             stream: widget.filesBloc.tasks,
             builder: (context, tasksSnapshot) {
               if (!uriSnapshot.hasData || !tasksSnapshot.hasData) {
@@ -57,7 +57,7 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
                   }
                   return false;
                 },
-                child: SortBoxBuilder<FilesSortProperty, WebDavFile>(
+                child: SortBoxBuilder(
                   sortBox: filesSortBox,
                   sortProperty: widget.bloc.options.filesSortPropertyOption,
                   sortBoxOrder: widget.bloc.options.filesSortBoxOrderOption,

--- a/packages/neon/neon_files/lib/src/widgets/dialog.dart
+++ b/packages/neon/neon_files/lib/src/widgets/dialog.dart
@@ -226,7 +226,7 @@ class FilesChooseFolderDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final dialogTheme = NeonDialogTheme.of(context);
 
-    return StreamBuilder<PathUri>(
+    return StreamBuilder(
       stream: bloc.uri,
       builder: (context, uriSnapshot) {
         final actions = [

--- a/packages/neon/neon_files/lib/src/widgets/file_list_tile.dart
+++ b/packages/neon/neon_files/lib/src/widgets/file_list_tile.dart
@@ -91,7 +91,7 @@ class _FileIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     Widget icon = Center(
       child: details.hasTask
-          ? StreamBuilder<double>(
+          ? StreamBuilder(
               stream: details.task!.progress,
               builder: (context, progress) => Column(
                 children: [

--- a/packages/neon/neon_files/lib/src/widgets/file_preview.dart
+++ b/packages/neon/neon_files/lib/src/widgets/file_preview.dart
@@ -44,7 +44,7 @@ class FilePreview extends StatelessWidget {
             );
           }
 
-          return ValueListenableBuilder<bool>(
+          return ValueListenableBuilder(
             valueListenable: bloc.options.showPreviewsOption,
             builder: (context, showPreviews, _) {
               if (showPreviews && (details.hasPreview ?? false)) {

--- a/packages/neon/neon_news/lib/src/blocs/article.dart
+++ b/packages/neon/neon_news/lib/src/blocs/article.dart
@@ -58,10 +58,10 @@ class _NewsArticleBloc extends InteractiveBloc implements NewsArticleBloc {
   }
 
   @override
-  BehaviorSubject<bool> starred = BehaviorSubject<bool>();
+  final starred = BehaviorSubject();
 
   @override
-  BehaviorSubject<bool> unread = BehaviorSubject<bool>();
+  final unread = BehaviorSubject();
 
   @override
   Future<void> refresh() async {}

--- a/packages/neon/neon_news/lib/src/blocs/articles.dart
+++ b/packages/neon/neon_news/lib/src/blocs/articles.dart
@@ -99,10 +99,10 @@ class _NewsArticlesBloc extends InteractiveBloc implements NewsArticlesBloc {
   }
 
   @override
-  BehaviorSubject<Result<BuiltList<news.Article>>> articles = BehaviorSubject<Result<BuiltList<news.Article>>>();
+  final articles = BehaviorSubject();
 
   @override
-  BehaviorSubject<FilterType> filterType = BehaviorSubject<FilterType>();
+  final filterType = BehaviorSubject();
 
   @override
   Future<void> refresh() async {
@@ -145,7 +145,7 @@ class _NewsArticlesBloc extends InteractiveBloc implements NewsArticlesBloc {
         }
     }
 
-    await RequestManager.instance.wrapNextcloud<BuiltList<news.Article>, news.ListArticles, void>(
+    await RequestManager.instance.wrapNextcloud(
       account: account,
       cacheKey: 'news-articles-${type.index}-$id-$getRead',
       subject: articles,

--- a/packages/neon/neon_news/lib/src/blocs/news.dart
+++ b/packages/neon/neon_news/lib/src/blocs/news.dart
@@ -94,31 +94,31 @@ class _NewsBloc extends InteractiveBloc implements NewsBloc, NewsMainArticlesBlo
   }
 
   @override
-  BehaviorSubject<Result<BuiltList<news.Feed>>> feeds = BehaviorSubject<Result<BuiltList<news.Feed>>>();
+  final feeds = BehaviorSubject();
 
   @override
-  BehaviorSubject<Result<BuiltList<news.Folder>>> folders = BehaviorSubject<Result<BuiltList<news.Folder>>>();
+  final folders = BehaviorSubject();
 
   @override
-  BehaviorSubject<int> unreadCounter = BehaviorSubject<int>();
+  final unreadCounter = BehaviorSubject();
 
   @override
-  late BehaviorSubject<Result<BuiltList<news.Article>>> articles = mainArticlesBloc.articles;
+  late final articles = mainArticlesBloc.articles;
 
   @override
-  late BehaviorSubject<FilterType> filterType = mainArticlesBloc.filterType;
+  late final filterType = mainArticlesBloc.filterType;
 
   @override
   Future<void> refresh() async {
     await Future.wait([
-      RequestManager.instance.wrapNextcloud<BuiltList<news.Folder>, news.ListFolders, void>(
+      RequestManager.instance.wrapNextcloud(
         account: account,
         cacheKey: 'news-folders',
         subject: folders,
         rawResponse: account.client.news.listFoldersRaw(),
         unwrap: (response) => response.body.folders,
       ),
-      RequestManager.instance.wrapNextcloud<BuiltList<news.Feed>, news.ListFeeds, void>(
+      RequestManager.instance.wrapNextcloud(
         account: account,
         cacheKey: 'news-feeds',
         subject: feeds,

--- a/packages/neon/neon_news/lib/src/pages/article.dart
+++ b/packages/neon/neon_news/lib/src/pages/article.dart
@@ -136,7 +136,7 @@ class _NewsArticlePageState extends State<NewsArticlePage> {
                     strokeWidth: 2,
                   ),
                 ),
-              StreamBuilder<bool>(
+              StreamBuilder(
                 stream: widget.bloc.starred,
                 builder: (context, starredSnapshot) {
                   final starred = starredSnapshot.data ?? false;
@@ -155,7 +155,7 @@ class _NewsArticlePageState extends State<NewsArticlePage> {
                   );
                 },
               ),
-              StreamBuilder<bool>(
+              StreamBuilder(
                 stream: widget.bloc.unread,
                 builder: (context, unreadSnapshot) {
                   final unread = unreadSnapshot.data ?? false;

--- a/packages/neon/neon_news/lib/src/widgets/articles_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/articles_view.dart
@@ -1,4 +1,3 @@
-import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:html/dom.dart' as html_dom;
 import 'package:html/parser.dart' as html_parser;
@@ -44,11 +43,11 @@ class _NewsArticlesViewState extends State<NewsArticlesView> {
   }
 
   @override
-  Widget build(BuildContext context) => ResultBuilder<BuiltList<news.Feed>>.behaviorSubject(
+  Widget build(BuildContext context) => ResultBuilder.behaviorSubject(
         subject: widget.newsBloc.feeds,
-        builder: (context, feeds) => ResultBuilder<BuiltList<news.Article>>.behaviorSubject(
+        builder: (context, feeds) => ResultBuilder.behaviorSubject(
           subject: widget.bloc.articles,
-          builder: (context, articles) => SortBoxBuilder<ArticlesSortProperty, news.Article>(
+          builder: (context, articles) => SortBoxBuilder(
             sortBox: articlesSortBox,
             sortProperty: widget.newsBloc.options.articlesSortPropertyOption,
             sortBoxOrder: widget.newsBloc.options.articlesSortBoxOrderOption,
@@ -74,11 +73,11 @@ class _NewsArticlesViewState extends State<NewsArticlesView> {
                 );
               },
               topFixedChildren: [
-                StreamBuilder<FilterType>(
+                StreamBuilder(
                   stream: widget.bloc.filterType,
                   builder: (context, selectedFilterTypeSnapshot) => Container(
                     margin: const EdgeInsets.symmetric(horizontal: 15),
-                    child: DropdownButton<FilterType>(
+                    child: DropdownButton(
                       isExpanded: true,
                       value: selectedFilterTypeSnapshot.data,
                       items: [
@@ -87,7 +86,7 @@ class _NewsArticlesViewState extends State<NewsArticlesView> {
                         if (widget.bloc.listType == null) ...[
                           FilterType.starred,
                         ],
-                      ].map<DropdownMenuItem<FilterType>>(
+                      ].map(
                         (a) {
                           late final String label;
                           switch (a) {

--- a/packages/neon/neon_news/lib/src/widgets/dialog.dart
+++ b/packages/neon/neon_news/lib/src/widgets/dialog.dart
@@ -86,7 +86,7 @@ class _NewsAddFeedDialogState extends State<NewsAddFeedDialog> {
       ),
     );
 
-    final folderSelector = ResultBuilder<BuiltList<news.Folder>>.behaviorSubject(
+    final folderSelector = ResultBuilder.behaviorSubject(
       subject: widget.bloc.folders,
       builder: (context, folders) {
         if (folders.hasError) {

--- a/packages/neon/neon_news/lib/src/widgets/feeds_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/feeds_view.dart
@@ -6,7 +6,6 @@ import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
 import 'package:neon_news/l10n/localizations.dart';
 import 'package:neon_news/src/blocs/news.dart';
-import 'package:neon_news/src/options.dart';
 import 'package:neon_news/src/pages/feed.dart';
 import 'package:neon_news/src/sort/feeds.dart';
 import 'package:neon_news/src/widgets/dialog.dart';
@@ -25,11 +24,11 @@ class NewsFeedsView extends StatelessWidget {
   final int? folderID;
 
   @override
-  Widget build(BuildContext context) => ResultBuilder<BuiltList<news.Folder>>.behaviorSubject(
+  Widget build(BuildContext context) => ResultBuilder.behaviorSubject(
         subject: bloc.folders,
-        builder: (context, folders) => ResultBuilder<BuiltList<news.Feed>>.behaviorSubject(
+        builder: (context, folders) => ResultBuilder.behaviorSubject(
           subject: bloc.feeds,
-          builder: (context, feeds) => SortBoxBuilder<FeedsSortProperty, news.Feed>(
+          builder: (context, feeds) => SortBoxBuilder(
             sortBox: feedsSortBox,
             sortProperty: bloc.options.feedsSortPropertyOption,
             sortBoxOrder: bloc.options.feedsSortBoxOrderOption,
@@ -87,7 +86,7 @@ class NewsFeedsView extends StatelessWidget {
                   ),
                 ),
               ),
-            PopupMenuButton<NewsFeedAction>(
+            PopupMenuButton(
               itemBuilder: (context) => [
                 PopupMenuItem(
                   value: NewsFeedAction.showURL,

--- a/packages/neon/neon_news/lib/src/widgets/folder_select.dart
+++ b/packages/neon/neon_news/lib/src/widgets/folder_select.dart
@@ -28,7 +28,7 @@ class NewsFolderSelect extends StatelessWidget {
             child: Text(NewsLocalizations.of(context).folderRoot),
           ),
           ...folders.map(
-            (f) => DropdownMenuItem<news.Folder>(
+            (f) => DropdownMenuItem(
               value: f,
               child: Text(f.name),
             ),

--- a/packages/neon/neon_news/lib/src/widgets/folder_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/folder_view.dart
@@ -31,12 +31,12 @@ class _NewsFolderViewState extends State<NewsFolderView> {
         children: [
           Container(
             margin: const EdgeInsets.symmetric(horizontal: 15),
-            child: DropdownButton<DefaultFolderViewType>(
+            child: DropdownButton(
               isExpanded: true,
               value: _viewType,
               items: option.values.keys
                   .map(
-                    (key) => DropdownMenuItem<DefaultFolderViewType>(
+                    (key) => DropdownMenuItem(
                       value: key,
                       child: Text(option.values[key]!(context)),
                     ),

--- a/packages/neon/neon_news/lib/src/widgets/folders_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/folders_view.dart
@@ -1,4 +1,3 @@
-import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/sort_box.dart';
@@ -6,11 +5,9 @@ import 'package:neon_framework/theme.dart';
 import 'package:neon_framework/widgets.dart';
 import 'package:neon_news/l10n/localizations.dart';
 import 'package:neon_news/src/blocs/news.dart';
-import 'package:neon_news/src/options.dart';
 import 'package:neon_news/src/pages/folder.dart';
 import 'package:neon_news/src/sort/folders.dart';
 import 'package:neon_news/utils/dialog.dart';
-import 'package:nextcloud/news.dart' as news;
 
 class NewsFoldersView extends StatelessWidget {
   const NewsFoldersView({
@@ -21,11 +18,11 @@ class NewsFoldersView extends StatelessWidget {
   final NewsBloc bloc;
 
   @override
-  Widget build(BuildContext context) => ResultBuilder<BuiltList<news.Folder>>.behaviorSubject(
+  Widget build(BuildContext context) => ResultBuilder.behaviorSubject(
         subject: bloc.folders,
-        builder: (context, folders) => ResultBuilder<BuiltList<news.Feed>>.behaviorSubject(
+        builder: (context, folders) => ResultBuilder.behaviorSubject(
           subject: bloc.feeds,
-          builder: (context, feeds) => SortBoxBuilder<FoldersSortProperty, FolderFeedsWrapper>(
+          builder: (context, feeds) => SortBoxBuilder(
             sortBox: foldersSortBox,
             sortProperty: bloc.options.foldersSortPropertyOption,
             sortBoxOrder: bloc.options.foldersSortBoxOrderOption,
@@ -86,7 +83,7 @@ class NewsFoldersView extends StatelessWidget {
           ],
         ),
       ),
-      trailing: PopupMenuButton<NewsFolderAction>(
+      trailing: PopupMenuButton(
         itemBuilder: (context) => [
           PopupMenuItem(
             value: NewsFolderAction.delete,

--- a/packages/neon/neon_notes/lib/src/blocs/note.dart
+++ b/packages/neon/neon_notes/lib/src/blocs/note.dart
@@ -92,7 +92,7 @@ class _NotesNoteBloc extends InteractiveBloc implements NotesNoteBloc {
   }
 
   @override
-  BehaviorSubject<String> category = BehaviorSubject<String>();
+  final category = BehaviorSubject();
 
   @override
   Future<void> refresh() async {}

--- a/packages/neon/neon_notes/lib/src/blocs/notes.dart
+++ b/packages/neon/neon_notes/lib/src/blocs/notes.dart
@@ -60,11 +60,11 @@ class _NotesBloc extends InteractiveBloc implements NotesBloc {
   }
 
   @override
-  BehaviorSubject<Result<BuiltList<notes.Note>>> notesList = BehaviorSubject<Result<BuiltList<notes.Note>>>();
+  final notesList = BehaviorSubject();
 
   @override
   Future<void> refresh() async {
-    await RequestManager.instance.wrapNextcloud<BuiltList<notes.Note>, BuiltList<notes.Note>, void>(
+    await RequestManager.instance.wrapNextcloud(
       account: account,
       cacheKey: 'notes-notes',
       subject: notesList,

--- a/packages/neon/neon_notes/lib/src/widgets/categories_view.dart
+++ b/packages/neon/neon_notes/lib/src/widgets/categories_view.dart
@@ -1,4 +1,3 @@
-import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:neon_framework/blocs.dart';
@@ -7,11 +6,9 @@ import 'package:neon_framework/theme.dart';
 import 'package:neon_framework/widgets.dart';
 import 'package:neon_notes/l10n/localizations.dart';
 import 'package:neon_notes/src/blocs/notes.dart';
-import 'package:neon_notes/src/options.dart';
 import 'package:neon_notes/src/pages/category.dart';
 import 'package:neon_notes/src/sort/categories.dart';
 import 'package:neon_notes/src/utils/category_color.dart';
-import 'package:nextcloud/notes.dart' as notes;
 
 class NotesCategoriesView extends StatelessWidget {
   const NotesCategoriesView({
@@ -22,9 +19,9 @@ class NotesCategoriesView extends StatelessWidget {
   final NotesBloc bloc;
 
   @override
-  Widget build(BuildContext context) => ResultBuilder<BuiltList<notes.Note>>.behaviorSubject(
+  Widget build(BuildContext context) => ResultBuilder.behaviorSubject(
         subject: bloc.notesList,
-        builder: (context, notes) => SortBoxBuilder<CategoriesSortProperty, NoteCategory>(
+        builder: (context, notes) => SortBoxBuilder(
           sortBox: categoriesSortBox,
           sortProperty: bloc.options.categoriesSortPropertyOption,
           sortBoxOrder: bloc.options.categoriesSortBoxOrderOption,

--- a/packages/neon/neon_notes/lib/src/widgets/category_select.dart
+++ b/packages/neon/neon_notes/lib/src/widgets/category_select.dart
@@ -28,7 +28,7 @@ class NotesCategorySelect extends StatelessWidget {
   final VoidCallback onSubmitted;
 
   @override
-  Widget build(BuildContext context) => Autocomplete<String>(
+  Widget build(BuildContext context) => Autocomplete(
         initialValue: initialValue != null
             ? TextEditingValue(
                 text: initialValue!,

--- a/packages/neon/neon_notes/lib/src/widgets/dialog.dart
+++ b/packages/neon/neon_notes/lib/src/widgets/dialog.dart
@@ -1,4 +1,3 @@
-import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/utils.dart';
@@ -6,7 +5,6 @@ import 'package:neon_framework/widgets.dart';
 import 'package:neon_notes/l10n/localizations.dart';
 import 'package:neon_notes/src/blocs/notes.dart';
 import 'package:neon_notes/src/widgets/category_select.dart';
-import 'package:nextcloud/notes.dart' as notes;
 
 /// A dialog for creating a note.
 class NotesCreateNoteDialog extends StatefulWidget {
@@ -61,7 +59,7 @@ class _NotesCreateNoteDialogState extends State<NotesCreateNoteDialog> {
       ),
     );
 
-    final folderSelector = ResultBuilder<BuiltList<notes.Note>>.behaviorSubject(
+    final folderSelector = ResultBuilder.behaviorSubject(
       subject: widget.bloc.notesList,
       builder: (context, notes) {
         if (notes.hasError) {
@@ -149,7 +147,7 @@ class _NotesSelectCategoryDialogState extends State<NotesSelectCategoryDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final folderSelector = ResultBuilder<BuiltList<notes.Note>>.behaviorSubject(
+    final folderSelector = ResultBuilder.behaviorSubject(
       subject: widget.bloc.notesList,
       builder: (context, notes) {
         if (notes.hasError) {

--- a/packages/neon/neon_notes/lib/src/widgets/notes_view.dart
+++ b/packages/neon/neon_notes/lib/src/widgets/notes_view.dart
@@ -1,4 +1,3 @@
-import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:neon_framework/blocs.dart';
@@ -26,9 +25,9 @@ class NotesView extends StatelessWidget {
   final String? category;
 
   @override
-  Widget build(BuildContext context) => ResultBuilder<BuiltList<notes.Note>>.behaviorSubject(
+  Widget build(BuildContext context) => ResultBuilder.behaviorSubject(
         subject: bloc.notesList,
-        builder: (context, notesList) => SortBoxBuilder<NotesSortProperty, notes.Note>(
+        builder: (context, notesList) => SortBoxBuilder(
           sortBox: notesSortBox,
           presort: const {
             (property: NotesSortProperty.favorite, order: SortBoxOrder.ascending),

--- a/packages/neon/neon_notifications/lib/src/blocs/notifications.dart
+++ b/packages/neon/neon_notifications/lib/src/blocs/notifications.dart
@@ -55,16 +55,14 @@ class _NotificationsBloc extends InteractiveBloc implements NotificationsBlocInt
   }
 
   @override
-  BehaviorSubject<Result<BuiltList<notifications.Notification>>> notificationsList =
-      BehaviorSubject<Result<BuiltList<notifications.Notification>>>();
+  final notificationsList = BehaviorSubject();
 
   @override
-  BehaviorSubject<int> unreadCounter = BehaviorSubject<int>();
+  final unreadCounter = BehaviorSubject();
 
   @override
   Future<void> refresh() async {
-    await RequestManager.instance.wrapNextcloud<BuiltList<notifications.Notification>,
-        notifications.EndpointListNotificationsResponseApplicationJson, void>(
+    await RequestManager.instance.wrapNextcloud(
       account: account,
       cacheKey: 'notifications-notifications',
       subject: notificationsList,

--- a/packages/neon/neon_notifications/lib/src/pages/main.dart
+++ b/packages/neon/neon_notifications/lib/src/pages/main.dart
@@ -35,11 +35,11 @@ class _NotificationsMainPageState extends State<NotificationsMainPage> {
   }
 
   @override
-  Widget build(BuildContext context) => ResultBuilder<BuiltList<notifications.Notification>>.behaviorSubject(
+  Widget build(BuildContext context) => ResultBuilder.behaviorSubject(
         subject: bloc.notificationsList,
         builder: (context, notifications) => Scaffold(
           resizeToAvoidBottomInset: false,
-          floatingActionButton: StreamBuilder<int>(
+          floatingActionButton: StreamBuilder(
             stream: bloc.unreadCounter,
             builder: (context, snapshot) {
               final unreadCount = snapshot.data ?? 0;

--- a/packages/neon_framework/lib/src/app.dart
+++ b/packages/neon_framework/lib/src/app.dart
@@ -25,7 +25,6 @@ import 'package:neon_framework/src/utils/localizations.dart';
 import 'package:neon_framework/src/utils/provider.dart';
 import 'package:neon_framework/src/utils/push_utils.dart';
 import 'package:neon_framework/src/widgets/options_collection_builder.dart';
-import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/nextcloud.dart';
 import 'package:quick_actions/quick_actions.dart';
 import 'package:universal_io/io.dart';
@@ -200,11 +199,11 @@ class _NeonAppState extends State<NeonApp> with WidgetsBindingObserver, WindowLi
   Widget build(BuildContext context) => DynamicColorBuilder(
         builder: (deviceThemeLight, deviceThemeDark) => OptionsCollectionBuilder(
           valueListenable: _globalOptions,
-          builder: (context, options, _) => StreamBuilder<Account?>(
+          builder: (context, options, _) => StreamBuilder(
             stream: _accountsBloc.activeAccount,
             builder: (context, activeAccountSnapshot) {
               FlutterNativeSplash.remove();
-              return ResultBuilder<core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data?>.behaviorSubject(
+              return ResultBuilder.behaviorSubject(
                 subject: activeAccountSnapshot.hasData
                     ? _accountsBloc.getCapabilitiesBlocFor(activeAccountSnapshot.data!).capabilities
                     : null,

--- a/packages/neon_framework/lib/src/blocs/accounts.dart
+++ b/packages/neon_framework/lib/src/blocs/accounts.dart
@@ -228,10 +228,10 @@ class _AccountsBloc extends Bloc implements AccountsBloc {
   }
 
   @override
-  BehaviorSubject<BuiltList<Account>> accounts = BehaviorSubject<BuiltList<Account>>.seeded(BuiltList());
+  final accounts = BehaviorSubject.seeded(BuiltList());
 
   @override
-  BehaviorSubject<Account?> activeAccount = BehaviorSubject();
+  final activeAccount = BehaviorSubject();
 
   @override
   void addAccount(Account account) {

--- a/packages/neon_framework/lib/src/blocs/apps.dart
+++ b/packages/neon_framework/lib/src/blocs/apps.dart
@@ -10,7 +10,6 @@ import 'package:neon_framework/src/blocs/capabilities.dart';
 import 'package:neon_framework/src/models/account.dart';
 import 'package:neon_framework/src/models/app_implementation.dart';
 import 'package:neon_framework/src/models/notifications_interface.dart';
-import 'package:neon_framework/src/settings/models/options_collection.dart';
 import 'package:neon_framework/src/utils/findable.dart';
 import 'package:neon_framework/src/utils/request_manager.dart';
 import 'package:nextcloud/core.dart' as core;
@@ -235,20 +234,19 @@ class _AppsBloc extends InteractiveBloc implements AppsBloc {
   }
 
   @override
-  BehaviorSubject<AppImplementation> activeApp = BehaviorSubject();
+  final activeApp = BehaviorSubject();
 
   @override
-  BehaviorSubject<Result<BuiltSet<AppImplementation<Bloc, AppImplementationOptions>>>> appImplementations =
-      BehaviorSubject();
+  final appImplementations = BehaviorSubject();
 
   @override
-  BehaviorSubject<Result<NotificationsAppInterface?>> notificationsAppImplementation = BehaviorSubject();
+  final notificationsAppImplementation = BehaviorSubject();
 
   @override
-  BehaviorSubject<void> openNotifications = BehaviorSubject();
+  final openNotifications = BehaviorSubject();
 
   @override
-  BehaviorSubject<Map<String, VersionCheck>> appVersionChecks = BehaviorSubject();
+  final appVersionChecks = BehaviorSubject();
 
   @override
   Future<void> refresh() async {

--- a/packages/neon_framework/lib/src/blocs/capabilities.dart
+++ b/packages/neon_framework/lib/src/blocs/capabilities.dart
@@ -35,7 +35,7 @@ class _CapabilitiesBloc extends InteractiveBloc implements CapabilitiesBloc {
   }
 
   @override
-  BehaviorSubject<Result<core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data>> capabilities = BehaviorSubject();
+  final capabilities = BehaviorSubject();
 
   @override
   Future<void> refresh() async {

--- a/packages/neon_framework/lib/src/blocs/first_launch.dart
+++ b/packages/neon_framework/lib/src/blocs/first_launch.dart
@@ -38,5 +38,5 @@ class _FirstLaunchBloc extends Bloc implements FirstLaunchBloc {
   }
 
   @override
-  final BehaviorSubject<void> onFirstLaunch = BehaviorSubject();
+  final onFirstLaunch = BehaviorSubject();
 }

--- a/packages/neon_framework/lib/src/blocs/login_check_account.dart
+++ b/packages/neon_framework/lib/src/blocs/login_check_account.dart
@@ -49,7 +49,7 @@ class _LoginCheckAccountBloc extends InteractiveBloc implements LoginCheckAccoun
   }
 
   @override
-  BehaviorSubject<Result<Account>> state = BehaviorSubject();
+  final state = BehaviorSubject();
 
   @override
   Future<void> refresh() async {

--- a/packages/neon_framework/lib/src/blocs/login_check_server_status.dart
+++ b/packages/neon_framework/lib/src/blocs/login_check_server_status.dart
@@ -33,7 +33,7 @@ class _LoginCheckServerStatusBloc extends InteractiveBloc implements LoginCheckS
   }
 
   @override
-  BehaviorSubject<Result<core.Status>> state = BehaviorSubject();
+  final state = BehaviorSubject();
 
   @override
   Future<void> refresh() async {

--- a/packages/neon_framework/lib/src/blocs/login_flow.dart
+++ b/packages/neon_framework/lib/src/blocs/login_flow.dart
@@ -47,10 +47,10 @@ class _LoginFlowBloc extends InteractiveBloc implements LoginFlowBloc {
   }
 
   @override
-  BehaviorSubject<Result<core.LoginFlowV2>> init = BehaviorSubject();
+  final init = BehaviorSubject();
 
   @override
-  late Stream<core.LoginFlowV2Credentials> result = resultController.stream.asBroadcastStream();
+  late final result = resultController.stream.asBroadcastStream();
 
   @override
   Future<void> refresh() async {

--- a/packages/neon_framework/lib/src/blocs/next_push.dart
+++ b/packages/neon_framework/lib/src/blocs/next_push.dart
@@ -92,5 +92,5 @@ class _NextPushBloc extends Bloc implements NextPushBloc {
   }
 
   @override
-  BehaviorSubject<void> onNextPushSupported = BehaviorSubject();
+  final onNextPushSupported = BehaviorSubject();
 }

--- a/packages/neon_framework/lib/src/blocs/unified_search.dart
+++ b/packages/neon_framework/lib/src/blocs/unified_search.dart
@@ -55,11 +55,10 @@ class _UnifiedSearchBloc extends InteractiveBloc implements UnifiedSearchBloc {
   String term = '';
 
   @override
-  BehaviorSubject<bool> enabled = BehaviorSubject.seeded(false);
+  final enabled = BehaviorSubject.seeded(false);
 
   @override
-  BehaviorSubject<Result<Map<core.UnifiedSearchProvider, Result<core.UnifiedSearchResult>>?>> results =
-      BehaviorSubject.seeded(Result.success(null));
+  final results = BehaviorSubject.seeded(Result.success(null));
 
   @override
   void dispose() {

--- a/packages/neon_framework/lib/src/blocs/user_details.dart
+++ b/packages/neon_framework/lib/src/blocs/user_details.dart
@@ -33,7 +33,7 @@ class _UserDetailsBloc extends InteractiveBloc implements UserDetailsBloc {
   }
 
   @override
-  BehaviorSubject<Result<provisioning_api.UserDetails>> userDetails = BehaviorSubject();
+  final userDetails = BehaviorSubject();
 
   @override
   Future<void> refresh() async {

--- a/packages/neon_framework/lib/src/blocs/user_status.dart
+++ b/packages/neon_framework/lib/src/blocs/user_status.dart
@@ -82,17 +82,17 @@ class _UserStatusBloc extends InteractiveBloc implements UserStatusBloc {
   }
 
   @override
-  final status = BehaviorSubject<Result<user_status.$PublicInterface>>();
+  final status = BehaviorSubject();
 
   @override
-  final statuses = BehaviorSubject<Map<String, Result<user_status.$PublicInterface>>>.seeded({});
+  final statuses = BehaviorSubject.seeded({});
 
   @override
-  final predefinedStatuses = BehaviorSubject<Result<BuiltList<user_status.Predefined>>>();
+  final predefinedStatuses = BehaviorSubject();
 
   @override
   Future<void> refresh() async {
-    await Future.wait<void>([
+    await Future.wait([
       RequestManager.instance.wrapNextcloud(
         account: account,
         cacheKey: 'user_status-predefined-statuses',

--- a/packages/neon_framework/lib/src/blocs/weather_status.dart
+++ b/packages/neon_framework/lib/src/blocs/weather_status.dart
@@ -68,13 +68,13 @@ class _WeatherStatusBloc extends InteractiveBloc implements WeatherStatusBloc {
   }
 
   @override
-  final isSupported = BehaviorSubject<bool>();
+  final isSupported = BehaviorSubject();
 
   @override
-  final location = BehaviorSubject<Result<weather_status.$LocationInterface>>();
+  final location = BehaviorSubject();
 
   @override
-  final forecasts = BehaviorSubject<Result<BuiltList<weather_status.Forecast>>>();
+  final forecasts = BehaviorSubject();
 
   @override
   Future<void> refresh() async {

--- a/packages/neon_framework/lib/src/pages/account_settings.dart
+++ b/packages/neon_framework/lib/src/pages/account_settings.dart
@@ -15,7 +15,6 @@ import 'package:neon_framework/src/theme/dialog.dart';
 import 'package:neon_framework/src/utils/adaptive.dart';
 import 'package:neon_framework/src/widgets/dialog.dart';
 import 'package:neon_framework/src/widgets/error.dart';
-import 'package:nextcloud/provisioning_api.dart' as provisioning_api;
 
 /// Account settings page.
 ///
@@ -105,7 +104,7 @@ class AccountSettingsPage extends StatelessWidget {
         SettingsCategory(
           title: Text(NeonLocalizations.of(context).accountOptionsCategoryStorageInfo),
           tiles: [
-            ResultBuilder<provisioning_api.UserDetails>.behaviorSubject(
+            ResultBuilder.behaviorSubject(
               subject: userDetailsBloc.userDetails,
               builder: (context, userDetails) {
                 if (userDetails.hasError) {

--- a/packages/neon_framework/lib/src/pages/home.dart
+++ b/packages/neon_framework/lib/src/pages/home.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/l10n/localizations.dart';
@@ -8,7 +7,6 @@ import 'package:neon_framework/src/bloc/result.dart';
 import 'package:neon_framework/src/blocs/accounts.dart';
 import 'package:neon_framework/src/blocs/apps.dart';
 import 'package:neon_framework/src/models/account.dart';
-import 'package:neon_framework/src/models/app_implementation.dart';
 import 'package:neon_framework/src/utils/dialog.dart';
 import 'package:neon_framework/src/utils/global_options.dart' as global_options;
 import 'package:neon_framework/src/utils/global_popups.dart';
@@ -108,7 +106,7 @@ class _HomePageState extends State<HomePage> {
         if (unifiedSearchEnabledSnapshot.data ?? false) {
           return const NeonUnifiedSearchResults();
         }
-        return ResultBuilder<BuiltSet<AppImplementation>>.behaviorSubject(
+        return ResultBuilder.behaviorSubject(
           subject: _appsBloc.appImplementations,
           builder: (context, appImplementations) {
             if (!appImplementations.hasData) {

--- a/packages/neon_framework/lib/src/utils/global_options.dart
+++ b/packages/neon_framework/lib/src/utils/global_options.dart
@@ -7,7 +7,6 @@ import 'package:neon_framework/src/models/label_builder.dart';
 import 'package:neon_framework/src/settings/models/option.dart';
 import 'package:neon_framework/src/settings/models/options_collection.dart';
 import 'package:neon_framework/src/storage/keys.dart';
-
 import 'package:neon_framework/storage.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -119,7 +118,7 @@ class GlobalOptions extends OptionsCollection {
   }
 
   /// The theme mode of the app implementing the Neon framework.
-  late final themeMode = SelectOption(
+  late final themeMode = SelectOption<ThemeMode>(
     storage: storage,
     key: GlobalOptionKeys.themeMode,
     label: (context) => NeonLocalizations.of(context).globalOptionsThemeMode,
@@ -233,7 +232,7 @@ class GlobalOptions extends OptionsCollection {
     values: {},
   );
 
-  late final navigationMode = SelectOption(
+  late final navigationMode = SelectOption<NavigationMode>(
     storage: storage,
     key: GlobalOptionKeys.navigationMode,
     label: (context) => NeonLocalizations.of(context).globalOptionsNavigationMode,

--- a/packages/neon_framework/lib/src/widgets/account_tile.dart
+++ b/packages/neon_framework/lib/src/widgets/account_tile.dart
@@ -11,7 +11,6 @@ import 'package:neon_framework/src/widgets/adaptive_widgets/list_tile.dart';
 import 'package:neon_framework/src/widgets/error.dart';
 import 'package:neon_framework/src/widgets/linear_progress_indicator.dart';
 import 'package:neon_framework/src/widgets/user_avatar.dart';
-import 'package:nextcloud/provisioning_api.dart' as provisioning_api;
 
 /// List tile to display account information.
 @internal
@@ -53,7 +52,7 @@ class NeonAccountTile extends StatelessWidget {
         showStatus: showStatus,
       ),
       trailing: trailing,
-      title: ResultBuilder<provisioning_api.UserDetails>.behaviorSubject(
+      title: ResultBuilder.behaviorSubject(
         subject: userDetailsBloc.userDetails,
         builder: (context, userDetails) => Row(
           children: [

--- a/packages/neon_framework/lib/src/widgets/app_bar.dart
+++ b/packages/neon_framework/lib/src/widgets/app_bar.dart
@@ -8,7 +8,6 @@ import 'package:neon_framework/src/bloc/result.dart';
 import 'package:neon_framework/src/blocs/accounts.dart';
 import 'package:neon_framework/src/blocs/apps.dart';
 import 'package:neon_framework/src/models/account.dart';
-import 'package:neon_framework/src/models/app_implementation.dart';
 import 'package:neon_framework/src/models/notifications_interface.dart';
 import 'package:neon_framework/src/utils/provider.dart';
 import 'package:neon_framework/src/widgets/account_switcher_button.dart';
@@ -65,7 +64,7 @@ class _NeonAppBarState extends State<NeonAppBar> {
   }
 
   @override
-  Widget build(BuildContext context) => ResultBuilder<BuiltSet<AppImplementation>>.behaviorSubject(
+  Widget build(BuildContext context) => ResultBuilder.behaviorSubject(
         subject: appsBloc.appImplementations,
         builder: (context, appImplementations) => StreamBuilder(
           stream: appsBloc.activeApp,
@@ -250,7 +249,7 @@ class _NotificationIconButtonState extends State<NotificationIconButton> {
   }
 
   @override
-  Widget build(BuildContext context) => ResultBuilder<NotificationsAppInterface?>.behaviorSubject(
+  Widget build(BuildContext context) => ResultBuilder.behaviorSubject(
         subject: _appsBloc.notificationsAppImplementation,
         builder: (context, notificationsAppImplementation) {
           if (!notificationsAppImplementation.hasData) {

--- a/packages/neon_framework/lib/src/widgets/drawer.dart
+++ b/packages/neon_framework/lib/src/widgets/drawer.dart
@@ -106,7 +106,7 @@ class NeonDrawerHeader extends StatelessWidget {
     final accountsBloc = NeonProvider.of<AccountsBloc>(context);
     final capabilitiesBloc = accountsBloc.activeCapabilitiesBloc;
 
-    final branding = ResultBuilder<core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data>.behaviorSubject(
+    final branding = ResultBuilder.behaviorSubject(
       subject: capabilitiesBloc.capabilities,
       builder: (context, capabilities) {
         if (!capabilities.hasData) {

--- a/packages/neon_framework/test/dialog_test.dart
+++ b/packages/neon_framework/test/dialog_test.dart
@@ -209,7 +209,7 @@ void main() {
 
       final now = DateTime(2024, 1, 20);
 
-      final status = BehaviorSubject<Result<user_status.$PublicInterface>>.seeded(
+      final status = BehaviorSubject.seeded(
         Result.success(
           user_status.Private(
             (b) => b

--- a/packages/neon_framework/test/option_test.dart
+++ b/packages/neon_framework/test/option_test.dart
@@ -74,7 +74,7 @@ void main() {
       final enabled = ValueNotifier(false);
       final callback = MockCallbackFunction();
 
-      option = SelectOption<SelectValues>.depend(
+      option = SelectOption.depend(
         storage: storage,
         key: key,
         label: labelBuilder,

--- a/packages/neon_framework/test/request_manager_test.dart
+++ b/packages/neon_framework/test/request_manager_test.dart
@@ -108,7 +108,7 @@ void main() {
 
         await subject.close();
 
-        subject = BehaviorSubject<Result<String>>.seeded(Result.success('Seed value'));
+        subject = BehaviorSubject.seeded(Result.success('Seed value'));
 
         // ignore: unawaited_futures
         expectLater(


### PR DESCRIPTION
Much cleaner code by omitting all the unnecessary generic type arguments.
In the Blocs I found a bunch of places where the subjects were not final, I fixed that too (I could extract it if really necessary).
I used the following regex to find all the potential places: ` [A-Z]+[A-Za-z]*<.*>(\(|\.)` (notice the leading space; this also finds a bunch of false-positives and in a few places the generics are still needed).