### PR TITLE
chore(deps): override package_info_plus to allow web 0.5.0

### DIFF
--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -756,12 +756,13 @@ packages:
     source: hosted
     version: "2.1.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: package_info_plus
-      sha256: "88bc797f44a94814f2213db1c9bd5badebafdfb8290ca9f78d4b9ee2a3db4d79"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/package_info_plus/package_info_plus"
+      ref: baa336fe79c29411542fc343d332846bcd7752c1
+      resolved-ref: baa336fe79c29411542fc343d332846bcd7752c1
+      url: "https://github.com/fluttercommunity/plus_plugins"
+    source: git
     version: "5.0.1"
   package_info_plus_platform_interface:
     dependency: transitive

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -47,3 +47,10 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+
+dependency_overrides:
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      path: packages/package_info_plus/package_info_plus
+      ref: baa336fe79c29411542fc343d332846bcd7752c1

--- a/packages/app/pubspec_overrides.yaml
+++ b/packages/app/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon_dashboard,neon_files,neon_framework,neon_lints,neon_news,neon_notes,neon_notifications,nextcloud,sort_box,package_info_plus
 dependency_overrides:
   dynamite_runtime:
     path: ../dynamite/dynamite_runtime
@@ -22,3 +22,8 @@ dependency_overrides:
     path: ../nextcloud
   sort_box:
     path: ../sort_box
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      ref: baa336fe79c29411542fc343d332846bcd7752c1
+      path: packages/package_info_plus/package_info_plus

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -88,3 +88,10 @@ flutter:
       web:
         pluginClass: WebNeonPlatform
         fileName: src/platform/web.dart
+
+dependency_overrides:
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      path: packages/package_info_plus/package_info_plus
+      ref: baa336fe79c29411542fc343d332846bcd7752c1

--- a/packages/neon_framework/pubspec_overrides.yaml
+++ b/packages/neon_framework/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: dynamite_runtime,neon_lints,nextcloud,sort_box,package_info_plus
 dependency_overrides:
   dynamite_runtime:
     path: ../dynamite/dynamite_runtime
@@ -8,3 +8,8 @@ dependency_overrides:
     path: ../nextcloud
   sort_box:
     path: ../sort_box
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      ref: baa336fe79c29411542fc343d332846bcd7752c1
+      path: packages/package_info_plus/package_info_plus


### PR DESCRIPTION
The new package_info_plus is not going to be released soon [comment](https://github.com/fluttercommunity/plus_plugins/pull/2605#issuecomment-1954955437).
Let's override it for now to unblock:
#1609 
#1607
#1627