### PR TITLE
refactor(neon_framework): use a separate persistence layer backing th…

### DIFF
--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -5,6 +5,7 @@ deeplinking
 flathub
 foss
 fullscreen
+persistences
 playstore
 postmarket
 provokateurin

--- a/packages/neon_framework/lib/src/storage/persistence.dart
+++ b/packages/neon_framework/lib/src/storage/persistence.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart' show protected;
+
+/// A persistent key value storage.
+abstract interface class Persistence<T extends Object> {
+  /// Whether a value exists at the given [key].
+  FutureOr<bool> containsKey(String key);
+
+  /// Clears all values from persistent storage.
+  FutureOr<bool> clear();
+
+  /// Removes an entry from persistent storage.
+  FutureOr<bool> remove(String key);
+
+  /// Saves a [value] to persistent storage.
+  FutureOr<bool> setValue(String key, T value);
+
+  /// Fetches the value persisted at the given [key] from the persistent
+  /// storage.
+  FutureOr<T?> getValue(String key);
+}
+
+/// A key value persistence that caches read values to be accessed
+/// synchronously.
+///
+/// Mutating values is asynchronous.
+abstract class CachedPersistence<T extends Object> implements Persistence<T> {
+  /// Fetches the latest values from the host platform.
+  ///
+  /// Use this method to observe modifications that were made in the background
+  /// like another isolate or native code while the app is already running.
+  Future<void> reload();
+
+  /// The cache that holds all values.
+  ///
+  /// It is instantiated to the current state of the backing database and then
+  /// kept in sync via setter methods in this class.
+  ///
+  /// It is NOT guaranteed that this cache and the backing database will remain
+  /// in sync since the setter method might fail for any reason.
+  @protected
+  final Map<String, T> cache = {};
+
+  @override
+  T? getValue(String key) => cache[key];
+
+  /// Saves a [value] to the cached storage.
+  ///
+  /// Use this method to cache type conversions of the value that do not change
+  /// the meaning of the actual value like a `BuiltList` to `List` conversion.
+  /// Changes will not be persisted to the backing storage and will be lost
+  /// when the app is restarted.
+  void setCache(String key, T value) => cache[key] = value;
+
+  @override
+  bool containsKey(String key) => cache.containsKey(key);
+
+  @override
+  Future<bool> clear();
+
+  @override
+  Future<bool> remove(String key);
+
+  @override
+  Future<bool> setValue(String key, T value);
+}

--- a/packages/neon_framework/lib/src/storage/shared_preferences_persistence.dart
+++ b/packages/neon_framework/lib/src/storage/shared_preferences_persistence.dart
@@ -1,0 +1,133 @@
+// ignore_for_file: cascade_invocations
+
+import 'package:meta/meta.dart';
+import 'package:neon_framework/src/storage/persistence.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/types.dart';
+
+/// The version of the [SharedPreferencesPersistence].
+///
+/// Needed to make potential migrations in the future.
+@visibleForTesting
+const int kSharedPreferenceVersion = 1;
+
+/// The default prefix used by `SharedPreferences`.
+///
+/// Used for legacy reasons to allow seamless upgrades.
+// TODO: replace with our packageID
+const String _defaultPrefix = 'flutter.';
+
+/// An SharedPreferences backed cached persistence for preferences.
+///
+/// There is only one cache backing all `SharedPreferencesPersistence`
+/// instances. Use the [_prefix] to separate different storages.
+/// Keys within a storage must be unique.
+@internal
+final class SharedPreferencesPersistence implements CachedPersistence {
+  /// Creates a new SharedPreferences persistence.
+  const SharedPreferencesPersistence({String prefix = ''})
+      : _prefix = prefix == '' ? _defaultPrefix : '$_defaultPrefix$prefix-';
+
+  static SharedPreferencesStorePlatform get _store => SharedPreferencesStorePlatform.instance;
+
+  /// The prefix of this persistence.
+  ///
+  /// Keys within it must be unique.
+  @protected
+  final String _prefix;
+
+  @override
+  Map<String, Object> get cache => _globalCache;
+
+  static final Map<String, Object> _globalCache = {};
+
+  static bool _initialized = false;
+
+  /// Initializes all persistences by setting up the backing SharedPreferences
+  /// storage and priming the global cache.
+  ///
+  /// This must be called and completed before any calls to persistence are made.
+  static Future<void> init() async {
+    if (_initialized) {
+      return;
+    }
+
+    final fromSystem = await _store.getAll();
+    _globalCache.addAll(fromSystem);
+
+    _initialized = true;
+  }
+
+  /// Resets class's static values to allow for testing multiple init calls.
+  @visibleForTesting
+  static void resetStatic() {
+    _globalCache.clear();
+    _initialized = false;
+  }
+
+  @override
+  Object? getValue(String key) {
+    final prefixedKey = '$_prefix$key';
+    return cache[prefixedKey];
+  }
+
+  @override
+  void setCache(String key, Object value) {
+    final prefixedKey = '$_prefix$key';
+    cache[prefixedKey] = value;
+  }
+
+  @override
+  bool containsKey(String key) {
+    final prefixedKey = '$_prefix$key';
+
+    return cache.containsKey(prefixedKey);
+  }
+
+  @override
+  Future<bool> clear() {
+    cache.removeWhere((key, _) => key.startsWith(_prefix));
+
+    return _store.clearWithParameters(
+      ClearParameters(
+        filter: PreferencesFilter(prefix: _prefix),
+      ),
+    );
+  }
+
+  @override
+  Future<void> reload() async {
+    final fromSystem = await _store.getAllWithParameters(
+      GetAllParameters(
+        filter: PreferencesFilter(prefix: _prefix),
+      ),
+    );
+
+    cache.removeWhere((key, _) => key.startsWith(_prefix));
+    cache.addAll(fromSystem);
+  }
+
+  @override
+  Future<bool> remove(String key) {
+    final prefixedKey = '$_prefix$key';
+
+    cache.remove(prefixedKey);
+    return _store.remove(prefixedKey);
+  }
+
+  @override
+  Future<bool> setValue(String key, Object value) {
+    final prefixedKey = '$_prefix$key';
+
+    cache[prefixedKey] = value;
+    return switch (value) {
+      int _ => _store.setValue('Int', prefixedKey, value),
+      double _ => _store.setValue('Double', prefixedKey, value),
+      String _ => _store.setValue('String', prefixedKey, value),
+      bool _ => _store.setValue('Bool', prefixedKey, value),
+      // Make a copy of the list so that later mutations won't propagate
+      Iterable<String> _ => _store.setValue('StringList', prefixedKey, value.toList()),
+      Object() => throw ArgumentError.value(value, 'value', 'Unsupported type.'),
+    };
+  }
+}

--- a/packages/neon_framework/lib/src/storage/shared_preferences_persistence.dart
+++ b/packages/neon_framework/lib/src/storage/shared_preferences_persistence.dart
@@ -55,6 +55,12 @@ final class SharedPreferencesPersistence implements CachedPersistence {
     final fromSystem = await _store.getAll();
     _globalCache.addAll(fromSystem);
 
+    const versionKey = 'neon-version';
+    const persistence = SharedPreferencesPersistence();
+    if (!persistence.containsKey(versionKey)) {
+      await persistence.setValue(versionKey, kSharedPreferenceVersion);
+    }
+
     _initialized = true;
   }
 

--- a/packages/neon_framework/lib/src/testing/mocks.dart
+++ b/packages/neon_framework/lib/src/testing/mocks.dart
@@ -12,9 +12,10 @@ import 'package:neon_framework/src/blocs/apps.dart';
 import 'package:neon_framework/src/blocs/capabilities.dart';
 import 'package:neon_framework/src/models/disposable.dart';
 import 'package:neon_framework/src/settings/models/exportable.dart';
+import 'package:neon_framework/src/storage/persistence.dart';
 import 'package:neon_framework/src/utils/account_options.dart';
 import 'package:neon_framework/storage.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 class MockAccount extends Mock implements Account {}
 
@@ -50,9 +51,14 @@ class MockNeonStorage extends Mock implements NeonStorage {
   }
 }
 
-class MockSharedPreferences extends Mock implements SharedPreferences {}
+class MockPersistence extends Mock implements CachedPersistence {}
 
 class MockSettingsStore extends Mock implements SettingsStore {}
+
+class MockSharedPreferencesPlatform extends Mock implements SharedPreferencesStorePlatform {
+  @override
+  bool get isMock => true;
+}
 
 class MockCallbackFunction<T> extends Mock {
   FutureOr<T> call();

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   quick_actions: ^1.0.0
   rxdart: ^0.27.4
   scrollable_positioned_list: ^0.3.0
-  shared_preferences: ^2.2.1
+  shared_preferences_platform_interface: ^2.3.2
   sort_box:
     git:
       url: https://github.com/nextcloud/neon
@@ -72,6 +72,7 @@ dev_dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/neon_lints
+  shared_preferences: ^2.2.1
   vector_graphics_compiler: ^1.1.11+1
 
 flutter:

--- a/packages/neon_framework/test/persistence_test.dart
+++ b/packages/neon_framework/test/persistence_test.dart
@@ -77,6 +77,7 @@ void main() {
         expect(
           stored,
           equals({
+            'flutter.neon-version': kSharedPreferenceVersion,
             'flutter.no_prefix': 56,
             'flutter.another-prefix': true,
           }),
@@ -137,7 +138,11 @@ void main() {
 
         await persistence.clear();
         stored = await sharedPreferences.getAll();
-        expect(stored, isEmpty);
+        expect(
+          stored,
+          isEmpty,
+          reason: 'An empty prefix matches every non empty one. Clearing everything.',
+        );
 
         await sharedPreferences.setValue('valueType', 'flutter.key', 'value');
         await persistence.reload();

--- a/packages/neon_framework/test/persistence_test.dart
+++ b/packages/neon_framework/test/persistence_test.dart
@@ -1,0 +1,148 @@
+// ignore_for_file: unnecessary_lambdas
+
+import 'package:built_collection/built_collection.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neon_framework/src/storage/shared_preferences_persistence.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+void main() {
+  group('Persistences', () {
+    group('SharedPreferencesPersistence', () {
+      late InMemorySharedPreferencesStore sharedPreferences;
+
+      setUp(() async {
+        sharedPreferences = InMemorySharedPreferencesStore.withData({
+          'flutter.no_prefix': 56,
+          'flutter.prefix-key': 0.8263038168331953,
+          'flutter.another-prefix': true,
+        });
+        SharedPreferencesStorePlatform.instance = sharedPreferences;
+
+        await SharedPreferencesPersistence.init();
+      });
+
+      tearDown(() {
+        SharedPreferencesPersistence.resetStatic();
+      });
+
+      test('with prefix', () async {
+        const persistence = SharedPreferencesPersistence(prefix: 'prefix');
+
+        expect(persistence.containsKey('key'), isTrue);
+        expect(persistence.containsKey('random-key'), isFalse);
+
+        await persistence.remove('key');
+        expect(persistence.containsKey('key'), isFalse);
+
+        // String
+        Object value = 'some new value';
+        await persistence.setValue('key', value);
+        expect(persistence.getValue('key'), equals(value));
+        expect(await sharedPreferences.getAll(), equals(persistence.cache));
+
+        // int
+        value = 20;
+        await persistence.setValue('key_bool', value);
+        expect(persistence.getValue('key_bool'), equals(value));
+        expect(await sharedPreferences.getAll(), equals(persistence.cache));
+
+        // double
+        value = 0.3196889951920666;
+        await persistence.setValue('key-double', value);
+        expect(persistence.getValue('key-double'), equals(value));
+        expect(await sharedPreferences.getAll(), equals(persistence.cache));
+
+        // bool
+        value = false;
+        await persistence.setValue('key/int', value);
+        expect(persistence.getValue('key/int'), equals(value));
+        expect(await sharedPreferences.getAll(), equals(persistence.cache));
+
+        // BuiltList<String>
+        value = BuiltList<String>(['76', 'true', '0.8633290067560915']);
+        await persistence.setValue('key.StringList', value);
+        expect(persistence.getValue('key.StringList'), equals(value));
+        expect(await sharedPreferences.getAll(), equals(persistence.cache));
+
+        // Invalid type
+        expect(() => persistence.setValue('key.StringList', {}), throwsA(isA<ArgumentError>()));
+
+        persistence.setCache('key.StringListCache', value);
+        expect(persistence.getValue('key.StringListCache'), equals(value));
+        var stored = await sharedPreferences.getAll();
+        expect(stored.containsKey('key.StringListCache'), isFalse);
+
+        await persistence.clear();
+        stored = await sharedPreferences.getAll();
+        expect(
+          stored,
+          equals({
+            'flutter.no_prefix': 56,
+            'flutter.another-prefix': true,
+          }),
+          reason: 'only clears withing the prefix',
+        );
+
+        await sharedPreferences.setValue('valueType', 'flutter.prefix-key', 'value');
+        await persistence.reload();
+        expect(persistence.containsKey('key'), isTrue);
+      });
+
+      test('no prefix', () async {
+        const persistence = SharedPreferencesPersistence();
+
+        expect(persistence.containsKey('no_prefix'), isTrue);
+        expect(persistence.containsKey('random-key'), isFalse);
+
+        await persistence.remove('no_prefix');
+        expect(persistence.containsKey('no_prefix'), isFalse);
+
+        // String
+        Object value = 'some new value';
+        await persistence.setValue('no_prefix', value);
+        expect(persistence.getValue('no_prefix'), equals(value));
+        expect(await sharedPreferences.getAll(), equals(persistence.cache));
+
+        // int
+        value = 20;
+        await persistence.setValue('no_prefix_bool', value);
+        expect(persistence.getValue('no_prefix_bool'), equals(value));
+        expect(await sharedPreferences.getAll(), equals(persistence.cache));
+
+        // double
+        value = 0.3196889951920666;
+        await persistence.setValue('no_prefix-double', value);
+        expect(persistence.getValue('no_prefix-double'), equals(value));
+        expect(await sharedPreferences.getAll(), equals(persistence.cache));
+
+        // bool
+        value = false;
+        await persistence.setValue('no_prefix/int', value);
+        expect(persistence.getValue('no_prefix/int'), equals(value));
+        expect(await sharedPreferences.getAll(), equals(persistence.cache));
+
+        // BuiltList<String>
+        value = BuiltList<String>(['76', 'true', '0.8633290067560915']);
+        await persistence.setValue('no_prefix.StringList', value);
+        expect(persistence.getValue('no_prefix.StringList'), equals(value));
+        expect(await sharedPreferences.getAll(), equals(persistence.cache));
+
+        // Invalid type
+        expect(() => persistence.setValue('no_prefix.StringList', {}), throwsA(isA<ArgumentError>()));
+
+        persistence.setCache('no_prefix.StringListCache', value);
+        expect(persistence.getValue('no_prefix.StringListCache'), equals(value));
+        var stored = await sharedPreferences.getAll();
+        expect(stored.containsKey('no_prefix.StringListCache'), isFalse);
+
+        await persistence.clear();
+        stored = await sharedPreferences.getAll();
+        expect(stored, isEmpty);
+
+        await sharedPreferences.setValue('valueType', 'flutter.key', 'value');
+        await persistence.reload();
+        expect(persistence.containsKey('key'), isTrue);
+      });
+    });
+  });
+}

--- a/packages/neon_framework/test/storage_test.dart
+++ b/packages/neon_framework/test/storage_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: inference_failure_on_instance_creation
+
 import 'package:built_collection/built_collection.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -8,98 +10,85 @@ import 'package:neon_framework/testing.dart';
 
 void main() {
   group('Storages', () {
-    late MockSharedPreferences sharedPreferences;
+    late MockPersistence persistence;
 
     setUp(() {
-      sharedPreferences = MockSharedPreferences();
-    });
-
-    test('AppStorage formatKey', () async {
-      var appStorage = DefaultSettingsStore(sharedPreferences, StorageKeys.accountOptions);
-      var key = appStorage.formatKey('test-key');
-      expect(key, 'accounts-test-key');
-      expect(appStorage.id, StorageKeys.accountOptions.value);
-
-      appStorage = DefaultSettingsStore(sharedPreferences, StorageKeys.accountOptions, 'test-suffix');
-      key = appStorage.formatKey('test-key');
-      expect(key, 'accounts-test-suffix-test-key');
-      expect(appStorage.id, 'test-suffix');
+      persistence = MockPersistence();
     });
 
     test('AppStorage interface', () async {
-      final appStorage = DefaultSettingsStore(sharedPreferences, StorageKeys.accountOptions);
+      final appStorage = DefaultSettingsStore(persistence, StorageKeys.accountOptions.value);
       const key = 'key';
-      final formattedKey = appStorage.formatKey(key);
 
-      when(() => sharedPreferences.remove(formattedKey)).thenAnswer((_) => Future.value(false));
+      when(() => persistence.remove(key)).thenAnswer((_) => Future.value(false));
       dynamic result = await appStorage.remove(key);
       expect(result, equals(false));
-      verify(() => sharedPreferences.remove(formattedKey)).called(1);
+      verify(() => persistence.remove(key)).called(1);
 
-      when(() => sharedPreferences.getString(formattedKey)).thenReturn(null);
+      when(() => persistence.getValue(key)).thenReturn(null);
       result = appStorage.getString(key);
       expect(result, isNull);
-      verify(() => sharedPreferences.getString(formattedKey)).called(1);
+      verify(() => persistence.getValue(key)).called(1);
 
-      when(() => sharedPreferences.setString(formattedKey, 'value')).thenAnswer((_) => Future.value(false));
+      when(() => persistence.setValue(key, 'value')).thenAnswer((_) => Future.value(false));
       result = await appStorage.setString(key, 'value');
       expect(result, false);
-      verify(() => sharedPreferences.setString(formattedKey, 'value')).called(1);
+      verify(() => persistence.setValue(key, 'value')).called(1);
 
-      when(() => sharedPreferences.getBool(formattedKey)).thenReturn(true);
+      when(() => persistence.getValue(key)).thenReturn(true);
       result = appStorage.getBool(key);
       expect(result, equals(true));
-      verify(() => sharedPreferences.getBool(formattedKey)).called(1);
+      verify(() => persistence.getValue(key)).called(1);
 
-      when(() => sharedPreferences.setBool(formattedKey, true)).thenAnswer((_) => Future.value(true));
+      when(() => persistence.setValue(key, true)).thenAnswer((_) => Future.value(true));
       result = await appStorage.setBool(key, true);
       expect(result, true);
-      verify(() => sharedPreferences.setBool(formattedKey, true)).called(1);
+      verify(() => persistence.setValue(key, true)).called(1);
     });
 
     test('SingleValueStorage', () async {
-      final storage = DefaultSingleValueStore(sharedPreferences, StorageKeys.global);
+      final storage = DefaultSingleValueStore(persistence, StorageKeys.global);
       final key = StorageKeys.global.value;
 
-      when(() => sharedPreferences.containsKey(key)).thenReturn(true);
+      when(() => persistence.containsKey(key)).thenReturn(true);
       dynamic result = storage.hasValue();
       expect(result, equals(true));
-      verify(() => sharedPreferences.containsKey(key)).called(1);
+      verify(() => persistence.containsKey(key)).called(1);
 
-      when(() => sharedPreferences.remove(key)).thenAnswer((_) => Future.value(false));
+      when(() => persistence.remove(key)).thenAnswer((_) => Future.value(false));
       result = await storage.remove();
       expect(result, equals(false));
-      verify(() => sharedPreferences.remove(key)).called(1);
+      verify(() => persistence.remove(key)).called(1);
 
-      when(() => sharedPreferences.getString(key)).thenReturn(null);
+      when(() => persistence.getValue(key)).thenReturn(null);
       result = storage.getString();
       expect(result, isNull);
-      verify(() => sharedPreferences.getString(key)).called(1);
+      verify(() => persistence.getValue(key)).called(1);
 
-      when(() => sharedPreferences.setString(key, 'value')).thenAnswer((_) => Future.value(false));
+      when(() => persistence.setValue(key, 'value')).thenAnswer((_) => Future.value(false));
       result = await storage.setString('value');
       expect(result, false);
-      verify(() => sharedPreferences.setString(key, 'value')).called(1);
+      verify(() => persistence.setValue(key, 'value')).called(1);
 
-      when(() => sharedPreferences.getBool(key)).thenReturn(true);
+      when(() => persistence.getValue(key)).thenReturn(true);
       result = storage.getBool();
       expect(result, equals(true));
-      verify(() => sharedPreferences.getBool(key)).called(1);
+      verify(() => persistence.getValue(key)).called(1);
 
-      when(() => sharedPreferences.setBool(key, true)).thenAnswer((_) => Future.value(true));
+      when(() => persistence.setValue(key, true)).thenAnswer((_) => Future.value(true));
       result = await storage.setBool(true);
       expect(result, true);
-      verify(() => sharedPreferences.setBool(key, true)).called(1);
+      verify(() => persistence.setValue(key, true)).called(1);
 
-      when(() => sharedPreferences.getStringList(key)).thenReturn(['hi there']);
+      when(() => persistence.getValue(key)).thenReturn(BuiltList(['hi there']));
       result = storage.getStringList();
       expect(result, equals(['hi there']));
-      verify(() => sharedPreferences.getStringList(key)).called(1);
+      verify(() => persistence.getValue(key)).called(1);
 
-      when(() => sharedPreferences.setStringList(key, ['hi there'])).thenAnswer((_) => Future.value(false));
+      when(() => persistence.setValue(key, BuiltList(['hi there']))).thenAnswer((_) => Future.value(false));
       result = await storage.setStringList(BuiltList(['hi there']));
       expect(result, false);
-      verify(() => sharedPreferences.setStringList(key, ['hi there'])).called(1);
+      verify(() => persistence.setValue(key, BuiltList(['hi there']))).called(1);
     });
   });
 }


### PR DESCRIPTION
…e storages

The general idea is to decouple the storage layer, the app is talking to, from the layer actually persisting the data.
A `Persistence` is just a basic CRUD like (maybe asynchronous) interface for the storage layers to use. Other implementations like the `CachedPersistence` cache the data in memory (HashMap) so reads can be synchronous while writes are asynchronous in the background.

In turn we can build a complete `SharedPreferences` implementation on to of the cached persistence. Currently the `SharedPreferencesPersistence` is just a `CachedPeristence` warper around the shared preferences (with some key handling magic to allow the current data to seamlessly be used without any migration).

I understand that the current default implementation of our storages (`SettingsStore` and `SingleValueStore`) are already wrappers themselves but with the up cumming migration to a SQLite persistence we will no longer have the double wrappers. This may seem like a lot of unnecessary boilerplate interfaces but as shown in #1585 it will allow us to make changes with minimal effort.

We can later consider changing some of these patterns but it was the easiest way to tackle it in a reviewable small patch-set.