### PR TITLE
feat(neon_framework): Allow additional matching app IDs

### DIFF
--- a/packages/neon_framework/lib/src/blocs/apps.dart
+++ b/packages/neon_framework/lib/src/blocs/apps.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:built_collection/built_collection.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/src/bloc/bloc.dart';
@@ -212,8 +213,12 @@ class _AppsBloc extends InteractiveBloc implements AppsBloc {
     return null;
   }
 
-  BuiltSet<AppImplementation> filteredAppImplementations(Iterable<String> appIds) =>
-      BuiltSet(allAppImplementations.where((a) => appIds.contains(a.id)));
+  BuiltSet<AppImplementation> filteredAppImplementations(Iterable<String> appIds) => BuiltSet(
+        allAppImplementations.where(
+          (a) =>
+              appIds.contains(a.id) || a.additionalMatchingIDs?.firstWhereOrNull((id) => appIds.contains(id)) != null,
+        ),
+      );
 
   final CapabilitiesBloc capabilitiesBloc;
   final AccountsBloc accountsBloc;

--- a/packages/neon_framework/lib/src/models/app_implementation.dart
+++ b/packages/neon_framework/lib/src/models/app_implementation.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:meta/meta.dart';
@@ -11,7 +12,6 @@ import 'package:neon_framework/src/models/account_cache.dart';
 import 'package:neon_framework/src/models/disposable.dart';
 import 'package:neon_framework/src/settings/models/options_collection.dart';
 import 'package:neon_framework/src/storage/keys.dart';
-
 import 'package:neon_framework/src/utils/findable.dart';
 import 'package:neon_framework/src/utils/provider.dart';
 import 'package:neon_framework/src/widgets/drawer_destination.dart';
@@ -33,6 +33,12 @@ abstract class AppImplementation<T extends Bloc, R extends AppImplementationOpti
   /// It is common to specify them in `AppIDs`.
   @override
   String get id;
+
+  /// A set of IDs that will match the server apps in addition to [id].
+  ///
+  /// This should only be used when the implementation ID does not match the app ID on the server
+  /// or the implementation supports multiple apps on the server.
+  BuiltSet<String>? get additionalMatchingIDs => null;
 
   /// {@macro flutter.widgets.widgetsApp.localizationsDelegates}
   LocalizationsDelegate<Object> get localizationsDelegate;


### PR DESCRIPTION
Will help with https://github.com/nextcloud/neon/issues/356 (different ID spreed vs. talk) and https://github.com/nextcloud/neon/issues/355 (multiple IDs photos vs. memories).
Sadly it's not possible to add tests because the whole Bloc has no tests yet.