### PR TITLE
fix(neon_framework): package_info_plus overrides needed for every pac…

### DIFF
--- a/packages/neon/neon_dashboard/pubspec.yaml
+++ b/packages/neon/neon_dashboard/pubspec.yaml
@@ -39,3 +39,10 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+
+dependency_overrides:
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      path: packages/package_info_plus/package_info_plus
+      ref: baa336fe79c29411542fc343d332846bcd7752c1

--- a/packages/neon/neon_dashboard/pubspec_overrides.yaml
+++ b/packages/neon/neon_dashboard/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box,package_info_plus
 dependency_overrides:
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
@@ -10,3 +10,8 @@ dependency_overrides:
     path: ../../nextcloud
   sort_box:
     path: ../../sort_box
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      ref: baa336fe79c29411542fc343d332846bcd7752c1
+      path: packages/package_info_plus/package_info_plus

--- a/packages/neon/neon_files/pubspec.yaml
+++ b/packages/neon/neon_files/pubspec.yaml
@@ -49,3 +49,10 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+
+dependency_overrides:
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      path: packages/package_info_plus/package_info_plus
+      ref: baa336fe79c29411542fc343d332846bcd7752c1

--- a/packages/neon/neon_files/pubspec_overrides.yaml
+++ b/packages/neon/neon_files/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon_framework,neon_lints,nextcloud,sort_box,package_info_plus
 dependency_overrides:
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
@@ -12,3 +12,8 @@ dependency_overrides:
     path: ../../nextcloud
   sort_box:
     path: ../../sort_box
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      ref: baa336fe79c29411542fc343d332846bcd7752c1
+      path: packages/package_info_plus/package_info_plus

--- a/packages/neon/neon_news/pubspec.yaml
+++ b/packages/neon/neon_news/pubspec.yaml
@@ -43,3 +43,10 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+
+dependency_overrides:
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      path: packages/package_info_plus/package_info_plus
+      ref: baa336fe79c29411542fc343d332846bcd7752c1

--- a/packages/neon/neon_news/pubspec_overrides.yaml
+++ b/packages/neon/neon_news/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box,package_info_plus
 dependency_overrides:
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
@@ -10,3 +10,8 @@ dependency_overrides:
     path: ../../nextcloud
   sort_box:
     path: ../../sort_box
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      ref: baa336fe79c29411542fc343d332846bcd7752c1
+      path: packages/package_info_plus/package_info_plus

--- a/packages/neon/neon_notes/pubspec.yaml
+++ b/packages/neon/neon_notes/pubspec.yaml
@@ -41,3 +41,10 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+
+dependency_overrides:
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      path: packages/package_info_plus/package_info_plus
+      ref: baa336fe79c29411542fc343d332846bcd7752c1

--- a/packages/neon/neon_notes/pubspec_overrides.yaml
+++ b/packages/neon/neon_notes/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box,package_info_plus
 dependency_overrides:
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
@@ -10,3 +10,8 @@ dependency_overrides:
     path: ../../nextcloud
   sort_box:
     path: ../../sort_box
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      ref: baa336fe79c29411542fc343d332846bcd7752c1
+      path: packages/package_info_plus/package_info_plus

--- a/packages/neon/neon_notifications/pubspec.yaml
+++ b/packages/neon/neon_notifications/pubspec.yaml
@@ -36,3 +36,10 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+
+dependency_overrides:
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      path: packages/package_info_plus/package_info_plus
+      ref: baa336fe79c29411542fc343d332846bcd7752c1

--- a/packages/neon/neon_notifications/pubspec_overrides.yaml
+++ b/packages/neon/neon_notifications/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box,package_info_plus
 dependency_overrides:
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
@@ -10,3 +10,8 @@ dependency_overrides:
     path: ../../nextcloud
   sort_box:
     path: ../../sort_box
+  package_info_plus:
+    git:
+      url: https://github.com/fluttercommunity/plus_plugins
+      ref: baa336fe79c29411542fc343d332846bcd7752c1
+      path: packages/package_info_plus/package_info_plus


### PR DESCRIPTION
…kage

for whatever reason we have to override it in every package importing `neon_framework`.
This is horrific but nothing else we con do.

At least it is now tested to work ontop of #1609 