### PR TITLE
feat(neon_talk): Remove newlines in message previews

### DIFF
--- a/packages/neon/neon_talk/lib/src/utils/message.dart
+++ b/packages/neon/neon_talk/lib/src/utils/message.dart
@@ -3,7 +3,7 @@ import 'package:nextcloud/spreed.dart' as spreed;
 
 /// Builds a [TextSpan] for the given [chatMessage].
 TextSpan buildChatMessage({
-  required spreed.ChatMessage chatMessage,
+  required spreed.$ChatMessageInterface chatMessage,
   bool isPreview = false,
   TextStyle? style,
 }) {

--- a/packages/neon/neon_talk/lib/src/utils/message.dart
+++ b/packages/neon/neon_talk/lib/src/utils/message.dart
@@ -5,6 +5,7 @@ import 'package:nextcloud/spreed.dart' as spreed;
 TextSpan buildChatMessage({
   required spreed.ChatMessage chatMessage,
   bool isPreview = false,
+  TextStyle? style,
 }) {
   var message = chatMessage.message;
   if (isPreview) {
@@ -13,5 +14,6 @@ TextSpan buildChatMessage({
 
   return TextSpan(
     text: message,
+    style: style,
   );
 }

--- a/packages/neon/neon_talk/lib/src/utils/message.dart
+++ b/packages/neon/neon_talk/lib/src/utils/message.dart
@@ -4,7 +4,14 @@ import 'package:nextcloud/spreed.dart' as spreed;
 /// Builds a [TextSpan] for the given [chatMessage].
 TextSpan buildChatMessage({
   required spreed.ChatMessage chatMessage,
-}) =>
-    TextSpan(
-      text: chatMessage.message,
-    );
+  bool isPreview = false,
+}) {
+  var message = chatMessage.message;
+  if (isPreview) {
+    message = message.replaceAll('\n', ' ');
+  }
+
+  return TextSpan(
+    text: message,
+  );
+}

--- a/packages/neon/neon_talk/lib/src/widgets/message_preview.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/message_preview.dart
@@ -50,6 +50,7 @@ class TalkMessagePreview extends StatelessWidget {
             ),
           buildChatMessage(
             chatMessage: chatMessage,
+            isPreview: true,
           ),
         ],
       ),

--- a/packages/neon/neon_talk/test/message_preview_test.dart
+++ b/packages/neon/neon_talk/test/message_preview_test.dart
@@ -105,4 +105,22 @@ void main() {
     );
     expect(find.text('message', findRichText: true), findsOne);
   });
+
+  testWidgets('Newline removed', (tester) async {
+    final chatMessage = MockChatMessage();
+    when(() => chatMessage.actorId).thenReturn('test');
+    when(() => chatMessage.message).thenReturn('message\n123');
+    when(() => chatMessage.messageType).thenReturn(spreed.MessageType.comment.name);
+
+    await tester.pumpWidget(
+      wrapWidget(
+        TalkMessagePreview(
+          actorId: 'abc',
+          roomType: spreed.RoomType.oneToOne,
+          chatMessage: chatMessage,
+        ),
+      ),
+    );
+    expect(find.text('message 123', findRichText: true), findsOne);
+  });
 }


### PR DESCRIPTION
A user might send a formatted message that includes newlines. This looks pretty bad in previews because only the first line will be shown.