### PR TITLE
fix(ci): Do not fail-fast in publish matrix

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,6 +90,7 @@ jobs:
     permissions:
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         architecture:
           - docker: amd64


### PR DESCRIPTION
Avoids cancelling the other jobs when a job in the matrix fails.