### PR TITLE
refactor(neon_framework): Allow using NeonUserAvatar without specifying the account

### DIFF
--- a/packages/neon/neon_talk/lib/src/widgets/room_avatar.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/room_avatar.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:neon_framework/blocs.dart';
-import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
 import 'package:nextcloud/spreed.dart' as spreed;
 
@@ -20,15 +18,12 @@ class TalkRoomAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final account = NeonProvider.of<AccountsBloc>(context).activeAccount.value!;
-
     if (room.isCustomAvatar ?? false) {
       final brightness = Theme.of(context).brightness;
 
       return CircleAvatar(
         child: ClipOval(
-          child: NeonApiImage.withAccount(
-            account: account,
+          child: NeonApiImage(
             getImage: (client) => switch (brightness) {
               Brightness.dark => client.spreed.avatar.getAvatarDarkRaw(token: room.token),
               Brightness.light => client.spreed.avatar.getAvatarRaw(token: room.token),
@@ -43,7 +38,6 @@ class TalkRoomAvatar extends StatelessWidget {
 
     return switch (spreed.RoomType.fromValue(room.type)) {
       spreed.RoomType.oneToOne => NeonUserAvatar(
-          account: account,
           username: room.name,
         ),
       spreed.RoomType.group => _buildIconAvatar(Icons.group),

--- a/packages/neon_framework/lib/src/widgets/account_switcher_button.dart
+++ b/packages/neon_framework/lib/src/widgets/account_switcher_button.dart
@@ -42,16 +42,9 @@ class AccountSwitcherButton extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
-    final accountsBloc = NeonProvider.of<AccountsBloc>(context);
-    final account = accountsBloc.activeAccount.value!;
-
-    return IconButton(
-      onPressed: () async => _onPressed(context),
-      tooltip: NeonLocalizations.of(context).settingsAccount,
-      icon: NeonUserAvatar(
-        account: account,
-      ),
-    );
-  }
+  Widget build(BuildContext context) => IconButton(
+        onPressed: () async => _onPressed(context),
+        tooltip: NeonLocalizations.of(context).settingsAccount,
+        icon: const NeonUserAvatar(),
+      );
 }

--- a/packages/neon_framework/lib/src/widgets/account_tile.dart
+++ b/packages/neon_framework/lib/src/widgets/account_tile.dart
@@ -47,7 +47,7 @@ class NeonAccountTile extends StatelessWidget {
 
     return AdaptiveListTile(
       onTap: onTap,
-      leading: NeonUserAvatar(
+      leading: NeonUserAvatar.withAccount(
         account: account,
         showStatus: showStatus,
       ),


### PR DESCRIPTION
Will help with https://github.com/nextcloud/neon/pull/1661.
NeonApiImage and NeonUriImage already provide this kind of API, so this just makes it easier to use all of them when the used account is the currently active one.