### PR TITLE
chore(tool): Use `dart run` instead of deprecated `dart pub run`

### DIFF
--- a/tool/generate-dynamite-e2e-test.sh
+++ b/tool/generate-dynamite-e2e-test.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")/.."
 (
   cd packages/dynamite/dynamite_end_to_end_test
   rm -rf .dart_tool/build/generated/dynamite
-  fvm dart pub run build_runner build --delete-conflicting-outputs
+  fvm dart run build_runner build --delete-conflicting-outputs
   fvm dart fix --apply lib/
   melos run format
 )

--- a/tool/generate-dynamite-petstore-example.sh
+++ b/tool/generate-dynamite-petstore-example.sh
@@ -7,7 +7,7 @@ cp external/openapi-specification/examples/v3.0/petstore-expanded.json packages/
 (
   cd packages/dynamite/dynamite/example
   rm -rf .dart_tool/build/generated/dynamite
-  fvm dart pub run build_runner build --delete-conflicting-outputs
+  fvm dart run build_runner build --delete-conflicting-outputs
   fvm dart fix --apply lib/
   melos run format
 )

--- a/tool/generate-nextcloud.sh
+++ b/tool/generate-nextcloud.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")/.."
   cd packages/nextcloud
   rm -rf .dart_tool/build/generated/dynamite
   fvm dart run generate_props.dart
-  fvm dart pub run build_runner build --delete-conflicting-outputs
+  fvm dart run build_runner build --delete-conflicting-outputs
   fvm dart run generate_exports.dart
   # For some reason we need to fix and format twice, otherwise not everything gets fixed
   fvm dart fix --apply lib/src/api/


### PR DESCRIPTION
The logs say that `dart pub run` is deprecated, so we shouldn't use it anymore.