### PR TITLE
fix(nextcloud): Add missing share types

### DIFF
--- a/packages/nextcloud/lib/src/helpers/core.dart
+++ b/packages/nextcloud/lib/src/helpers/core.dart
@@ -37,6 +37,7 @@ extension CoreStatusVersionCheck on core.Status {
       );
 }
 
+// https://github.com/nextcloud/server/blob/master/lib/public/Share/IShare.php
 enum ShareType {
   user,
   group,
@@ -54,4 +55,7 @@ enum ShareType {
   userroom,
   deck,
   deckUser,
+  // ignore: unused_field
+  _unused,
+  scienceMesh,
 }


### PR DESCRIPTION
Aligned with https://github.com/nextcloud/server/blob/master/lib/public/Share/IShare.php
I had to use the value backed enum because it seems like 14 was just skipped. In the future we might also want to just remove the deprecated values, so this prepares us for that as well.