### PR TITLE
feat(dynamite)!: Show field names in oneOf/anyOf validation errors

### DIFF
--- a/packages/dynamite/dynamite/lib/src/builder/generate_ofs.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/generate_ofs.dart
@@ -90,13 +90,25 @@ Iterable<Spec> generateSomeOf(
       ..body = Code('[${fields.values.join(',')}]');
   });
 
+  final names = Method((b) {
+    b
+      ..returns = refer('List<String>')
+      ..type = MethodType.getter
+      ..name = '_names'
+      ..lambda = true
+      ..body = Code('const [${fields.values.map(escapeDartString).join(',')}]');
+  });
+
   final oneOfValidator = Method((b) {
     b
       ..docs.add('/// {@macro Dynamite.validateOneOf}')
       ..name = 'validateOneOf'
       ..returns = refer('void')
       ..lambda = true
-      ..body = refer('validateOneOf', 'package:dynamite_runtime/utils.dart').call([refer('_values')]).code;
+      ..body = refer('validateOneOf', 'package:dynamite_runtime/utils.dart').call([
+        refer('_values'),
+        refer('_names'),
+      ]).code;
   });
 
   final anyOfValidator = Method((b) {
@@ -105,7 +117,10 @@ Iterable<Spec> generateSomeOf(
       ..name = 'validateAnyOf'
       ..returns = refer('void')
       ..lambda = true
-      ..body = refer('validateAnyOf', 'package:dynamite_runtime/utils.dart').call([refer('_values')]).code;
+      ..body = refer('validateAnyOf', 'package:dynamite_runtime/utils.dart').call([
+        refer('_values'),
+        refer('_names'),
+      ]).code;
   });
 
   final serializerMethod = Method(
@@ -157,6 +172,7 @@ Iterable<Spec> generateSomeOf(
       ])
       ..methods.addAll([
         values,
+        names,
         oneOfValidator,
         anyOfValidator,
         serializerMethod,

--- a/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.dart
@@ -177,12 +177,19 @@ typedef _$0c9017d9a03ba2eb2f15acadeab85bbe = ({ObjectAnyOf0? objectAnyOf0, Objec
 // ignore: library_private_types_in_public_api
 extension $0c9017d9a03ba2eb2f15acadeab85bbeExtension on _$0c9017d9a03ba2eb2f15acadeab85bbe {
   List<dynamic> get _values => [objectAnyOf0, objectAnyOf1];
+  List<String> get _names => const ['objectAnyOf0', 'objectAnyOf1'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$0c9017d9a03ba2eb2f15acadeab85bbe> get _serializer =>
       const _$0c9017d9a03ba2eb2f15acadeab85bbeSerializer();
   static _$0c9017d9a03ba2eb2f15acadeab85bbe _fromJson(Object? json) =>
@@ -246,12 +253,19 @@ typedef _$fba45e085ee99d64c5141852d4323e3d = ({MixedAnyOf1? mixedAnyOf1, String?
 // ignore: library_private_types_in_public_api
 extension $fba45e085ee99d64c5141852d4323e3dExtension on _$fba45e085ee99d64c5141852d4323e3d {
   List<dynamic> get _values => [mixedAnyOf1, string];
+  List<String> get _names => const ['mixedAnyOf1', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$fba45e085ee99d64c5141852d4323e3d> get _serializer =>
       const _$fba45e085ee99d64c5141852d4323e3dSerializer();
   static _$fba45e085ee99d64c5141852d4323e3d _fromJson(Object? json) =>
@@ -315,12 +329,19 @@ typedef _$b6d67dc2a96424d2f407f8e51557f3de = ({num? $num, String? string});
 // ignore: library_private_types_in_public_api
 extension $b6d67dc2a96424d2f407f8e51557f3deExtension on _$b6d67dc2a96424d2f407f8e51557f3de {
   List<dynamic> get _values => [$num, string];
+  List<String> get _names => const [r'$num', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$b6d67dc2a96424d2f407f8e51557f3de> get _serializer =>
       const _$b6d67dc2a96424d2f407f8e51557f3deSerializer();
   static _$b6d67dc2a96424d2f407f8e51557f3de _fromJson(Object? json) =>

--- a/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
@@ -344,12 +344,19 @@ typedef _$b2c4857c0136baea42828d89c87c757d = ({int? $int, String? string});
 // ignore: library_private_types_in_public_api
 extension $b2c4857c0136baea42828d89c87c757dExtension on _$b2c4857c0136baea42828d89c87c757d {
   List<dynamic> get _values => [$int, string];
+  List<String> get _names => const [r'$int', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i4.validateOneOf(_values);
+  void validateOneOf() => _i4.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i4.validateAnyOf(_values);
+  void validateAnyOf() => _i4.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$b2c4857c0136baea42828d89c87c757d> get _serializer =>
       const _$b2c4857c0136baea42828d89c87c757dSerializer();
   static _$b2c4857c0136baea42828d89c87c757d _fromJson(Object? json) =>

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
@@ -268,12 +268,19 @@ typedef _$fc0451dbdd462718bd075afd2e3ce0ec = ({BaseOneOf1? baseOneOf1, double? $
 // ignore: library_private_types_in_public_api
 extension $fc0451dbdd462718bd075afd2e3ce0ecExtension on _$fc0451dbdd462718bd075afd2e3ce0ec {
   List<dynamic> get _values => [baseOneOf1, $double];
+  List<String> get _names => const ['baseOneOf1', r'$double'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$fc0451dbdd462718bd075afd2e3ce0ec> get _serializer =>
       const _$fc0451dbdd462718bd075afd2e3ce0ecSerializer();
   static _$fc0451dbdd462718bd075afd2e3ce0ec _fromJson(Object? json) =>
@@ -337,12 +344,19 @@ typedef _$ce3c7b262d1c503446a436c461be5be9 = ({BaseAnyOf1? baseAnyOf1, int? $int
 // ignore: library_private_types_in_public_api
 extension $ce3c7b262d1c503446a436c461be5be9Extension on _$ce3c7b262d1c503446a436c461be5be9 {
   List<dynamic> get _values => [baseAnyOf1, $int];
+  List<String> get _names => const ['baseAnyOf1', r'$int'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$ce3c7b262d1c503446a436c461be5be9> get _serializer =>
       const _$ce3c7b262d1c503446a436c461be5be9Serializer();
   static _$ce3c7b262d1c503446a436c461be5be9 _fromJson(Object? json) =>
@@ -412,12 +426,19 @@ typedef _$8da5087c0b3f2cce06998d453af8ad19 = ({
 // ignore: library_private_types_in_public_api
 extension $8da5087c0b3f2cce06998d453af8ad19Extension on _$8da5087c0b3f2cce06998d453af8ad19 {
   List<dynamic> get _values => [baseAllOf, baseAnyOf, baseNestedOneOf3, baseOneOf1, $double];
+  List<String> get _names => const ['baseAllOf', 'baseAnyOf', 'baseNestedOneOf3', 'baseOneOf1', r'$double'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$8da5087c0b3f2cce06998d453af8ad19> get _serializer =>
       const _$8da5087c0b3f2cce06998d453af8ad19Serializer();
   static _$8da5087c0b3f2cce06998d453af8ad19 _fromJson(Object? json) =>
@@ -519,12 +540,19 @@ typedef _$523892e2348458a2bdb28f9f942dca37 = ({
 // ignore: library_private_types_in_public_api
 extension $523892e2348458a2bdb28f9f942dca37Extension on _$523892e2348458a2bdb28f9f942dca37 {
   List<dynamic> get _values => [baseAllOf, baseAnyOf1, baseNestedAnyOf3, baseOneOf, $int];
+  List<String> get _names => const ['baseAllOf', 'baseAnyOf1', 'baseNestedAnyOf3', 'baseOneOf', r'$int'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$523892e2348458a2bdb28f9f942dca37> get _serializer =>
       const _$523892e2348458a2bdb28f9f942dca37Serializer();
   static _$523892e2348458a2bdb28f9f942dca37 _fromJson(Object? json) =>
@@ -620,12 +648,19 @@ typedef _$abe6d27882a5771a98ede04cd64de567 = ({BaseOneOf1? baseOneOf1, num? $num
 // ignore: library_private_types_in_public_api
 extension $abe6d27882a5771a98ede04cd64de567Extension on _$abe6d27882a5771a98ede04cd64de567 {
   List<dynamic> get _values => [baseOneOf1, $num];
+  List<String> get _names => const ['baseOneOf1', r'$num'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$abe6d27882a5771a98ede04cd64de567> get _serializer =>
       const _$abe6d27882a5771a98ede04cd64de567Serializer();
   static _$abe6d27882a5771a98ede04cd64de567 _fromJson(Object? json) =>

--- a/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.dart
@@ -265,12 +265,19 @@ typedef _$6c828020e1dac1d58ded0a29ef8b0c41 = ({ObjectOneOf0? objectOneOf0, Objec
 // ignore: library_private_types_in_public_api
 extension $6c828020e1dac1d58ded0a29ef8b0c41Extension on _$6c828020e1dac1d58ded0a29ef8b0c41 {
   List<dynamic> get _values => [objectOneOf0, objectOneOf1];
+  List<String> get _names => const ['objectOneOf0', 'objectOneOf1'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$6c828020e1dac1d58ded0a29ef8b0c41> get _serializer =>
       const _$6c828020e1dac1d58ded0a29ef8b0c41Serializer();
   static _$6c828020e1dac1d58ded0a29ef8b0c41 _fromJson(Object? json) =>
@@ -334,12 +341,19 @@ typedef _$d1b40dfcebdca2dfa1f3e52ac98462a5 = ({MixedOneOf1? mixedOneOf1, String?
 // ignore: library_private_types_in_public_api
 extension $d1b40dfcebdca2dfa1f3e52ac98462a5Extension on _$d1b40dfcebdca2dfa1f3e52ac98462a5 {
   List<dynamic> get _values => [mixedOneOf1, string];
+  List<String> get _names => const ['mixedOneOf1', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$d1b40dfcebdca2dfa1f3e52ac98462a5> get _serializer =>
       const _$d1b40dfcebdca2dfa1f3e52ac98462a5Serializer();
   static _$d1b40dfcebdca2dfa1f3e52ac98462a5 _fromJson(Object? json) =>
@@ -403,12 +417,19 @@ typedef _$b6d67dc2a96424d2f407f8e51557f3de = ({num? $num, String? string});
 // ignore: library_private_types_in_public_api
 extension $b6d67dc2a96424d2f407f8e51557f3deExtension on _$b6d67dc2a96424d2f407f8e51557f3de {
   List<dynamic> get _values => [$num, string];
+  List<String> get _names => const [r'$num', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$b6d67dc2a96424d2f407f8e51557f3de> get _serializer =>
       const _$b6d67dc2a96424d2f407f8e51557f3deSerializer();
   static _$b6d67dc2a96424d2f407f8e51557f3de _fromJson(Object? json) =>
@@ -475,12 +496,19 @@ typedef _$00f31f9753d01398a2c3705cd335c56e = ({
 // ignore: library_private_types_in_public_api
 extension $00f31f9753d01398a2c3705cd335c56eExtension on _$00f31f9753d01398a2c3705cd335c56e {
   List<dynamic> get _values => [builtListJsonObject, oneOfUnspecifiedArray0];
+  List<String> get _names => const ['builtListJsonObject', 'oneOfUnspecifiedArray0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$00f31f9753d01398a2c3705cd335c56e> get _serializer =>
       const _$00f31f9753d01398a2c3705cd335c56eSerializer();
   static _$00f31f9753d01398a2c3705cd335c56e _fromJson(Object? json) =>
@@ -551,12 +579,19 @@ typedef _$5fb8a7f8bbb305dd61a4a05d6996c58b = ({
 // ignore: library_private_types_in_public_api
 extension $5fb8a7f8bbb305dd61a4a05d6996c58bExtension on _$5fb8a7f8bbb305dd61a4a05d6996c58b {
   List<dynamic> get _values => [builtListString, oneOfStringArray0];
+  List<String> get _names => const ['builtListString', 'oneOfStringArray0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$5fb8a7f8bbb305dd61a4a05d6996c58b> get _serializer =>
       const _$5fb8a7f8bbb305dd61a4a05d6996c58bSerializer();
   static _$5fb8a7f8bbb305dd61a4a05d6996c58b _fromJson(Object? json) =>

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
@@ -741,12 +741,19 @@ typedef _$93403da1a64cb6a7b1597c7a05e9b2be = ({bool? $bool, String? string});
 // ignore: library_private_types_in_public_api
 extension $93403da1a64cb6a7b1597c7a05e9b2beExtension on _$93403da1a64cb6a7b1597c7a05e9b2be {
   List<dynamic> get _values => [$bool, string];
+  List<String> get _names => const [r'$bool', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$93403da1a64cb6a7b1597c7a05e9b2be> get _serializer =>
       const _$93403da1a64cb6a7b1597c7a05e9b2beSerializer();
   static _$93403da1a64cb6a7b1597c7a05e9b2be _fromJson(Object? json) =>

--- a/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.dart
@@ -109,12 +109,19 @@ typedef _$b6d67dc2a96424d2f407f8e51557f3de = ({num? $num, String? string});
 // ignore: library_private_types_in_public_api
 extension $b6d67dc2a96424d2f407f8e51557f3deExtension on _$b6d67dc2a96424d2f407f8e51557f3de {
   List<dynamic> get _values => [$num, string];
+  List<String> get _names => const [r'$num', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$b6d67dc2a96424d2f407f8e51557f3de> get _serializer =>
       const _$b6d67dc2a96424d2f407f8e51557f3deSerializer();
   static _$b6d67dc2a96424d2f407f8e51557f3de _fromJson(Object? json) =>

--- a/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.dart
@@ -96,12 +96,19 @@ typedef _$e1c7ecea8e5fdae7b94cd86c0dc4f1ba = ({Base? base, int? $int, JsonObject
 // ignore: library_private_types_in_public_api
 extension $e1c7ecea8e5fdae7b94cd86c0dc4f1baExtension on _$e1c7ecea8e5fdae7b94cd86c0dc4f1ba {
   List<dynamic> get _values => [base, $int, jsonObject];
+  List<String> get _names => const ['base', r'$int', 'jsonObject'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$e1c7ecea8e5fdae7b94cd86c0dc4f1ba> get _serializer =>
       const _$e1c7ecea8e5fdae7b94cd86c0dc4f1baSerializer();
   static _$e1c7ecea8e5fdae7b94cd86c0dc4f1ba _fromJson(Object? json) =>

--- a/packages/dynamite/dynamite_runtime/lib/src/utils/some_of_validators.dart
+++ b/packages/dynamite/dynamite_runtime/lib/src/utils/some_of_validators.dart
@@ -3,19 +3,19 @@ import 'package:collection/collection.dart';
 /// Validates that at least one value in the given list is not `null`.
 ///
 /// Throws a [Exception] in the case all values are null.
-void validateAnyOf(List<dynamic> values) {
+void validateAnyOf(List<dynamic> values, List<String> names) {
   final match = values.firstWhereOrNull((x) => x != null);
   if (match == null) {
-    throw Exception('At least one of $values must not be null');
+    throw Exception('At least one of $names must not be null');
   }
 }
 
 /// Validates that exactly one value in the given list is not null.
 ///
 /// Throws a [Exception] when no or more than one value is not null.
-void validateOneOf(List<dynamic> values) {
+void validateOneOf(List<dynamic> values, List<String> names) {
   final match = values.singleWhereOrNull((x) => x != null);
   if (match == null) {
-    throw Exception('Exactly one of $values must not be null');
+    throw Exception('Exactly one of $names must not be null: $values');
   }
 }

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -13060,12 +13060,19 @@ typedef _$87e48e5649cd72b4d2947aaaea13ccd8 = ({AutocompleteResult_Status0? autoc
 // ignore: library_private_types_in_public_api
 extension $87e48e5649cd72b4d2947aaaea13ccd8Extension on _$87e48e5649cd72b4d2947aaaea13ccd8 {
   List<dynamic> get _values => [autocompleteResultStatus0, string];
+  List<String> get _names => const ['autocompleteResultStatus0', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$87e48e5649cd72b4d2947aaaea13ccd8> get _serializer =>
       const _$87e48e5649cd72b4d2947aaaea13ccd8Serializer();
   static _$87e48e5649cd72b4d2947aaaea13ccd8 _fromJson(Object? json) =>
@@ -13132,12 +13139,19 @@ typedef _$b2c4857c0136baea42828d89c87c757d = ({int? $int, String? string});
 // ignore: library_private_types_in_public_api
 extension $b2c4857c0136baea42828d89c87c757dExtension on _$b2c4857c0136baea42828d89c87c757d {
   List<dynamic> get _values => [$int, string];
+  List<String> get _names => const [r'$int', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$b2c4857c0136baea42828d89c87c757d> get _serializer =>
       const _$b2c4857c0136baea42828d89c87c757dSerializer();
   static _$b2c4857c0136baea42828d89c87c757d _fromJson(Object? json) =>
@@ -13204,12 +13218,19 @@ typedef _$46564992d3ed3482aa6c1162698aac99 = ({
 // ignore: library_private_types_in_public_api
 extension $46564992d3ed3482aa6c1162698aac99Extension on _$46564992d3ed3482aa6c1162698aac99 {
   List<dynamic> get _values => [builtListNever, sharebymailCapabilities0];
+  List<String> get _names => const ['builtListNever', 'sharebymailCapabilities0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$46564992d3ed3482aa6c1162698aac99> get _serializer =>
       const _$46564992d3ed3482aa6c1162698aac99Serializer();
   static _$46564992d3ed3482aa6c1162698aac99 _fromJson(Object? json) =>
@@ -13278,12 +13299,19 @@ typedef _$06c2e47196a84ebc3718dccf9eb4b29d = ({
 // ignore: library_private_types_in_public_api
 extension $06c2e47196a84ebc3718dccf9eb4b29dExtension on _$06c2e47196a84ebc3718dccf9eb4b29d {
   List<dynamic> get _values => [builtListNever, spreedPublicCapabilities0];
+  List<String> get _names => const ['builtListNever', 'spreedPublicCapabilities0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$06c2e47196a84ebc3718dccf9eb4b29d> get _serializer =>
       const _$06c2e47196a84ebc3718dccf9eb4b29dSerializer();
   static _$06c2e47196a84ebc3718dccf9eb4b29d _fromJson(Object? json) =>
@@ -13383,12 +13411,35 @@ extension $d7df54b8bef6b092d401eed2bcfbb6f0Extension on _$d7df54b8bef6b092d401ee
         userStatusCapabilities,
         weatherStatusCapabilities,
       ];
+  List<String> get _names => const [
+        'commentsCapabilities',
+        'davCapabilities',
+        'dropAccountCapabilities',
+        'filesCapabilities',
+        'filesSharingCapabilities',
+        'filesTrashbinCapabilities',
+        'filesVersionsCapabilities',
+        'notesCapabilities',
+        'notificationsCapabilities',
+        'provisioningApiCapabilities',
+        'sharebymailCapabilities',
+        'spreedPublicCapabilities',
+        'themingPublicCapabilities',
+        'userStatusCapabilities',
+        'weatherStatusCapabilities',
+      ];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$d7df54b8bef6b092d401eed2bcfbb6f0> get _serializer =>
       const _$d7df54b8bef6b092d401eed2bcfbb6f0Serializer();
   static _$d7df54b8bef6b092d401eed2bcfbb6f0 _fromJson(Object? json) =>

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -5683,12 +5683,19 @@ typedef _$07eaa0304017ba8abe7f9f20d6a736f3 = ({BuiltList<int>? builtListInt, int
 // ignore: library_private_types_in_public_api
 extension $07eaa0304017ba8abe7f9f20d6a736f3Extension on _$07eaa0304017ba8abe7f9f20d6a736f3 {
   List<dynamic> get _values => [builtListInt, $int];
+  List<String> get _names => const ['builtListInt', r'$int'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$07eaa0304017ba8abe7f9f20d6a736f3> get _serializer =>
       const _$07eaa0304017ba8abe7f9f20d6a736f3Serializer();
   static _$07eaa0304017ba8abe7f9f20d6a736f3 _fromJson(Object? json) =>

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -7970,12 +7970,19 @@ typedef _$c4bc4131e74e61dae681408e87e2e2bd = ({bool? $bool, int? $int});
 // ignore: library_private_types_in_public_api
 extension $c4bc4131e74e61dae681408e87e2e2bdExtension on _$c4bc4131e74e61dae681408e87e2e2bd {
   List<dynamic> get _values => [$bool, $int];
+  List<String> get _names => const [r'$bool', r'$int'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$c4bc4131e74e61dae681408e87e2e2bd> get _serializer =>
       const _$c4bc4131e74e61dae681408e87e2e2bdSerializer();
   static _$c4bc4131e74e61dae681408e87e2e2bd _fromJson(Object? json) =>
@@ -8039,12 +8046,19 @@ typedef _$b6d67dc2a96424d2f407f8e51557f3de = ({num? $num, String? string});
 // ignore: library_private_types_in_public_api
 extension $b6d67dc2a96424d2f407f8e51557f3deExtension on _$b6d67dc2a96424d2f407f8e51557f3de {
   List<dynamic> get _values => [$num, string];
+  List<String> get _names => const [r'$num', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$b6d67dc2a96424d2f407f8e51557f3de> get _serializer =>
       const _$b6d67dc2a96424d2f407f8e51557f3deSerializer();
   static _$b6d67dc2a96424d2f407f8e51557f3de _fromJson(Object? json) =>
@@ -8111,12 +8125,19 @@ typedef _$b20d370ea28764b414e70ac5df151f1b = ({
 // ignore: library_private_types_in_public_api
 extension $b20d370ea28764b414e70ac5df151f1bExtension on _$b20d370ea28764b414e70ac5df151f1b {
   List<dynamic> get _values => [groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1, userDetails];
+  List<String> get _names => const ['groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1', 'userDetails'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$b20d370ea28764b414e70ac5df151f1b> get _serializer =>
       const _$b20d370ea28764b414e70ac5df151f1bSerializer();
   static _$b20d370ea28764b414e70ac5df151f1b _fromJson(Object? json) =>
@@ -8194,12 +8215,19 @@ typedef _$1e1cd5e43e0a1022a23a294e58225d74 = ({
 // ignore: library_private_types_in_public_api
 extension $1e1cd5e43e0a1022a23a294e58225d74Extension on _$1e1cd5e43e0a1022a23a294e58225d74 {
   List<dynamic> get _values => [userDetails, usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1];
+  List<String> get _names => const ['userDetails', 'usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$1e1cd5e43e0a1022a23a294e58225d74> get _serializer =>
       const _$1e1cd5e43e0a1022a23a294e58225d74Serializer();
   static _$1e1cd5e43e0a1022a23a294e58225d74 _fromJson(Object? json) =>
@@ -8276,12 +8304,19 @@ typedef _$f9d75e948689049b3f3e23e024d4be73 = ({
 // ignore: library_private_types_in_public_api
 extension $f9d75e948689049b3f3e23e024d4be73Extension on _$f9d75e948689049b3f3e23e024d4be73 {
   List<dynamic> get _values => [userDetails, usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1];
+  List<String> get _names => const ['userDetails', 'usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$f9d75e948689049b3f3e23e024d4be73> get _serializer =>
       const _$f9d75e948689049b3f3e23e024d4be73Serializer();
   static _$f9d75e948689049b3f3e23e024d4be73 _fromJson(Object? json) =>

--- a/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
+++ b/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
@@ -274,12 +274,19 @@ typedef _$7f1b9936cf688676379074249fff891b = ({BuiltList<Never>? builtListNever,
 // ignore: library_private_types_in_public_api
 extension $7f1b9936cf688676379074249fff891bExtension on _$7f1b9936cf688676379074249fff891b {
   List<dynamic> get _values => [builtListNever, capabilities0];
+  List<String> get _names => const ['builtListNever', 'capabilities0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(_values);
+  void validateOneOf() => _i1.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(_values);
+  void validateAnyOf() => _i1.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$7f1b9936cf688676379074249fff891b> get _serializer =>
       const _$7f1b9936cf688676379074249fff891bSerializer();
   static _$7f1b9936cf688676379074249fff891b _fromJson(Object? json) =>

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -38896,12 +38896,19 @@ typedef _$e620970959f428e934829e52f32b7089 = ({BuiltList<Never>? builtListNever,
 // ignore: library_private_types_in_public_api
 extension $e620970959f428e934829e52f32b7089Extension on _$e620970959f428e934829e52f32b7089 {
   List<dynamic> get _values => [builtListNever, chatMessage];
+  List<String> get _names => const ['builtListNever', 'chatMessage'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$e620970959f428e934829e52f32b7089> get _serializer =>
       const _$e620970959f428e934829e52f32b7089Serializer();
   static _$e620970959f428e934829e52f32b7089 _fromJson(Object? json) =>
@@ -38969,12 +38976,19 @@ typedef _$bd993fb3f40af33e8594d0d698208560 = ({
 // ignore: library_private_types_in_public_api
 extension $bd993fb3f40af33e8594d0d698208560Extension on _$bd993fb3f40af33e8594d0d698208560 {
   List<dynamic> get _values => [builtListNever, roomAddParticipantToRoomResponseApplicationJsonOcsData0];
+  List<String> get _names => const ['builtListNever', 'roomAddParticipantToRoomResponseApplicationJsonOcsData0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$bd993fb3f40af33e8594d0d698208560> get _serializer =>
       const _$bd993fb3f40af33e8594d0d698208560Serializer();
   static _$bd993fb3f40af33e8594d0d698208560 _fromJson(Object? json) =>
@@ -39048,12 +39062,19 @@ typedef _$b2c4857c0136baea42828d89c87c757d = ({int? $int, String? string});
 // ignore: library_private_types_in_public_api
 extension $b2c4857c0136baea42828d89c87c757dExtension on _$b2c4857c0136baea42828d89c87c757d {
   List<dynamic> get _values => [$int, string];
+  List<String> get _names => const [r'$int', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$b2c4857c0136baea42828d89c87c757d> get _serializer =>
       const _$b2c4857c0136baea42828d89c87c757dSerializer();
   static _$b2c4857c0136baea42828d89c87c757d _fromJson(Object? json) =>
@@ -39117,12 +39138,19 @@ typedef _$1df642f5035aea3b22543ab331c3fb01 = ({BuiltList<SignalingSession>? buil
 // ignore: library_private_types_in_public_api
 extension $1df642f5035aea3b22543ab331c3fb01Extension on _$1df642f5035aea3b22543ab331c3fb01 {
   List<dynamic> get _values => [builtListSignalingSession, string];
+  List<String> get _names => const ['builtListSignalingSession', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$1df642f5035aea3b22543ab331c3fb01> get _serializer =>
       const _$1df642f5035aea3b22543ab331c3fb01Serializer();
   static _$1df642f5035aea3b22543ab331c3fb01 _fromJson(Object? json) =>
@@ -39192,12 +39220,19 @@ typedef _$bc4aac45771b11649d372f39a92b1cf3 = ({
 // ignore: library_private_types_in_public_api
 extension $bc4aac45771b11649d372f39a92b1cf3Extension on _$bc4aac45771b11649d372f39a92b1cf3 {
   List<dynamic> get _values => [builtListNever, publicCapabilities0];
+  List<String> get _names => const ['builtListNever', 'publicCapabilities0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$bc4aac45771b11649d372f39a92b1cf3> get _serializer =>
       const _$bc4aac45771b11649d372f39a92b1cf3Serializer();
   static _$bc4aac45771b11649d372f39a92b1cf3 _fromJson(Object? json) =>

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -2249,12 +2249,19 @@ typedef _$557344b3ba734aacc7109e5420fcb6c5 = ({ClearAtTimeType? clearAtTimeType,
 // ignore: library_private_types_in_public_api
 extension $557344b3ba734aacc7109e5420fcb6c5Extension on _$557344b3ba734aacc7109e5420fcb6c5 {
   List<dynamic> get _values => [clearAtTimeType, $int];
+  List<String> get _names => const ['clearAtTimeType', r'$int'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$557344b3ba734aacc7109e5420fcb6c5> get _serializer =>
       const _$557344b3ba734aacc7109e5420fcb6c5Serializer();
   static _$557344b3ba734aacc7109e5420fcb6c5 _fromJson(Object? json) =>
@@ -2319,12 +2326,19 @@ typedef _$d77829de8b7590d2e16cdb714800f5be = ({BuiltList<Never>? builtListNever,
 // ignore: library_private_types_in_public_api
 extension $d77829de8b7590d2e16cdb714800f5beExtension on _$d77829de8b7590d2e16cdb714800f5be {
   List<dynamic> get _values => [builtListNever, private];
+  List<String> get _names => const ['builtListNever', 'private'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$d77829de8b7590d2e16cdb714800f5be> get _serializer =>
       const _$d77829de8b7590d2e16cdb714800f5beSerializer();
   static _$d77829de8b7590d2e16cdb714800f5be _fromJson(Object? json) =>

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -2007,12 +2007,19 @@ typedef _$20fe3de793aed6fbf929c9b82b472b1a = ({
 // ignore: library_private_types_in_public_api
 extension $20fe3de793aed6fbf929c9b82b472b1aExtension on _$20fe3de793aed6fbf929c9b82b472b1a {
   List<dynamic> get _values => [builtListForecast, weatherStatusGetForecastResponseApplicationJsonOcsData1];
+  List<String> get _names => const ['builtListForecast', 'weatherStatusGetForecastResponseApplicationJsonOcsData1'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(_values);
+  void validateOneOf() => _i2.validateOneOf(
+        _values,
+        _names,
+      );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(_values);
+  void validateAnyOf() => _i2.validateAnyOf(
+        _values,
+        _names,
+      );
   static Serializer<_$20fe3de793aed6fbf929c9b82b472b1a> get _serializer =>
       const _$20fe3de793aed6fbf929c9b82b472b1aSerializer();
   static _$20fe3de793aed6fbf929c9b82b472b1a _fromJson(Object? json) =>


### PR DESCRIPTION
An error message like `At least one of [null, null, null, null, null, null, null, null, null, null, null, null, null, null, null] must not be null` for anyOf is really not helpful and we should show the field names instead.
