### PR TITLE
fix(neon_talk): Hide the user name in previews for system messages

### DIFF
--- a/packages/neon/neon_talk/lib/src/widgets/message_preview.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/message_preview.dart
@@ -25,10 +25,12 @@ class TalkMessagePreview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     String? actorName;
-    if (chatMessage.actorId == actorId) {
-      actorName = TalkLocalizations.of(context).actorSelf;
-    } else if (!roomType.isSingleUser) {
-      actorName = chatMessage.actorDisplayName;
+    if (chatMessage.messageType != spreed.MessageType.system.name) {
+      if (chatMessage.actorId == actorId) {
+        actorName = TalkLocalizations.of(context).actorSelf;
+      } else if (!roomType.isSingleUser) {
+        actorName = chatMessage.actorDisplayName;
+      }
     }
 
     return RichText(

--- a/packages/neon/neon_talk/test/message_preview_test.dart
+++ b/packages/neon/neon_talk/test/message_preview_test.dart
@@ -19,6 +19,7 @@ void main() {
     final chatMessage = MockChatMessage();
     when(() => chatMessage.actorId).thenReturn('test');
     when(() => chatMessage.message).thenReturn('message');
+    when(() => chatMessage.messageType).thenReturn(spreed.MessageType.comment.name);
 
     await tester.pumpWidget(
       wrapWidget(
@@ -37,6 +38,7 @@ void main() {
     when(() => chatMessage.actorId).thenReturn('test');
     when(() => chatMessage.actorDisplayName).thenReturn('Test');
     when(() => chatMessage.message).thenReturn('message');
+    when(() => chatMessage.messageType).thenReturn(spreed.MessageType.comment.name);
 
     await tester.pumpWidget(
       wrapWidget(
@@ -54,6 +56,7 @@ void main() {
     final chatMessage = MockChatMessage();
     when(() => chatMessage.actorId).thenReturn('test');
     when(() => chatMessage.message).thenReturn('message');
+    when(() => chatMessage.messageType).thenReturn(spreed.MessageType.comment.name);
 
     await tester.pumpWidget(
       wrapWidget(
@@ -71,12 +74,31 @@ void main() {
     final chatMessage = MockChatMessage();
     when(() => chatMessage.actorId).thenReturn('test');
     when(() => chatMessage.message).thenReturn('message');
+    when(() => chatMessage.messageType).thenReturn(spreed.MessageType.comment.name);
 
     await tester.pumpWidget(
       wrapWidget(
         TalkMessagePreview(
           actorId: 'abc',
           roomType: spreed.RoomType.oneToOne,
+          chatMessage: chatMessage,
+        ),
+      ),
+    );
+    expect(find.text('message', findRichText: true), findsOne);
+  });
+
+  testWidgets('System', (tester) async {
+    final chatMessage = MockChatMessage();
+    when(() => chatMessage.actorId).thenReturn('test');
+    when(() => chatMessage.message).thenReturn('message');
+    when(() => chatMessage.messageType).thenReturn(spreed.MessageType.system.name);
+
+    await tester.pumpWidget(
+      wrapWidget(
+        TalkMessagePreview(
+          actorId: 'abc',
+          roomType: spreed.RoomType.group,
           chatMessage: chatMessage,
         ),
       ),


### PR DESCRIPTION
System messages already contain the user's name as a mention, so it doesn't need to be displayed again.