### PR TITLE
Refactor/dynamite/prepare_httpclient_request_flow

### DIFF
--- a/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
+++ b/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
@@ -28,13 +28,13 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart' as _i5;
 import 'package:dynamite_runtime/built_value.dart' as _i4;
-import 'package:dynamite_runtime/http_client.dart' as _i2;
-import 'package:meta/meta.dart' as _i3;
-import 'package:uri/uri.dart' as _i1;
+import 'package:dynamite_runtime/http_client.dart' as _i1;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i3;
 
 part 'petstore.openapi.g.dart';
 
-class $Client extends _i2.DynamiteClient {
+class $Client extends _i1.DynamiteClient {
   /// Creates a new `DynamiteClient` for untagged requests.
   $Client(
     super.baseURL, {
@@ -44,7 +44,7 @@ class $Client extends _i2.DynamiteClient {
   });
 
   /// Creates a new [$Client] from another [client].
-  $Client.fromClient(_i2.DynamiteClient client)
+  $Client.fromClient(_i1.DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -72,7 +72,7 @@ class $Client extends _i2.DynamiteClient {
   ///
   /// See:
   ///  * [findPetsRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i2.DynamiteResponse<BuiltList<Pet>, void>> findPets({
+  Future<_i1.DynamiteResponse<BuiltList<Pet>, void>> findPets({
     BuiltList<String>? tags,
     int? limit,
   }) async {
@@ -105,8 +105,8 @@ class $Client extends _i2.DynamiteClient {
   ///
   /// See:
   ///  * [findPets] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
-  _i2.DynamiteRawResponse<BuiltList<Pet>, void> findPetsRaw({
+  @_i2.experimental
+  _i1.DynamiteRawResponse<BuiltList<Pet>, void> findPetsRaw({
     BuiltList<String>? tags,
     int? limit,
   }) {
@@ -119,8 +119,8 @@ class $Client extends _i2.DynamiteClient {
     final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
     _parameters['limit'] = $limit;
 
-    final _path = _i1.UriTemplate('/pets{?tags*,limit*}').expand(_parameters);
-    return _i2.DynamiteRawResponse<BuiltList<Pet>, void>(
+    final _path = _i3.UriTemplate('/pets{?tags*,limit*}').expand(_parameters);
+    return _i1.DynamiteRawResponse<BuiltList<Pet>, void>(
       response: executeRequest(
         'get',
         _path,
@@ -144,7 +144,7 @@ class $Client extends _i2.DynamiteClient {
   ///
   /// See:
   ///  * [addPetRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i2.DynamiteResponse<Pet, void>> addPet({required NewPet newPet}) async {
+  Future<_i1.DynamiteResponse<Pet, void>> addPet({required NewPet newPet}) async {
     final rawResponse = addPetRaw(
       newPet: newPet,
     );
@@ -165,15 +165,15 @@ class $Client extends _i2.DynamiteClient {
   ///
   /// See:
   ///  * [addPet] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
-  _i2.DynamiteRawResponse<Pet, void> addPetRaw({required NewPet newPet}) {
+  @_i2.experimental
+  _i1.DynamiteRawResponse<Pet, void> addPetRaw({required NewPet newPet}) {
     final _headers = <String, String>{'Accept': 'application/json'};
     Uint8List? _body;
 
     _headers['Content-Type'] = 'application/json';
     _body = utf8.encode(json.encode(_$jsonSerializers.serialize(newPet, specifiedType: const FullType(NewPet))));
     const _path = '/pets';
-    return _i2.DynamiteRawResponse<Pet, void>(
+    return _i1.DynamiteRawResponse<Pet, void>(
       response: executeRequest(
         'post',
         _path,
@@ -201,7 +201,7 @@ class $Client extends _i2.DynamiteClient {
   ///
   /// See:
   ///  * [findPetByIdRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i2.DynamiteResponse<Pet, void>> findPetById({required int id}) async {
+  Future<_i1.DynamiteResponse<Pet, void>> findPetById({required int id}) async {
     final rawResponse = findPetByIdRaw(
       id: id,
     );
@@ -225,16 +225,16 @@ class $Client extends _i2.DynamiteClient {
   ///
   /// See:
   ///  * [findPetById] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
-  _i2.DynamiteRawResponse<Pet, void> findPetByIdRaw({required int id}) {
+  @_i2.experimental
+  _i1.DynamiteRawResponse<Pet, void> findPetByIdRaw({required int id}) {
     final _parameters = <String, dynamic>{};
     const _headers = <String, String>{'Accept': 'application/json'};
 
     final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
     _parameters['id'] = $id;
 
-    final _path = _i1.UriTemplate('/pets/{id}').expand(_parameters);
-    return _i2.DynamiteRawResponse<Pet, void>(
+    final _path = _i3.UriTemplate('/pets/{id}').expand(_parameters);
+    return _i1.DynamiteRawResponse<Pet, void>(
       response: executeRequest(
         'get',
         _path,
@@ -261,7 +261,7 @@ class $Client extends _i2.DynamiteClient {
   ///
   /// See:
   ///  * [deletePetRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i2.DynamiteResponse<void, void>> deletePet({required int id}) async {
+  Future<_i1.DynamiteResponse<void, void>> deletePet({required int id}) async {
     final rawResponse = deletePetRaw(
       id: id,
     );
@@ -285,15 +285,15 @@ class $Client extends _i2.DynamiteClient {
   ///
   /// See:
   ///  * [deletePet] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
-  _i2.DynamiteRawResponse<void, void> deletePetRaw({required int id}) {
+  @_i2.experimental
+  _i1.DynamiteRawResponse<void, void> deletePetRaw({required int id}) {
     final _parameters = <String, dynamic>{};
 
     final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
     _parameters['id'] = $id;
 
-    final _path = _i1.UriTemplate('/pets/{id}').expand(_parameters);
-    return _i2.DynamiteRawResponse<void, void>(
+    final _path = _i3.UriTemplate('/pets/{id}').expand(_parameters);
+    return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'delete',
         _path,
@@ -394,7 +394,7 @@ abstract class Error implements $ErrorInterface, Built<Error, ErrorBuilder> {
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(BuiltList, [FullType(String)]), ListBuilder<String>.new)
@@ -411,7 +411,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i4.DynamiteDoubleSerializer())

--- a/packages/dynamite/dynamite/lib/src/builder/client.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/client.dart
@@ -311,14 +311,23 @@ Iterable<Method> buildTags(
         }
 
         final rawParameters = operationParameters.map((p) => '${p.name}: ${p.name},').join('\n');
-        final responseType = refer(
-          'DynamiteResponse<${bodyType.name}, ${headersType.name}>',
-          'package:dynamite_runtime/http_client.dart',
-        ).accept(state.emitter);
+        final responseType = TypeReference(
+          (b) => b
+            ..symbol = 'DynamiteResponse'
+            ..types.addAll([
+              refer(bodyType.name),
+              refer(headersType.name),
+            ])
+            ..url = 'package:dynamite_runtime/http_client.dart',
+        );
 
         b
           ..optionalParameters.addAll(operationParameters)
-          ..returns = refer('Future<$responseType>')
+          ..returns = TypeReference(
+            (b) => b
+              ..symbol = 'Future'
+              ..types.add(responseType),
+          )
           ..body = Code('''
 final rawResponse = ${name}Raw(
   $rawParameters

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_mime_type.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_mime_type.dart
@@ -1,9 +1,6 @@
-import 'package:built_collection/built_collection.dart';
-import 'package:code_builder/code_builder.dart';
 import 'package:dynamite/src/builder/resolve_type.dart';
 import 'package:dynamite/src/builder/state.dart';
 import 'package:dynamite/src/helpers/dart_helpers.dart';
-import 'package:dynamite/src/helpers/dynamite.dart';
 import 'package:dynamite/src/models/openapi.dart' as openapi;
 import 'package:dynamite/src/models/type_result.dart';
 
@@ -42,87 +39,35 @@ TypeResult? resolveMimeTypeDecode(
   return null;
 }
 
-Iterable<String> resolveMimeTypeEncode(
-  openapi.Operation operation,
-  openapi.OpenAPI spec,
-  State state,
-  String identifier,
-  ListBuilder<Parameter> b,
-) sync* {
-  if (operation.requestBody != null) {
-    if (operation.requestBody!.content!.length > 1) {
-      print('Can not work with multiple mime types right now. Using the first supported.');
-    }
-    for (final content in operation.requestBody!.content!.entries) {
-      final mimeType = content.key;
-      final mediaType = content.value;
+void resolveMimeTypeEncode(
+  String mimeType,
+  TypeResult result,
+  StringSink output,
+) {
+  output.writeln("_headers['Content-Type'] = '$mimeType';");
+  final parameterName = toDartName(result.name);
 
-      yield "_headers['Content-Type'] = '$mimeType';";
-
-      final dartParameterNullable = isDartParameterNullable(
-        operation.requestBody!.required,
-        mediaType.schema,
-      );
-
-      final result = resolveType(
-        spec,
-        state,
-        toDartName('$identifier-request-$mimeType', className: true),
-        mediaType.schema!,
-        nullable: dartParameterNullable,
-      );
-      final parameterName = toDartName(result.name);
-      switch (mimeType) {
-        case 'application/json':
-        case 'application/x-www-form-urlencoded':
-          final dartParameterRequired = isRequired(
-            operation.requestBody!.required,
-            mediaType.schema,
-          );
-          b.add(
-            Parameter(
-              (b) => b
-                ..name = parameterName
-                ..type = refer(result.nullableName)
-                ..named = true
-                ..required = dartParameterRequired,
-            ),
-          );
-
-          if (dartParameterNullable) {
-            yield 'if ($parameterName != null) {';
-          }
-          yield '_body = utf8.encode(${result.encode(parameterName, mimeType: mimeType)});';
-          if (dartParameterNullable) {
-            yield '}';
-          }
-          return;
-        case 'application/octet-stream':
-          final dartParameterRequired = isRequired(
-            operation.requestBody!.required,
-            mediaType.schema,
-          );
-          b.add(
-            Parameter(
-              (b) => b
-                ..name = parameterName
-                ..type = refer(result.nullableName)
-                ..named = true
-                ..required = dartParameterRequired,
-            ),
-          );
-
-          if (dartParameterNullable) {
-            yield 'if ($parameterName != null) {';
-          }
-          yield '_body = ${result.encode(parameterName, mimeType: mimeType)};';
-          if (dartParameterNullable) {
-            yield '}';
-          }
-          return;
+  switch (mimeType) {
+    case 'application/json':
+    case 'application/x-www-form-urlencoded':
+      if (result.nullable) {
+        output.writeln('if ($parameterName != null) {');
       }
-    }
-
-    throw Exception('Can not parse any mime type of Operation: "$identifier"');
+      output.writeln('_body = utf8.encode(${result.encode(parameterName, mimeType: mimeType)});');
+      if (result.nullable) {
+        output.writeln('}');
+      }
+      return;
+    case 'application/octet-stream':
+      if (result.nullable) {
+        output.writeln('if ($parameterName != null) {');
+      }
+      output.writeln('_body = ${result.encode(parameterName, mimeType: mimeType)};');
+      if (result.nullable) {
+        output.writeln('}');
+      }
+      return;
+    case _:
+      throw Exception('Can not parse any mime type of the Operation.');
   }
 }

--- a/packages/dynamite/dynamite/pubspec.yaml
+++ b/packages/dynamite/dynamite/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   collection: ^1.0.0
   crypto: ^3.0.0
   dart_style: ^2.0.0
-  intersperse: ^2.0.0
   meta: ^1.0.0
   path: ^1.0.0
   pub_semver: ^2.1.0

--- a/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
@@ -26,15 +26,15 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:dynamite_runtime/built_value.dart' as _i5;
-import 'package:dynamite_runtime/http_client.dart' as _i2;
+import 'package:dynamite_runtime/http_client.dart' as _i1;
 import 'package:dynamite_runtime/utils.dart' as _i4;
-import 'package:meta/meta.dart' as _i3;
-import 'package:uri/uri.dart' as _i1;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i3;
 
 part 'documentation.openapi.g.dart';
 
 /// the root client used for root requests.
-class $Client extends _i2.DynamiteClient {
+class $Client extends _i1.DynamiteClient {
   /// Creates a new `DynamiteClient` for untagged requests.
   $Client(
     super.baseURL, {
@@ -44,7 +44,7 @@ class $Client extends _i2.DynamiteClient {
   });
 
   /// Creates a new [$Client] from another [client].
-  $Client.fromClient(_i2.DynamiteClient client)
+  $Client.fromClient(_i1.DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -76,7 +76,7 @@ class $Client extends _i2.DynamiteClient {
   ///
   /// See:
   ///  * [findValuesRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i2.DynamiteResponse<Object1, void>> findValues({
+  Future<_i1.DynamiteResponse<Object1, void>> findValues({
     BuiltList<String>? tags,
     int? limit,
   }) async {
@@ -110,8 +110,8 @@ class $Client extends _i2.DynamiteClient {
   ///
   /// See:
   ///  * [findValues] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
-  _i2.DynamiteRawResponse<Object1, void> findValuesRaw({
+  @_i2.experimental
+  _i1.DynamiteRawResponse<Object1, void> findValuesRaw({
     BuiltList<String>? tags,
     int? limit,
   }) {
@@ -124,8 +124,8 @@ class $Client extends _i2.DynamiteClient {
     final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
     _parameters['limit'] = $limit;
 
-    final _path = _i1.UriTemplate('/{?tags*,limit*}').expand(_parameters);
-    return _i2.DynamiteRawResponse<Object1, void>(
+    final _path = _i3.UriTemplate('/{?tags*,limit*}').expand(_parameters);
+    return _i1.DynamiteRawResponse<Object1, void>(
       response: executeRequest(
         'get',
         _path,
@@ -155,7 +155,7 @@ class $NonRootClientClient {
   ///
   /// See:
   ///  * [setModeRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i2.DynamiteResponse<Object1, void>> setMode() async {
+  Future<_i1.DynamiteResponse<Object1, void>> setMode() async {
     final rawResponse = setModeRaw();
 
     return rawResponse.future;
@@ -173,12 +173,12 @@ class $NonRootClientClient {
   ///
   /// See:
   ///  * [setMode] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
-  _i2.DynamiteRawResponse<Object1, void> setModeRaw() {
+  @_i2.experimental
+  _i1.DynamiteRawResponse<Object1, void> setModeRaw() {
     const _headers = <String, String>{'Accept': 'application/json'};
 
     const _path = '/other-endpoint';
-    return _i2.DynamiteRawResponse<Object1, void>(
+    return _i1.DynamiteRawResponse<Object1, void>(
       response: _rootClient.executeRequest(
         'post',
         _path,
@@ -419,7 +419,7 @@ class _$b2c4857c0136baea42828d89c87c757dSerializer implements PrimitiveSerialize
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(BuiltList, [FullType(String)]), ListBuilder<String>.new)
@@ -435,7 +435,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
@@ -16,15 +16,15 @@ import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:dynamite_runtime/built_value.dart' as _i5;
-import 'package:dynamite_runtime/http_client.dart' as _i3;
+import 'package:dynamite_runtime/http_client.dart' as _i1;
 import 'package:dynamite_runtime/models.dart';
-import 'package:dynamite_runtime/utils.dart' as _i1;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i2;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'parameters.openapi.g.dart';
 
-class $Client extends _i3.DynamiteClient {
+class $Client extends _i1.DynamiteClient {
   /// Creates a new `DynamiteClient` for untagged requests.
   $Client(
     super.baseURL, {
@@ -34,7 +34,7 @@ class $Client extends _i3.DynamiteClient {
   });
 
   /// Creates a new [$Client] from another [client].
-  $Client.fromClient(_i3.DynamiteClient client)
+  $Client.fromClient(_i1.DynamiteClient client)
       : super(
           client.baseURL,
           baseHeaders: client.baseHeaders,
@@ -67,7 +67,7 @@ class $Client extends _i3.DynamiteClient {
   ///
   /// See:
   ///  * [$getRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i3.DynamiteResponse<JsonObject, void>> $get({
+  Future<_i1.DynamiteResponse<JsonObject, void>> $get({
     ContentString<BuiltMap<String, JsonObject>>? contentString,
     ContentString<BuiltMap<String, JsonObject>>? contentParameter,
     BuiltList<JsonObject>? array,
@@ -129,8 +129,8 @@ class $Client extends _i3.DynamiteClient {
   ///
   /// See:
   ///  * [$get] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
-  _i3.DynamiteRawResponse<JsonObject, void> $getRaw({
+  @_i2.experimental
+  _i1.DynamiteRawResponse<JsonObject, void> $getRaw({
     ContentString<BuiltMap<String, JsonObject>>? contentString,
     ContentString<BuiltMap<String, JsonObject>>? contentParameter,
     BuiltList<JsonObject>? array,
@@ -200,17 +200,17 @@ class $Client extends _i3.DynamiteClient {
     _parameters['anyOf'] = $anyOf;
 
     final $enumPattern = _$jsonSerializers.serialize(enumPattern, specifiedType: const FullType(GetEnumPattern));
-    _i1.checkPattern(
+    _i3.checkPattern(
       $enumPattern as String?,
       RegExp('[a-z]'),
       'enumPattern',
     );
     _parameters['enum_pattern'] = $enumPattern;
 
-    final _path = _i2.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/{?content_string*,content_parameter*,array*,array_string*,bool*,string*,string_binary*,int*,double*,num*,object*,oneOf*,anyOf*,enum_pattern*}',
     ).expand(_parameters);
-    return _i3.DynamiteRawResponse<JsonObject, void>(
+    return _i1.DynamiteRawResponse<JsonObject, void>(
       response: executeRequest(
         'get',
         _path,
@@ -247,7 +247,7 @@ class $Client extends _i3.DynamiteClient {
   ///
   /// See:
   ///  * [getHeadersRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i3.DynamiteResponse<JsonObject, void>> getHeaders({
+  Future<_i1.DynamiteResponse<JsonObject, void>> getHeaders({
     ContentString<BuiltMap<String, JsonObject>>? contentString,
     ContentString<BuiltMap<String, JsonObject>>? contentParameter,
     BuiltList<JsonObject>? array,
@@ -309,8 +309,8 @@ class $Client extends _i3.DynamiteClient {
   ///
   /// See:
   ///  * [getHeaders] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
-  _i3.DynamiteRawResponse<JsonObject, void> getHeadersRaw({
+  @_i2.experimental
+  _i1.DynamiteRawResponse<JsonObject, void> getHeadersRaw({
     ContentString<BuiltMap<String, JsonObject>>? contentString,
     ContentString<BuiltMap<String, JsonObject>>? contentParameter,
     BuiltList<JsonObject>? array,
@@ -335,7 +335,7 @@ class $Client extends _i3.DynamiteClient {
       ]),
     );
     if ($contentString != null) {
-      _headers['content_string'] = const _i1.HeaderEncoder().convert($contentString);
+      _headers['content_string'] = const _i3.HeaderEncoder().convert($contentString);
     }
 
     final $contentParameter = _$jsonSerializers.serialize(
@@ -345,77 +345,77 @@ class $Client extends _i3.DynamiteClient {
       ]),
     );
     if ($contentParameter != null) {
-      _headers['content_parameter'] = const _i1.HeaderEncoder().convert($contentParameter);
+      _headers['content_parameter'] = const _i3.HeaderEncoder().convert($contentParameter);
     }
 
     final $array = _$jsonSerializers.serialize(array, specifiedType: const FullType(BuiltList, [FullType(JsonObject)]));
     if ($array != null) {
-      _headers['array'] = const _i1.HeaderEncoder().convert($array);
+      _headers['array'] = const _i3.HeaderEncoder().convert($array);
     }
 
     final $arrayString =
         _$jsonSerializers.serialize(arrayString, specifiedType: const FullType(BuiltList, [FullType(String)]));
     if ($arrayString != null) {
-      _headers['array_string'] = const _i1.HeaderEncoder().convert($arrayString);
+      _headers['array_string'] = const _i3.HeaderEncoder().convert($arrayString);
     }
 
     final $$bool = _$jsonSerializers.serialize($bool, specifiedType: const FullType(bool));
     if ($$bool != null) {
-      _headers['bool'] = const _i1.HeaderEncoder().convert($$bool);
+      _headers['bool'] = const _i3.HeaderEncoder().convert($$bool);
     }
 
     final $string = _$jsonSerializers.serialize(string, specifiedType: const FullType(String));
     if ($string != null) {
-      _headers['string'] = const _i1.HeaderEncoder().convert($string);
+      _headers['string'] = const _i3.HeaderEncoder().convert($string);
     }
 
     final $stringBinary = _$jsonSerializers.serialize(stringBinary, specifiedType: const FullType(Uint8List));
     if ($stringBinary != null) {
-      _headers['string_binary'] = const _i1.HeaderEncoder().convert($stringBinary);
+      _headers['string_binary'] = const _i3.HeaderEncoder().convert($stringBinary);
     }
 
     final $$int = _$jsonSerializers.serialize($int, specifiedType: const FullType(int));
     if ($$int != null) {
-      _headers['int'] = const _i1.HeaderEncoder().convert($$int);
+      _headers['int'] = const _i3.HeaderEncoder().convert($$int);
     }
 
     final $$double = _$jsonSerializers.serialize($double, specifiedType: const FullType(double));
     if ($$double != null) {
-      _headers['double'] = const _i1.HeaderEncoder().convert($$double);
+      _headers['double'] = const _i3.HeaderEncoder().convert($$double);
     }
 
     final $$num = _$jsonSerializers.serialize($num, specifiedType: const FullType(num));
     if ($$num != null) {
-      _headers['num'] = const _i1.HeaderEncoder().convert($$num);
+      _headers['num'] = const _i3.HeaderEncoder().convert($$num);
     }
 
     final $object = _$jsonSerializers.serialize(object, specifiedType: const FullType(JsonObject));
     if ($object != null) {
-      _headers['object'] = const _i1.HeaderEncoder().convert($object);
+      _headers['object'] = const _i3.HeaderEncoder().convert($object);
     }
 
     final $oneOf = _$jsonSerializers.serialize(oneOf, specifiedType: const FullType(GetHeadersOneOf));
     if ($oneOf != null) {
-      _headers['oneOf'] = const _i1.HeaderEncoder().convert($oneOf);
+      _headers['oneOf'] = const _i3.HeaderEncoder().convert($oneOf);
     }
 
     final $anyOf = _$jsonSerializers.serialize(anyOf, specifiedType: const FullType(GetHeadersAnyOf));
     if ($anyOf != null) {
-      _headers['anyOf'] = const _i1.HeaderEncoder().convert($anyOf);
+      _headers['anyOf'] = const _i3.HeaderEncoder().convert($anyOf);
     }
 
     final $enumPattern = _$jsonSerializers.serialize(enumPattern, specifiedType: const FullType(GetHeadersEnumPattern));
-    _i1.checkPattern(
+    _i3.checkPattern(
       $enumPattern as String?,
       RegExp('[a-z]'),
       'enumPattern',
     );
     if ($enumPattern != null) {
-      _headers['enum_pattern'] = const _i1.HeaderEncoder().convert($enumPattern);
+      _headers['enum_pattern'] = const _i3.HeaderEncoder().convert($enumPattern);
     }
 
     const _path = '/headers';
-    return _i3.DynamiteRawResponse<JsonObject, void>(
+    return _i1.DynamiteRawResponse<JsonObject, void>(
       response: executeRequest(
         'get',
         _path,
@@ -436,7 +436,7 @@ class $Client extends _i3.DynamiteClient {
   ///
   /// See:
   ///  * [getPathParameterRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i3.DynamiteResponse<JsonObject, void>> getPathParameter({required String pathParameter}) async {
+  Future<_i1.DynamiteResponse<JsonObject, void>> getPathParameter({required String pathParameter}) async {
     final rawResponse = getPathParameterRaw(
       pathParameter: pathParameter,
     );
@@ -454,16 +454,16 @@ class $Client extends _i3.DynamiteClient {
   ///
   /// See:
   ///  * [getPathParameter] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
-  _i3.DynamiteRawResponse<JsonObject, void> getPathParameterRaw({required String pathParameter}) {
+  @_i2.experimental
+  _i1.DynamiteRawResponse<JsonObject, void> getPathParameterRaw({required String pathParameter}) {
     final _parameters = <String, dynamic>{};
     const _headers = <String, String>{'Accept': 'application/json'};
 
     final $pathParameter = _$jsonSerializers.serialize(pathParameter, specifiedType: const FullType(String));
     _parameters['path_parameter'] = $pathParameter;
 
-    final _path = _i2.UriTemplate('/{path_parameter}').expand(_parameters);
-    return _i3.DynamiteRawResponse<JsonObject, void>(
+    final _path = _i4.UriTemplate('/{path_parameter}').expand(_parameters);
+    return _i1.DynamiteRawResponse<JsonObject, void>(
       response: executeRequest(
         'get',
         _path,
@@ -484,7 +484,7 @@ class $Client extends _i3.DynamiteClient {
   ///
   /// See:
   ///  * [getNamingCollisionsRaw] for an experimental operation that returns a `DynamiteRawResponse` that can be serialized.
-  Future<_i3.DynamiteResponse<JsonObject, void>> getNamingCollisions({
+  Future<_i1.DynamiteResponse<JsonObject, void>> getNamingCollisions({
     required String jsonSerializers,
     required String serializers,
     required String body,
@@ -512,8 +512,8 @@ class $Client extends _i3.DynamiteClient {
   ///
   /// See:
   ///  * [getNamingCollisions] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
-  _i3.DynamiteRawResponse<JsonObject, void> getNamingCollisionsRaw({
+  @_i2.experimental
+  _i1.DynamiteRawResponse<JsonObject, void> getNamingCollisionsRaw({
     required String jsonSerializers,
     required String serializers,
     required String body,
@@ -528,26 +528,26 @@ class $Client extends _i3.DynamiteClient {
 
     final $serializers = _$jsonSerializers.serialize(serializers, specifiedType: const FullType(String));
     if ($serializers != null) {
-      _headers['%24serializers'] = const _i1.HeaderEncoder().convert($serializers);
+      _headers['%24serializers'] = const _i3.HeaderEncoder().convert($serializers);
     }
 
     final $body = _$jsonSerializers.serialize(body, specifiedType: const FullType(String));
     if ($body != null) {
-      _headers['_body'] = const _i1.HeaderEncoder().convert($body);
+      _headers['_body'] = const _i3.HeaderEncoder().convert($body);
     }
 
     final $parameters = _$jsonSerializers.serialize(parameters, specifiedType: const FullType(String));
     if ($parameters != null) {
-      _headers['_parameters'] = const _i1.HeaderEncoder().convert($parameters);
+      _headers['_parameters'] = const _i3.HeaderEncoder().convert($parameters);
     }
 
     final $headers = _$jsonSerializers.serialize(headers, specifiedType: const FullType(String));
     if ($headers != null) {
-      _headers['_headers'] = const _i1.HeaderEncoder().convert($headers);
+      _headers['_headers'] = const _i3.HeaderEncoder().convert($headers);
     }
 
-    final _path = _i2.UriTemplate('/naming_collisions{?%24jsonSerializers*}').expand(_parameters);
-    return _i3.DynamiteRawResponse<JsonObject, void>(
+    final _path = _i4.UriTemplate('/naming_collisions{?%24jsonSerializers*}').expand(_parameters);
+    return _i1.DynamiteRawResponse<JsonObject, void>(
       response: executeRequest(
         'get',
         _path,
@@ -744,13 +744,13 @@ extension $93403da1a64cb6a7b1597c7a05e9b2beExtension on _$93403da1a64cb6a7b1597c
   List<String> get _names => const [r'$bool', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i1.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i1.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -816,7 +816,7 @@ class _$93403da1a64cb6a7b1597c7a05e9b2beSerializer implements PrimitiveSerialize
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
@@ -841,7 +841,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -25,9 +25,9 @@ import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
 import 'package:dynamite_runtime/models.dart';
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'core.openapi.g.dart';
 
@@ -118,7 +118,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [getStatus] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Status, void> getStatusRaw() {
     const _headers = <String, String>{'Accept': 'application/json'};
 
@@ -183,7 +183,7 @@ class $AppPasswordClient {
   ///
   /// See:
   ///  * [getAppPassword] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AppPasswordGetAppPasswordResponseApplicationJson, void> getAppPasswordRaw({
     bool? oCSAPIRequest,
   }) {
@@ -208,7 +208,7 @@ class $AppPasswordClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/core/getapppassword';
     return _i1.DynamiteRawResponse<AppPasswordGetAppPasswordResponseApplicationJson, void>(
@@ -264,7 +264,7 @@ class $AppPasswordClient {
   ///
   /// See:
   ///  * [rotateAppPassword] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AppPasswordRotateAppPasswordResponseApplicationJson, void> rotateAppPasswordRaw({
     bool? oCSAPIRequest,
   }) {
@@ -289,7 +289,7 @@ class $AppPasswordClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/core/apppassword/rotate';
     return _i1.DynamiteRawResponse<AppPasswordRotateAppPasswordResponseApplicationJson, void>(
@@ -345,7 +345,7 @@ class $AppPasswordClient {
   ///
   /// See:
   ///  * [deleteAppPassword] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AppPasswordDeleteAppPasswordResponseApplicationJson, void> deleteAppPasswordRaw({
     bool? oCSAPIRequest,
   }) {
@@ -370,7 +370,7 @@ class $AppPasswordClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/core/apppassword';
     return _i1.DynamiteRawResponse<AppPasswordDeleteAppPasswordResponseApplicationJson, void>(
@@ -455,7 +455,7 @@ class $AutoCompleteClient {
   ///
   /// See:
   ///  * [$get] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AutoCompleteGetResponseApplicationJson, void> $getRaw({
     required String search,
     String? itemType,
@@ -508,9 +508,9 @@ class $AutoCompleteClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/core/autocomplete/get{?search*,itemType*,itemId*,sorter*,shareTypes%5B%5D*,limit*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<AutoCompleteGetResponseApplicationJson, void>(
@@ -578,7 +578,7 @@ class $AvatarClient {
   ///
   /// See:
   ///  * [getAvatarDark] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, AvatarAvatarGetAvatarDarkHeaders> getAvatarDarkRaw({
     required String userId,
     required int size,
@@ -607,7 +607,7 @@ class $AvatarClient {
     final $size = _$jsonSerializers.serialize(size, specifiedType: const FullType(int));
     _parameters['size'] = $size;
 
-    final _path = _i3.UriTemplate('/index.php/avatar/{userId}/{size}/dark').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/avatar/{userId}/{size}/dark').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, AvatarAvatarGetAvatarDarkHeaders>(
       response: _rootClient.executeRequest(
         'get',
@@ -665,7 +665,7 @@ class $AvatarClient {
   ///
   /// See:
   ///  * [getAvatar] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, AvatarAvatarGetAvatarHeaders> getAvatarRaw({
     required String userId,
     required int size,
@@ -694,7 +694,7 @@ class $AvatarClient {
     final $size = _$jsonSerializers.serialize(size, specifiedType: const FullType(int));
     _parameters['size'] = $size;
 
-    final _path = _i3.UriTemplate('/index.php/avatar/{userId}/{size}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/avatar/{userId}/{size}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, AvatarAvatarGetAvatarHeaders>(
       response: _rootClient.executeRequest(
         'get',
@@ -753,7 +753,7 @@ class $ClientFlowLoginV2Client {
   ///
   /// See:
   ///  * [poll] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<LoginFlowV2Credentials, void> pollRaw({required String token}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -776,7 +776,7 @@ class $ClientFlowLoginV2Client {
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _parameters['token'] = $token;
 
-    final _path = _i3.UriTemplate('/index.php/login/v2/poll{?token*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/login/v2/poll{?token*}').expand(_parameters);
     return _i1.DynamiteRawResponse<LoginFlowV2Credentials, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -818,7 +818,7 @@ class $ClientFlowLoginV2Client {
   ///
   /// See:
   ///  * [init] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<LoginFlowV2, void> initRaw() {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -902,7 +902,7 @@ class $CollaborationResourcesClient {
   ///
   /// See:
   ///  * [searchCollections] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CollaborationResourcesSearchCollectionsResponseApplicationJson, void> searchCollectionsRaw({
     required String filter,
     bool? oCSAPIRequest,
@@ -932,10 +932,10 @@ class $CollaborationResourcesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/collaboration/resources/collections/search/{filter}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/collaboration/resources/collections/search/{filter}').expand(_parameters);
     return _i1.DynamiteRawResponse<CollaborationResourcesSearchCollectionsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -995,7 +995,7 @@ class $CollaborationResourcesClient {
   ///
   /// See:
   ///  * [listCollection] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CollaborationResourcesListCollectionResponseApplicationJson, void> listCollectionRaw({
     required int collectionId,
     bool? oCSAPIRequest,
@@ -1025,9 +1025,9 @@ class $CollaborationResourcesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}').expand(_parameters);
     return _i1.DynamiteRawResponse<CollaborationResourcesListCollectionResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1091,7 +1091,7 @@ class $CollaborationResourcesClient {
   ///
   /// See:
   ///  * [renameCollection] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CollaborationResourcesRenameCollectionResponseApplicationJson, void> renameCollectionRaw({
     required String collectionName,
     required int collectionId,
@@ -1125,9 +1125,9 @@ class $CollaborationResourcesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?collectionName*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?collectionName*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<CollaborationResourcesRenameCollectionResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1196,7 +1196,7 @@ class $CollaborationResourcesClient {
   ///
   /// See:
   ///  * [addResource] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CollaborationResourcesAddResourceResponseApplicationJson, void> addResourceRaw({
     required String resourceType,
     required String resourceId,
@@ -1234,10 +1234,10 @@ class $CollaborationResourcesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?resourceType*,resourceId*}')
+        _i4.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?resourceType*,resourceId*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<CollaborationResourcesAddResourceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1306,7 +1306,7 @@ class $CollaborationResourcesClient {
   ///
   /// See:
   ///  * [removeResource] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CollaborationResourcesRemoveResourceResponseApplicationJson, void> removeResourceRaw({
     required String resourceType,
     required String resourceId,
@@ -1344,10 +1344,10 @@ class $CollaborationResourcesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?resourceType*,resourceId*}')
+        _i4.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?resourceType*,resourceId*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<CollaborationResourcesRemoveResourceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1411,7 +1411,7 @@ class $CollaborationResourcesClient {
   ///
   /// See:
   ///  * [getCollectionsByResource] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson, void>
       getCollectionsByResourceRaw({
     required String resourceType,
@@ -1446,10 +1446,10 @@ class $CollaborationResourcesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/collaboration/resources/{resourceType}/{resourceId}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/collaboration/resources/{resourceType}/{resourceId}').expand(_parameters);
     return _i1.DynamiteRawResponse<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1520,7 +1520,7 @@ class $CollaborationResourcesClient {
   ///
   /// See:
   ///  * [createCollectionOnResource] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson, void>
       createCollectionOnResourceRaw({
     required String name,
@@ -1559,9 +1559,9 @@ class $CollaborationResourcesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/collaboration/resources/{baseResourceType}/{baseResourceId}{?name*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/collaboration/resources/{baseResourceType}/{baseResourceId}{?name*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1630,7 +1630,7 @@ class $GuestAvatarClient {
   ///
   /// See:
   ///  * [getAvatarDark] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getAvatarDarkRaw({
     required String guestName,
     required String size,
@@ -1659,7 +1659,7 @@ class $GuestAvatarClient {
     final $size = _$jsonSerializers.serialize(size, specifiedType: const FullType(String));
     _parameters['size'] = $size;
 
-    final _path = _i3.UriTemplate('/index.php/avatar/guest/{guestName}/{size}/dark').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/avatar/guest/{guestName}/{size}/dark').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1726,7 +1726,7 @@ class $GuestAvatarClient {
   ///
   /// See:
   ///  * [getAvatar] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getAvatarRaw({
     required String guestName,
     required String size,
@@ -1761,7 +1761,7 @@ class $GuestAvatarClient {
     $darkTheme ??= 0;
     _parameters['darkTheme'] = $darkTheme;
 
-    final _path = _i3.UriTemplate('/index.php/avatar/guest/{guestName}/{size}{?darkTheme*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/avatar/guest/{guestName}/{size}{?darkTheme*}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1829,7 +1829,7 @@ class $HoverCardClient {
   ///
   /// See:
   ///  * [getUser] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<HoverCardGetUserResponseApplicationJson, void> getUserRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -1859,9 +1859,9 @@ class $HoverCardClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/hovercard/v1/{userId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/hovercard/v1/{userId}').expand(_parameters);
     return _i1.DynamiteRawResponse<HoverCardGetUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1926,7 +1926,7 @@ class $NavigationClient {
   ///
   /// See:
   ///  * [getAppsNavigation] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<NavigationGetAppsNavigationResponseApplicationJson, void> getAppsNavigationRaw({
     NavigationGetAppsNavigationAbsolute? absolute,
     bool? oCSAPIRequest,
@@ -1958,9 +1958,9 @@ class $NavigationClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/core/navigation/apps{?absolute*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/core/navigation/apps{?absolute*}').expand(_parameters);
     return _i1.DynamiteRawResponse<NavigationGetAppsNavigationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -2018,7 +2018,7 @@ class $NavigationClient {
   ///
   /// See:
   ///  * [getSettingsNavigation] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<NavigationGetSettingsNavigationResponseApplicationJson, void> getSettingsNavigationRaw({
     NavigationGetSettingsNavigationAbsolute? absolute,
     bool? oCSAPIRequest,
@@ -2050,9 +2050,9 @@ class $NavigationClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/core/navigation/settings{?absolute*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/core/navigation/settings{?absolute*}').expand(_parameters);
     return _i1.DynamiteRawResponse<NavigationGetSettingsNavigationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -2104,7 +2104,7 @@ class $OcmClient {
   ///
   /// See:
   ///  * [discovery] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<OcmDiscoveryResponseApplicationJson, OcmOcmDiscoveryHeaders> discoveryRaw() {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -2182,7 +2182,7 @@ class $OcsClient {
   ///
   /// See:
   ///  * [getCapabilities] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<OcsGetCapabilitiesResponseApplicationJson, void> getCapabilitiesRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -2203,7 +2203,7 @@ class $OcsClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/cloud/capabilities';
     return _i1.DynamiteRawResponse<OcsGetCapabilitiesResponseApplicationJson, void>(
@@ -2296,7 +2296,7 @@ class $PreviewClient {
   ///
   /// See:
   ///  * [getPreviewByFileId] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getPreviewByFileIdRaw({
     int? fileId,
     int? x,
@@ -2356,7 +2356,7 @@ class $PreviewClient {
     $mimeFallback ??= 0;
     _parameters['mimeFallback'] = $mimeFallback;
 
-    final _path = _i3.UriTemplate('/index.php/core/preview{?fileId*,x*,y*,a*,forceIcon*,mode*,mimeFallback*}')
+    final _path = _i4.UriTemplate('/index.php/core/preview{?fileId*,x*,y*,a*,forceIcon*,mode*,mimeFallback*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -2441,7 +2441,7 @@ class $PreviewClient {
   ///
   /// See:
   ///  * [getPreview] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getPreviewRaw({
     String? file,
     int? x,
@@ -2500,7 +2500,7 @@ class $PreviewClient {
     $mimeFallback ??= 0;
     _parameters['mimeFallback'] = $mimeFallback;
 
-    final _path = _i3.UriTemplate('/index.php/core/preview.png{?file*,x*,y*,a*,forceIcon*,mode*,mimeFallback*}')
+    final _path = _i4.UriTemplate('/index.php/core/preview.png{?file*,x*,y*,a*,forceIcon*,mode*,mimeFallback*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -2578,7 +2578,7 @@ class $ProfileApiClient {
   ///
   /// See:
   ///  * [setVisibility] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ProfileApiSetVisibilityResponseApplicationJson, void> setVisibilityRaw({
     required String paramId,
     required String visibility,
@@ -2616,9 +2616,9 @@ class $ProfileApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/profile/{targetUserId}{?paramId*,visibility*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/profile/{targetUserId}{?paramId*,visibility*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ProfileApiSetVisibilityResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -2677,7 +2677,7 @@ class $ReferenceClient {
   ///
   /// See:
   ///  * [preview] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> previewRaw({required String referenceId}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': '*/*'};
@@ -2700,7 +2700,7 @@ class $ReferenceClient {
     final $referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
     _parameters['referenceId'] = $referenceId;
 
-    final _path = _i3.UriTemplate('/index.php/core/references/preview/{referenceId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/core/references/preview/{referenceId}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -2763,7 +2763,7 @@ class $ReferenceApiClient {
   ///
   /// See:
   ///  * [resolveOne] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ReferenceApiResolveOneResponseApplicationJson, void> resolveOneRaw({
     required String reference,
     bool? oCSAPIRequest,
@@ -2793,9 +2793,9 @@ class $ReferenceApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/references/resolve{?reference*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/references/resolve{?reference*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ReferenceApiResolveOneResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -2855,7 +2855,7 @@ class $ReferenceApiClient {
   ///
   /// See:
   ///  * [resolve] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ReferenceApiResolveResponseApplicationJson, void> resolveRaw({
     required BuiltList<String> references,
     int? limit,
@@ -2891,9 +2891,9 @@ class $ReferenceApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/references/resolve{?references%5B%5D*,limit*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/references/resolve{?references%5B%5D*,limit*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ReferenceApiResolveResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -2957,7 +2957,7 @@ class $ReferenceApiClient {
   ///
   /// See:
   ///  * [extract] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ReferenceApiExtractResponseApplicationJson, void> extractRaw({
     required String text,
     ReferenceApiExtractResolve? resolve,
@@ -2997,9 +2997,9 @@ class $ReferenceApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/references/extract{?text*,resolve*,limit*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/references/extract{?text*,resolve*,limit*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ReferenceApiExtractResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -3051,7 +3051,7 @@ class $ReferenceApiClient {
   ///
   /// See:
   ///  * [getProvidersInfo] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ReferenceApiGetProvidersInfoResponseApplicationJson, void> getProvidersInfoRaw({
     bool? oCSAPIRequest,
   }) {
@@ -3076,7 +3076,7 @@ class $ReferenceApiClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/references/providers';
     return _i1.DynamiteRawResponse<ReferenceApiGetProvidersInfoResponseApplicationJson, void>(
@@ -3138,7 +3138,7 @@ class $ReferenceApiClient {
   ///
   /// See:
   ///  * [touchProvider] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ReferenceApiTouchProviderResponseApplicationJson, void> touchProviderRaw({
     required String providerId,
     int? timestamp,
@@ -3172,9 +3172,9 @@ class $ReferenceApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/references/provider/{providerId}{?timestamp*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/references/provider/{providerId}{?timestamp*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ReferenceApiTouchProviderResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -3233,7 +3233,7 @@ class $TextProcessingApiClient {
   ///
   /// See:
   ///  * [taskTypes] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TextProcessingApiTaskTypesResponseApplicationJson, void> taskTypesRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -3254,7 +3254,7 @@ class $TextProcessingApiClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/textprocessing/tasktypes';
     return _i1.DynamiteRawResponse<TextProcessingApiTaskTypesResponseApplicationJson, void>(
@@ -3330,7 +3330,7 @@ class $TextProcessingApiClient {
   ///
   /// See:
   ///  * [schedule] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TextProcessingApiScheduleResponseApplicationJson, void> scheduleRaw({
     required String input,
     required String type,
@@ -3371,10 +3371,10 @@ class $TextProcessingApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/textprocessing/schedule{?input*,type*,appId*,identifier*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/textprocessing/schedule{?input*,type*,appId*,identifier*}').expand(_parameters);
     return _i1.DynamiteRawResponse<TextProcessingApiScheduleResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -3434,7 +3434,7 @@ class $TextProcessingApiClient {
   ///
   /// See:
   ///  * [getTask] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TextProcessingApiGetTaskResponseApplicationJson, void> getTaskRaw({
     required int id,
     bool? oCSAPIRequest,
@@ -3462,9 +3462,9 @@ class $TextProcessingApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/textprocessing/task/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/textprocessing/task/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<TextProcessingApiGetTaskResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -3524,7 +3524,7 @@ class $TextProcessingApiClient {
   ///
   /// See:
   ///  * [deleteTask] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TextProcessingApiDeleteTaskResponseApplicationJson, void> deleteTaskRaw({
     required int id,
     bool? oCSAPIRequest,
@@ -3554,9 +3554,9 @@ class $TextProcessingApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/textprocessing/task/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/textprocessing/task/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<TextProcessingApiDeleteTaskResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -3618,7 +3618,7 @@ class $TextProcessingApiClient {
   ///
   /// See:
   ///  * [listTasksByApp] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TextProcessingApiListTasksByAppResponseApplicationJson, void> listTasksByAppRaw({
     required String appId,
     String? identifier,
@@ -3652,9 +3652,9 @@ class $TextProcessingApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/textprocessing/tasks/app/{appId}{?identifier*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/textprocessing/tasks/app/{appId}{?identifier*}').expand(_parameters);
     return _i1.DynamiteRawResponse<TextProcessingApiListTasksByAppResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -3713,7 +3713,7 @@ class $TextToImageApiClient {
   ///
   /// See:
   ///  * [isAvailable] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TextToImageApiIsAvailableResponseApplicationJson, void> isAvailableRaw({
     bool? oCSAPIRequest,
   }) {
@@ -3736,7 +3736,7 @@ class $TextToImageApiClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/text2image/is_available';
     return _i1.DynamiteRawResponse<TextToImageApiIsAvailableResponseApplicationJson, void>(
@@ -3810,7 +3810,7 @@ class $TextToImageApiClient {
   ///
   /// See:
   ///  * [schedule] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TextToImageApiScheduleResponseApplicationJson, void> scheduleRaw({
     required String input,
     required String appId,
@@ -3852,9 +3852,9 @@ class $TextToImageApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/text2image/schedule{?input*,appId*,identifier*,numberOfImages*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/text2image/schedule{?input*,appId*,identifier*,numberOfImages*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<TextToImageApiScheduleResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3915,7 +3915,7 @@ class $TextToImageApiClient {
   ///
   /// See:
   ///  * [getTask] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TextToImageApiGetTaskResponseApplicationJson, void> getTaskRaw({
     required int id,
     bool? oCSAPIRequest,
@@ -3943,9 +3943,9 @@ class $TextToImageApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/text2image/task/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/text2image/task/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<TextToImageApiGetTaskResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -4005,7 +4005,7 @@ class $TextToImageApiClient {
   ///
   /// See:
   ///  * [deleteTask] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TextToImageApiDeleteTaskResponseApplicationJson, void> deleteTaskRaw({
     required int id,
     bool? oCSAPIRequest,
@@ -4035,9 +4035,9 @@ class $TextToImageApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/text2image/task/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/text2image/task/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<TextToImageApiDeleteTaskResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -4101,7 +4101,7 @@ class $TextToImageApiClient {
   ///
   /// See:
   ///  * [getImage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getImageRaw({
     required int id,
     required int index,
@@ -4133,9 +4133,9 @@ class $TextToImageApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/text2image/task/{id}/image/{index}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/text2image/task/{id}/image/{index}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -4197,7 +4197,7 @@ class $TextToImageApiClient {
   ///
   /// See:
   ///  * [listTasksByApp] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TextToImageApiListTasksByAppResponseApplicationJson, void> listTasksByAppRaw({
     required String appId,
     String? identifier,
@@ -4231,9 +4231,9 @@ class $TextToImageApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/text2image/tasks/app/{appId}{?identifier*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/text2image/tasks/app/{appId}{?identifier*}').expand(_parameters);
     return _i1.DynamiteRawResponse<TextToImageApiListTasksByAppResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -4292,7 +4292,7 @@ class $TranslationApiClient {
   ///
   /// See:
   ///  * [languages] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TranslationApiLanguagesResponseApplicationJson, void> languagesRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -4313,7 +4313,7 @@ class $TranslationApiClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/translation/languages';
     return _i1.DynamiteRawResponse<TranslationApiLanguagesResponseApplicationJson, void>(
@@ -4385,7 +4385,7 @@ class $TranslationApiClient {
   ///
   /// See:
   ///  * [translate] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TranslationApiTranslateResponseApplicationJson, void> translateRaw({
     required String text,
     required String toLanguage,
@@ -4421,10 +4421,10 @@ class $TranslationApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/translation/translate{?text*,toLanguage*,fromLanguage*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/translation/translate{?text*,toLanguage*,fromLanguage*}').expand(_parameters);
     return _i1.DynamiteRawResponse<TranslationApiTranslateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -4487,7 +4487,7 @@ class $UnifiedSearchClient {
   ///
   /// See:
   ///  * [getProviders] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UnifiedSearchGetProvidersResponseApplicationJson, void> getProvidersRaw({
     String? from,
     bool? oCSAPIRequest,
@@ -4518,9 +4518,9 @@ class $UnifiedSearchClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/search/providers{?from*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/search/providers{?from*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UnifiedSearchGetProvidersResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -4602,7 +4602,7 @@ class $UnifiedSearchClient {
   ///
   /// See:
   ///  * [search] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UnifiedSearchSearchResponseApplicationJson, void> searchRaw({
     required String providerId,
     String? term,
@@ -4654,10 +4654,10 @@ class $UnifiedSearchClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/search/providers/{providerId}/search{?term*,sortOrder*,limit*,cursor*,from*}')
+        _i4.UriTemplate('/ocs/v2.php/search/providers/{providerId}/search{?term*,sortOrder*,limit*,cursor*,from*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<UnifiedSearchSearchResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4717,7 +4717,7 @@ class $WhatsNewClient {
   ///
   /// See:
   ///  * [$get] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<WhatsNewGetResponseApplicationJson, void> $getRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -4740,7 +4740,7 @@ class $WhatsNewClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/core/whatsnew';
     return _i1.DynamiteRawResponse<WhatsNewGetResponseApplicationJson, void>(
@@ -4800,7 +4800,7 @@ class $WhatsNewClient {
   ///
   /// See:
   ///  * [dismiss] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<WhatsNewDismissResponseApplicationJson, void> dismissRaw({
     required String version,
     bool? oCSAPIRequest,
@@ -4830,9 +4830,9 @@ class $WhatsNewClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/core/whatsnew{?version*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/core/whatsnew{?version*}').expand(_parameters);
     return _i1.DynamiteRawResponse<WhatsNewDismissResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -4891,7 +4891,7 @@ class $WipeClient {
   ///
   /// See:
   ///  * [checkWipe] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<WipeCheckWipeResponseApplicationJson, void> checkWipeRaw({required String token}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -4914,7 +4914,7 @@ class $WipeClient {
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _parameters['token'] = $token;
 
-    final _path = _i3.UriTemplate('/index.php/core/wipe/check{?token*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/core/wipe/check{?token*}').expand(_parameters);
     return _i1.DynamiteRawResponse<WipeCheckWipeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -4966,7 +4966,7 @@ class $WipeClient {
   ///
   /// See:
   ///  * [wipeDone] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<JsonObject, void> wipeDoneRaw({required String token}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -4989,7 +4989,7 @@ class $WipeClient {
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _parameters['token'] = $token;
 
-    final _path = _i3.UriTemplate('/index.php/core/wipe/success{?token*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/core/wipe/success{?token*}').expand(_parameters);
     return _i1.DynamiteRawResponse<JsonObject, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -6942,104 +6942,6 @@ abstract class NavigationGetSettingsNavigationResponseApplicationJson
       _$navigationGetSettingsNavigationResponseApplicationJsonSerializer;
 }
 
-class OcmOcmDiscoveryHeaders_XNextcloudOcmProviders extends EnumClass {
-  const OcmOcmDiscoveryHeaders_XNextcloudOcmProviders._(super.name);
-
-  /// `true`
-  @BuiltValueEnumConst(wireName: 'true')
-  static const OcmOcmDiscoveryHeaders_XNextcloudOcmProviders $true =
-      _$ocmOcmDiscoveryHeadersXNextcloudOcmProviders$true;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get values =>
-      _$ocmOcmDiscoveryHeadersXNextcloudOcmProvidersValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static OcmOcmDiscoveryHeaders_XNextcloudOcmProviders valueOf(String name) =>
-      _$valueOfOcmOcmDiscoveryHeaders_XNextcloudOcmProviders(name);
-
-  /// Returns the serialized value of this enum value.
-  bool get value => _$jsonSerializers.serializeWith(serializer, this)! as bool;
-
-  /// Serializer for OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get serializer =>
-      const _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer();
-}
-
-class _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer
-    implements PrimitiveSerializer<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> {
-  const _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer();
-
-  static const Map<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders, Object> _toWire =
-      <OcmOcmDiscoveryHeaders_XNextcloudOcmProviders, Object>{
-    OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.$true: true,
-  };
-
-  static const Map<Object, OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> _fromWire =
-      <Object, OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>{
-    true: OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.$true,
-  };
-
-  @override
-  Iterable<Type> get types => const [OcmOcmDiscoveryHeaders_XNextcloudOcmProviders];
-
-  @override
-  String get wireName => 'OcmOcmDiscoveryHeaders_XNextcloudOcmProviders';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    OcmOcmDiscoveryHeaders_XNextcloudOcmProviders object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  OcmOcmDiscoveryHeaders_XNextcloudOcmProviders deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $OcmOcmDiscoveryHeadersInterface {
-  @BuiltValueField(wireName: 'x-nextcloud-ocm-providers')
-  Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? get xNextcloudOcmProviders;
-}
-
-abstract class OcmOcmDiscoveryHeaders
-    implements $OcmOcmDiscoveryHeadersInterface, Built<OcmOcmDiscoveryHeaders, OcmOcmDiscoveryHeadersBuilder> {
-  /// Creates a new OcmOcmDiscoveryHeaders object using the builder pattern.
-  factory OcmOcmDiscoveryHeaders([void Function(OcmOcmDiscoveryHeadersBuilder)? b]) = _$OcmOcmDiscoveryHeaders;
-
-  // coverage:ignore-start
-  const OcmOcmDiscoveryHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory OcmOcmDiscoveryHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for OcmOcmDiscoveryHeaders.
-  static Serializer<OcmOcmDiscoveryHeaders> get serializer => _$ocmOcmDiscoveryHeadersSerializer;
-}
-
 @BuiltValue(instantiable: false)
 abstract interface class $OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterface {
   String get webdav;
@@ -7158,6 +7060,104 @@ abstract class OcmDiscoveryResponseApplicationJson
   /// Serializer for OcmDiscoveryResponseApplicationJson.
   static Serializer<OcmDiscoveryResponseApplicationJson> get serializer =>
       _$ocmDiscoveryResponseApplicationJsonSerializer;
+}
+
+class OcmOcmDiscoveryHeaders_XNextcloudOcmProviders extends EnumClass {
+  const OcmOcmDiscoveryHeaders_XNextcloudOcmProviders._(super.name);
+
+  /// `true`
+  @BuiltValueEnumConst(wireName: 'true')
+  static const OcmOcmDiscoveryHeaders_XNextcloudOcmProviders $true =
+      _$ocmOcmDiscoveryHeadersXNextcloudOcmProviders$true;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get values =>
+      _$ocmOcmDiscoveryHeadersXNextcloudOcmProvidersValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static OcmOcmDiscoveryHeaders_XNextcloudOcmProviders valueOf(String name) =>
+      _$valueOfOcmOcmDiscoveryHeaders_XNextcloudOcmProviders(name);
+
+  /// Returns the serialized value of this enum value.
+  bool get value => _$jsonSerializers.serializeWith(serializer, this)! as bool;
+
+  /// Serializer for OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get serializer =>
+      const _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer();
+}
+
+class _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer
+    implements PrimitiveSerializer<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> {
+  const _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer();
+
+  static const Map<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders, Object> _toWire =
+      <OcmOcmDiscoveryHeaders_XNextcloudOcmProviders, Object>{
+    OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.$true: true,
+  };
+
+  static const Map<Object, OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> _fromWire =
+      <Object, OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>{
+    true: OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.$true,
+  };
+
+  @override
+  Iterable<Type> get types => const [OcmOcmDiscoveryHeaders_XNextcloudOcmProviders];
+
+  @override
+  String get wireName => 'OcmOcmDiscoveryHeaders_XNextcloudOcmProviders';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    OcmOcmDiscoveryHeaders_XNextcloudOcmProviders object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  OcmOcmDiscoveryHeaders_XNextcloudOcmProviders deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $OcmOcmDiscoveryHeadersInterface {
+  @BuiltValueField(wireName: 'x-nextcloud-ocm-providers')
+  Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? get xNextcloudOcmProviders;
+}
+
+abstract class OcmOcmDiscoveryHeaders
+    implements $OcmOcmDiscoveryHeadersInterface, Built<OcmOcmDiscoveryHeaders, OcmOcmDiscoveryHeadersBuilder> {
+  /// Creates a new OcmOcmDiscoveryHeaders object using the builder pattern.
+  factory OcmOcmDiscoveryHeaders([void Function(OcmOcmDiscoveryHeadersBuilder)? b]) = _$OcmOcmDiscoveryHeaders;
+
+  // coverage:ignore-start
+  const OcmOcmDiscoveryHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory OcmOcmDiscoveryHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for OcmOcmDiscoveryHeaders.
+  static Serializer<OcmOcmDiscoveryHeaders> get serializer => _$ocmOcmDiscoveryHeadersSerializer;
 }
 
 @BuiltValue(instantiable: false)
@@ -13063,13 +13063,13 @@ extension $87e48e5649cd72b4d2947aaaea13ccd8Extension on _$87e48e5649cd72b4d2947a
   List<String> get _names => const ['autocompleteResultStatus0', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -13142,13 +13142,13 @@ extension $b2c4857c0136baea42828d89c87c757dExtension on _$b2c4857c0136baea42828d
   List<String> get _names => const [r'$int', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -13221,13 +13221,13 @@ extension $46564992d3ed3482aa6c1162698aac99Extension on _$46564992d3ed3482aa6c11
   List<String> get _names => const ['builtListNever', 'sharebymailCapabilities0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -13302,13 +13302,13 @@ extension $06c2e47196a84ebc3718dccf9eb4b29dExtension on _$06c2e47196a84ebc3718dc
   List<String> get _names => const ['builtListNever', 'spreedPublicCapabilities0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -13430,13 +13430,13 @@ extension $d7df54b8bef6b092d401eed2bcfbb6f0Extension on _$d7df54b8bef6b092d401ee
       ];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -13653,7 +13653,7 @@ class _$d7df54b8bef6b092d401eed2bcfbb6f0Serializer implements PrimitiveSerialize
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(Status), StatusBuilder.new)
@@ -13859,13 +13859,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
         NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder.new,
       )
       ..add(NavigationGetSettingsNavigationResponseApplicationJson_Ocs.serializer)
-      ..addBuilderFactory(const FullType(OcmOcmDiscoveryHeaders), OcmOcmDiscoveryHeadersBuilder.new)
-      ..add(OcmOcmDiscoveryHeaders.serializer)
-      ..add(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.serializer)
-      ..addBuilderFactory(
-        const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)]),
-        HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>.new,
-      )
       ..addBuilderFactory(
         const FullType(OcmDiscoveryResponseApplicationJson),
         OcmDiscoveryResponseApplicationJsonBuilder.new,
@@ -13885,6 +13878,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
         const FullType(BuiltList, [FullType(OcmDiscoveryResponseApplicationJson_ResourceTypes)]),
         ListBuilder<OcmDiscoveryResponseApplicationJson_ResourceTypes>.new,
+      )
+      ..addBuilderFactory(const FullType(OcmOcmDiscoveryHeaders), OcmOcmDiscoveryHeadersBuilder.new)
+      ..add(OcmOcmDiscoveryHeaders.serializer)
+      ..add(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.serializer)
+      ..addBuilderFactory(
+        const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)]),
+        HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>.new,
       )
       ..addBuilderFactory(
         const FullType(OcsGetCapabilitiesResponseApplicationJson),
@@ -14509,7 +14509,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/core.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.g.dart
@@ -399,7 +399,6 @@ Serializer<NavigationGetSettingsNavigationResponseApplicationJson_Ocs>
 Serializer<NavigationGetSettingsNavigationResponseApplicationJson>
     _$navigationGetSettingsNavigationResponseApplicationJsonSerializer =
     _$NavigationGetSettingsNavigationResponseApplicationJsonSerializer();
-Serializer<OcmOcmDiscoveryHeaders> _$ocmOcmDiscoveryHeadersSerializer = _$OcmOcmDiscoveryHeadersSerializer();
 Serializer<OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols>
     _$ocmDiscoveryResponseApplicationJsonResourceTypesProtocolsSerializer =
     _$OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsSerializer();
@@ -408,6 +407,7 @@ Serializer<OcmDiscoveryResponseApplicationJson_ResourceTypes>
     _$OcmDiscoveryResponseApplicationJson_ResourceTypesSerializer();
 Serializer<OcmDiscoveryResponseApplicationJson> _$ocmDiscoveryResponseApplicationJsonSerializer =
     _$OcmDiscoveryResponseApplicationJsonSerializer();
+Serializer<OcmOcmDiscoveryHeaders> _$ocmOcmDiscoveryHeadersSerializer = _$OcmOcmDiscoveryHeadersSerializer();
 Serializer<OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version>
     _$ocsGetCapabilitiesResponseApplicationJsonOcsDataVersionSerializer =
     _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionSerializer();
@@ -2985,50 +2985,6 @@ class _$NavigationGetSettingsNavigationResponseApplicationJsonSerializer
   }
 }
 
-class _$OcmOcmDiscoveryHeadersSerializer implements StructuredSerializer<OcmOcmDiscoveryHeaders> {
-  @override
-  final Iterable<Type> types = const [OcmOcmDiscoveryHeaders, _$OcmOcmDiscoveryHeaders];
-  @override
-  final String wireName = 'OcmOcmDiscoveryHeaders';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, OcmOcmDiscoveryHeaders object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.xNextcloudOcmProviders;
-    if (value != null) {
-      result
-        ..add('x-nextcloud-ocm-providers')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)])));
-    }
-    return result;
-  }
-
-  @override
-  OcmOcmDiscoveryHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = OcmOcmDiscoveryHeadersBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'x-nextcloud-ocm-providers':
-          result.xNextcloudOcmProviders.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)]))!
-              as Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>);
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsSerializer
     implements StructuredSerializer<OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols> {
   @override
@@ -3179,6 +3135,50 @@ class _$OcmDiscoveryResponseApplicationJsonSerializer
                   specifiedType:
                       const FullType(BuiltList, [FullType(OcmDiscoveryResponseApplicationJson_ResourceTypes)]))!
               as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$OcmOcmDiscoveryHeadersSerializer implements StructuredSerializer<OcmOcmDiscoveryHeaders> {
+  @override
+  final Iterable<Type> types = const [OcmOcmDiscoveryHeaders, _$OcmOcmDiscoveryHeaders];
+  @override
+  final String wireName = 'OcmOcmDiscoveryHeaders';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, OcmOcmDiscoveryHeaders object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.xNextcloudOcmProviders;
+    if (value != null) {
+      result
+        ..add('x-nextcloud-ocm-providers')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)])));
+    }
+    return result;
+  }
+
+  @override
+  OcmOcmDiscoveryHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = OcmOcmDiscoveryHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'x-nextcloud-ocm-providers':
+          result.xNextcloudOcmProviders.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)]))!
+              as Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>);
           break;
       }
     }
@@ -15550,106 +15550,6 @@ class NavigationGetSettingsNavigationResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $OcmOcmDiscoveryHeadersInterfaceBuilder {
-  void replace($OcmOcmDiscoveryHeadersInterface other);
-  void update(void Function($OcmOcmDiscoveryHeadersInterfaceBuilder) updates);
-  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get xNextcloudOcmProviders;
-  set xNextcloudOcmProviders(HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders);
-}
-
-class _$OcmOcmDiscoveryHeaders extends OcmOcmDiscoveryHeaders {
-  @override
-  final Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders;
-
-  factory _$OcmOcmDiscoveryHeaders([void Function(OcmOcmDiscoveryHeadersBuilder)? updates]) =>
-      (OcmOcmDiscoveryHeadersBuilder()..update(updates))._build();
-
-  _$OcmOcmDiscoveryHeaders._({this.xNextcloudOcmProviders}) : super._();
-
-  @override
-  OcmOcmDiscoveryHeaders rebuild(void Function(OcmOcmDiscoveryHeadersBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  OcmOcmDiscoveryHeadersBuilder toBuilder() => OcmOcmDiscoveryHeadersBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is OcmOcmDiscoveryHeaders && xNextcloudOcmProviders == other.xNextcloudOcmProviders;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, xNextcloudOcmProviders.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'OcmOcmDiscoveryHeaders')
-          ..add('xNextcloudOcmProviders', xNextcloudOcmProviders))
-        .toString();
-  }
-}
-
-class OcmOcmDiscoveryHeadersBuilder
-    implements Builder<OcmOcmDiscoveryHeaders, OcmOcmDiscoveryHeadersBuilder>, $OcmOcmDiscoveryHeadersInterfaceBuilder {
-  _$OcmOcmDiscoveryHeaders? _$v;
-
-  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? _xNextcloudOcmProviders;
-  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get xNextcloudOcmProviders =>
-      _$this._xNextcloudOcmProviders ??= HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>();
-  set xNextcloudOcmProviders(
-          covariant HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders) =>
-      _$this._xNextcloudOcmProviders = xNextcloudOcmProviders;
-
-  OcmOcmDiscoveryHeadersBuilder();
-
-  OcmOcmDiscoveryHeadersBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _xNextcloudOcmProviders = $v.xNextcloudOcmProviders?.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant OcmOcmDiscoveryHeaders other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$OcmOcmDiscoveryHeaders;
-  }
-
-  @override
-  void update(void Function(OcmOcmDiscoveryHeadersBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  OcmOcmDiscoveryHeaders build() => _build();
-
-  _$OcmOcmDiscoveryHeaders _build() {
-    _$OcmOcmDiscoveryHeaders _$result;
-    try {
-      _$result = _$v ?? _$OcmOcmDiscoveryHeaders._(xNextcloudOcmProviders: _xNextcloudOcmProviders?.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'xNextcloudOcmProviders';
-        _xNextcloudOcmProviders?.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'OcmOcmDiscoveryHeaders', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
 abstract mixin class $OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterfaceBuilder {
   void replace($OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterface other);
   void update(void Function($OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterfaceBuilder) updates);
@@ -16043,6 +15943,106 @@ class OcmDiscoveryResponseApplicationJsonBuilder
         resourceTypes.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'OcmDiscoveryResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $OcmOcmDiscoveryHeadersInterfaceBuilder {
+  void replace($OcmOcmDiscoveryHeadersInterface other);
+  void update(void Function($OcmOcmDiscoveryHeadersInterfaceBuilder) updates);
+  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get xNextcloudOcmProviders;
+  set xNextcloudOcmProviders(HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders);
+}
+
+class _$OcmOcmDiscoveryHeaders extends OcmOcmDiscoveryHeaders {
+  @override
+  final Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders;
+
+  factory _$OcmOcmDiscoveryHeaders([void Function(OcmOcmDiscoveryHeadersBuilder)? updates]) =>
+      (OcmOcmDiscoveryHeadersBuilder()..update(updates))._build();
+
+  _$OcmOcmDiscoveryHeaders._({this.xNextcloudOcmProviders}) : super._();
+
+  @override
+  OcmOcmDiscoveryHeaders rebuild(void Function(OcmOcmDiscoveryHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OcmOcmDiscoveryHeadersBuilder toBuilder() => OcmOcmDiscoveryHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OcmOcmDiscoveryHeaders && xNextcloudOcmProviders == other.xNextcloudOcmProviders;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, xNextcloudOcmProviders.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OcmOcmDiscoveryHeaders')
+          ..add('xNextcloudOcmProviders', xNextcloudOcmProviders))
+        .toString();
+  }
+}
+
+class OcmOcmDiscoveryHeadersBuilder
+    implements Builder<OcmOcmDiscoveryHeaders, OcmOcmDiscoveryHeadersBuilder>, $OcmOcmDiscoveryHeadersInterfaceBuilder {
+  _$OcmOcmDiscoveryHeaders? _$v;
+
+  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? _xNextcloudOcmProviders;
+  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get xNextcloudOcmProviders =>
+      _$this._xNextcloudOcmProviders ??= HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>();
+  set xNextcloudOcmProviders(
+          covariant HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders) =>
+      _$this._xNextcloudOcmProviders = xNextcloudOcmProviders;
+
+  OcmOcmDiscoveryHeadersBuilder();
+
+  OcmOcmDiscoveryHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _xNextcloudOcmProviders = $v.xNextcloudOcmProviders?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OcmOcmDiscoveryHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OcmOcmDiscoveryHeaders;
+  }
+
+  @override
+  void update(void Function(OcmOcmDiscoveryHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OcmOcmDiscoveryHeaders build() => _build();
+
+  _$OcmOcmDiscoveryHeaders _build() {
+    _$OcmOcmDiscoveryHeaders _$result;
+    try {
+      _$result = _$v ?? _$OcmOcmDiscoveryHeaders._(xNextcloudOcmProviders: _xNextcloudOcmProviders?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'xNextcloudOcmProviders';
+        _xNextcloudOcmProviders?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'OcmOcmDiscoveryHeaders', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.dart
@@ -22,9 +22,9 @@ import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
 import 'package:dynamite_runtime/models.dart';
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'dashboard.openapi.g.dart';
 
@@ -95,7 +95,7 @@ class $DashboardApiClient {
   ///
   /// See:
   ///  * [getWidgets] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DashboardApiGetWidgetsResponseApplicationJson, void> getWidgetsRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -118,7 +118,7 @@ class $DashboardApiClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/dashboard/api/v1/widgets';
     return _i1.DynamiteRawResponse<DashboardApiGetWidgetsResponseApplicationJson, void>(
@@ -184,7 +184,7 @@ class $DashboardApiClient {
   ///
   /// See:
   ///  * [getWidgetItems] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DashboardApiGetWidgetItemsResponseApplicationJson, void> getWidgetItemsRaw({
     ContentString<BuiltMap<String, String>>? sinceIds,
     int? limit,
@@ -229,9 +229,9 @@ class $DashboardApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/dashboard/api/v1/widget-items{?sinceIds*,limit*,widgets%5B%5D*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/dashboard/api/v1/widget-items{?sinceIds*,limit*,widgets%5B%5D*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<DashboardApiGetWidgetItemsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -300,7 +300,7 @@ class $DashboardApiClient {
   ///
   /// See:
   ///  * [getWidgetItemsV2] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DashboardApiGetWidgetItemsV2ResponseApplicationJson, void> getWidgetItemsV2Raw({
     ContentString<BuiltMap<String, String>>? sinceIds,
     int? limit,
@@ -345,9 +345,9 @@ class $DashboardApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/dashboard/api/v2/widget-items{?sinceIds*,limit*,widgets%5B%5D*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/dashboard/api/v2/widget-items{?sinceIds*,limit*,widgets%5B%5D*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<DashboardApiGetWidgetItemsV2ResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -787,7 +787,7 @@ abstract class DashboardApiGetWidgetItemsV2ResponseApplicationJson
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
@@ -866,7 +866,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -21,9 +21,9 @@ import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'dav.openapi.g.dart';
 
@@ -110,7 +110,7 @@ class $DirectClient {
   ///
   /// See:
   ///  * [getUrl] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DirectGetUrlResponseApplicationJson, void> getUrlRaw({
     required int fileId,
     required int expirationTime,
@@ -144,9 +144,9 @@ class $DirectClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/dav/api/v1/direct{?fileId*,expirationTime*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/direct{?fileId*,expirationTime*}').expand(_parameters);
     return _i1.DynamiteRawResponse<DirectGetUrlResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -212,7 +212,7 @@ class $OutOfOfficeClient {
   ///
   /// See:
   ///  * [getCurrentOutOfOfficeData] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson, void>
       getCurrentOutOfOfficeDataRaw({
     required String userId,
@@ -243,9 +243,9 @@ class $OutOfOfficeClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}/now').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}/now').expand(_parameters);
     return _i1.DynamiteRawResponse<OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -303,7 +303,7 @@ class $OutOfOfficeClient {
   ///
   /// See:
   ///  * [getOutOfOffice] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<OutOfOfficeGetOutOfOfficeResponseApplicationJson, void> getOutOfOfficeRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -333,9 +333,9 @@ class $OutOfOfficeClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
     return _i1.DynamiteRawResponse<OutOfOfficeGetOutOfOfficeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -411,7 +411,7 @@ class $OutOfOfficeClient {
   ///
   /// See:
   ///  * [setOutOfOffice] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<OutOfOfficeSetOutOfOfficeResponseApplicationJson, void> setOutOfOfficeRaw({
     required String firstDay,
     required String lastDay,
@@ -457,10 +457,10 @@ class $OutOfOfficeClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}{?firstDay*,lastDay*,status*,message*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}{?firstDay*,lastDay*,status*,message*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<OutOfOfficeSetOutOfOfficeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -519,7 +519,7 @@ class $OutOfOfficeClient {
   ///
   /// See:
   ///  * [clearOutOfOffice] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<OutOfOfficeClearOutOfOfficeResponseApplicationJson, void> clearOutOfOfficeRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -549,9 +549,9 @@ class $OutOfOfficeClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
     return _i1.DynamiteRawResponse<OutOfOfficeClearOutOfOfficeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -1206,7 +1206,7 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
@@ -1282,7 +1282,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -24,9 +24,9 @@ import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'files.openapi.g.dart';
 
@@ -117,7 +117,7 @@ class $ApiClient {
   ///
   /// See:
   ///  * [getThumbnail] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getThumbnailRaw({
     required int x,
     required int y,
@@ -150,14 +150,14 @@ class $ApiClient {
     _parameters['y'] = $y;
 
     final $file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $file as String?,
       RegExp(r'^.+$'),
       'file',
     );
     _parameters['file'] = $file;
 
-    final _path = _i3.UriTemplate('/index.php/apps/files/api/v1/thumbnail/{x}/{y}/{file}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/apps/files/api/v1/thumbnail/{x}/{y}/{file}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -214,7 +214,7 @@ class $DirectEditingClient {
   ///
   /// See:
   ///  * [info] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DirectEditingInfoResponseApplicationJson, void> infoRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -237,7 +237,7 @@ class $DirectEditingClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/files/api/v1/directEditing';
     return _i1.DynamiteRawResponse<DirectEditingInfoResponseApplicationJson, void>(
@@ -301,7 +301,7 @@ class $DirectEditingClient {
   ///
   /// See:
   ///  * [templates] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DirectEditingTemplatesResponseApplicationJson, void> templatesRaw({
     required String editorId,
     required String creatorId,
@@ -335,9 +335,9 @@ class $DirectEditingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/templates/{editorId}/{creatorId}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/templates/{editorId}/{creatorId}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<DirectEditingTemplatesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -406,7 +406,7 @@ class $DirectEditingClient {
   ///
   /// See:
   ///  * [open] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DirectEditingOpenResponseApplicationJson, void> openRaw({
     required String path,
     String? editorId,
@@ -444,9 +444,9 @@ class $DirectEditingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/open{?path*,editorId*,fileId*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/open{?path*,editorId*,fileId*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<DirectEditingOpenResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -519,7 +519,7 @@ class $DirectEditingClient {
   ///
   /// See:
   ///  * [create] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DirectEditingCreateResponseApplicationJson, void> createRaw({
     required String path,
     required String editorId,
@@ -561,10 +561,10 @@ class $DirectEditingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/create{?path*,editorId*,creatorId*,templateId*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/create{?path*,editorId*,creatorId*,templateId*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<DirectEditingCreateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -630,7 +630,7 @@ class $OpenLocalEditorClient {
   ///
   /// See:
   ///  * [create] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<OpenLocalEditorCreateResponseApplicationJson, void> createRaw({
     required String path,
     bool? oCSAPIRequest,
@@ -660,9 +660,9 @@ class $OpenLocalEditorClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor{?path*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor{?path*}').expand(_parameters);
     return _i1.DynamiteRawResponse<OpenLocalEditorCreateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -724,7 +724,7 @@ class $OpenLocalEditorClient {
   ///
   /// See:
   ///  * [validate] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<OpenLocalEditorValidateResponseApplicationJson, void> validateRaw({
     required String path,
     required String token,
@@ -758,9 +758,9 @@ class $OpenLocalEditorClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor/{token}{?path*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor/{token}{?path*}').expand(_parameters);
     return _i1.DynamiteRawResponse<OpenLocalEditorValidateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -817,7 +817,7 @@ class $TemplateClient {
   ///
   /// See:
   ///  * [list] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TemplateListResponseApplicationJson, void> listRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -840,7 +840,7 @@ class $TemplateClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/files/api/v1/templates';
     return _i1.DynamiteRawResponse<TemplateListResponseApplicationJson, void>(
@@ -908,7 +908,7 @@ class $TemplateClient {
   ///
   /// See:
   ///  * [create] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TemplateCreateResponseApplicationJson, void> createRaw({
     required String filePath,
     String? templatePath,
@@ -948,10 +948,10 @@ class $TemplateClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/files/api/v1/templates/create{?filePath*,templatePath*,templateType*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/files/api/v1/templates/create{?filePath*,templatePath*,templateType*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<TemplateCreateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1014,7 +1014,7 @@ class $TemplateClient {
   ///
   /// See:
   ///  * [path] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TemplatePathResponseApplicationJson, void> pathRaw({
     String? templatePath,
     TemplatePathCopySystemTemplates? copySystemTemplates,
@@ -1053,9 +1053,9 @@ class $TemplateClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files/api/v1/templates/path{?templatePath*,copySystemTemplates*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files/api/v1/templates/path{?templatePath*,copySystemTemplates*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<TemplatePathResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1127,7 +1127,7 @@ class $TransferOwnershipClient {
   ///
   /// See:
   ///  * [transfer] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TransferOwnershipTransferResponseApplicationJson, void> transferRaw({
     required String recipient,
     required String path,
@@ -1161,10 +1161,10 @@ class $TransferOwnershipClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership{?recipient*,path*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership{?recipient*,path*}').expand(_parameters);
     return _i1.DynamiteRawResponse<TransferOwnershipTransferResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -1228,7 +1228,7 @@ class $TransferOwnershipClient {
   ///
   /// See:
   ///  * [accept] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TransferOwnershipAcceptResponseApplicationJson, void> acceptRaw({
     required int id,
     bool? oCSAPIRequest,
@@ -1258,9 +1258,9 @@ class $TransferOwnershipClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<TransferOwnershipAcceptResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -1324,7 +1324,7 @@ class $TransferOwnershipClient {
   ///
   /// See:
   ///  * [reject] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TransferOwnershipRejectResponseApplicationJson, void> rejectRaw({
     required int id,
     bool? oCSAPIRequest,
@@ -1354,9 +1354,9 @@ class $TransferOwnershipClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<TransferOwnershipRejectResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -3002,7 +3002,7 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
@@ -3221,7 +3221,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/files_external.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.dart
@@ -22,8 +22,8 @@ import 'package:built_value/standard_json_plugin.dart' as _i5;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i4;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
 
 part 'files_external.openapi.g.dart';
 
@@ -94,7 +94,7 @@ class $ApiClient {
   ///
   /// See:
   ///  * [getUserMounts] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ApiGetUserMountsResponseApplicationJson, void> getUserMountsRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -117,7 +117,7 @@ class $ApiClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/files_external/api/v1/mounts';
     return _i1.DynamiteRawResponse<ApiGetUserMountsResponseApplicationJson, void>(
@@ -511,7 +511,7 @@ abstract class ApiGetUserMountsResponseApplicationJson
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
@@ -545,7 +545,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i4.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
@@ -21,9 +21,9 @@ import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'files_reminders.openapi.g.dart';
 
@@ -104,7 +104,7 @@ class $ApiClient {
   ///
   /// See:
   ///  * [$get] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ApiGetResponseApplicationJson, void> $getRaw({
     required String version,
     required int fileId,
@@ -131,7 +131,7 @@ class $ApiClient {
 
 // coverage:ignore-end
     final $version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $version as String?,
       RegExp(r'^1$'),
       'version',
@@ -143,9 +143,9 @@ class $ApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}').expand(_parameters);
     return _i1.DynamiteRawResponse<ApiGetResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -217,7 +217,7 @@ class $ApiClient {
   ///
   /// See:
   ///  * [$set] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ApiSetResponseApplicationJson, void> $setRaw({
     required String dueDate,
     required String version,
@@ -248,7 +248,7 @@ class $ApiClient {
     _parameters['dueDate'] = $dueDate;
 
     final $version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $version as String?,
       RegExp(r'^1$'),
       'version',
@@ -260,10 +260,10 @@ class $ApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}{?dueDate*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}{?dueDate*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ApiSetResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -333,7 +333,7 @@ class $ApiClient {
   ///
   /// See:
   ///  * [remove] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ApiRemoveResponseApplicationJson, void> removeRaw({
     required String version,
     required int fileId,
@@ -360,7 +360,7 @@ class $ApiClient {
 
 // coverage:ignore-end
     final $version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $version as String?,
       RegExp(r'^1$'),
       'version',
@@ -372,9 +372,9 @@ class $ApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}').expand(_parameters);
     return _i1.DynamiteRawResponse<ApiRemoveResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -690,7 +690,7 @@ abstract class ApiRemoveResponseApplicationJson
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(ApiGetResponseApplicationJson), ApiGetResponseApplicationJsonBuilder.new)
@@ -727,7 +727,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -24,9 +24,9 @@ import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'files_sharing.openapi.g.dart';
 
@@ -105,7 +105,7 @@ class $DeletedShareapiClient {
   ///
   /// See:
   ///  * [index] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DeletedShareapiIndexResponseApplicationJson, void> indexRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -128,7 +128,7 @@ class $DeletedShareapiClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/files_sharing/api/v1/deletedshares';
     return _i1.DynamiteRawResponse<DeletedShareapiIndexResponseApplicationJson, void>(
@@ -188,7 +188,7 @@ class $DeletedShareapiClient {
   ///
   /// See:
   ///  * [undelete] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DeletedShareapiUndeleteResponseApplicationJson, void> undeleteRaw({
     required String id,
     bool? oCSAPIRequest,
@@ -218,9 +218,9 @@ class $DeletedShareapiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/deletedshares/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/deletedshares/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<DeletedShareapiUndeleteResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -283,7 +283,7 @@ class $PublicPreviewClient {
   ///
   /// See:
   ///  * [directLink] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> directLinkRaw({required String token}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': '*/*'};
@@ -306,7 +306,7 @@ class $PublicPreviewClient {
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _parameters['token'] = $token;
 
-    final _path = _i3.UriTemplate('/index.php/s/{token}/preview').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/s/{token}/preview').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -380,7 +380,7 @@ class $PublicPreviewClient {
   ///
   /// See:
   ///  * [getPreview] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getPreviewRaw({
     required String token,
     String? file,
@@ -426,7 +426,7 @@ class $PublicPreviewClient {
     _parameters['a'] = $a;
 
     final _path =
-        _i3.UriTemplate('/index.php/apps/files_sharing/publicpreview/{token}{?file*,x*,y*,a*}').expand(_parameters);
+        _i4.UriTemplate('/index.php/apps/files_sharing/publicpreview/{token}{?file*,x*,y*,a*}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -483,7 +483,7 @@ class $RemoteClient {
   ///
   /// See:
   ///  * [getShares] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RemoteGetSharesResponseApplicationJson, void> getSharesRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -506,7 +506,7 @@ class $RemoteClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/files_sharing/api/v1/remote_shares';
     return _i1.DynamiteRawResponse<RemoteGetSharesResponseApplicationJson, void>(
@@ -560,7 +560,7 @@ class $RemoteClient {
   ///
   /// See:
   ///  * [getOpenShares] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RemoteGetOpenSharesResponseApplicationJson, void> getOpenSharesRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -583,7 +583,7 @@ class $RemoteClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending';
     return _i1.DynamiteRawResponse<RemoteGetOpenSharesResponseApplicationJson, void>(
@@ -643,7 +643,7 @@ class $RemoteClient {
   ///
   /// See:
   ///  * [acceptShare] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RemoteAcceptShareResponseApplicationJson, void> acceptShareRaw({
     required int id,
     bool? oCSAPIRequest,
@@ -673,10 +673,10 @@ class $RemoteClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/{id}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<RemoteAcceptShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -734,7 +734,7 @@ class $RemoteClient {
   ///
   /// See:
   ///  * [declineShare] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RemoteDeclineShareResponseApplicationJson, void> declineShareRaw({
     required int id,
     bool? oCSAPIRequest,
@@ -764,10 +764,10 @@ class $RemoteClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/{id}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<RemoteDeclineShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -825,7 +825,7 @@ class $RemoteClient {
   ///
   /// See:
   ///  * [getShare] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RemoteGetShareResponseApplicationJson, void> getShareRaw({
     required int id,
     bool? oCSAPIRequest,
@@ -855,9 +855,9 @@ class $RemoteClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<RemoteGetShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -917,7 +917,7 @@ class $RemoteClient {
   ///
   /// See:
   ///  * [unshare] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RemoteUnshareResponseApplicationJson, void> unshareRaw({
     required int id,
     bool? oCSAPIRequest,
@@ -947,9 +947,9 @@ class $RemoteClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<RemoteUnshareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -1024,7 +1024,7 @@ class $ShareInfoClient {
   ///
   /// See:
   ///  * [info] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareInfo, void> infoRaw({
     required String t,
     String? password,
@@ -1063,7 +1063,7 @@ class $ShareInfoClient {
     _parameters['depth'] = $depth;
 
     final _path =
-        _i3.UriTemplate('/index.php/apps/files_sharing/shareinfo{?t*,password*,dir*,depth*}').expand(_parameters);
+        _i4.UriTemplate('/index.php/apps/files_sharing/shareinfo{?t*,password*,dir*,depth*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ShareInfo, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -1144,7 +1144,7 @@ class $ShareapiClient {
   ///
   /// See:
   ///  * [getShares] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareapiGetSharesResponseApplicationJson, void> getSharesRaw({
     String? sharedWithMe,
     String? reshares,
@@ -1195,9 +1195,9 @@ class $ShareapiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/files_sharing/api/v1/shares{?shared_with_me*,reshares*,subfiles*,path*,include_tags*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<ShareapiGetSharesResponseApplicationJson, void>(
@@ -1301,7 +1301,7 @@ class $ShareapiClient {
   ///
   /// See:
   ///  * [createShare] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareapiCreateShareResponseApplicationJson, void> createShareRaw({
     String? path,
     int? permissions,
@@ -1377,9 +1377,9 @@ class $ShareapiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/files_sharing/api/v1/shares{?path*,permissions*,shareType*,shareWith*,publicUpload*,password*,sendPasswordByTalk*,expireDate*,note*,label*,attributes*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<ShareapiCreateShareResponseApplicationJson, void>(
@@ -1441,7 +1441,7 @@ class $ShareapiClient {
   ///
   /// See:
   ///  * [getInheritedShares] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareapiGetInheritedSharesResponseApplicationJson, void> getInheritedSharesRaw({
     required String path,
     bool? oCSAPIRequest,
@@ -1471,9 +1471,9 @@ class $ShareapiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/inherited{?path*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/inherited{?path*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ShareapiGetInheritedSharesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1525,7 +1525,7 @@ class $ShareapiClient {
   ///
   /// See:
   ///  * [pendingShares] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareapiPendingSharesResponseApplicationJson, void> pendingSharesRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -1548,7 +1548,7 @@ class $ShareapiClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/files_sharing/api/v1/shares/pending';
     return _i1.DynamiteRawResponse<ShareapiPendingSharesResponseApplicationJson, void>(
@@ -1612,7 +1612,7 @@ class $ShareapiClient {
   ///
   /// See:
   ///  * [getShare] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareapiGetShareResponseApplicationJson, void> getShareRaw({
     required String id,
     ShareapiGetShareIncludeTags? includeTags,
@@ -1648,10 +1648,10 @@ class $ShareapiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}{?include_tags*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}{?include_tags*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ShareapiGetShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1749,7 +1749,7 @@ class $ShareapiClient {
   ///
   /// See:
   ///  * [updateShare] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareapiUpdateShareResponseApplicationJson, void> updateShareRaw({
     required String id,
     int? permissions,
@@ -1815,9 +1815,9 @@ class $ShareapiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}{?permissions*,password*,sendPasswordByTalk*,publicUpload*,expireDate*,note*,label*,hideDownload*,attributes*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<ShareapiUpdateShareResponseApplicationJson, void>(
@@ -1879,7 +1879,7 @@ class $ShareapiClient {
   ///
   /// See:
   ///  * [deleteShare] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareapiDeleteShareResponseApplicationJson, void> deleteShareRaw({
     required String id,
     bool? oCSAPIRequest,
@@ -1909,9 +1909,9 @@ class $ShareapiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<ShareapiDeleteShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -1971,7 +1971,7 @@ class $ShareapiClient {
   ///
   /// See:
   ///  * [acceptShare] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareapiAcceptShareResponseApplicationJson, void> acceptShareRaw({
     required String id,
     bool? oCSAPIRequest,
@@ -2001,9 +2001,9 @@ class $ShareapiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/pending/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/pending/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<ShareapiAcceptShareResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -2088,7 +2088,7 @@ class $ShareesapiClient {
   ///
   /// See:
   ///  * [search] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareesapiSearchResponseApplicationJson, ShareesapiShareesapiSearchHeaders> searchRaw({
     String? search,
     String? itemType,
@@ -2142,9 +2142,9 @@ class $ShareesapiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/files_sharing/api/v1/sharees{?search*,itemType*,page*,perPage*,shareType*,lookup*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<ShareesapiSearchResponseApplicationJson, ShareesapiShareesapiSearchHeaders>(
@@ -2206,7 +2206,7 @@ class $ShareesapiClient {
   ///
   /// See:
   ///  * [findRecommended] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ShareesapiFindRecommendedResponseApplicationJson, void> findRecommendedRaw({
     required String itemType,
     ShareesapiFindRecommendedShareType? shareType,
@@ -2241,9 +2241,9 @@ class $ShareesapiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/sharees_recommended{?itemType*,shareType*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/sharees_recommended{?itemType*,shareType*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<ShareesapiFindRecommendedResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4189,42 +4189,6 @@ class _$ShareesapiSearchLookupSerializer implements PrimitiveSerializer<Shareesa
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ShareesapiShareesapiSearchHeadersInterface {
-  String? get link;
-}
-
-abstract class ShareesapiShareesapiSearchHeaders
-    implements
-        $ShareesapiShareesapiSearchHeadersInterface,
-        Built<ShareesapiShareesapiSearchHeaders, ShareesapiShareesapiSearchHeadersBuilder> {
-  /// Creates a new ShareesapiShareesapiSearchHeaders object using the builder pattern.
-  factory ShareesapiShareesapiSearchHeaders([void Function(ShareesapiShareesapiSearchHeadersBuilder)? b]) =
-      _$ShareesapiShareesapiSearchHeaders;
-
-  // coverage:ignore-start
-  const ShareesapiShareesapiSearchHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory ShareesapiShareesapiSearchHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for ShareesapiShareesapiSearchHeaders.
-  static Serializer<ShareesapiShareesapiSearchHeaders> get serializer => _$shareesapiShareesapiSearchHeadersSerializer;
-}
-
-@BuiltValue(instantiable: false)
 abstract interface class $ShareeInterface {
   int? get count;
   String get label;
@@ -4890,6 +4854,42 @@ abstract class ShareesapiSearchResponseApplicationJson
   /// Serializer for ShareesapiSearchResponseApplicationJson.
   static Serializer<ShareesapiSearchResponseApplicationJson> get serializer =>
       _$shareesapiSearchResponseApplicationJsonSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $ShareesapiShareesapiSearchHeadersInterface {
+  String? get link;
+}
+
+abstract class ShareesapiShareesapiSearchHeaders
+    implements
+        $ShareesapiShareesapiSearchHeadersInterface,
+        Built<ShareesapiShareesapiSearchHeaders, ShareesapiShareesapiSearchHeadersBuilder> {
+  /// Creates a new ShareesapiShareesapiSearchHeaders object using the builder pattern.
+  factory ShareesapiShareesapiSearchHeaders([void Function(ShareesapiShareesapiSearchHeadersBuilder)? b]) =
+      _$ShareesapiShareesapiSearchHeaders;
+
+  // coverage:ignore-start
+  const ShareesapiShareesapiSearchHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ShareesapiShareesapiSearchHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ShareesapiShareesapiSearchHeaders.
+  static Serializer<ShareesapiShareesapiSearchHeaders> get serializer => _$shareesapiShareesapiSearchHeadersSerializer;
 }
 
 typedef ShareesapiFindRecommendedShareType = ({BuiltList<int>? builtListInt, int? $int});
@@ -5686,13 +5686,13 @@ extension $07eaa0304017ba8abe7f9f20d6a736f3Extension on _$07eaa0304017ba8abe7f9f
   List<String> get _names => const ['builtListInt', r'$int'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -5759,7 +5759,7 @@ class _$07eaa0304017ba8abe7f9f20d6a736f3Serializer implements PrimitiveSerialize
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
@@ -5956,11 +5956,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add($07eaa0304017ba8abe7f9f20d6a736f3Extension._serializer)
       ..add(ShareesapiSearchLookup.serializer)
       ..addBuilderFactory(
-        const FullType(ShareesapiShareesapiSearchHeaders),
-        ShareesapiShareesapiSearchHeadersBuilder.new,
-      )
-      ..add(ShareesapiShareesapiSearchHeaders.serializer)
-      ..addBuilderFactory(
         const FullType(ShareesapiSearchResponseApplicationJson),
         ShareesapiSearchResponseApplicationJsonBuilder.new,
       )
@@ -6011,6 +6006,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(ShareeLookup_Value), ShareeLookup_ValueBuilder.new)
       ..add(ShareeLookup_Value.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(ShareeLookup)]), ListBuilder<ShareeLookup>.new)
+      ..addBuilderFactory(
+        const FullType(ShareesapiShareesapiSearchHeaders),
+        ShareesapiShareesapiSearchHeadersBuilder.new,
+      )
+      ..add(ShareesapiShareesapiSearchHeaders.serializer)
       ..addBuilderFactory(
         const FullType(ShareesapiFindRecommendedResponseApplicationJson),
         ShareesapiFindRecommendedResponseApplicationJsonBuilder.new,
@@ -6088,7 +6088,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
@@ -197,8 +197,6 @@ Serializer<ShareapiAcceptShareResponseApplicationJson_Ocs> _$shareapiAcceptShare
     _$ShareapiAcceptShareResponseApplicationJson_OcsSerializer();
 Serializer<ShareapiAcceptShareResponseApplicationJson> _$shareapiAcceptShareResponseApplicationJsonSerializer =
     _$ShareapiAcceptShareResponseApplicationJsonSerializer();
-Serializer<ShareesapiShareesapiSearchHeaders> _$shareesapiShareesapiSearchHeadersSerializer =
-    _$ShareesapiShareesapiSearchHeadersSerializer();
 Serializer<Sharee> _$shareeSerializer = _$ShareeSerializer();
 Serializer<ShareeValue> _$shareeValueSerializer = _$ShareeValueSerializer();
 Serializer<ShareeCircle_Value> _$shareeCircleValueSerializer = _$ShareeCircle_ValueSerializer();
@@ -220,6 +218,8 @@ Serializer<ShareesapiSearchResponseApplicationJson_Ocs> _$shareesapiSearchRespon
     _$ShareesapiSearchResponseApplicationJson_OcsSerializer();
 Serializer<ShareesapiSearchResponseApplicationJson> _$shareesapiSearchResponseApplicationJsonSerializer =
     _$ShareesapiSearchResponseApplicationJsonSerializer();
+Serializer<ShareesapiShareesapiSearchHeaders> _$shareesapiShareesapiSearchHeadersSerializer =
+    _$ShareesapiShareesapiSearchHeadersSerializer();
 Serializer<ShareesRecommendedResult_Exact> _$shareesRecommendedResultExactSerializer =
     _$ShareesRecommendedResult_ExactSerializer();
 Serializer<ShareesRecommendedResult> _$shareesRecommendedResultSerializer = _$ShareesRecommendedResultSerializer();
@@ -2547,47 +2547,6 @@ class _$ShareapiAcceptShareResponseApplicationJsonSerializer
   }
 }
 
-class _$ShareesapiShareesapiSearchHeadersSerializer implements StructuredSerializer<ShareesapiShareesapiSearchHeaders> {
-  @override
-  final Iterable<Type> types = const [ShareesapiShareesapiSearchHeaders, _$ShareesapiShareesapiSearchHeaders];
-  @override
-  final String wireName = 'ShareesapiShareesapiSearchHeaders';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, ShareesapiShareesapiSearchHeaders object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.link;
-    if (value != null) {
-      result
-        ..add('link')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    return result;
-  }
-
-  @override
-  ShareesapiShareesapiSearchHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = ShareesapiShareesapiSearchHeadersBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'link':
-          result.link = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$ShareeSerializer implements StructuredSerializer<Sharee> {
   @override
   final Iterable<Type> types = const [Sharee, _$Sharee];
@@ -3740,6 +3699,47 @@ class _$ShareesapiSearchResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ShareesapiSearchResponseApplicationJson_Ocs))!
               as ShareesapiSearchResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ShareesapiShareesapiSearchHeadersSerializer implements StructuredSerializer<ShareesapiShareesapiSearchHeaders> {
+  @override
+  final Iterable<Type> types = const [ShareesapiShareesapiSearchHeaders, _$ShareesapiShareesapiSearchHeaders];
+  @override
+  final String wireName = 'ShareesapiShareesapiSearchHeaders';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ShareesapiShareesapiSearchHeaders object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.link;
+    if (value != null) {
+      result
+        ..add('link')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ShareesapiShareesapiSearchHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ShareesapiShareesapiSearchHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'link':
+          result.link = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -10369,91 +10369,6 @@ class ShareapiAcceptShareResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $ShareesapiShareesapiSearchHeadersInterfaceBuilder {
-  void replace($ShareesapiShareesapiSearchHeadersInterface other);
-  void update(void Function($ShareesapiShareesapiSearchHeadersInterfaceBuilder) updates);
-  String? get link;
-  set link(String? link);
-}
-
-class _$ShareesapiShareesapiSearchHeaders extends ShareesapiShareesapiSearchHeaders {
-  @override
-  final String? link;
-
-  factory _$ShareesapiShareesapiSearchHeaders([void Function(ShareesapiShareesapiSearchHeadersBuilder)? updates]) =>
-      (ShareesapiShareesapiSearchHeadersBuilder()..update(updates))._build();
-
-  _$ShareesapiShareesapiSearchHeaders._({this.link}) : super._();
-
-  @override
-  ShareesapiShareesapiSearchHeaders rebuild(void Function(ShareesapiShareesapiSearchHeadersBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  ShareesapiShareesapiSearchHeadersBuilder toBuilder() => ShareesapiShareesapiSearchHeadersBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is ShareesapiShareesapiSearchHeaders && link == other.link;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, link.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'ShareesapiShareesapiSearchHeaders')..add('link', link)).toString();
-  }
-}
-
-class ShareesapiShareesapiSearchHeadersBuilder
-    implements
-        Builder<ShareesapiShareesapiSearchHeaders, ShareesapiShareesapiSearchHeadersBuilder>,
-        $ShareesapiShareesapiSearchHeadersInterfaceBuilder {
-  _$ShareesapiShareesapiSearchHeaders? _$v;
-
-  String? _link;
-  String? get link => _$this._link;
-  set link(covariant String? link) => _$this._link = link;
-
-  ShareesapiShareesapiSearchHeadersBuilder();
-
-  ShareesapiShareesapiSearchHeadersBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _link = $v.link;
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant ShareesapiShareesapiSearchHeaders other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ShareesapiShareesapiSearchHeaders;
-  }
-
-  @override
-  void update(void Function(ShareesapiShareesapiSearchHeadersBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  ShareesapiShareesapiSearchHeaders build() => _build();
-
-  _$ShareesapiShareesapiSearchHeaders _build() {
-    final _$result = _$v ?? _$ShareesapiShareesapiSearchHeaders._(link: link);
-    replace(_$result);
-    return _$result;
-  }
-}
-
 abstract mixin class $ShareeInterfaceBuilder {
   void replace($ShareeInterface other);
   void update(void Function($ShareeInterfaceBuilder) updates);
@@ -13352,6 +13267,91 @@ class ShareesapiSearchResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ShareesapiShareesapiSearchHeadersInterfaceBuilder {
+  void replace($ShareesapiShareesapiSearchHeadersInterface other);
+  void update(void Function($ShareesapiShareesapiSearchHeadersInterfaceBuilder) updates);
+  String? get link;
+  set link(String? link);
+}
+
+class _$ShareesapiShareesapiSearchHeaders extends ShareesapiShareesapiSearchHeaders {
+  @override
+  final String? link;
+
+  factory _$ShareesapiShareesapiSearchHeaders([void Function(ShareesapiShareesapiSearchHeadersBuilder)? updates]) =>
+      (ShareesapiShareesapiSearchHeadersBuilder()..update(updates))._build();
+
+  _$ShareesapiShareesapiSearchHeaders._({this.link}) : super._();
+
+  @override
+  ShareesapiShareesapiSearchHeaders rebuild(void Function(ShareesapiShareesapiSearchHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ShareesapiShareesapiSearchHeadersBuilder toBuilder() => ShareesapiShareesapiSearchHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ShareesapiShareesapiSearchHeaders && link == other.link;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, link.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ShareesapiShareesapiSearchHeaders')..add('link', link)).toString();
+  }
+}
+
+class ShareesapiShareesapiSearchHeadersBuilder
+    implements
+        Builder<ShareesapiShareesapiSearchHeaders, ShareesapiShareesapiSearchHeadersBuilder>,
+        $ShareesapiShareesapiSearchHeadersInterfaceBuilder {
+  _$ShareesapiShareesapiSearchHeaders? _$v;
+
+  String? _link;
+  String? get link => _$this._link;
+  set link(covariant String? link) => _$this._link = link;
+
+  ShareesapiShareesapiSearchHeadersBuilder();
+
+  ShareesapiShareesapiSearchHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _link = $v.link;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ShareesapiShareesapiSearchHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ShareesapiShareesapiSearchHeaders;
+  }
+
+  @override
+  void update(void Function(ShareesapiShareesapiSearchHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ShareesapiShareesapiSearchHeaders build() => _build();
+
+  _$ShareesapiShareesapiSearchHeaders _build() {
+    final _$result = _$v ?? _$ShareesapiShareesapiSearchHeaders._(link: link);
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -23,8 +23,8 @@ import 'package:built_value/standard_json_plugin.dart' as _i5;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i4;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:meta/meta.dart' as _i3;
-import 'package:uri/uri.dart' as _i2;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i3;
 
 part 'files_trashbin.openapi.g.dart';
 
@@ -111,7 +111,7 @@ class $PreviewClient {
   ///
   /// See:
   ///  * [getPreview] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getPreviewRaw({
     int? fileId,
     int? x,
@@ -154,7 +154,7 @@ class $PreviewClient {
     $a ??= 0;
     _parameters['a'] = $a;
 
-    final _path = _i2.UriTemplate('/index.php/apps/files_trashbin/preview{?fileId*,x*,y*,a*}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/files_trashbin/preview{?fileId*,x*,y*,a*}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -301,7 +301,7 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..add(PreviewGetPreviewA.serializer)
@@ -315,7 +315,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i4.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.dart
@@ -22,8 +22,8 @@ import 'package:built_value/standard_json_plugin.dart' as _i5;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i4;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:meta/meta.dart' as _i3;
-import 'package:uri/uri.dart' as _i2;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i3;
 
 part 'files_versions.openapi.g.dart';
 
@@ -110,7 +110,7 @@ class $PreviewClient {
   ///
   /// See:
   ///  * [getPreview] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getPreviewRaw({
     String? file,
     int? x,
@@ -153,7 +153,7 @@ class $PreviewClient {
     $version ??= '';
     _parameters['version'] = $version;
 
-    final _path = _i2.UriTemplate('/index.php/apps/files_versions/preview{?file*,x*,y*,version*}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/files_versions/preview{?file*,x*,y*,version*}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -241,7 +241,7 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(Capabilities), CapabilitiesBuilder.new)
@@ -254,7 +254,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i4.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/news.openapi.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.dart
@@ -12,7 +12,7 @@
 ///
 /// Use of this source code is governed by a agpl license.
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0.html`.
-@_i3.experimental
+@_i2.experimental
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:built_collection/built_collection.dart';
@@ -23,8 +23,8 @@ import 'package:built_value/standard_json_plugin.dart' as _i5;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i4;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:meta/meta.dart' as _i3;
-import 'package:uri/uri.dart' as _i2;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i3;
 
 part 'news.openapi.g.dart';
 
@@ -72,7 +72,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [getSupportedApiVersions] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SupportedAPIVersions, void> getSupportedApiVersionsRaw() {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -131,7 +131,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [listFolders] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ListFolders, void> listFoldersRaw() {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -198,7 +198,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [createFolder] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ListFolders, void> createFolderRaw({required String name}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -223,7 +223,7 @@ class $Client extends _i1.DynamiteClient {
     final $name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
     _parameters['name'] = $name;
 
-    final _path = _i2.UriTemplate('/index.php/apps/news/api/v1-3/folders{?name*}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/news/api/v1-3/folders{?name*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ListFolders, void>(
       response: executeRequest(
         'post',
@@ -273,7 +273,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [renameFolder] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> renameFolderRaw({
     required int folderId,
     required String name,
@@ -304,7 +304,7 @@ class $Client extends _i1.DynamiteClient {
     final $name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
     _parameters['name'] = $name;
 
-    final _path = _i2.UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}{?name*}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}{?name*}').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'put',
@@ -344,7 +344,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [deleteFolder] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> deleteFolderRaw({required int folderId}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{};
@@ -369,7 +369,7 @@ class $Client extends _i1.DynamiteClient {
     final $folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
     _parameters['folderId'] = $folderId;
 
-    final _path = _i2.UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'delete',
@@ -419,7 +419,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [markFolderAsRead] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> markFolderAsReadRaw({
     required int folderId,
     required int newestItemId,
@@ -451,7 +451,7 @@ class $Client extends _i1.DynamiteClient {
     _parameters['newestItemId'] = $newestItemId;
 
     final _path =
-        _i2.UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}/read{?newestItemId*}').expand(_parameters);
+        _i3.UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}/read{?newestItemId*}').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'post',
@@ -489,7 +489,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [listFeeds] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ListFeeds, void> listFeedsRaw() {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -562,7 +562,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [addFeed] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ListFeeds, void> addFeedRaw({
     required String url,
     int? folderId,
@@ -593,7 +593,7 @@ class $Client extends _i1.DynamiteClient {
     final $folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
     _parameters['folderId'] = $folderId;
 
-    final _path = _i2.UriTemplate('/index.php/apps/news/api/v1-3/feeds{?url*,folderId*}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/news/api/v1-3/feeds{?url*,folderId*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ListFeeds, void>(
       response: executeRequest(
         'post',
@@ -633,7 +633,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [deleteFeed] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> deleteFeedRaw({required int feedId}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{};
@@ -658,7 +658,7 @@ class $Client extends _i1.DynamiteClient {
     final $feedId = _$jsonSerializers.serialize(feedId, specifiedType: const FullType(int));
     _parameters['feedId'] = $feedId;
 
-    final _path = _i2.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'delete',
@@ -708,7 +708,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [moveFeed] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> moveFeedRaw({
     required int feedId,
     int? folderId,
@@ -739,7 +739,7 @@ class $Client extends _i1.DynamiteClient {
     final $folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
     _parameters['folderId'] = $folderId;
 
-    final _path = _i2.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/move{?folderId*}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/move{?folderId*}').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'post',
@@ -789,7 +789,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [renameFeed] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> renameFeedRaw({
     required int feedId,
     required String feedTitle,
@@ -821,7 +821,7 @@ class $Client extends _i1.DynamiteClient {
     _parameters['feedTitle'] = $feedTitle;
 
     final _path =
-        _i2.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/rename{?feedTitle*}').expand(_parameters);
+        _i3.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/rename{?feedTitle*}').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'post',
@@ -871,7 +871,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [markFeedAsRead] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> markFeedAsReadRaw({
     required int feedId,
     required int newestItemId,
@@ -903,7 +903,7 @@ class $Client extends _i1.DynamiteClient {
     _parameters['newestItemId'] = $newestItemId;
 
     final _path =
-        _i2.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/read{?newestItemId*}').expand(_parameters);
+        _i3.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/read{?newestItemId*}').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'post',
@@ -971,7 +971,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [listArticles] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ListArticles, void> listArticlesRaw({
     int? type,
     int? id,
@@ -1025,7 +1025,7 @@ class $Client extends _i1.DynamiteClient {
     _parameters['oldestFirst'] = $oldestFirst;
 
     final _path =
-        _i2.UriTemplate('/index.php/apps/news/api/v1-3/items{?type*,id*,getRead*,batchSize*,offset*,oldestFirst*}')
+        _i3.UriTemplate('/index.php/apps/news/api/v1-3/items{?type*,id*,getRead*,batchSize*,offset*,oldestFirst*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<ListArticles, void>(
       response: executeRequest(
@@ -1082,7 +1082,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [listUpdatedArticles] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ListArticles, void> listUpdatedArticlesRaw({
     int? type,
     int? id,
@@ -1121,7 +1121,7 @@ class $Client extends _i1.DynamiteClient {
     _parameters['lastModified'] = $lastModified;
 
     final _path =
-        _i2.UriTemplate('/index.php/apps/news/api/v1-3/items/updated{?type*,id*,lastModified*}').expand(_parameters);
+        _i3.UriTemplate('/index.php/apps/news/api/v1-3/items/updated{?type*,id*,lastModified*}').expand(_parameters);
     return _i1.DynamiteRawResponse<ListArticles, void>(
       response: executeRequest(
         'get',
@@ -1161,7 +1161,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [markArticleAsRead] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> markArticleAsReadRaw({required int itemId}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{};
@@ -1186,7 +1186,7 @@ class $Client extends _i1.DynamiteClient {
     final $itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
     _parameters['itemId'] = $itemId;
 
-    final _path = _i2.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/read').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/read').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'post',
@@ -1226,7 +1226,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [markArticleAsUnread] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> markArticleAsUnreadRaw({required int itemId}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{};
@@ -1251,7 +1251,7 @@ class $Client extends _i1.DynamiteClient {
     final $itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
     _parameters['itemId'] = $itemId;
 
-    final _path = _i2.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/unread').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/unread').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'post',
@@ -1291,7 +1291,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [starArticle] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> starArticleRaw({required int itemId}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{};
@@ -1316,7 +1316,7 @@ class $Client extends _i1.DynamiteClient {
     final $itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
     _parameters['itemId'] = $itemId;
 
-    final _path = _i2.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/star').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/star').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'post',
@@ -1356,7 +1356,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [unstarArticle] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<void, void> unstarArticleRaw({required int itemId}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{};
@@ -1381,7 +1381,7 @@ class $Client extends _i1.DynamiteClient {
     final $itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
     _parameters['itemId'] = $itemId;
 
-    final _path = _i2.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/unstar').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/unstar').expand(_parameters);
     return _i1.DynamiteRawResponse<void, void>(
       response: executeRequest(
         'post',
@@ -1756,7 +1756,7 @@ abstract class EmptyOCS implements $EmptyOCSInterface, Built<EmptyOCS, EmptyOCSB
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(SupportedAPIVersions), SupportedAPIVersionsBuilder.new)
@@ -1790,7 +1790,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i4.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/notes.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.dart
@@ -12,7 +12,7 @@
 ///
 /// Use of this source code is governed by a agpl license.
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0.html`.
-@_i4.experimental
+@_i2.experimental
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'dart:convert';
@@ -26,9 +26,9 @@ import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'notes.openapi.g.dart';
 
@@ -106,7 +106,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [getNotes] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BuiltList<Note>, void> getNotesRaw({
     String? category,
     String? exclude,
@@ -155,11 +155,11 @@ class $Client extends _i1.DynamiteClient {
 
     final $ifNoneMatch = _$jsonSerializers.serialize(ifNoneMatch, specifiedType: const FullType(String));
     if ($ifNoneMatch != null) {
-      _headers['If-None-Match'] = const _i2.HeaderEncoder().convert($ifNoneMatch);
+      _headers['If-None-Match'] = const _i3.HeaderEncoder().convert($ifNoneMatch);
     }
 
     final _path =
-        _i3.UriTemplate('/index.php/apps/notes/api/v1/notes{?category*,exclude*,pruneBefore*,chunkSize*,chunkCursor*}')
+        _i4.UriTemplate('/index.php/apps/notes/api/v1/notes{?category*,exclude*,pruneBefore*,chunkSize*,chunkCursor*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<BuiltList<Note>, void>(
       response: executeRequest(
@@ -224,7 +224,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [createNote] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Note, void> createNoteRaw({
     String? category,
     String? title,
@@ -272,7 +272,7 @@ class $Client extends _i1.DynamiteClient {
     $favorite ??= 0;
     _parameters['favorite'] = $favorite;
 
-    final _path = _i3.UriTemplate('/index.php/apps/notes/api/v1/notes{?category*,title*,content*,modified*,favorite*}')
+    final _path = _i4.UriTemplate('/index.php/apps/notes/api/v1/notes{?category*,title*,content*,modified*,favorite*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<Note, void>(
       response: executeRequest(
@@ -327,7 +327,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [getNote] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Note, void> getNoteRaw({
     required int id,
     String? exclude,
@@ -362,10 +362,10 @@ class $Client extends _i1.DynamiteClient {
 
     final $ifNoneMatch = _$jsonSerializers.serialize(ifNoneMatch, specifiedType: const FullType(String));
     if ($ifNoneMatch != null) {
-      _headers['If-None-Match'] = const _i2.HeaderEncoder().convert($ifNoneMatch);
+      _headers['If-None-Match'] = const _i3.HeaderEncoder().convert($ifNoneMatch);
     }
 
-    final _path = _i3.UriTemplate('/index.php/apps/notes/api/v1/notes/{id}{?exclude*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/apps/notes/api/v1/notes/{id}{?exclude*}').expand(_parameters);
     return _i1.DynamiteRawResponse<Note, void>(
       response: executeRequest(
         'get',
@@ -435,7 +435,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [updateNote] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Note, void> updateNoteRaw({
     required int id,
     String? content,
@@ -485,11 +485,11 @@ class $Client extends _i1.DynamiteClient {
 
     final $ifMatch = _$jsonSerializers.serialize(ifMatch, specifiedType: const FullType(String));
     if ($ifMatch != null) {
-      _headers['If-Match'] = const _i2.HeaderEncoder().convert($ifMatch);
+      _headers['If-Match'] = const _i3.HeaderEncoder().convert($ifMatch);
     }
 
     final _path =
-        _i3.UriTemplate('/index.php/apps/notes/api/v1/notes/{id}{?content*,modified*,title*,category*,favorite*}')
+        _i4.UriTemplate('/index.php/apps/notes/api/v1/notes/{id}{?content*,modified*,title*,category*,favorite*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<Note, void>(
       response: executeRequest(
@@ -530,7 +530,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [deleteNote] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<String, void> deleteNoteRaw({required int id}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -555,7 +555,7 @@ class $Client extends _i1.DynamiteClient {
     final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
     _parameters['id'] = $id;
 
-    final _path = _i3.UriTemplate('/index.php/apps/notes/api/v1/notes/{id}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/apps/notes/api/v1/notes/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<String, void>(
       response: executeRequest(
         'delete',
@@ -593,7 +593,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [getSettings] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Settings, void> getSettingsRaw() {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -654,7 +654,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [updateSettings] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Settings, void> updateSettingsRaw({required Settings settings}) {
     final _headers = <String, String>{'Accept': 'application/json'};
     Uint8List? _body;
@@ -1002,7 +1002,7 @@ abstract class EmptyOCS implements $EmptyOCSInterface, Built<EmptyOCS, EmptyOCSB
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(Note), NoteBuilder.new)
@@ -1029,7 +1029,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/notifications.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.dart
@@ -22,9 +22,9 @@ import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'notifications.openapi.g.dart';
 
@@ -127,7 +127,7 @@ class $ApiClient {
   ///
   /// See:
   ///  * [generateNotification] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ApiGenerateNotificationResponseApplicationJson, void> generateNotificationRaw({
     required String shortMessage,
     required String userId,
@@ -172,9 +172,9 @@ class $ApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/notifications/api/{apiVersion}/admin_notifications/{userId}{?shortMessage*,longMessage*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<ApiGenerateNotificationResponseApplicationJson, void>(
@@ -244,7 +244,7 @@ class $EndpointClient {
   ///
   /// See:
   ///  * [listNotifications] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<EndpointListNotificationsResponseApplicationJson, EndpointEndpointListNotificationsHeaders>
       listNotificationsRaw({
     EndpointListNotificationsApiVersion? apiVersion,
@@ -277,9 +277,9 @@ class $EndpointClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications').expand(_parameters);
     return _i1.DynamiteRawResponse<EndpointListNotificationsResponseApplicationJson,
         EndpointEndpointListNotificationsHeaders>(
       response: _rootClient.executeRequest(
@@ -338,7 +338,7 @@ class $EndpointClient {
   ///
   /// See:
   ///  * [deleteAllNotifications] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<EndpointDeleteAllNotificationsResponseApplicationJson, void> deleteAllNotificationsRaw({
     EndpointDeleteAllNotificationsApiVersion? apiVersion,
     bool? oCSAPIRequest,
@@ -372,9 +372,9 @@ class $EndpointClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications').expand(_parameters);
     return _i1.DynamiteRawResponse<EndpointDeleteAllNotificationsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -436,7 +436,7 @@ class $EndpointClient {
   ///
   /// See:
   ///  * [getNotification] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<EndpointGetNotificationResponseApplicationJson, void> getNotificationRaw({
     required int id,
     EndpointGetNotificationApiVersion? apiVersion,
@@ -472,10 +472,10 @@ class $EndpointClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/{id}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<EndpointGetNotificationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -539,7 +539,7 @@ class $EndpointClient {
   ///
   /// See:
   ///  * [deleteNotification] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<EndpointDeleteNotificationResponseApplicationJson, void> deleteNotificationRaw({
     required int id,
     EndpointDeleteNotificationApiVersion? apiVersion,
@@ -575,10 +575,10 @@ class $EndpointClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/{id}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/{id}').expand(_parameters);
     return _i1.DynamiteRawResponse<EndpointDeleteNotificationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -640,7 +640,7 @@ class $EndpointClient {
   ///
   /// See:
   ///  * [confirmIdsForUser] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<EndpointConfirmIdsForUserResponseApplicationJson, void> confirmIdsForUserRaw({
     required BuiltList<int> ids,
     EndpointConfirmIdsForUserApiVersion? apiVersion,
@@ -676,9 +676,9 @@ class $EndpointClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/exists{?ids%5B%5D*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/exists{?ids%5B%5D*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<EndpointConfirmIdsForUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -763,7 +763,7 @@ class $PushClient {
   ///
   /// See:
   ///  * [registerDevice] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PushRegisterDeviceResponseApplicationJson, void> registerDeviceRaw({
     required String pushTokenHash,
     required String devicePublicKey,
@@ -807,9 +807,9 @@ class $PushClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/notifications/api/{apiVersion}/push{?pushTokenHash*,devicePublicKey*,proxyServer*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<PushRegisterDeviceResponseApplicationJson, void>(
@@ -876,7 +876,7 @@ class $PushClient {
   ///
   /// See:
   ///  * [removeDevice] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PushRemoveDeviceResponseApplicationJson, void> removeDeviceRaw({
     PushRemoveDeviceApiVersion? apiVersion,
     bool? oCSAPIRequest,
@@ -908,9 +908,9 @@ class $PushClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/push').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/push').expand(_parameters);
     return _i1.DynamiteRawResponse<PushRemoveDeviceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -989,7 +989,7 @@ class $SettingsClient {
   ///
   /// See:
   ///  * [personal] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SettingsPersonalResponseApplicationJson, void> personalRaw({
     required int batchSetting,
     required String soundNotification,
@@ -1033,9 +1033,9 @@ class $SettingsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/notifications/api/{apiVersion}/settings{?batchSetting*,soundNotification*,soundTalk*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<SettingsPersonalResponseApplicationJson, void>(
@@ -1109,7 +1109,7 @@ class $SettingsClient {
   ///
   /// See:
   ///  * [admin] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SettingsAdminResponseApplicationJson, void> adminRaw({
     required int batchSetting,
     required String soundNotification,
@@ -1152,9 +1152,9 @@ class $SettingsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/notifications/api/{apiVersion}/settings/admin{?batchSetting*,soundNotification*,soundTalk*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<SettingsAdminResponseApplicationJson, void>(
@@ -1411,45 +1411,6 @@ class _$EndpointListNotificationsApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $EndpointEndpointListNotificationsHeadersInterface {
-  @BuiltValueField(wireName: 'x-nextcloud-user-status')
-  String? get xNextcloudUserStatus;
-}
-
-abstract class EndpointEndpointListNotificationsHeaders
-    implements
-        $EndpointEndpointListNotificationsHeadersInterface,
-        Built<EndpointEndpointListNotificationsHeaders, EndpointEndpointListNotificationsHeadersBuilder> {
-  /// Creates a new EndpointEndpointListNotificationsHeaders object using the builder pattern.
-  factory EndpointEndpointListNotificationsHeaders([
-    void Function(EndpointEndpointListNotificationsHeadersBuilder)? b,
-  ]) = _$EndpointEndpointListNotificationsHeaders;
-
-  // coverage:ignore-start
-  const EndpointEndpointListNotificationsHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory EndpointEndpointListNotificationsHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for EndpointEndpointListNotificationsHeaders.
-  static Serializer<EndpointEndpointListNotificationsHeaders> get serializer =>
-      _$endpointEndpointListNotificationsHeadersSerializer;
-}
-
-@BuiltValue(instantiable: false)
 abstract interface class $NotificationActionInterface {
   String get label;
   String get link;
@@ -1611,6 +1572,45 @@ abstract class EndpointListNotificationsResponseApplicationJson
   /// Serializer for EndpointListNotificationsResponseApplicationJson.
   static Serializer<EndpointListNotificationsResponseApplicationJson> get serializer =>
       _$endpointListNotificationsResponseApplicationJsonSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $EndpointEndpointListNotificationsHeadersInterface {
+  @BuiltValueField(wireName: 'x-nextcloud-user-status')
+  String? get xNextcloudUserStatus;
+}
+
+abstract class EndpointEndpointListNotificationsHeaders
+    implements
+        $EndpointEndpointListNotificationsHeadersInterface,
+        Built<EndpointEndpointListNotificationsHeaders, EndpointEndpointListNotificationsHeadersBuilder> {
+  /// Creates a new EndpointEndpointListNotificationsHeaders object using the builder pattern.
+  factory EndpointEndpointListNotificationsHeaders([
+    void Function(EndpointEndpointListNotificationsHeadersBuilder)? b,
+  ]) = _$EndpointEndpointListNotificationsHeaders;
+
+  // coverage:ignore-start
+  const EndpointEndpointListNotificationsHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory EndpointEndpointListNotificationsHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for EndpointEndpointListNotificationsHeaders.
+  static Serializer<EndpointEndpointListNotificationsHeaders> get serializer =>
+      _$endpointEndpointListNotificationsHeadersSerializer;
 }
 
 class EndpointDeleteAllNotificationsApiVersion extends EnumClass {
@@ -2825,7 +2825,7 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ApiGenerateNotificationApiVersion.serializer)
@@ -2842,11 +2842,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(OCSMeta), OCSMetaBuilder.new)
       ..add(OCSMeta.serializer)
       ..add(EndpointListNotificationsApiVersion.serializer)
-      ..addBuilderFactory(
-        const FullType(EndpointEndpointListNotificationsHeaders),
-        EndpointEndpointListNotificationsHeadersBuilder.new,
-      )
-      ..add(EndpointEndpointListNotificationsHeaders.serializer)
       ..addBuilderFactory(
         const FullType(EndpointListNotificationsResponseApplicationJson),
         EndpointListNotificationsResponseApplicationJsonBuilder.new,
@@ -2870,6 +2865,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         MapBuilder<String, JsonObject>.new,
       )
       ..addBuilderFactory(const FullType(BuiltList, [FullType(Notification)]), ListBuilder<Notification>.new)
+      ..addBuilderFactory(
+        const FullType(EndpointEndpointListNotificationsHeaders),
+        EndpointEndpointListNotificationsHeadersBuilder.new,
+      )
+      ..add(EndpointEndpointListNotificationsHeaders.serializer)
       ..add(EndpointDeleteAllNotificationsApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(EndpointDeleteAllNotificationsResponseApplicationJson),
@@ -2972,7 +2972,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/notifications.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.g.dart
@@ -208,8 +208,6 @@ Serializer<ApiGenerateNotificationResponseApplicationJson_Ocs>
     _$ApiGenerateNotificationResponseApplicationJson_OcsSerializer();
 Serializer<ApiGenerateNotificationResponseApplicationJson> _$apiGenerateNotificationResponseApplicationJsonSerializer =
     _$ApiGenerateNotificationResponseApplicationJsonSerializer();
-Serializer<EndpointEndpointListNotificationsHeaders> _$endpointEndpointListNotificationsHeadersSerializer =
-    _$EndpointEndpointListNotificationsHeadersSerializer();
 Serializer<NotificationAction> _$notificationActionSerializer = _$NotificationActionSerializer();
 Serializer<Notification> _$notificationSerializer = _$NotificationSerializer();
 Serializer<EndpointListNotificationsResponseApplicationJson_Ocs>
@@ -218,6 +216,8 @@ Serializer<EndpointListNotificationsResponseApplicationJson_Ocs>
 Serializer<EndpointListNotificationsResponseApplicationJson>
     _$endpointListNotificationsResponseApplicationJsonSerializer =
     _$EndpointListNotificationsResponseApplicationJsonSerializer();
+Serializer<EndpointEndpointListNotificationsHeaders> _$endpointEndpointListNotificationsHeadersSerializer =
+    _$EndpointEndpointListNotificationsHeadersSerializer();
 Serializer<EndpointDeleteAllNotificationsResponseApplicationJson_Ocs>
     _$endpointDeleteAllNotificationsResponseApplicationJsonOcsSerializer =
     _$EndpointDeleteAllNotificationsResponseApplicationJson_OcsSerializer();
@@ -415,52 +415,6 @@ class _$ApiGenerateNotificationResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ApiGenerateNotificationResponseApplicationJson_Ocs))!
               as ApiGenerateNotificationResponseApplicationJson_Ocs);
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
-class _$EndpointEndpointListNotificationsHeadersSerializer
-    implements StructuredSerializer<EndpointEndpointListNotificationsHeaders> {
-  @override
-  final Iterable<Type> types = const [
-    EndpointEndpointListNotificationsHeaders,
-    _$EndpointEndpointListNotificationsHeaders
-  ];
-  @override
-  final String wireName = 'EndpointEndpointListNotificationsHeaders';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, EndpointEndpointListNotificationsHeaders object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.xNextcloudUserStatus;
-    if (value != null) {
-      result
-        ..add('x-nextcloud-user-status')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    return result;
-  }
-
-  @override
-  EndpointEndpointListNotificationsHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = EndpointEndpointListNotificationsHeadersBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'x-nextcloud-user-status':
-          result.xNextcloudUserStatus =
-              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -750,6 +704,52 @@ class _$EndpointListNotificationsResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(EndpointListNotificationsResponseApplicationJson_Ocs))!
               as EndpointListNotificationsResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$EndpointEndpointListNotificationsHeadersSerializer
+    implements StructuredSerializer<EndpointEndpointListNotificationsHeaders> {
+  @override
+  final Iterable<Type> types = const [
+    EndpointEndpointListNotificationsHeaders,
+    _$EndpointEndpointListNotificationsHeaders
+  ];
+  @override
+  final String wireName = 'EndpointEndpointListNotificationsHeaders';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, EndpointEndpointListNotificationsHeaders object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.xNextcloudUserStatus;
+    if (value != null) {
+      result
+        ..add('x-nextcloud-user-status')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  EndpointEndpointListNotificationsHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = EndpointEndpointListNotificationsHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'x-nextcloud-user-status':
+          result.xNextcloudUserStatus =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -2003,97 +2003,6 @@ class ApiGenerateNotificationResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $EndpointEndpointListNotificationsHeadersInterfaceBuilder {
-  void replace($EndpointEndpointListNotificationsHeadersInterface other);
-  void update(void Function($EndpointEndpointListNotificationsHeadersInterfaceBuilder) updates);
-  String? get xNextcloudUserStatus;
-  set xNextcloudUserStatus(String? xNextcloudUserStatus);
-}
-
-class _$EndpointEndpointListNotificationsHeaders extends EndpointEndpointListNotificationsHeaders {
-  @override
-  final String? xNextcloudUserStatus;
-
-  factory _$EndpointEndpointListNotificationsHeaders(
-          [void Function(EndpointEndpointListNotificationsHeadersBuilder)? updates]) =>
-      (EndpointEndpointListNotificationsHeadersBuilder()..update(updates))._build();
-
-  _$EndpointEndpointListNotificationsHeaders._({this.xNextcloudUserStatus}) : super._();
-
-  @override
-  EndpointEndpointListNotificationsHeaders rebuild(
-          void Function(EndpointEndpointListNotificationsHeadersBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  EndpointEndpointListNotificationsHeadersBuilder toBuilder() =>
-      EndpointEndpointListNotificationsHeadersBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is EndpointEndpointListNotificationsHeaders && xNextcloudUserStatus == other.xNextcloudUserStatus;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, xNextcloudUserStatus.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'EndpointEndpointListNotificationsHeaders')
-          ..add('xNextcloudUserStatus', xNextcloudUserStatus))
-        .toString();
-  }
-}
-
-class EndpointEndpointListNotificationsHeadersBuilder
-    implements
-        Builder<EndpointEndpointListNotificationsHeaders, EndpointEndpointListNotificationsHeadersBuilder>,
-        $EndpointEndpointListNotificationsHeadersInterfaceBuilder {
-  _$EndpointEndpointListNotificationsHeaders? _$v;
-
-  String? _xNextcloudUserStatus;
-  String? get xNextcloudUserStatus => _$this._xNextcloudUserStatus;
-  set xNextcloudUserStatus(covariant String? xNextcloudUserStatus) =>
-      _$this._xNextcloudUserStatus = xNextcloudUserStatus;
-
-  EndpointEndpointListNotificationsHeadersBuilder();
-
-  EndpointEndpointListNotificationsHeadersBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _xNextcloudUserStatus = $v.xNextcloudUserStatus;
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant EndpointEndpointListNotificationsHeaders other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$EndpointEndpointListNotificationsHeaders;
-  }
-
-  @override
-  void update(void Function(EndpointEndpointListNotificationsHeadersBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  EndpointEndpointListNotificationsHeaders build() => _build();
-
-  _$EndpointEndpointListNotificationsHeaders _build() {
-    final _$result = _$v ?? _$EndpointEndpointListNotificationsHeaders._(xNextcloudUserStatus: xNextcloudUserStatus);
-    replace(_$result);
-    return _$result;
-  }
-}
-
 abstract mixin class $NotificationActionInterfaceBuilder {
   void replace($NotificationActionInterface other);
   void update(void Function($NotificationActionInterfaceBuilder) updates);
@@ -2800,6 +2709,97 @@ class EndpointListNotificationsResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $EndpointEndpointListNotificationsHeadersInterfaceBuilder {
+  void replace($EndpointEndpointListNotificationsHeadersInterface other);
+  void update(void Function($EndpointEndpointListNotificationsHeadersInterfaceBuilder) updates);
+  String? get xNextcloudUserStatus;
+  set xNextcloudUserStatus(String? xNextcloudUserStatus);
+}
+
+class _$EndpointEndpointListNotificationsHeaders extends EndpointEndpointListNotificationsHeaders {
+  @override
+  final String? xNextcloudUserStatus;
+
+  factory _$EndpointEndpointListNotificationsHeaders(
+          [void Function(EndpointEndpointListNotificationsHeadersBuilder)? updates]) =>
+      (EndpointEndpointListNotificationsHeadersBuilder()..update(updates))._build();
+
+  _$EndpointEndpointListNotificationsHeaders._({this.xNextcloudUserStatus}) : super._();
+
+  @override
+  EndpointEndpointListNotificationsHeaders rebuild(
+          void Function(EndpointEndpointListNotificationsHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  EndpointEndpointListNotificationsHeadersBuilder toBuilder() =>
+      EndpointEndpointListNotificationsHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is EndpointEndpointListNotificationsHeaders && xNextcloudUserStatus == other.xNextcloudUserStatus;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, xNextcloudUserStatus.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'EndpointEndpointListNotificationsHeaders')
+          ..add('xNextcloudUserStatus', xNextcloudUserStatus))
+        .toString();
+  }
+}
+
+class EndpointEndpointListNotificationsHeadersBuilder
+    implements
+        Builder<EndpointEndpointListNotificationsHeaders, EndpointEndpointListNotificationsHeadersBuilder>,
+        $EndpointEndpointListNotificationsHeadersInterfaceBuilder {
+  _$EndpointEndpointListNotificationsHeaders? _$v;
+
+  String? _xNextcloudUserStatus;
+  String? get xNextcloudUserStatus => _$this._xNextcloudUserStatus;
+  set xNextcloudUserStatus(covariant String? xNextcloudUserStatus) =>
+      _$this._xNextcloudUserStatus = xNextcloudUserStatus;
+
+  EndpointEndpointListNotificationsHeadersBuilder();
+
+  EndpointEndpointListNotificationsHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _xNextcloudUserStatus = $v.xNextcloudUserStatus;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant EndpointEndpointListNotificationsHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$EndpointEndpointListNotificationsHeaders;
+  }
+
+  @override
+  void update(void Function(EndpointEndpointListNotificationsHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  EndpointEndpointListNotificationsHeaders build() => _build();
+
+  _$EndpointEndpointListNotificationsHeaders _build() {
+    final _$result = _$v ?? _$EndpointEndpointListNotificationsHeaders._(xNextcloudUserStatus: xNextcloudUserStatus);
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -23,9 +23,9 @@ import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
 import 'package:dynamite_runtime/models.dart';
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'provisioning_api.openapi.g.dart';
 
@@ -106,7 +106,7 @@ class $AppConfigClient {
   ///
   /// See:
   ///  * [getApps] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AppConfigGetAppsResponseApplicationJson, void> getAppsRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -129,7 +129,7 @@ class $AppConfigClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/provisioning_api/api/v1/config/apps';
     return _i1.DynamiteRawResponse<AppConfigGetAppsResponseApplicationJson, void>(
@@ -193,7 +193,7 @@ class $AppConfigClient {
   ///
   /// See:
   ///  * [getKeys] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AppConfigGetKeysResponseApplicationJson, void> getKeysRaw({
     required String app,
     bool? oCSAPIRequest,
@@ -223,9 +223,9 @@ class $AppConfigClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}').expand(_parameters);
     return _i1.DynamiteRawResponse<AppConfigGetKeysResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -291,7 +291,7 @@ class $AppConfigClient {
   ///
   /// See:
   ///  * [setValue] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AppConfigSetValueResponseApplicationJson, void> setValueRaw({
     required String value,
     required String app,
@@ -329,9 +329,9 @@ class $AppConfigClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}/{key}{?value*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}/{key}{?value*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<AppConfigSetValueResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -399,7 +399,7 @@ class $AppsClient {
   ///
   /// See:
   ///  * [getApps] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AppsGetAppsResponseApplicationJson, void> getAppsRaw({
     String? filter,
     bool? oCSAPIRequest,
@@ -429,9 +429,9 @@ class $AppsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/apps{?filter*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/apps{?filter*}').expand(_parameters);
     return _i1.DynamiteRawResponse<AppsGetAppsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -491,7 +491,7 @@ class $AppsClient {
   ///
   /// See:
   ///  * [getAppInfo] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AppsGetAppInfoResponseApplicationJson, void> getAppInfoRaw({
     required String app,
     bool? oCSAPIRequest,
@@ -521,9 +521,9 @@ class $AppsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(_parameters);
     return _i1.DynamiteRawResponse<AppsGetAppInfoResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -583,7 +583,7 @@ class $AppsClient {
   ///
   /// See:
   ///  * [enable] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AppsEnableResponseApplicationJson, void> enableRaw({
     required String app,
     bool? oCSAPIRequest,
@@ -613,9 +613,9 @@ class $AppsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(_parameters);
     return _i1.DynamiteRawResponse<AppsEnableResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -675,7 +675,7 @@ class $AppsClient {
   ///
   /// See:
   ///  * [disable] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AppsDisableResponseApplicationJson, void> disableRaw({
     required String app,
     bool? oCSAPIRequest,
@@ -705,9 +705,9 @@ class $AppsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(_parameters);
     return _i1.DynamiteRawResponse<AppsDisableResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -774,7 +774,7 @@ class $GroupsClient {
   ///
   /// See:
   ///  * [getSubAdminsOfGroup] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<GroupsGetSubAdminsOfGroupResponseApplicationJson, void> getSubAdminsOfGroupRaw({
     required String groupId,
     bool? oCSAPIRequest,
@@ -800,7 +800,7 @@ class $GroupsClient {
 
 // coverage:ignore-end
     final $groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $groupId as String?,
       RegExp(r'^.+$'),
       'groupId',
@@ -809,9 +809,9 @@ class $GroupsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/subadmins').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/subadmins').expand(_parameters);
     return _i1.DynamiteRawResponse<GroupsGetSubAdminsOfGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -875,7 +875,7 @@ class $GroupsClient {
   ///
   /// See:
   ///  * [getGroups] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<GroupsGetGroupsResponseApplicationJson, void> getGroupsRaw({
     String? search,
     int? limit,
@@ -915,9 +915,9 @@ class $GroupsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/groups{?search*,limit*,offset*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/groups{?search*,limit*,offset*}').expand(_parameters);
     return _i1.DynamiteRawResponse<GroupsGetGroupsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -974,7 +974,7 @@ class $GroupsClient {
   ///
   /// See:
   ///  * [getGroup] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   @Deprecated('')
   _i1.DynamiteRawResponse<GroupsGetGroupResponseApplicationJson, void> getGroupRaw({
     required String groupId,
@@ -1001,7 +1001,7 @@ class $GroupsClient {
 
 // coverage:ignore-end
     final $groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $groupId as String?,
       RegExp(r'^.+$'),
       'groupId',
@@ -1010,9 +1010,9 @@ class $GroupsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}').expand(_parameters);
     return _i1.DynamiteRawResponse<GroupsGetGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1076,7 +1076,7 @@ class $GroupsClient {
   ///
   /// See:
   ///  * [getGroupsDetails] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<GroupsGetGroupsDetailsResponseApplicationJson, void> getGroupsDetailsRaw({
     String? search,
     int? limit,
@@ -1116,9 +1116,9 @@ class $GroupsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/groups/details{?search*,limit*,offset*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/groups/details{?search*,limit*,offset*}').expand(_parameters);
     return _i1.DynamiteRawResponse<GroupsGetGroupsDetailsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1178,7 +1178,7 @@ class $GroupsClient {
   ///
   /// See:
   ///  * [getGroupUsers] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<GroupsGetGroupUsersResponseApplicationJson, void> getGroupUsersRaw({
     required String groupId,
     bool? oCSAPIRequest,
@@ -1204,7 +1204,7 @@ class $GroupsClient {
 
 // coverage:ignore-end
     final $groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $groupId as String?,
       RegExp(r'^.+$'),
       'groupId',
@@ -1213,9 +1213,9 @@ class $GroupsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/users').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/users').expand(_parameters);
     return _i1.DynamiteRawResponse<GroupsGetGroupUsersResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1283,7 +1283,7 @@ class $GroupsClient {
   ///
   /// See:
   ///  * [getGroupUsersDetails] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<GroupsGetGroupUsersDetailsResponseApplicationJson, void> getGroupUsersDetailsRaw({
     required String groupId,
     String? search,
@@ -1312,7 +1312,7 @@ class $GroupsClient {
 
 // coverage:ignore-end
     final $groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $groupId as String?,
       RegExp(r'^.+$'),
       'groupId',
@@ -1332,9 +1332,9 @@ class $GroupsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/users/details{?search*,limit*,offset*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/users/details{?search*,limit*,offset*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<GroupsGetGroupUsersDetailsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1408,7 +1408,7 @@ class $PreferencesClient {
   ///
   /// See:
   ///  * [setPreference] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PreferencesSetPreferenceResponseApplicationJson, void> setPreferenceRaw({
     required String configValue,
     required String appId,
@@ -1446,10 +1446,10 @@ class $PreferencesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}{?configValue*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}{?configValue*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<PreferencesSetPreferenceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1515,7 +1515,7 @@ class $PreferencesClient {
   ///
   /// See:
   ///  * [deletePreference] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PreferencesDeletePreferenceResponseApplicationJson, void> deletePreferenceRaw({
     required String appId,
     required String configKey,
@@ -1549,9 +1549,9 @@ class $PreferencesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<PreferencesDeletePreferenceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1617,7 +1617,7 @@ class $PreferencesClient {
   ///
   /// See:
   ///  * [setMultiplePreferences] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PreferencesSetMultiplePreferencesResponseApplicationJson, void> setMultiplePreferencesRaw({
     required ContentString<BuiltMap<String, String>> configs,
     required String appId,
@@ -1656,10 +1656,10 @@ class $PreferencesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}{?configs*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}{?configs*}').expand(_parameters);
     return _i1.DynamiteRawResponse<PreferencesSetMultiplePreferencesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -1725,7 +1725,7 @@ class $PreferencesClient {
   ///
   /// See:
   ///  * [deleteMultiplePreference] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PreferencesDeleteMultiplePreferenceResponseApplicationJson, void>
       deleteMultiplePreferenceRaw({
     required BuiltList<String> configKeys,
@@ -1761,9 +1761,9 @@ class $PreferencesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}{?configKeys%5B%5D*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}{?configKeys%5B%5D*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<PreferencesDeleteMultiplePreferenceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1834,7 +1834,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [getUserSubAdminGroups] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersGetUserSubAdminGroupsResponseApplicationJson, void> getUserSubAdminGroupsRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -1864,9 +1864,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersGetUserSubAdminGroupsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1930,7 +1930,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [addSubAdmin] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersAddSubAdminResponseApplicationJson, void> addSubAdminRaw({
     required String groupid,
     required String userId,
@@ -1964,9 +1964,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins{?groupid*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins{?groupid*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersAddSubAdminResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -2030,7 +2030,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [removeSubAdmin] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersRemoveSubAdminResponseApplicationJson, void> removeSubAdminRaw({
     required String groupid,
     required String userId,
@@ -2064,9 +2064,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins{?groupid*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins{?groupid*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersRemoveSubAdminResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -2130,7 +2130,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [getUsers] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersGetUsersResponseApplicationJson, void> getUsersRaw({
     String? search,
     int? limit,
@@ -2170,9 +2170,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users{?search*,limit*,offset*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users{?search*,limit*,offset*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersGetUsersResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -2262,7 +2262,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [addUser] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersAddUserResponseApplicationJson, void> addUserRaw({
     required String userid,
     String? password,
@@ -2331,9 +2331,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/cloud/users{?userid*,password*,displayName*,email*,groups%5B%5D*,subadmin%5B%5D*,quota*,language*,manager*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<UsersAddUserResponseApplicationJson, void>(
@@ -2399,7 +2399,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [getUsersDetails] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersGetUsersDetailsResponseApplicationJson, void> getUsersDetailsRaw({
     String? search,
     int? limit,
@@ -2439,9 +2439,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/details{?search*,limit*,offset*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/details{?search*,limit*,offset*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersGetUsersDetailsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -2501,7 +2501,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [getDisabledUsersDetails] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersGetDisabledUsersDetailsResponseApplicationJson, void> getDisabledUsersDetailsRaw({
     int? limit,
     int? offset,
@@ -2536,9 +2536,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/disabled{?limit*,offset*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/disabled{?limit*,offset*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersGetDisabledUsersDetailsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -2600,7 +2600,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [searchByPhoneNumbers] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersSearchByPhoneNumbersResponseApplicationJson, void> searchByPhoneNumbersRaw({
     required String location,
     required ContentString<BuiltMap<String, BuiltList<String>>> search,
@@ -2642,9 +2642,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/search/by-phone{?location*,search*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/search/by-phone{?location*,search*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersSearchByPhoneNumbersResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -2700,7 +2700,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [getUser] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersGetUserResponseApplicationJson, void> getUserRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -2730,9 +2730,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersGetUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -2796,7 +2796,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [editUser] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersEditUserResponseApplicationJson, void> editUserRaw({
     required String key,
     required String value,
@@ -2834,9 +2834,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}{?key*,value*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}{?key*,value*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersEditUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -2892,7 +2892,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [deleteUser] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersDeleteUserResponseApplicationJson, void> deleteUserRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -2922,9 +2922,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersDeleteUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -2976,7 +2976,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [getCurrentUser] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersGetCurrentUserResponseApplicationJson, void> getCurrentUserRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -2999,7 +2999,7 @@ class $UsersClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/cloud/user';
     return _i1.DynamiteRawResponse<UsersGetCurrentUserResponseApplicationJson, void>(
@@ -3053,7 +3053,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [getEditableFields] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersGetEditableFieldsResponseApplicationJson, void> getEditableFieldsRaw({
     bool? oCSAPIRequest,
   }) {
@@ -3078,7 +3078,7 @@ class $UsersClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/cloud/user/fields';
     return _i1.DynamiteRawResponse<UsersGetEditableFieldsResponseApplicationJson, void>(
@@ -3136,7 +3136,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [getEditableFieldsForUser] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersGetEditableFieldsForUserResponseApplicationJson, void> getEditableFieldsForUserRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -3166,9 +3166,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/user/fields/{userId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/user/fields/{userId}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersGetEditableFieldsForUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -3236,7 +3236,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [editUserMultiValue] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersEditUserMultiValueResponseApplicationJson, void> editUserMultiValueRaw({
     required String key,
     required String value,
@@ -3274,7 +3274,7 @@ class $UsersClient {
     _parameters['userId'] = $userId;
 
     final $collectionName = _$jsonSerializers.serialize(collectionName, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $collectionName as String?,
       RegExp(r'^(?!enable$|disable$)[a-zA-Z0-9_]*$'),
       'collectionName',
@@ -3283,10 +3283,10 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/{collectionName}{?key*,value*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/{collectionName}{?key*,value*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersEditUserMultiValueResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -3342,7 +3342,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [wipeUserDevices] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersWipeUserDevicesResponseApplicationJson, void> wipeUserDevicesRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -3372,9 +3372,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/wipe').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/wipe').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersWipeUserDevicesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -3430,7 +3430,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [enableUser] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersEnableUserResponseApplicationJson, void> enableUserRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -3460,9 +3460,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/enable').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/enable').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersEnableUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -3518,7 +3518,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [disableUser] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersDisableUserResponseApplicationJson, void> disableUserRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -3548,9 +3548,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/disable').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/disable').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersDisableUserResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -3606,7 +3606,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [getUsersGroups] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersGetUsersGroupsResponseApplicationJson, void> getUsersGroupsRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -3636,9 +3636,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersGetUsersGroupsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -3698,7 +3698,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [addToGroup] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersAddToGroupResponseApplicationJson, void> addToGroupRaw({
     required String userId,
     String? groupid,
@@ -3733,9 +3733,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups{?groupid*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups{?groupid*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersAddToGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -3795,7 +3795,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [removeFromGroup] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersRemoveFromGroupResponseApplicationJson, void> removeFromGroupRaw({
     required String groupid,
     required String userId,
@@ -3829,9 +3829,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups{?groupid*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups{?groupid*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersRemoveFromGroupResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -3887,7 +3887,7 @@ class $UsersClient {
   ///
   /// See:
   ///  * [resendWelcomeMessage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UsersResendWelcomeMessageResponseApplicationJson, void> resendWelcomeMessageRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -3917,9 +3917,9 @@ class $UsersClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/cloud/users/{userId}/welcome').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/cloud/users/{userId}/welcome').expand(_parameters);
     return _i1.DynamiteRawResponse<UsersResendWelcomeMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -7973,13 +7973,13 @@ extension $c4bc4131e74e61dae681408e87e2e2bdExtension on _$c4bc4131e74e61dae68140
   List<String> get _names => const [r'$bool', r'$int'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -8049,13 +8049,13 @@ extension $b6d67dc2a96424d2f407f8e51557f3deExtension on _$b6d67dc2a96424d2f407f8
   List<String> get _names => const [r'$num', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -8128,13 +8128,13 @@ extension $b20d370ea28764b414e70ac5df151f1bExtension on _$b20d370ea28764b414e70a
   List<String> get _names => const ['groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1', 'userDetails'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -8218,13 +8218,13 @@ extension $1e1cd5e43e0a1022a23a294e58225d74Extension on _$1e1cd5e43e0a1022a23a29
   List<String> get _names => const ['userDetails', 'usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -8307,13 +8307,13 @@ extension $f9d75e948689049b3f3e23e024d4be73Extension on _$f9d75e948689049b3f3e23
   List<String> get _names => const ['userDetails', 'usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -8390,7 +8390,7 @@ class _$f9d75e948689049b3f3e23e024d4be73Serializer implements PrimitiveSerialize
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
@@ -8942,7 +8942,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -25,9 +25,9 @@ import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
 import 'package:dynamite_runtime/models.dart';
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'spreed.openapi.g.dart';
 
@@ -146,7 +146,7 @@ class $AvatarClient {
   ///
   /// See:
   ///  * [getAvatar] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getAvatarRaw({
     required String token,
     AvatarGetAvatarDarkTheme? darkTheme,
@@ -172,7 +172,7 @@ class $AvatarClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -189,9 +189,9 @@ class $AvatarClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar{?darkTheme*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar{?darkTheme*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
@@ -254,7 +254,7 @@ class $AvatarClient {
   ///
   /// See:
   ///  * [uploadAvatar] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AvatarUploadAvatarResponseApplicationJson, void> uploadAvatarRaw({
     required String token,
     AvatarUploadAvatarApiVersion? apiVersion,
@@ -279,7 +279,7 @@ class $AvatarClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -293,9 +293,9 @@ class $AvatarClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar').expand(_parameters);
     return _i1.DynamiteRawResponse<AvatarUploadAvatarResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -355,7 +355,7 @@ class $AvatarClient {
   ///
   /// See:
   ///  * [deleteAvatar] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AvatarDeleteAvatarResponseApplicationJson, void> deleteAvatarRaw({
     required String token,
     AvatarDeleteAvatarApiVersion? apiVersion,
@@ -380,7 +380,7 @@ class $AvatarClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -394,9 +394,9 @@ class $AvatarClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar').expand(_parameters);
     return _i1.DynamiteRawResponse<AvatarDeleteAvatarResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -466,7 +466,7 @@ class $AvatarClient {
   ///
   /// See:
   ///  * [emojiAvatar] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<AvatarEmojiAvatarResponseApplicationJson, void> emojiAvatarRaw({
     required String emoji,
     required String token,
@@ -496,7 +496,7 @@ class $AvatarClient {
     _parameters['emoji'] = $emoji;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -513,9 +513,9 @@ class $AvatarClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar/emoji{?emoji*,color*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar/emoji{?emoji*,color*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<AvatarEmojiAvatarResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -576,7 +576,7 @@ class $AvatarClient {
   ///
   /// See:
   ///  * [getAvatarDark] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getAvatarDarkRaw({
     required String token,
     AvatarGetAvatarDarkApiVersion? apiVersion,
@@ -601,7 +601,7 @@ class $AvatarClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -615,10 +615,10 @@ class $AvatarClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar/dark').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar/dark').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -711,7 +711,7 @@ class $BotClient {
   ///
   /// See:
   ///  * [sendMessage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BotSendMessageResponseApplicationJson, void> sendMessageRaw({
     required String message,
     required String token,
@@ -743,7 +743,7 @@ class $BotClient {
     _parameters['message'] = $message;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -768,9 +768,9 @@ class $BotClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/message{?message*,referenceId*,replyTo*,silent*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<BotSendMessageResponseApplicationJson, void>(
@@ -853,7 +853,7 @@ class $BotClient {
   ///
   /// See:
   ///  * [react] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BotReactResponseApplicationJson, void> reactRaw({
     required String reaction,
     required String token,
@@ -883,7 +883,7 @@ class $BotClient {
     _parameters['reaction'] = $reaction;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -899,10 +899,10 @@ class $BotClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}{?reaction*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}{?reaction*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<BotReactResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -983,7 +983,7 @@ class $BotClient {
   ///
   /// See:
   ///  * [deleteReaction] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BotDeleteReactionResponseApplicationJson, void> deleteReactionRaw({
     required String reaction,
     required String token,
@@ -1013,7 +1013,7 @@ class $BotClient {
     _parameters['reaction'] = $reaction;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -1030,10 +1030,10 @@ class $BotClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}{?reaction*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}{?reaction*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<BotDeleteReactionResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1099,7 +1099,7 @@ class $BotClient {
   ///
   /// See:
   ///  * [listBots] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BotListBotsResponseApplicationJson, void> listBotsRaw({
     required String token,
     BotListBotsApiVersion? apiVersion,
@@ -1126,7 +1126,7 @@ class $BotClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -1139,9 +1139,9 @@ class $BotClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<BotListBotsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1209,7 +1209,7 @@ class $BotClient {
   ///
   /// See:
   ///  * [enableBot] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BotEnableBotResponseApplicationJson, void> enableBotRaw({
     required String token,
     required int botId,
@@ -1237,7 +1237,7 @@ class $BotClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -1253,9 +1253,9 @@ class $BotClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/{botId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/{botId}').expand(_parameters);
     return _i1.DynamiteRawResponse<BotEnableBotResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -1324,7 +1324,7 @@ class $BotClient {
   ///
   /// See:
   ///  * [disableBot] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BotDisableBotResponseApplicationJson, void> disableBotRaw({
     required String token,
     required int botId,
@@ -1352,7 +1352,7 @@ class $BotClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -1368,9 +1368,9 @@ class $BotClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/{botId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/{botId}').expand(_parameters);
     return _i1.DynamiteRawResponse<BotDisableBotResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -1430,7 +1430,7 @@ class $BotClient {
   ///
   /// See:
   ///  * [adminListBots] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BotAdminListBotsResponseApplicationJson, void> adminListBotsRaw({
     BotAdminListBotsApiVersion? apiVersion,
     bool? oCSAPIRequest,
@@ -1462,9 +1462,9 @@ class $BotClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/admin').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/admin').expand(_parameters);
     return _i1.DynamiteRawResponse<BotAdminListBotsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -1545,7 +1545,7 @@ class $BreakoutRoomClient {
   ///
   /// See:
   ///  * [configureBreakoutRooms] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson, void> configureBreakoutRoomsRaw({
     required BreakoutRoomConfigureBreakoutRoomsMode mode,
     required int amount,
@@ -1582,7 +1582,7 @@ class $BreakoutRoomClient {
     _parameters['amount'] = $amount;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -1602,10 +1602,10 @@ class $BreakoutRoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}{?mode*,amount*,attendeeMap*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}{?mode*,amount*,attendeeMap*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1666,7 +1666,7 @@ class $BreakoutRoomClient {
   ///
   /// See:
   ///  * [removeBreakoutRooms] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson, void> removeBreakoutRoomsRaw({
     required String token,
     BreakoutRoomRemoveBreakoutRoomsApiVersion? apiVersion,
@@ -1693,7 +1693,7 @@ class $BreakoutRoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -1709,10 +1709,10 @@ class $BreakoutRoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -1780,7 +1780,7 @@ class $BreakoutRoomClient {
   ///
   /// See:
   ///  * [broadcastChatMessage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BreakoutRoomBroadcastChatMessageResponseApplicationJson, void> broadcastChatMessageRaw({
     required String message,
     required String token,
@@ -1811,7 +1811,7 @@ class $BreakoutRoomClient {
     _parameters['message'] = $message;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -1827,10 +1827,10 @@ class $BreakoutRoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/broadcast{?message*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/broadcast{?message*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<BreakoutRoomBroadcastChatMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -1897,7 +1897,7 @@ class $BreakoutRoomClient {
   ///
   /// See:
   ///  * [applyAttendeeMap] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BreakoutRoomApplyAttendeeMapResponseApplicationJson, void> applyAttendeeMapRaw({
     required String attendeeMap,
     required String token,
@@ -1928,7 +1928,7 @@ class $BreakoutRoomClient {
     _parameters['attendeeMap'] = $attendeeMap;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -1942,10 +1942,10 @@ class $BreakoutRoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/attendees{?attendeeMap*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/attendees{?attendeeMap*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<BreakoutRoomApplyAttendeeMapResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2008,7 +2008,7 @@ class $BreakoutRoomClient {
   ///
   /// See:
   ///  * [requestAssistance] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BreakoutRoomRequestAssistanceResponseApplicationJson, void> requestAssistanceRaw({
     required String token,
     BreakoutRoomRequestAssistanceApiVersion? apiVersion,
@@ -2035,7 +2035,7 @@ class $BreakoutRoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -2049,9 +2049,9 @@ class $BreakoutRoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/request-assistance')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/request-assistance')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<BreakoutRoomRequestAssistanceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2115,7 +2115,7 @@ class $BreakoutRoomClient {
   ///
   /// See:
   ///  * [resetRequestForAssistance] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BreakoutRoomResetRequestForAssistanceResponseApplicationJson, void>
       resetRequestForAssistanceRaw({
     required String token,
@@ -2143,7 +2143,7 @@ class $BreakoutRoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -2159,9 +2159,9 @@ class $BreakoutRoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/request-assistance')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/request-assistance')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<BreakoutRoomResetRequestForAssistanceResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2224,7 +2224,7 @@ class $BreakoutRoomClient {
   ///
   /// See:
   ///  * [startBreakoutRooms] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BreakoutRoomStartBreakoutRoomsResponseApplicationJson, void> startBreakoutRoomsRaw({
     required String token,
     BreakoutRoomStartBreakoutRoomsApiVersion? apiVersion,
@@ -2251,7 +2251,7 @@ class $BreakoutRoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -2267,10 +2267,10 @@ class $BreakoutRoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/rooms').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/rooms').expand(_parameters);
     return _i1.DynamiteRawResponse<BreakoutRoomStartBreakoutRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -2332,7 +2332,7 @@ class $BreakoutRoomClient {
   ///
   /// See:
   ///  * [stopBreakoutRooms] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BreakoutRoomStopBreakoutRoomsResponseApplicationJson, void> stopBreakoutRoomsRaw({
     required String token,
     BreakoutRoomStopBreakoutRoomsApiVersion? apiVersion,
@@ -2359,7 +2359,7 @@ class $BreakoutRoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -2373,10 +2373,10 @@ class $BreakoutRoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/rooms').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/rooms').expand(_parameters);
     return _i1.DynamiteRawResponse<BreakoutRoomStopBreakoutRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -2442,7 +2442,7 @@ class $BreakoutRoomClient {
   ///
   /// See:
   ///  * [switchBreakoutRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson, void> switchBreakoutRoomRaw({
     required String target,
     required String token,
@@ -2473,7 +2473,7 @@ class $BreakoutRoomClient {
     _parameters['target'] = $target;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -2489,9 +2489,9 @@ class $BreakoutRoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/switch{?target*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/switch{?target*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -2559,7 +2559,7 @@ class $CallClient {
   ///
   /// See:
   ///  * [getPeersForCall] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CallGetPeersForCallResponseApplicationJson, void> getPeersForCallRaw({
     required String token,
     CallGetPeersForCallApiVersion? apiVersion,
@@ -2584,7 +2584,7 @@ class $CallClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -2598,9 +2598,9 @@ class $CallClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<CallGetPeersForCallResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -2668,7 +2668,7 @@ class $CallClient {
   ///
   /// See:
   ///  * [updateCallFlags] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CallUpdateCallFlagsResponseApplicationJson, void> updateCallFlagsRaw({
     required int flags,
     required String token,
@@ -2697,7 +2697,7 @@ class $CallClient {
     _parameters['flags'] = $flags;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -2711,9 +2711,9 @@ class $CallClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?flags*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?flags*}').expand(_parameters);
     return _i1.DynamiteRawResponse<CallUpdateCallFlagsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -2797,7 +2797,7 @@ class $CallClient {
   ///
   /// See:
   ///  * [joinCall] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CallJoinCallResponseApplicationJson, void> joinCallRaw({
     required String token,
     CallJoinCallFlags? flags,
@@ -2826,7 +2826,7 @@ class $CallClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -2855,9 +2855,9 @@ class $CallClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?flags*,forcePermissions*,silent*,recordingConsent*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<CallJoinCallResponseApplicationJson, void>(
@@ -2928,7 +2928,7 @@ class $CallClient {
   ///
   /// See:
   ///  * [leaveCall] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CallLeaveCallResponseApplicationJson, void> leaveCallRaw({
     required String token,
     CallLeaveCallAll? all,
@@ -2954,7 +2954,7 @@ class $CallClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -2971,9 +2971,9 @@ class $CallClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?all*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?all*}').expand(_parameters);
     return _i1.DynamiteRawResponse<CallLeaveCallResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -3044,7 +3044,7 @@ class $CallClient {
   ///
   /// See:
   ///  * [ringAttendee] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CallRingAttendeeResponseApplicationJson, void> ringAttendeeRaw({
     required String token,
     required int attendeeId,
@@ -3070,7 +3070,7 @@ class $CallClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -3087,10 +3087,10 @@ class $CallClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/ring/{attendeeId}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/ring/{attendeeId}').expand(_parameters);
     return _i1.DynamiteRawResponse<CallRingAttendeeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -3164,7 +3164,7 @@ class $CallClient {
   ///
   /// See:
   ///  * [sipDialOut] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CallSipDialOutResponseApplicationJson, void> sipDialOutRaw({
     required String token,
     required int attendeeId,
@@ -3190,7 +3190,7 @@ class $CallClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -3206,9 +3206,9 @@ class $CallClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/dialout/{attendeeId}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/dialout/{attendeeId}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<CallSipDialOutResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -3288,7 +3288,7 @@ class $CertificateClient {
   ///
   /// See:
   ///  * [getCertificateExpiration] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CertificateGetCertificateExpirationResponseApplicationJson, void>
       getCertificateExpirationRaw({
     required String host,
@@ -3327,10 +3327,10 @@ class $CertificateClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/certificate/expiration{?host*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/certificate/expiration{?host*}').expand(_parameters);
     return _i1.DynamiteRawResponse<CertificateGetCertificateExpirationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -3444,7 +3444,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [receiveMessages] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatReceiveMessagesResponseApplicationJson, ChatChatReceiveMessagesHeaders>
       receiveMessagesRaw({
     required ChatReceiveMessagesLookIntoFuture lookIntoFuture,
@@ -3483,7 +3483,7 @@ class $ChatClient {
     _parameters['lookIntoFuture'] = $lookIntoFuture;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -3537,9 +3537,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}{?lookIntoFuture*,limit*,lastKnownMessageId*,lastCommonReadId*,timeout*,setReadMarker*,includeLastKnown*,noStatusUpdate*,markNotificationsAsRead*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<ChatReceiveMessagesResponseApplicationJson, ChatChatReceiveMessagesHeaders>(
@@ -3634,7 +3634,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [sendMessage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatSendMessageResponseApplicationJson, ChatChatSendMessageHeaders> sendMessageRaw({
     required String message,
     required String token,
@@ -3667,7 +3667,7 @@ class $ChatClient {
     _parameters['message'] = $message;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -3696,9 +3696,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}{?message*,actorDisplayName*,referenceId*,replyTo*,silent*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<ChatSendMessageResponseApplicationJson, ChatChatSendMessageHeaders>(
@@ -3764,7 +3764,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [clearHistory] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatClearHistoryResponseApplicationJson, ChatChatClearHistoryHeaders> clearHistoryRaw({
     required String token,
     ChatClearHistoryApiVersion? apiVersion,
@@ -3791,7 +3791,7 @@ class $ChatClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -3805,9 +3805,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<ChatClearHistoryResponseApplicationJson, ChatChatClearHistoryHeaders>(
       response: _rootClient.executeRequest(
         'delete',
@@ -3884,7 +3884,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [deleteMessage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatDeleteMessageResponseApplicationJson, ChatChatDeleteMessageHeaders> deleteMessageRaw({
     required String token,
     required int messageId,
@@ -3912,7 +3912,7 @@ class $ChatClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -3929,10 +3929,10 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}').expand(_parameters);
     return _i1.DynamiteRawResponse<ChatDeleteMessageResponseApplicationJson, ChatChatDeleteMessageHeaders>(
       response: _rootClient.executeRequest(
         'delete',
@@ -4006,7 +4006,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [getMessageContext] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatGetMessageContextResponseApplicationJson, ChatChatGetMessageContextHeaders>
       getMessageContextRaw({
     required String token,
@@ -4034,7 +4034,7 @@ class $ChatClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -4055,9 +4055,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/context{?limit*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/context{?limit*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<ChatGetMessageContextResponseApplicationJson, ChatChatGetMessageContextHeaders>(
       response: _rootClient.executeRequest(
@@ -4127,7 +4127,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [getReminder] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatGetReminderResponseApplicationJson, void> getReminderRaw({
     required String token,
     required int messageId,
@@ -4155,7 +4155,7 @@ class $ChatClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -4171,9 +4171,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<ChatGetReminderResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4244,7 +4244,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [setReminder] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatSetReminderResponseApplicationJson, void> setReminderRaw({
     required int timestamp,
     required String token,
@@ -4276,7 +4276,7 @@ class $ChatClient {
     _parameters['timestamp'] = $timestamp;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -4292,10 +4292,10 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder{?timestamp*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder{?timestamp*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<ChatSetReminderResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4362,7 +4362,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [deleteReminder] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatDeleteReminderResponseApplicationJson, void> deleteReminderRaw({
     required String token,
     required int messageId,
@@ -4390,7 +4390,7 @@ class $ChatClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -4407,9 +4407,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<ChatDeleteReminderResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -4477,7 +4477,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [setReadMarker] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatSetReadMarkerResponseApplicationJson, ChatChatSetReadMarkerHeaders> setReadMarkerRaw({
     required int lastReadMessage,
     required String token,
@@ -4508,7 +4508,7 @@ class $ChatClient {
     _parameters['lastReadMessage'] = $lastReadMessage;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -4522,9 +4522,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/read{?lastReadMessage*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/read{?lastReadMessage*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<ChatSetReadMarkerResponseApplicationJson, ChatChatSetReadMarkerHeaders>(
       response: _rootClient.executeRequest(
@@ -4585,7 +4585,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [markUnread] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatMarkUnreadResponseApplicationJson, ChatChatMarkUnreadHeaders> markUnreadRaw({
     required String token,
     ChatMarkUnreadApiVersion? apiVersion,
@@ -4612,7 +4612,7 @@ class $ChatClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -4625,9 +4625,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/read').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/read').expand(_parameters);
     return _i1.DynamiteRawResponse<ChatMarkUnreadResponseApplicationJson, ChatChatMarkUnreadHeaders>(
       response: _rootClient.executeRequest(
         'delete',
@@ -4699,7 +4699,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [mentions] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatMentionsResponseApplicationJson, void> mentionsRaw({
     required String search,
     required String token,
@@ -4730,7 +4730,7 @@ class $ChatClient {
     _parameters['search'] = $search;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -4752,9 +4752,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/mentions{?search*,limit*,includeStatus*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<ChatMentionsResponseApplicationJson, void>(
@@ -4829,7 +4829,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [getObjectsSharedInRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatGetObjectsSharedInRoomResponseApplicationJson, ChatChatGetObjectsSharedInRoomHeaders>
       getObjectsSharedInRoomRaw({
     required String objectType,
@@ -4861,7 +4861,7 @@ class $ChatClient {
     _parameters['objectType'] = $objectType;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -4883,9 +4883,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share{?objectType*,lastKnownMessageId*,limit*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<ChatGetObjectsSharedInRoomResponseApplicationJson,
@@ -4979,7 +4979,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [shareObjectToChat] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatShareObjectToChatResponseApplicationJson, ChatChatShareObjectToChatHeaders>
       shareObjectToChatRaw({
     required String objectType,
@@ -5016,7 +5016,7 @@ class $ChatClient {
     _parameters['objectId'] = $objectId;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -5042,9 +5042,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share{?objectType*,objectId*,metaData*,actorDisplayName*,referenceId*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<ChatShareObjectToChatResponseApplicationJson, ChatChatShareObjectToChatHeaders>(
@@ -5111,7 +5111,7 @@ class $ChatClient {
   ///
   /// See:
   ///  * [getObjectsSharedInRoomOverview] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson, void>
       getObjectsSharedInRoomOverviewRaw({
     required String token,
@@ -5138,7 +5138,7 @@ class $ChatClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -5158,9 +5158,9 @@ class $ChatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share/overview{?limit*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share/overview{?limit*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5240,7 +5240,7 @@ class $FilesIntegrationClient {
   ///
   /// See:
   ///  * [getRoomByFileId] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<FilesIntegrationGetRoomByFileIdResponseApplicationJson, void> getRoomByFileIdRaw({
     required String fileId,
     FilesIntegrationGetRoomByFileIdApiVersion? apiVersion,
@@ -5267,7 +5267,7 @@ class $FilesIntegrationClient {
 
 // coverage:ignore-end
     final $fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $fileId as String?,
       RegExp(r'^.+$'),
       'fileId',
@@ -5283,9 +5283,9 @@ class $FilesIntegrationClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/file/{fileId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/file/{fileId}').expand(_parameters);
     return _i1.DynamiteRawResponse<FilesIntegrationGetRoomByFileIdResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -5359,7 +5359,7 @@ class $FilesIntegrationClient {
   ///
   /// See:
   ///  * [getRoomByShareToken] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<FilesIntegrationGetRoomByShareTokenResponseApplicationJson, void> getRoomByShareTokenRaw({
     required String shareToken,
     FilesIntegrationGetRoomByShareTokenApiVersion? apiVersion,
@@ -5384,7 +5384,7 @@ class $FilesIntegrationClient {
 
 // coverage:ignore-end
     final $shareToken = _$jsonSerializers.serialize(shareToken, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $shareToken as String?,
       RegExp(r'^.+$'),
       'shareToken',
@@ -5400,10 +5400,10 @@ class $FilesIntegrationClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/publicshare/{shareToken}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/publicshare/{shareToken}').expand(_parameters);
     return _i1.DynamiteRawResponse<FilesIntegrationGetRoomByShareTokenResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -5478,7 +5478,7 @@ class $GuestClient {
   ///
   /// See:
   ///  * [setDisplayName] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<GuestSetDisplayNameResponseApplicationJson, void> setDisplayNameRaw({
     required String displayName,
     required String token,
@@ -5507,7 +5507,7 @@ class $GuestClient {
     _parameters['displayName'] = $displayName;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -5521,9 +5521,9 @@ class $GuestClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/guest/{token}/name{?displayName*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/guest/{token}/name{?displayName*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<GuestSetDisplayNameResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -5619,7 +5619,7 @@ class $HostedSignalingServerClient {
   ///
   /// See:
   ///  * [requestTrial] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<HostedSignalingServerRequestTrialResponseApplicationJson, void> requestTrialRaw({
     required String url,
     required String name,
@@ -5673,9 +5673,9 @@ class $HostedSignalingServerClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/hostedsignalingserver/requesttrial{?url*,name*,email*,language*,country*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<HostedSignalingServerRequestTrialResponseApplicationJson, void>(
@@ -5741,7 +5741,7 @@ class $HostedSignalingServerClient {
   ///
   /// See:
   ///  * [deleteAccount] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<HostedSignalingServerDeleteAccountResponseApplicationJson, void> deleteAccountRaw({
     HostedSignalingServerDeleteAccountApiVersion? apiVersion,
     bool? oCSAPIRequest,
@@ -5775,10 +5775,10 @@ class $HostedSignalingServerClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/hostedsignalingserver/delete').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/hostedsignalingserver/delete').expand(_parameters);
     return _i1.DynamiteRawResponse<HostedSignalingServerDeleteAccountResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -5845,7 +5845,7 @@ class $MatterbridgeClient {
   ///
   /// See:
   ///  * [getBridgeOfRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<MatterbridgeGetBridgeOfRoomResponseApplicationJson, void> getBridgeOfRoomRaw({
     required String token,
     MatterbridgeGetBridgeOfRoomApiVersion? apiVersion,
@@ -5872,7 +5872,7 @@ class $MatterbridgeClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -5886,9 +5886,9 @@ class $MatterbridgeClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<MatterbridgeGetBridgeOfRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -5958,7 +5958,7 @@ class $MatterbridgeClient {
   ///
   /// See:
   ///  * [editBridgeOfRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void> editBridgeOfRoomRaw({
     required MatterbridgeEditBridgeOfRoomEnabled enabled,
     required String token,
@@ -5991,7 +5991,7 @@ class $MatterbridgeClient {
     _parameters['enabled'] = $enabled;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -6015,9 +6015,9 @@ class $MatterbridgeClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}{?enabled*,parts*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}{?enabled*,parts*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6080,7 +6080,7 @@ class $MatterbridgeClient {
   ///
   /// See:
   ///  * [deleteBridgeOfRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson, void> deleteBridgeOfRoomRaw({
     required String token,
     MatterbridgeDeleteBridgeOfRoomApiVersion? apiVersion,
@@ -6107,7 +6107,7 @@ class $MatterbridgeClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -6123,9 +6123,9 @@ class $MatterbridgeClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -6185,7 +6185,7 @@ class $MatterbridgeClient {
   ///
   /// See:
   ///  * [getBridgeProcessState] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<MatterbridgeGetBridgeProcessStateResponseApplicationJson, void> getBridgeProcessStateRaw({
     required String token,
     MatterbridgeGetBridgeProcessStateApiVersion? apiVersion,
@@ -6212,7 +6212,7 @@ class $MatterbridgeClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -6228,10 +6228,10 @@ class $MatterbridgeClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}/process').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}/process').expand(_parameters);
     return _i1.DynamiteRawResponse<MatterbridgeGetBridgeProcessStateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -6300,7 +6300,7 @@ class $MatterbridgeSettingsClient {
   ///
   /// See:
   ///  * [stopAllBridges] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<MatterbridgeSettingsStopAllBridgesResponseApplicationJson, void> stopAllBridgesRaw({
     MatterbridgeSettingsStopAllBridgesApiVersion? apiVersion,
     bool? oCSAPIRequest,
@@ -6334,9 +6334,9 @@ class $MatterbridgeSettingsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge').expand(_parameters);
     return _i1.DynamiteRawResponse<MatterbridgeSettingsStopAllBridgesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -6399,7 +6399,7 @@ class $MatterbridgeSettingsClient {
   ///
   /// See:
   ///  * [getMatterbridgeVersion] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson, void>
       getMatterbridgeVersionRaw({
     MatterbridgeSettingsGetMatterbridgeVersionApiVersion? apiVersion,
@@ -6434,9 +6434,9 @@ class $MatterbridgeSettingsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/version').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/version').expand(_parameters);
     return _i1.DynamiteRawResponse<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -6521,7 +6521,7 @@ class $PollClient {
   ///
   /// See:
   ///  * [createPoll] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PollCreatePollResponseApplicationJson, void> createPollRaw({
     required String question,
     required BuiltList<String> options,
@@ -6563,7 +6563,7 @@ class $PollClient {
     _parameters['maxVotes'] = $maxVotes;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -6576,9 +6576,9 @@ class $PollClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}{?question*,options%5B%5D*,resultMode*,maxVotes*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<PollCreatePollResponseApplicationJson, void>(
@@ -6646,7 +6646,7 @@ class $PollClient {
   ///
   /// See:
   ///  * [showPoll] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PollShowPollResponseApplicationJson, void> showPollRaw({
     required String token,
     required int pollId,
@@ -6672,7 +6672,7 @@ class $PollClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -6688,9 +6688,9 @@ class $PollClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}').expand(_parameters);
     return _i1.DynamiteRawResponse<PollShowPollResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -6762,7 +6762,7 @@ class $PollClient {
   ///
   /// See:
   ///  * [votePoll] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PollVotePollResponseApplicationJson, void> votePollRaw({
     required String token,
     required int pollId,
@@ -6789,7 +6789,7 @@ class $PollClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -6809,9 +6809,9 @@ class $PollClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}{?optionIds%5B%5D*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}{?optionIds%5B%5D*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<PollVotePollResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -6884,7 +6884,7 @@ class $PollClient {
   ///
   /// See:
   ///  * [closePoll] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PollClosePollResponseApplicationJson, void> closePollRaw({
     required String token,
     required int pollId,
@@ -6910,7 +6910,7 @@ class $PollClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -6926,9 +6926,9 @@ class $PollClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}').expand(_parameters);
     return _i1.DynamiteRawResponse<PollClosePollResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -7003,7 +7003,7 @@ class $PublicShareAuthClient {
   ///
   /// See:
   ///  * [createRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PublicShareAuthCreateRoomResponseApplicationJson, void> createRoomRaw({
     required String shareToken,
     PublicShareAuthCreateRoomApiVersion? apiVersion,
@@ -7037,10 +7037,10 @@ class $PublicShareAuthClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/publicshareauth{?shareToken*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/publicshareauth{?shareToken*}').expand(_parameters);
     return _i1.DynamiteRawResponse<PublicShareAuthCreateRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -7117,7 +7117,7 @@ class $ReactionClient {
   ///
   /// See:
   ///  * [getReactions] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ReactionGetReactionsResponseApplicationJson, void> getReactionsRaw({
     required String token,
     required int messageId,
@@ -7144,7 +7144,7 @@ class $ReactionClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -7164,9 +7164,9 @@ class $ReactionClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<ReactionGetReactionsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7241,7 +7241,7 @@ class $ReactionClient {
   ///
   /// See:
   ///  * [react] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ReactionReactResponseApplicationJson, void> reactRaw({
     required String reaction,
     required String token,
@@ -7271,7 +7271,7 @@ class $ReactionClient {
     _parameters['reaction'] = $reaction;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -7287,9 +7287,9 @@ class $ReactionClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<ReactionReactResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7365,7 +7365,7 @@ class $ReactionClient {
   ///
   /// See:
   ///  * [$delete] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ReactionDeleteResponseApplicationJson, void> $deleteRaw({
     required String reaction,
     required String token,
@@ -7395,7 +7395,7 @@ class $ReactionClient {
     _parameters['reaction'] = $reaction;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -7411,9 +7411,9 @@ class $ReactionClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<ReactionDeleteResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7487,7 +7487,7 @@ class $RecordingClient {
   ///
   /// See:
   ///  * [start] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RecordingStartResponseApplicationJson, void> startRaw({
     required int status,
     required String token,
@@ -7518,7 +7518,7 @@ class $RecordingClient {
     _parameters['status'] = $status;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -7531,10 +7531,10 @@ class $RecordingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}{?status*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}{?status*}').expand(_parameters);
     return _i1.DynamiteRawResponse<RecordingStartResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -7596,7 +7596,7 @@ class $RecordingClient {
   ///
   /// See:
   ///  * [stop] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RecordingStopResponseApplicationJson, void> stopRaw({
     required String token,
     RecordingStopApiVersion? apiVersion,
@@ -7623,7 +7623,7 @@ class $RecordingClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -7636,9 +7636,9 @@ class $RecordingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<RecordingStopResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -7706,7 +7706,7 @@ class $RecordingClient {
   ///
   /// See:
   ///  * [store] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RecordingStoreResponseApplicationJson, void> storeRaw({
     required String owner,
     required String token,
@@ -7735,7 +7735,7 @@ class $RecordingClient {
     _parameters['owner'] = $owner;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -7748,9 +7748,9 @@ class $RecordingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/store{?owner*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/store{?owner*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RecordingStoreResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7817,7 +7817,7 @@ class $RecordingClient {
   ///
   /// See:
   ///  * [notificationDismiss] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RecordingNotificationDismissResponseApplicationJson, void> notificationDismissRaw({
     required int timestamp,
     required String token,
@@ -7848,7 +7848,7 @@ class $RecordingClient {
     _parameters['timestamp'] = $timestamp;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -7862,10 +7862,10 @@ class $RecordingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/notification{?timestamp*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/notification{?timestamp*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<RecordingNotificationDismissResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -7936,7 +7936,7 @@ class $RecordingClient {
   ///
   /// See:
   ///  * [shareToChat] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RecordingShareToChatResponseApplicationJson, void> shareToChatRaw({
     required int fileId,
     required int timestamp,
@@ -7971,7 +7971,7 @@ class $RecordingClient {
     _parameters['timestamp'] = $timestamp;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -7985,10 +7985,10 @@ class $RecordingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/share-chat{?fileId*,timestamp*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/share-chat{?fileId*,timestamp*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<RecordingShareToChatResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -8057,7 +8057,7 @@ class $RecordingClient {
   ///
   /// See:
   ///  * [getWelcomeMessage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RecordingGetWelcomeMessageResponseApplicationJson, void> getWelcomeMessageRaw({
     required int serverId,
     RecordingGetWelcomeMessageApiVersion? apiVersion,
@@ -8093,10 +8093,10 @@ class $RecordingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/welcome/{serverId}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/welcome/{serverId}').expand(_parameters);
     return _i1.DynamiteRawResponse<RecordingGetWelcomeMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -8171,7 +8171,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [getRooms] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders> getRoomsRaw({
     RoomGetRoomsNoStatusUpdate? noStatusUpdate,
     RoomGetRoomsIncludeStatus? includeStatus,
@@ -8219,10 +8219,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room{?noStatusUpdate*,includeStatus*,modifiedSince*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room{?noStatusUpdate*,includeStatus*,modifiedSince*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders>(
       response: _rootClient.executeRequest(
@@ -8311,7 +8311,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [createRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomCreateRoomResponseApplicationJson, void> createRoomRaw({
     required int roomType,
     String? invite,
@@ -8371,9 +8371,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/room{?roomType*,invite*,roomName*,source*,objectType*,objectId*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<RoomCreateRoomResponseApplicationJson, void>(
@@ -8438,7 +8438,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [getListedRooms] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomGetListedRoomsResponseApplicationJson, void> getListedRoomsRaw({
     String? searchTerm,
     RoomGetListedRoomsApiVersion? apiVersion,
@@ -8475,10 +8475,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/listed-room{?searchTerm*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/listed-room{?searchTerm*}').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomGetListedRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -8540,7 +8540,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [getNoteToSelfConversation] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomGetNoteToSelfConversationResponseApplicationJson,
       RoomRoomGetNoteToSelfConversationHeaders> getNoteToSelfConversationRaw({
     RoomGetNoteToSelfConversationApiVersion? apiVersion,
@@ -8573,9 +8573,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/note-to-self').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/note-to-self').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomGetNoteToSelfConversationResponseApplicationJson,
         RoomRoomGetNoteToSelfConversationHeaders>(
       response: _rootClient.executeRequest(
@@ -8640,7 +8640,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [getSingleRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomGetSingleRoomResponseApplicationJson, RoomRoomGetSingleRoomHeaders> getSingleRoomRaw({
     required String token,
     RoomGetSingleRoomApiVersion? apiVersion,
@@ -8665,7 +8665,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -8679,9 +8679,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomGetSingleRoomResponseApplicationJson, RoomRoomGetSingleRoomHeaders>(
       response: _rootClient.executeRequest(
         'get',
@@ -8747,7 +8747,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [renameRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomRenameRoomResponseApplicationJson, void> renameRoomRaw({
     required String roomName,
     required String token,
@@ -8776,7 +8776,7 @@ class $RoomClient {
     _parameters['roomName'] = $roomName;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -8789,10 +8789,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}{?roomName*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}{?roomName*}').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomRenameRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -8857,7 +8857,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [deleteRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomDeleteRoomResponseApplicationJson, void> deleteRoomRaw({
     required String token,
     RoomDeleteRoomApiVersion? apiVersion,
@@ -8882,7 +8882,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -8895,9 +8895,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomDeleteRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -8966,7 +8966,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [getBreakoutRooms] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomGetBreakoutRoomsResponseApplicationJson, void> getBreakoutRoomsRaw({
     required String token,
     RoomGetBreakoutRoomsApiVersion? apiVersion,
@@ -8993,7 +8993,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -9007,10 +9007,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/breakout-rooms').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/breakout-rooms').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomGetBreakoutRoomsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -9072,7 +9072,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [makePublic] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomMakePublicResponseApplicationJson, void> makePublicRaw({
     required String token,
     RoomMakePublicApiVersion? apiVersion,
@@ -9099,7 +9099,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -9112,9 +9112,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/public').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/public').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomMakePublicResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -9179,7 +9179,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [makePrivate] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomMakePrivateResponseApplicationJson, void> makePrivateRaw({
     required String token,
     RoomMakePrivateApiVersion? apiVersion,
@@ -9206,7 +9206,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -9219,9 +9219,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/public').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/public').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomMakePrivateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -9290,7 +9290,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setDescription] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetDescriptionResponseApplicationJson, void> setDescriptionRaw({
     required String description,
     required String token,
@@ -9319,7 +9319,7 @@ class $RoomClient {
     _parameters['description'] = $description;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -9333,9 +9333,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/description{?description*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/description{?description*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetDescriptionResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -9405,7 +9405,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setReadOnly] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetReadOnlyResponseApplicationJson, void> setReadOnlyRaw({
     required RoomSetReadOnlyState state,
     required String token,
@@ -9436,7 +9436,7 @@ class $RoomClient {
     _parameters['state'] = $state;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -9449,10 +9449,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/read-only{?state*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/read-only{?state*}').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetReadOnlyResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -9521,7 +9521,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setListable] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetListableResponseApplicationJson, void> setListableRaw({
     required RoomSetListableScope scope,
     required String token,
@@ -9552,7 +9552,7 @@ class $RoomClient {
     _parameters['scope'] = $scope;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -9565,10 +9565,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/listable{?scope*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/listable{?scope*}').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetListableResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -9639,7 +9639,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setPassword] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetPasswordResponseApplicationJson, void> setPasswordRaw({
     required String password,
     required String token,
@@ -9668,7 +9668,7 @@ class $RoomClient {
     _parameters['password'] = $password;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -9681,9 +9681,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/password{?password*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/password{?password*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetPasswordResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -9757,7 +9757,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setPermissions] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetPermissionsResponseApplicationJson, void> setPermissionsRaw({
     required RoomSetPermissionsPermissions permissions,
     required String token,
@@ -9788,7 +9788,7 @@ class $RoomClient {
     _parameters['permissions'] = $permissions;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -9796,7 +9796,7 @@ class $RoomClient {
     _parameters['token'] = $token;
 
     final $mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(RoomSetPermissionsMode));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $mode as String?,
       RegExp(r'^(call|default)$'),
       'mode',
@@ -9810,10 +9810,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/permissions/{mode}{?permissions*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/permissions/{mode}{?permissions*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetPermissionsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -9881,7 +9881,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [getParticipants] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>
       getParticipantsRaw({
     required String token,
@@ -9908,7 +9908,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -9927,9 +9927,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants{?includeStatus*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants{?includeStatus*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>(
       response: _rootClient.executeRequest(
@@ -10004,7 +10004,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [addParticipantToRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomAddParticipantToRoomResponseApplicationJson, void> addParticipantToRoomRaw({
     required String newParticipant,
     required String token,
@@ -10036,7 +10036,7 @@ class $RoomClient {
     _parameters['newParticipant'] = $newParticipant;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -10054,10 +10054,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants{?newParticipant*,source*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants{?newParticipant*,source*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomAddParticipantToRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10128,7 +10128,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [getBreakoutRoomParticipants] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
       RoomRoomGetBreakoutRoomParticipantsHeaders> getBreakoutRoomParticipantsRaw({
     required String token,
@@ -10155,7 +10155,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -10178,9 +10178,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/breakout-rooms/participants{?includeStatus*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
@@ -10247,7 +10247,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [removeSelfFromRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomRemoveSelfFromRoomResponseApplicationJson, void> removeSelfFromRoomRaw({
     required String token,
     RoomRemoveSelfFromRoomApiVersion? apiVersion,
@@ -10274,7 +10274,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -10288,10 +10288,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/self').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/self').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomRemoveSelfFromRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -10365,7 +10365,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [removeAttendeeFromRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomRemoveAttendeeFromRoomResponseApplicationJson, void> removeAttendeeFromRoomRaw({
     required int attendeeId,
     required String token,
@@ -10394,7 +10394,7 @@ class $RoomClient {
     _parameters['attendeeId'] = $attendeeId;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -10408,9 +10408,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees{?attendeeId*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees{?attendeeId*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomRemoveAttendeeFromRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10494,7 +10494,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setAttendeePermissions] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetAttendeePermissionsResponseApplicationJson, void> setAttendeePermissionsRaw({
     required int attendeeId,
     required RoomSetAttendeePermissionsMethod method,
@@ -10533,7 +10533,7 @@ class $RoomClient {
     _parameters['permissions'] = $permissions;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -10547,9 +10547,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees/permissions{?attendeeId*,method*,permissions*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetAttendeePermissionsResponseApplicationJson, void>(
@@ -10626,7 +10626,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setAllAttendeesPermissions] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetAllAttendeesPermissionsResponseApplicationJson, void> setAllAttendeesPermissionsRaw({
     required RoomSetAllAttendeesPermissionsMethod method,
     required RoomSetAllAttendeesPermissionsPermissions permissions,
@@ -10663,7 +10663,7 @@ class $RoomClient {
     _parameters['permissions'] = $permissions;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -10679,9 +10679,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees/permissions/all{?method*,permissions*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetAllAttendeesPermissionsResponseApplicationJson, void>(
@@ -10757,7 +10757,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [joinRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomJoinRoomResponseApplicationJson, void> joinRoomRaw({
     required String token,
     String? password,
@@ -10784,7 +10784,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -10805,10 +10805,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/active{?password*,force*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/active{?password*,force*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomJoinRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10869,7 +10869,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [leaveRoom] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomLeaveRoomResponseApplicationJson, void> leaveRoomRaw({
     required String token,
     RoomLeaveRoomApiVersion? apiVersion,
@@ -10894,7 +10894,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -10907,9 +10907,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/active')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/active')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomLeaveRoomResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -10976,7 +10976,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [resendInvitations] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomResendInvitationsResponseApplicationJson, void> resendInvitationsRaw({
     required String token,
     int? attendeeId,
@@ -11004,7 +11004,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -11021,9 +11021,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/resend-invitations{?attendeeId*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<RoomResendInvitationsResponseApplicationJson, void>(
@@ -11096,7 +11096,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setSessionState] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetSessionStateResponseApplicationJson, void> setSessionStateRaw({
     required RoomSetSessionStateState state,
     required String token,
@@ -11125,7 +11125,7 @@ class $RoomClient {
     _parameters['state'] = $state;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -11139,9 +11139,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/state{?state*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/state{?state*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetSessionStateResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11212,7 +11212,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [promoteModerator] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomPromoteModeratorResponseApplicationJson, void> promoteModeratorRaw({
     required int attendeeId,
     required String token,
@@ -11241,7 +11241,7 @@ class $RoomClient {
     _parameters['attendeeId'] = $attendeeId;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -11255,9 +11255,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators{?attendeeId*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators{?attendeeId*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomPromoteModeratorResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11333,7 +11333,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [demoteModerator] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomDemoteModeratorResponseApplicationJson, void> demoteModeratorRaw({
     required int attendeeId,
     required String token,
@@ -11362,7 +11362,7 @@ class $RoomClient {
     _parameters['attendeeId'] = $attendeeId;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -11376,9 +11376,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators{?attendeeId*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators{?attendeeId*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomDemoteModeratorResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11444,7 +11444,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [addToFavorites] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomAddToFavoritesResponseApplicationJson, void> addToFavoritesRaw({
     required String token,
     RoomAddToFavoritesApiVersion? apiVersion,
@@ -11471,7 +11471,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -11485,9 +11485,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomAddToFavoritesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -11547,7 +11547,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [removeFromFavorites] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomRemoveFromFavoritesResponseApplicationJson, void> removeFromFavoritesRaw({
     required String token,
     RoomRemoveFromFavoritesApiVersion? apiVersion,
@@ -11574,7 +11574,7 @@ class $RoomClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -11588,9 +11588,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomRemoveFromFavoritesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -11656,7 +11656,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setNotificationLevel] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetNotificationLevelResponseApplicationJson, void> setNotificationLevelRaw({
     required int level,
     required String token,
@@ -11687,7 +11687,7 @@ class $RoomClient {
     _parameters['level'] = $level;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -11701,10 +11701,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify{?level*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify{?level*}').expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetNotificationLevelResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -11773,7 +11773,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setNotificationCalls] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetNotificationCallsResponseApplicationJson, void> setNotificationCallsRaw({
     required int level,
     required String token,
@@ -11804,7 +11804,7 @@ class $RoomClient {
     _parameters['level'] = $level;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -11818,9 +11818,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify-calls{?level*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify-calls{?level*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetNotificationCallsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -11894,7 +11894,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setLobby] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetLobbyResponseApplicationJson, void> setLobbyRaw({
     required int state,
     required String token,
@@ -11926,7 +11926,7 @@ class $RoomClient {
     _parameters['state'] = $state;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -11942,9 +11942,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/lobby{?state*,timer*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/lobby{?state*,timer*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetLobbyResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -12017,7 +12017,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setsipEnabled] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetsipEnabledResponseApplicationJson, void> setsipEnabledRaw({
     required RoomSetsipEnabledState state,
     required String token,
@@ -12048,7 +12048,7 @@ class $RoomClient {
     _parameters['state'] = $state;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -12062,9 +12062,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/sip{?state*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/sip{?state*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetsipEnabledResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -12133,7 +12133,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setRecordingConsent] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetRecordingConsentResponseApplicationJson, void> setRecordingConsentRaw({
     required int recordingConsent,
     required String token,
@@ -12164,7 +12164,7 @@ class $RoomClient {
     _parameters['recordingConsent'] = $recordingConsent;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -12178,10 +12178,10 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/recording-consent{?recordingConsent*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/recording-consent{?recordingConsent*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetRecordingConsentResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -12248,7 +12248,7 @@ class $RoomClient {
   ///
   /// See:
   ///  * [setMessageExpiration] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<RoomSetMessageExpirationResponseApplicationJson, void> setMessageExpirationRaw({
     required int seconds,
     required String token,
@@ -12277,7 +12277,7 @@ class $RoomClient {
     _parameters['seconds'] = $seconds;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -12291,9 +12291,9 @@ class $RoomClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/message-expiration{?seconds*}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/message-expiration{?seconds*}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<RoomSetMessageExpirationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -12367,7 +12367,7 @@ class $SettingsClient {
   ///
   /// See:
   ///  * [setUserSetting] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SettingsSetUserSettingResponseApplicationJson, void> setUserSettingRaw({
     required SettingsSetUserSettingKey key,
     SettingsSetUserSettingValue? value,
@@ -12407,10 +12407,10 @@ class $SettingsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/user{?key*,value*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/user{?key*,value*}').expand(_parameters);
     return _i1.DynamiteRawResponse<SettingsSetUserSettingResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -12485,7 +12485,7 @@ class $SettingsClient {
   ///
   /// See:
   ///  * [setsipSettings] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SettingsSetsipSettingsResponseApplicationJson, void> setsipSettingsRaw({
     BuiltList<String>? sipGroups,
     String? dialInInfo,
@@ -12533,9 +12533,9 @@ class $SettingsClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/sip{?sipGroups%5B%5D*,dialInInfo*,sharedSecret*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<SettingsSetsipSettingsResponseApplicationJson, void>(
@@ -12608,7 +12608,7 @@ class $SignalingClient {
   ///
   /// See:
   ///  * [getSettings] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SignalingGetSettingsResponseApplicationJson, void> getSettingsRaw({
     String? token,
     SignalingGetSettingsApiVersion? apiVersion,
@@ -12643,10 +12643,10 @@ class $SignalingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/settings{?token*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/settings{?token*}').expand(_parameters);
     return _i1.DynamiteRawResponse<SignalingGetSettingsResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -12712,7 +12712,7 @@ class $SignalingClient {
   ///
   /// See:
   ///  * [pullMessages] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SignalingPullMessagesResponseApplicationJson, void> pullMessagesRaw({
     required String token,
     SignalingPullMessagesApiVersion? apiVersion,
@@ -12737,7 +12737,7 @@ class $SignalingClient {
 
 // coverage:ignore-end
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -12751,9 +12751,9 @@ class $SignalingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<SignalingPullMessagesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -12823,7 +12823,7 @@ class $SignalingClient {
   ///
   /// See:
   ///  * [sendMessages] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SignalingSendMessagesResponseApplicationJson, void> sendMessagesRaw({
     required String messages,
     required String token,
@@ -12852,7 +12852,7 @@ class $SignalingClient {
     _parameters['messages'] = $messages;
 
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _i2.checkPattern(
+    _i3.checkPattern(
       $token as String?,
       RegExp(r'^[a-z0-9]{4,30}$'),
       'token',
@@ -12866,10 +12866,10 @@ class $SignalingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}{?messages*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}{?messages*}').expand(_parameters);
     return _i1.DynamiteRawResponse<SignalingSendMessagesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'post',
@@ -12939,7 +12939,7 @@ class $SignalingClient {
   ///
   /// See:
   ///  * [getWelcomeMessage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SignalingGetWelcomeMessageResponseApplicationJson, void> getWelcomeMessageRaw({
     required int serverId,
     SignalingGetWelcomeMessageApiVersion? apiVersion,
@@ -12975,10 +12975,10 @@ class $SignalingClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/welcome/{serverId}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/welcome/{serverId}').expand(_parameters);
     return _i1.DynamiteRawResponse<SignalingGetWelcomeMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -13039,7 +13039,7 @@ class $TempAvatarClient {
   ///
   /// See:
   ///  * [postAvatar] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TempAvatarPostAvatarResponseApplicationJson, void> postAvatarRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -13062,7 +13062,7 @@ class $TempAvatarClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/spreed/temp-user-avatar';
     return _i1.DynamiteRawResponse<TempAvatarPostAvatarResponseApplicationJson, void>(
@@ -13118,7 +13118,7 @@ class $TempAvatarClient {
   ///
   /// See:
   ///  * [deleteAvatar] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<TempAvatarDeleteAvatarResponseApplicationJson, void> deleteAvatarRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -13141,7 +13141,7 @@ class $TempAvatarClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/spreed/temp-user-avatar';
     return _i1.DynamiteRawResponse<TempAvatarDeleteAvatarResponseApplicationJson, void>(
@@ -19930,45 +19930,6 @@ class _$ChatReceiveMessagesApiVersionSerializer implements PrimitiveSerializer<C
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ChatChatReceiveMessagesHeadersInterface {
-  @BuiltValueField(wireName: 'x-chat-last-common-read')
-  String? get xChatLastCommonRead;
-  @BuiltValueField(wireName: 'x-chat-last-given')
-  String? get xChatLastGiven;
-}
-
-abstract class ChatChatReceiveMessagesHeaders
-    implements
-        $ChatChatReceiveMessagesHeadersInterface,
-        Built<ChatChatReceiveMessagesHeaders, ChatChatReceiveMessagesHeadersBuilder> {
-  /// Creates a new ChatChatReceiveMessagesHeaders object using the builder pattern.
-  factory ChatChatReceiveMessagesHeaders([void Function(ChatChatReceiveMessagesHeadersBuilder)? b]) =
-      _$ChatChatReceiveMessagesHeaders;
-
-  // coverage:ignore-start
-  const ChatChatReceiveMessagesHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory ChatChatReceiveMessagesHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for ChatChatReceiveMessagesHeaders.
-  static Serializer<ChatChatReceiveMessagesHeaders> get serializer => _$chatChatReceiveMessagesHeadersSerializer;
-}
-
-@BuiltValue(instantiable: false)
 abstract interface class $ChatMessageWithParentInterface implements $ChatMessageInterface {
   ChatMessage? get parent;
 }
@@ -20076,6 +20037,45 @@ abstract class ChatReceiveMessagesResponseApplicationJson
   /// Serializer for ChatReceiveMessagesResponseApplicationJson.
   static Serializer<ChatReceiveMessagesResponseApplicationJson> get serializer =>
       _$chatReceiveMessagesResponseApplicationJsonSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $ChatChatReceiveMessagesHeadersInterface {
+  @BuiltValueField(wireName: 'x-chat-last-common-read')
+  String? get xChatLastCommonRead;
+  @BuiltValueField(wireName: 'x-chat-last-given')
+  String? get xChatLastGiven;
+}
+
+abstract class ChatChatReceiveMessagesHeaders
+    implements
+        $ChatChatReceiveMessagesHeadersInterface,
+        Built<ChatChatReceiveMessagesHeaders, ChatChatReceiveMessagesHeadersBuilder> {
+  /// Creates a new ChatChatReceiveMessagesHeaders object using the builder pattern.
+  factory ChatChatReceiveMessagesHeaders([void Function(ChatChatReceiveMessagesHeadersBuilder)? b]) =
+      _$ChatChatReceiveMessagesHeaders;
+
+  // coverage:ignore-start
+  const ChatChatReceiveMessagesHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatChatReceiveMessagesHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatChatReceiveMessagesHeaders.
+  static Serializer<ChatChatReceiveMessagesHeaders> get serializer => _$chatChatReceiveMessagesHeadersSerializer;
 }
 
 class ChatSendMessageSilent extends EnumClass {
@@ -20198,43 +20198,6 @@ class _$ChatSendMessageApiVersionSerializer implements PrimitiveSerializer<ChatS
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ChatChatSendMessageHeadersInterface {
-  @BuiltValueField(wireName: 'x-chat-last-common-read')
-  String? get xChatLastCommonRead;
-}
-
-abstract class ChatChatSendMessageHeaders
-    implements
-        $ChatChatSendMessageHeadersInterface,
-        Built<ChatChatSendMessageHeaders, ChatChatSendMessageHeadersBuilder> {
-  /// Creates a new ChatChatSendMessageHeaders object using the builder pattern.
-  factory ChatChatSendMessageHeaders([void Function(ChatChatSendMessageHeadersBuilder)? b]) =
-      _$ChatChatSendMessageHeaders;
-
-  // coverage:ignore-start
-  const ChatChatSendMessageHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory ChatChatSendMessageHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for ChatChatSendMessageHeaders.
-  static Serializer<ChatChatSendMessageHeaders> get serializer => _$chatChatSendMessageHeadersSerializer;
-}
-
-@BuiltValue(instantiable: false)
 abstract interface class $ChatSendMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessageWithParent? get data;
@@ -20310,6 +20273,43 @@ abstract class ChatSendMessageResponseApplicationJson
       _$chatSendMessageResponseApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class $ChatChatSendMessageHeadersInterface {
+  @BuiltValueField(wireName: 'x-chat-last-common-read')
+  String? get xChatLastCommonRead;
+}
+
+abstract class ChatChatSendMessageHeaders
+    implements
+        $ChatChatSendMessageHeadersInterface,
+        Built<ChatChatSendMessageHeaders, ChatChatSendMessageHeadersBuilder> {
+  /// Creates a new ChatChatSendMessageHeaders object using the builder pattern.
+  factory ChatChatSendMessageHeaders([void Function(ChatChatSendMessageHeadersBuilder)? b]) =
+      _$ChatChatSendMessageHeaders;
+
+  // coverage:ignore-start
+  const ChatChatSendMessageHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatChatSendMessageHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatChatSendMessageHeaders.
+  static Serializer<ChatChatSendMessageHeaders> get serializer => _$chatChatSendMessageHeadersSerializer;
+}
+
 class ChatClearHistoryApiVersion extends EnumClass {
   const ChatClearHistoryApiVersion._(super.name);
 
@@ -20364,43 +20364,6 @@ class _$ChatClearHistoryApiVersionSerializer implements PrimitiveSerializer<Chat
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $ChatChatClearHistoryHeadersInterface {
-  @BuiltValueField(wireName: 'x-chat-last-common-read')
-  String? get xChatLastCommonRead;
-}
-
-abstract class ChatChatClearHistoryHeaders
-    implements
-        $ChatChatClearHistoryHeadersInterface,
-        Built<ChatChatClearHistoryHeaders, ChatChatClearHistoryHeadersBuilder> {
-  /// Creates a new ChatChatClearHistoryHeaders object using the builder pattern.
-  factory ChatChatClearHistoryHeaders([void Function(ChatChatClearHistoryHeadersBuilder)? b]) =
-      _$ChatChatClearHistoryHeaders;
-
-  // coverage:ignore-start
-  const ChatChatClearHistoryHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory ChatChatClearHistoryHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for ChatChatClearHistoryHeaders.
-  static Serializer<ChatChatClearHistoryHeaders> get serializer => _$chatChatClearHistoryHeadersSerializer;
 }
 
 @BuiltValue(instantiable: false)
@@ -20479,6 +20442,43 @@ abstract class ChatClearHistoryResponseApplicationJson
       _$chatClearHistoryResponseApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class $ChatChatClearHistoryHeadersInterface {
+  @BuiltValueField(wireName: 'x-chat-last-common-read')
+  String? get xChatLastCommonRead;
+}
+
+abstract class ChatChatClearHistoryHeaders
+    implements
+        $ChatChatClearHistoryHeadersInterface,
+        Built<ChatChatClearHistoryHeaders, ChatChatClearHistoryHeadersBuilder> {
+  /// Creates a new ChatChatClearHistoryHeaders object using the builder pattern.
+  factory ChatChatClearHistoryHeaders([void Function(ChatChatClearHistoryHeadersBuilder)? b]) =
+      _$ChatChatClearHistoryHeaders;
+
+  // coverage:ignore-start
+  const ChatChatClearHistoryHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatChatClearHistoryHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatChatClearHistoryHeaders.
+  static Serializer<ChatChatClearHistoryHeaders> get serializer => _$chatChatClearHistoryHeadersSerializer;
+}
+
 class ChatDeleteMessageApiVersion extends EnumClass {
   const ChatDeleteMessageApiVersion._(super.name);
 
@@ -20533,43 +20533,6 @@ class _$ChatDeleteMessageApiVersionSerializer implements PrimitiveSerializer<Cha
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $ChatChatDeleteMessageHeadersInterface {
-  @BuiltValueField(wireName: 'x-chat-last-common-read')
-  String? get xChatLastCommonRead;
-}
-
-abstract class ChatChatDeleteMessageHeaders
-    implements
-        $ChatChatDeleteMessageHeadersInterface,
-        Built<ChatChatDeleteMessageHeaders, ChatChatDeleteMessageHeadersBuilder> {
-  /// Creates a new ChatChatDeleteMessageHeaders object using the builder pattern.
-  factory ChatChatDeleteMessageHeaders([void Function(ChatChatDeleteMessageHeadersBuilder)? b]) =
-      _$ChatChatDeleteMessageHeaders;
-
-  // coverage:ignore-start
-  const ChatChatDeleteMessageHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory ChatChatDeleteMessageHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for ChatChatDeleteMessageHeaders.
-  static Serializer<ChatChatDeleteMessageHeaders> get serializer => _$chatChatDeleteMessageHeadersSerializer;
 }
 
 @BuiltValue(instantiable: false)
@@ -20649,6 +20612,43 @@ abstract class ChatDeleteMessageResponseApplicationJson
       _$chatDeleteMessageResponseApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class $ChatChatDeleteMessageHeadersInterface {
+  @BuiltValueField(wireName: 'x-chat-last-common-read')
+  String? get xChatLastCommonRead;
+}
+
+abstract class ChatChatDeleteMessageHeaders
+    implements
+        $ChatChatDeleteMessageHeadersInterface,
+        Built<ChatChatDeleteMessageHeaders, ChatChatDeleteMessageHeadersBuilder> {
+  /// Creates a new ChatChatDeleteMessageHeaders object using the builder pattern.
+  factory ChatChatDeleteMessageHeaders([void Function(ChatChatDeleteMessageHeadersBuilder)? b]) =
+      _$ChatChatDeleteMessageHeaders;
+
+  // coverage:ignore-start
+  const ChatChatDeleteMessageHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatChatDeleteMessageHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatChatDeleteMessageHeaders.
+  static Serializer<ChatChatDeleteMessageHeaders> get serializer => _$chatChatDeleteMessageHeadersSerializer;
+}
+
 class ChatGetMessageContextApiVersion extends EnumClass {
   const ChatGetMessageContextApiVersion._(super.name);
 
@@ -20704,45 +20704,6 @@ class _$ChatGetMessageContextApiVersionSerializer implements PrimitiveSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $ChatChatGetMessageContextHeadersInterface {
-  @BuiltValueField(wireName: 'x-chat-last-common-read')
-  String? get xChatLastCommonRead;
-  @BuiltValueField(wireName: 'x-chat-last-given')
-  String? get xChatLastGiven;
-}
-
-abstract class ChatChatGetMessageContextHeaders
-    implements
-        $ChatChatGetMessageContextHeadersInterface,
-        Built<ChatChatGetMessageContextHeaders, ChatChatGetMessageContextHeadersBuilder> {
-  /// Creates a new ChatChatGetMessageContextHeaders object using the builder pattern.
-  factory ChatChatGetMessageContextHeaders([void Function(ChatChatGetMessageContextHeadersBuilder)? b]) =
-      _$ChatChatGetMessageContextHeaders;
-
-  // coverage:ignore-start
-  const ChatChatGetMessageContextHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory ChatChatGetMessageContextHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for ChatChatGetMessageContextHeaders.
-  static Serializer<ChatChatGetMessageContextHeaders> get serializer => _$chatChatGetMessageContextHeadersSerializer;
 }
 
 @BuiltValue(instantiable: false)
@@ -20821,6 +20782,45 @@ abstract class ChatGetMessageContextResponseApplicationJson
   /// Serializer for ChatGetMessageContextResponseApplicationJson.
   static Serializer<ChatGetMessageContextResponseApplicationJson> get serializer =>
       _$chatGetMessageContextResponseApplicationJsonSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $ChatChatGetMessageContextHeadersInterface {
+  @BuiltValueField(wireName: 'x-chat-last-common-read')
+  String? get xChatLastCommonRead;
+  @BuiltValueField(wireName: 'x-chat-last-given')
+  String? get xChatLastGiven;
+}
+
+abstract class ChatChatGetMessageContextHeaders
+    implements
+        $ChatChatGetMessageContextHeadersInterface,
+        Built<ChatChatGetMessageContextHeaders, ChatChatGetMessageContextHeadersBuilder> {
+  /// Creates a new ChatChatGetMessageContextHeaders object using the builder pattern.
+  factory ChatChatGetMessageContextHeaders([void Function(ChatChatGetMessageContextHeadersBuilder)? b]) =
+      _$ChatChatGetMessageContextHeaders;
+
+  // coverage:ignore-start
+  const ChatChatGetMessageContextHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatChatGetMessageContextHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatChatGetMessageContextHeaders.
+  static Serializer<ChatChatGetMessageContextHeaders> get serializer => _$chatChatGetMessageContextHeadersSerializer;
 }
 
 class ChatGetReminderApiVersion extends EnumClass {
@@ -21311,43 +21311,6 @@ class _$ChatSetReadMarkerApiVersionSerializer implements PrimitiveSerializer<Cha
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ChatChatSetReadMarkerHeadersInterface {
-  @BuiltValueField(wireName: 'x-chat-last-common-read')
-  String? get xChatLastCommonRead;
-}
-
-abstract class ChatChatSetReadMarkerHeaders
-    implements
-        $ChatChatSetReadMarkerHeadersInterface,
-        Built<ChatChatSetReadMarkerHeaders, ChatChatSetReadMarkerHeadersBuilder> {
-  /// Creates a new ChatChatSetReadMarkerHeaders object using the builder pattern.
-  factory ChatChatSetReadMarkerHeaders([void Function(ChatChatSetReadMarkerHeadersBuilder)? b]) =
-      _$ChatChatSetReadMarkerHeaders;
-
-  // coverage:ignore-start
-  const ChatChatSetReadMarkerHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory ChatChatSetReadMarkerHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for ChatChatSetReadMarkerHeaders.
-  static Serializer<ChatChatSetReadMarkerHeaders> get serializer => _$chatChatSetReadMarkerHeadersSerializer;
-}
-
-@BuiltValue(instantiable: false)
 abstract interface class $ChatSetReadMarkerResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -21424,6 +21387,43 @@ abstract class ChatSetReadMarkerResponseApplicationJson
       _$chatSetReadMarkerResponseApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class $ChatChatSetReadMarkerHeadersInterface {
+  @BuiltValueField(wireName: 'x-chat-last-common-read')
+  String? get xChatLastCommonRead;
+}
+
+abstract class ChatChatSetReadMarkerHeaders
+    implements
+        $ChatChatSetReadMarkerHeadersInterface,
+        Built<ChatChatSetReadMarkerHeaders, ChatChatSetReadMarkerHeadersBuilder> {
+  /// Creates a new ChatChatSetReadMarkerHeaders object using the builder pattern.
+  factory ChatChatSetReadMarkerHeaders([void Function(ChatChatSetReadMarkerHeadersBuilder)? b]) =
+      _$ChatChatSetReadMarkerHeaders;
+
+  // coverage:ignore-start
+  const ChatChatSetReadMarkerHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatChatSetReadMarkerHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatChatSetReadMarkerHeaders.
+  static Serializer<ChatChatSetReadMarkerHeaders> get serializer => _$chatChatSetReadMarkerHeadersSerializer;
+}
+
 class ChatMarkUnreadApiVersion extends EnumClass {
   const ChatMarkUnreadApiVersion._(super.name);
 
@@ -21478,40 +21478,6 @@ class _$ChatMarkUnreadApiVersionSerializer implements PrimitiveSerializer<ChatMa
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $ChatChatMarkUnreadHeadersInterface {
-  @BuiltValueField(wireName: 'x-chat-last-common-read')
-  String? get xChatLastCommonRead;
-}
-
-abstract class ChatChatMarkUnreadHeaders
-    implements $ChatChatMarkUnreadHeadersInterface, Built<ChatChatMarkUnreadHeaders, ChatChatMarkUnreadHeadersBuilder> {
-  /// Creates a new ChatChatMarkUnreadHeaders object using the builder pattern.
-  factory ChatChatMarkUnreadHeaders([void Function(ChatChatMarkUnreadHeadersBuilder)? b]) = _$ChatChatMarkUnreadHeaders;
-
-  // coverage:ignore-start
-  const ChatChatMarkUnreadHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory ChatChatMarkUnreadHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for ChatChatMarkUnreadHeaders.
-  static Serializer<ChatChatMarkUnreadHeaders> get serializer => _$chatChatMarkUnreadHeadersSerializer;
 }
 
 @BuiltValue(instantiable: false)
@@ -21588,6 +21554,40 @@ abstract class ChatMarkUnreadResponseApplicationJson
   /// Serializer for ChatMarkUnreadResponseApplicationJson.
   static Serializer<ChatMarkUnreadResponseApplicationJson> get serializer =>
       _$chatMarkUnreadResponseApplicationJsonSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $ChatChatMarkUnreadHeadersInterface {
+  @BuiltValueField(wireName: 'x-chat-last-common-read')
+  String? get xChatLastCommonRead;
+}
+
+abstract class ChatChatMarkUnreadHeaders
+    implements $ChatChatMarkUnreadHeadersInterface, Built<ChatChatMarkUnreadHeaders, ChatChatMarkUnreadHeadersBuilder> {
+  /// Creates a new ChatChatMarkUnreadHeaders object using the builder pattern.
+  factory ChatChatMarkUnreadHeaders([void Function(ChatChatMarkUnreadHeadersBuilder)? b]) = _$ChatChatMarkUnreadHeaders;
+
+  // coverage:ignore-start
+  const ChatChatMarkUnreadHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatChatMarkUnreadHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatChatMarkUnreadHeaders.
+  static Serializer<ChatChatMarkUnreadHeaders> get serializer => _$chatChatMarkUnreadHeadersSerializer;
 }
 
 class ChatMentionsIncludeStatus extends EnumClass {
@@ -21885,44 +21885,6 @@ class _$ChatGetObjectsSharedInRoomApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $ChatChatGetObjectsSharedInRoomHeadersInterface {
-  @BuiltValueField(wireName: 'x-chat-last-given')
-  String? get xChatLastGiven;
-}
-
-abstract class ChatChatGetObjectsSharedInRoomHeaders
-    implements
-        $ChatChatGetObjectsSharedInRoomHeadersInterface,
-        Built<ChatChatGetObjectsSharedInRoomHeaders, ChatChatGetObjectsSharedInRoomHeadersBuilder> {
-  /// Creates a new ChatChatGetObjectsSharedInRoomHeaders object using the builder pattern.
-  factory ChatChatGetObjectsSharedInRoomHeaders([void Function(ChatChatGetObjectsSharedInRoomHeadersBuilder)? b]) =
-      _$ChatChatGetObjectsSharedInRoomHeaders;
-
-  // coverage:ignore-start
-  const ChatChatGetObjectsSharedInRoomHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory ChatChatGetObjectsSharedInRoomHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for ChatChatGetObjectsSharedInRoomHeaders.
-  static Serializer<ChatChatGetObjectsSharedInRoomHeaders> get serializer =>
-      _$chatChatGetObjectsSharedInRoomHeadersSerializer;
-}
-
-@BuiltValue(instantiable: false)
 abstract interface class $ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ChatMessage> get data;
@@ -22001,6 +21963,44 @@ abstract class ChatGetObjectsSharedInRoomResponseApplicationJson
       _$chatGetObjectsSharedInRoomResponseApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class $ChatChatGetObjectsSharedInRoomHeadersInterface {
+  @BuiltValueField(wireName: 'x-chat-last-given')
+  String? get xChatLastGiven;
+}
+
+abstract class ChatChatGetObjectsSharedInRoomHeaders
+    implements
+        $ChatChatGetObjectsSharedInRoomHeadersInterface,
+        Built<ChatChatGetObjectsSharedInRoomHeaders, ChatChatGetObjectsSharedInRoomHeadersBuilder> {
+  /// Creates a new ChatChatGetObjectsSharedInRoomHeaders object using the builder pattern.
+  factory ChatChatGetObjectsSharedInRoomHeaders([void Function(ChatChatGetObjectsSharedInRoomHeadersBuilder)? b]) =
+      _$ChatChatGetObjectsSharedInRoomHeaders;
+
+  // coverage:ignore-start
+  const ChatChatGetObjectsSharedInRoomHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatChatGetObjectsSharedInRoomHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatChatGetObjectsSharedInRoomHeaders.
+  static Serializer<ChatChatGetObjectsSharedInRoomHeaders> get serializer =>
+      _$chatChatGetObjectsSharedInRoomHeadersSerializer;
+}
+
 class ChatShareObjectToChatApiVersion extends EnumClass {
   const ChatShareObjectToChatApiVersion._(super.name);
 
@@ -22056,43 +22056,6 @@ class _$ChatShareObjectToChatApiVersionSerializer implements PrimitiveSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $ChatChatShareObjectToChatHeadersInterface {
-  @BuiltValueField(wireName: 'x-chat-last-common-read')
-  String? get xChatLastCommonRead;
-}
-
-abstract class ChatChatShareObjectToChatHeaders
-    implements
-        $ChatChatShareObjectToChatHeadersInterface,
-        Built<ChatChatShareObjectToChatHeaders, ChatChatShareObjectToChatHeadersBuilder> {
-  /// Creates a new ChatChatShareObjectToChatHeaders object using the builder pattern.
-  factory ChatChatShareObjectToChatHeaders([void Function(ChatChatShareObjectToChatHeadersBuilder)? b]) =
-      _$ChatChatShareObjectToChatHeaders;
-
-  // coverage:ignore-start
-  const ChatChatShareObjectToChatHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory ChatChatShareObjectToChatHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for ChatChatShareObjectToChatHeaders.
-  static Serializer<ChatChatShareObjectToChatHeaders> get serializer => _$chatChatShareObjectToChatHeadersSerializer;
 }
 
 @BuiltValue(instantiable: false)
@@ -22171,6 +22134,43 @@ abstract class ChatShareObjectToChatResponseApplicationJson
   /// Serializer for ChatShareObjectToChatResponseApplicationJson.
   static Serializer<ChatShareObjectToChatResponseApplicationJson> get serializer =>
       _$chatShareObjectToChatResponseApplicationJsonSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $ChatChatShareObjectToChatHeadersInterface {
+  @BuiltValueField(wireName: 'x-chat-last-common-read')
+  String? get xChatLastCommonRead;
+}
+
+abstract class ChatChatShareObjectToChatHeaders
+    implements
+        $ChatChatShareObjectToChatHeadersInterface,
+        Built<ChatChatShareObjectToChatHeaders, ChatChatShareObjectToChatHeadersBuilder> {
+  /// Creates a new ChatChatShareObjectToChatHeaders object using the builder pattern.
+  factory ChatChatShareObjectToChatHeaders([void Function(ChatChatShareObjectToChatHeadersBuilder)? b]) =
+      _$ChatChatShareObjectToChatHeaders;
+
+  // coverage:ignore-start
+  const ChatChatShareObjectToChatHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatChatShareObjectToChatHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatChatShareObjectToChatHeaders.
+  static Serializer<ChatChatShareObjectToChatHeaders> get serializer => _$chatChatShareObjectToChatHeadersSerializer;
 }
 
 class ChatGetObjectsSharedInRoomOverviewApiVersion extends EnumClass {
@@ -26454,42 +26454,6 @@ class _$RoomGetRoomsApiVersionSerializer implements PrimitiveSerializer<RoomGetR
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $RoomRoomGetRoomsHeadersInterface {
-  @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
-  String? get xNextcloudTalkHash;
-  @BuiltValueField(wireName: 'x-nextcloud-talk-modified-before')
-  String? get xNextcloudTalkModifiedBefore;
-}
-
-abstract class RoomRoomGetRoomsHeaders
-    implements $RoomRoomGetRoomsHeadersInterface, Built<RoomRoomGetRoomsHeaders, RoomRoomGetRoomsHeadersBuilder> {
-  /// Creates a new RoomRoomGetRoomsHeaders object using the builder pattern.
-  factory RoomRoomGetRoomsHeaders([void Function(RoomRoomGetRoomsHeadersBuilder)? b]) = _$RoomRoomGetRoomsHeaders;
-
-  // coverage:ignore-start
-  const RoomRoomGetRoomsHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory RoomRoomGetRoomsHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for RoomRoomGetRoomsHeaders.
-  static Serializer<RoomRoomGetRoomsHeaders> get serializer => _$roomRoomGetRoomsHeadersSerializer;
-}
-
-@BuiltValue(instantiable: false)
 abstract interface class $RoomGetRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
@@ -26562,6 +26526,42 @@ abstract class RoomGetRoomsResponseApplicationJson
   /// Serializer for RoomGetRoomsResponseApplicationJson.
   static Serializer<RoomGetRoomsResponseApplicationJson> get serializer =>
       _$roomGetRoomsResponseApplicationJsonSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $RoomRoomGetRoomsHeadersInterface {
+  @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
+  String? get xNextcloudTalkHash;
+  @BuiltValueField(wireName: 'x-nextcloud-talk-modified-before')
+  String? get xNextcloudTalkModifiedBefore;
+}
+
+abstract class RoomRoomGetRoomsHeaders
+    implements $RoomRoomGetRoomsHeadersInterface, Built<RoomRoomGetRoomsHeaders, RoomRoomGetRoomsHeadersBuilder> {
+  /// Creates a new RoomRoomGetRoomsHeaders object using the builder pattern.
+  factory RoomRoomGetRoomsHeaders([void Function(RoomRoomGetRoomsHeadersBuilder)? b]) = _$RoomRoomGetRoomsHeaders;
+
+  // coverage:ignore-start
+  const RoomRoomGetRoomsHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomRoomGetRoomsHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomRoomGetRoomsHeaders.
+  static Serializer<RoomRoomGetRoomsHeaders> get serializer => _$roomRoomGetRoomsHeadersSerializer;
 }
 
 class RoomCreateRoomApiVersion extends EnumClass {
@@ -26892,45 +26892,6 @@ class _$RoomGetNoteToSelfConversationApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $RoomRoomGetNoteToSelfConversationHeadersInterface {
-  @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
-  String? get xNextcloudTalkHash;
-}
-
-abstract class RoomRoomGetNoteToSelfConversationHeaders
-    implements
-        $RoomRoomGetNoteToSelfConversationHeadersInterface,
-        Built<RoomRoomGetNoteToSelfConversationHeaders, RoomRoomGetNoteToSelfConversationHeadersBuilder> {
-  /// Creates a new RoomRoomGetNoteToSelfConversationHeaders object using the builder pattern.
-  factory RoomRoomGetNoteToSelfConversationHeaders([
-    void Function(RoomRoomGetNoteToSelfConversationHeadersBuilder)? b,
-  ]) = _$RoomRoomGetNoteToSelfConversationHeaders;
-
-  // coverage:ignore-start
-  const RoomRoomGetNoteToSelfConversationHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory RoomRoomGetNoteToSelfConversationHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for RoomRoomGetNoteToSelfConversationHeaders.
-  static Serializer<RoomRoomGetNoteToSelfConversationHeaders> get serializer =>
-      _$roomRoomGetNoteToSelfConversationHeadersSerializer;
-}
-
-@BuiltValue(instantiable: false)
 abstract interface class $RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
@@ -27009,6 +26970,45 @@ abstract class RoomGetNoteToSelfConversationResponseApplicationJson
       _$roomGetNoteToSelfConversationResponseApplicationJsonSerializer;
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class $RoomRoomGetNoteToSelfConversationHeadersInterface {
+  @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
+  String? get xNextcloudTalkHash;
+}
+
+abstract class RoomRoomGetNoteToSelfConversationHeaders
+    implements
+        $RoomRoomGetNoteToSelfConversationHeadersInterface,
+        Built<RoomRoomGetNoteToSelfConversationHeaders, RoomRoomGetNoteToSelfConversationHeadersBuilder> {
+  /// Creates a new RoomRoomGetNoteToSelfConversationHeaders object using the builder pattern.
+  factory RoomRoomGetNoteToSelfConversationHeaders([
+    void Function(RoomRoomGetNoteToSelfConversationHeadersBuilder)? b,
+  ]) = _$RoomRoomGetNoteToSelfConversationHeaders;
+
+  // coverage:ignore-start
+  const RoomRoomGetNoteToSelfConversationHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomRoomGetNoteToSelfConversationHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomRoomGetNoteToSelfConversationHeaders.
+  static Serializer<RoomRoomGetNoteToSelfConversationHeaders> get serializer =>
+      _$roomRoomGetNoteToSelfConversationHeadersSerializer;
+}
+
 class RoomGetSingleRoomApiVersion extends EnumClass {
   const RoomGetSingleRoomApiVersion._(super.name);
 
@@ -27063,43 +27063,6 @@ class _$RoomGetSingleRoomApiVersionSerializer implements PrimitiveSerializer<Roo
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
-}
-
-@BuiltValue(instantiable: false)
-abstract interface class $RoomRoomGetSingleRoomHeadersInterface {
-  @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
-  String? get xNextcloudTalkHash;
-}
-
-abstract class RoomRoomGetSingleRoomHeaders
-    implements
-        $RoomRoomGetSingleRoomHeadersInterface,
-        Built<RoomRoomGetSingleRoomHeaders, RoomRoomGetSingleRoomHeadersBuilder> {
-  /// Creates a new RoomRoomGetSingleRoomHeaders object using the builder pattern.
-  factory RoomRoomGetSingleRoomHeaders([void Function(RoomRoomGetSingleRoomHeadersBuilder)? b]) =
-      _$RoomRoomGetSingleRoomHeaders;
-
-  // coverage:ignore-start
-  const RoomRoomGetSingleRoomHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory RoomRoomGetSingleRoomHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for RoomRoomGetSingleRoomHeaders.
-  static Serializer<RoomRoomGetSingleRoomHeaders> get serializer => _$roomRoomGetSingleRoomHeadersSerializer;
 }
 
 @BuiltValue(instantiable: false)
@@ -27177,6 +27140,43 @@ abstract class RoomGetSingleRoomResponseApplicationJson
   /// Serializer for RoomGetSingleRoomResponseApplicationJson.
   static Serializer<RoomGetSingleRoomResponseApplicationJson> get serializer =>
       _$roomGetSingleRoomResponseApplicationJsonSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $RoomRoomGetSingleRoomHeadersInterface {
+  @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
+  String? get xNextcloudTalkHash;
+}
+
+abstract class RoomRoomGetSingleRoomHeaders
+    implements
+        $RoomRoomGetSingleRoomHeadersInterface,
+        Built<RoomRoomGetSingleRoomHeaders, RoomRoomGetSingleRoomHeadersBuilder> {
+  /// Creates a new RoomRoomGetSingleRoomHeaders object using the builder pattern.
+  factory RoomRoomGetSingleRoomHeaders([void Function(RoomRoomGetSingleRoomHeadersBuilder)? b]) =
+      _$RoomRoomGetSingleRoomHeaders;
+
+  // coverage:ignore-start
+  const RoomRoomGetSingleRoomHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomRoomGetSingleRoomHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomRoomGetSingleRoomHeaders.
+  static Serializer<RoomRoomGetSingleRoomHeaders> get serializer => _$roomRoomGetSingleRoomHeadersSerializer;
 }
 
 class RoomRenameRoomApiVersion extends EnumClass {
@@ -30405,43 +30405,6 @@ class _$RoomGetParticipantsApiVersionSerializer implements PrimitiveSerializer<R
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $RoomRoomGetParticipantsHeadersInterface {
-  @BuiltValueField(wireName: 'x-nextcloud-has-user-statuses')
-  Header<bool>? get xNextcloudHasUserStatuses;
-}
-
-abstract class RoomRoomGetParticipantsHeaders
-    implements
-        $RoomRoomGetParticipantsHeadersInterface,
-        Built<RoomRoomGetParticipantsHeaders, RoomRoomGetParticipantsHeadersBuilder> {
-  /// Creates a new RoomRoomGetParticipantsHeaders object using the builder pattern.
-  factory RoomRoomGetParticipantsHeaders([void Function(RoomRoomGetParticipantsHeadersBuilder)? b]) =
-      _$RoomRoomGetParticipantsHeaders;
-
-  // coverage:ignore-start
-  const RoomRoomGetParticipantsHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory RoomRoomGetParticipantsHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for RoomRoomGetParticipantsHeaders.
-  static Serializer<RoomRoomGetParticipantsHeaders> get serializer => _$roomRoomGetParticipantsHeadersSerializer;
-}
-
-@BuiltValue(instantiable: false)
 abstract interface class $ParticipantInterface {
   String get actorId;
   ActorType get actorType;
@@ -30564,6 +30527,43 @@ abstract class RoomGetParticipantsResponseApplicationJson
   /// Serializer for RoomGetParticipantsResponseApplicationJson.
   static Serializer<RoomGetParticipantsResponseApplicationJson> get serializer =>
       _$roomGetParticipantsResponseApplicationJsonSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $RoomRoomGetParticipantsHeadersInterface {
+  @BuiltValueField(wireName: 'x-nextcloud-has-user-statuses')
+  Header<bool>? get xNextcloudHasUserStatuses;
+}
+
+abstract class RoomRoomGetParticipantsHeaders
+    implements
+        $RoomRoomGetParticipantsHeadersInterface,
+        Built<RoomRoomGetParticipantsHeaders, RoomRoomGetParticipantsHeadersBuilder> {
+  /// Creates a new RoomRoomGetParticipantsHeaders object using the builder pattern.
+  factory RoomRoomGetParticipantsHeaders([void Function(RoomRoomGetParticipantsHeadersBuilder)? b]) =
+      _$RoomRoomGetParticipantsHeaders;
+
+  // coverage:ignore-start
+  const RoomRoomGetParticipantsHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomRoomGetParticipantsHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomRoomGetParticipantsHeaders.
+  static Serializer<RoomRoomGetParticipantsHeaders> get serializer => _$roomRoomGetParticipantsHeadersSerializer;
 }
 
 class RoomAddParticipantToRoomSource extends EnumClass {
@@ -30965,45 +30965,6 @@ class _$RoomGetBreakoutRoomParticipantsApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $RoomRoomGetBreakoutRoomParticipantsHeadersInterface {
-  @BuiltValueField(wireName: 'x-nextcloud-has-user-statuses')
-  Header<bool>? get xNextcloudHasUserStatuses;
-}
-
-abstract class RoomRoomGetBreakoutRoomParticipantsHeaders
-    implements
-        $RoomRoomGetBreakoutRoomParticipantsHeadersInterface,
-        Built<RoomRoomGetBreakoutRoomParticipantsHeaders, RoomRoomGetBreakoutRoomParticipantsHeadersBuilder> {
-  /// Creates a new RoomRoomGetBreakoutRoomParticipantsHeaders object using the builder pattern.
-  factory RoomRoomGetBreakoutRoomParticipantsHeaders([
-    void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder)? b,
-  ]) = _$RoomRoomGetBreakoutRoomParticipantsHeaders;
-
-  // coverage:ignore-start
-  const RoomRoomGetBreakoutRoomParticipantsHeaders._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory RoomRoomGetBreakoutRoomParticipantsHeaders.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for RoomRoomGetBreakoutRoomParticipantsHeaders.
-  static Serializer<RoomRoomGetBreakoutRoomParticipantsHeaders> get serializer =>
-      _$roomRoomGetBreakoutRoomParticipantsHeadersSerializer;
-}
-
-@BuiltValue(instantiable: false)
 abstract interface class $RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Participant> get data;
@@ -31080,6 +31041,45 @@ abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson
   /// Serializer for RoomGetBreakoutRoomParticipantsResponseApplicationJson.
   static Serializer<RoomGetBreakoutRoomParticipantsResponseApplicationJson> get serializer =>
       _$roomGetBreakoutRoomParticipantsResponseApplicationJsonSerializer;
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $RoomRoomGetBreakoutRoomParticipantsHeadersInterface {
+  @BuiltValueField(wireName: 'x-nextcloud-has-user-statuses')
+  Header<bool>? get xNextcloudHasUserStatuses;
+}
+
+abstract class RoomRoomGetBreakoutRoomParticipantsHeaders
+    implements
+        $RoomRoomGetBreakoutRoomParticipantsHeadersInterface,
+        Built<RoomRoomGetBreakoutRoomParticipantsHeaders, RoomRoomGetBreakoutRoomParticipantsHeadersBuilder> {
+  /// Creates a new RoomRoomGetBreakoutRoomParticipantsHeaders object using the builder pattern.
+  factory RoomRoomGetBreakoutRoomParticipantsHeaders([
+    void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder)? b,
+  ]) = _$RoomRoomGetBreakoutRoomParticipantsHeaders;
+
+  // coverage:ignore-start
+  const RoomRoomGetBreakoutRoomParticipantsHeaders._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomRoomGetBreakoutRoomParticipantsHeaders.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomRoomGetBreakoutRoomParticipantsHeaders.
+  static Serializer<RoomRoomGetBreakoutRoomParticipantsHeaders> get serializer =>
+      _$roomRoomGetBreakoutRoomParticipantsHeadersSerializer;
 }
 
 class RoomRemoveSelfFromRoomApiVersion extends EnumClass {
@@ -38917,13 +38917,13 @@ extension $e620970959f428e934829e52f32b7089Extension on _$e620970959f428e934829e
   List<String> get _names => const ['builtListNever', 'chatMessage'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -38997,13 +38997,13 @@ extension $bd993fb3f40af33e8594d0d698208560Extension on _$bd993fb3f40af33e8594d0
   List<String> get _names => const ['builtListNever', 'roomAddParticipantToRoomResponseApplicationJsonOcsData0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -39083,13 +39083,13 @@ extension $b2c4857c0136baea42828d89c87c757dExtension on _$b2c4857c0136baea42828d
   List<String> get _names => const [r'$int', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -39159,13 +39159,13 @@ extension $1df642f5035aea3b22543ab331c3fb01Extension on _$1df642f5035aea3b22543a
   List<String> get _names => const ['builtListSignalingSession', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -39241,13 +39241,13 @@ extension $bc4aac45771b11649d372f39a92b1cf3Extension on _$bc4aac45771b11649d372f
   List<String> get _names => const ['builtListNever', 'publicCapabilities0'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -39315,7 +39315,7 @@ class _$bc4aac45771b11649d372f39a92b1cf3Serializer implements PrimitiveSerialize
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..add(AvatarGetAvatarDarkTheme.serializer)
@@ -39660,8 +39660,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ChatReceiveMessagesNoStatusUpdate.serializer)
       ..add(ChatReceiveMessagesMarkNotificationsAsRead.serializer)
       ..add(ChatReceiveMessagesApiVersion.serializer)
-      ..addBuilderFactory(const FullType(ChatChatReceiveMessagesHeaders), ChatChatReceiveMessagesHeadersBuilder.new)
-      ..add(ChatChatReceiveMessagesHeaders.serializer)
       ..addBuilderFactory(
         const FullType(ChatReceiveMessagesResponseApplicationJson),
         ChatReceiveMessagesResponseApplicationJsonBuilder.new,
@@ -39678,10 +39676,10 @@ final Serializers _$serializers = (Serializers().toBuilder()
         const FullType(BuiltList, [FullType(ChatMessageWithParent)]),
         ListBuilder<ChatMessageWithParent>.new,
       )
+      ..addBuilderFactory(const FullType(ChatChatReceiveMessagesHeaders), ChatChatReceiveMessagesHeadersBuilder.new)
+      ..add(ChatChatReceiveMessagesHeaders.serializer)
       ..add(ChatSendMessageSilent.serializer)
       ..add(ChatSendMessageApiVersion.serializer)
-      ..addBuilderFactory(const FullType(ChatChatSendMessageHeaders), ChatChatSendMessageHeadersBuilder.new)
-      ..add(ChatChatSendMessageHeaders.serializer)
       ..addBuilderFactory(
         const FullType(ChatSendMessageResponseApplicationJson),
         ChatSendMessageResponseApplicationJsonBuilder.new,
@@ -39692,9 +39690,9 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ChatSendMessageResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ChatSendMessageResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(const FullType(ChatChatSendMessageHeaders), ChatChatSendMessageHeadersBuilder.new)
+      ..add(ChatChatSendMessageHeaders.serializer)
       ..add(ChatClearHistoryApiVersion.serializer)
-      ..addBuilderFactory(const FullType(ChatChatClearHistoryHeaders), ChatChatClearHistoryHeadersBuilder.new)
-      ..add(ChatChatClearHistoryHeaders.serializer)
       ..addBuilderFactory(
         const FullType(ChatClearHistoryResponseApplicationJson),
         ChatClearHistoryResponseApplicationJsonBuilder.new,
@@ -39705,9 +39703,9 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ChatClearHistoryResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ChatClearHistoryResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(const FullType(ChatChatClearHistoryHeaders), ChatChatClearHistoryHeadersBuilder.new)
+      ..add(ChatChatClearHistoryHeaders.serializer)
       ..add(ChatDeleteMessageApiVersion.serializer)
-      ..addBuilderFactory(const FullType(ChatChatDeleteMessageHeaders), ChatChatDeleteMessageHeadersBuilder.new)
-      ..add(ChatChatDeleteMessageHeaders.serializer)
       ..addBuilderFactory(
         const FullType(ChatDeleteMessageResponseApplicationJson),
         ChatDeleteMessageResponseApplicationJsonBuilder.new,
@@ -39718,9 +39716,9 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ChatDeleteMessageResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ChatDeleteMessageResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(const FullType(ChatChatDeleteMessageHeaders), ChatChatDeleteMessageHeadersBuilder.new)
+      ..add(ChatChatDeleteMessageHeaders.serializer)
       ..add(ChatGetMessageContextApiVersion.serializer)
-      ..addBuilderFactory(const FullType(ChatChatGetMessageContextHeaders), ChatChatGetMessageContextHeadersBuilder.new)
-      ..add(ChatChatGetMessageContextHeaders.serializer)
       ..addBuilderFactory(
         const FullType(ChatGetMessageContextResponseApplicationJson),
         ChatGetMessageContextResponseApplicationJsonBuilder.new,
@@ -39731,6 +39729,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ChatGetMessageContextResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ChatGetMessageContextResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(const FullType(ChatChatGetMessageContextHeaders), ChatChatGetMessageContextHeadersBuilder.new)
+      ..add(ChatChatGetMessageContextHeaders.serializer)
       ..add(ChatGetReminderApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(ChatGetReminderResponseApplicationJson),
@@ -39767,8 +39767,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(ChatDeleteReminderResponseApplicationJson_Ocs.serializer)
       ..add(ChatSetReadMarkerApiVersion.serializer)
-      ..addBuilderFactory(const FullType(ChatChatSetReadMarkerHeaders), ChatChatSetReadMarkerHeadersBuilder.new)
-      ..add(ChatChatSetReadMarkerHeaders.serializer)
       ..addBuilderFactory(
         const FullType(ChatSetReadMarkerResponseApplicationJson),
         ChatSetReadMarkerResponseApplicationJsonBuilder.new,
@@ -39779,9 +39777,9 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ChatSetReadMarkerResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ChatSetReadMarkerResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(const FullType(ChatChatSetReadMarkerHeaders), ChatChatSetReadMarkerHeadersBuilder.new)
+      ..add(ChatChatSetReadMarkerHeaders.serializer)
       ..add(ChatMarkUnreadApiVersion.serializer)
-      ..addBuilderFactory(const FullType(ChatChatMarkUnreadHeaders), ChatChatMarkUnreadHeadersBuilder.new)
-      ..add(ChatChatMarkUnreadHeaders.serializer)
       ..addBuilderFactory(
         const FullType(ChatMarkUnreadResponseApplicationJson),
         ChatMarkUnreadResponseApplicationJsonBuilder.new,
@@ -39792,6 +39790,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ChatMarkUnreadResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ChatMarkUnreadResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(const FullType(ChatChatMarkUnreadHeaders), ChatChatMarkUnreadHeadersBuilder.new)
+      ..add(ChatChatMarkUnreadHeaders.serializer)
       ..add(ChatMentionsIncludeStatus.serializer)
       ..add(ChatMentionsApiVersion.serializer)
       ..addBuilderFactory(
@@ -39812,11 +39812,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(ChatGetObjectsSharedInRoomApiVersion.serializer)
       ..addBuilderFactory(
-        const FullType(ChatChatGetObjectsSharedInRoomHeaders),
-        ChatChatGetObjectsSharedInRoomHeadersBuilder.new,
-      )
-      ..add(ChatChatGetObjectsSharedInRoomHeaders.serializer)
-      ..addBuilderFactory(
         const FullType(ChatGetObjectsSharedInRoomResponseApplicationJson),
         ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder.new,
       )
@@ -39827,9 +39822,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(ChatMessage)]), ListBuilder<ChatMessage>.new)
+      ..addBuilderFactory(
+        const FullType(ChatChatGetObjectsSharedInRoomHeaders),
+        ChatChatGetObjectsSharedInRoomHeadersBuilder.new,
+      )
+      ..add(ChatChatGetObjectsSharedInRoomHeaders.serializer)
       ..add(ChatShareObjectToChatApiVersion.serializer)
-      ..addBuilderFactory(const FullType(ChatChatShareObjectToChatHeaders), ChatChatShareObjectToChatHeadersBuilder.new)
-      ..add(ChatChatShareObjectToChatHeaders.serializer)
       ..addBuilderFactory(
         const FullType(ChatShareObjectToChatResponseApplicationJson),
         ChatShareObjectToChatResponseApplicationJsonBuilder.new,
@@ -39840,6 +39838,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ChatShareObjectToChatResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ChatShareObjectToChatResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(const FullType(ChatChatShareObjectToChatHeaders), ChatChatShareObjectToChatHeadersBuilder.new)
+      ..add(ChatChatShareObjectToChatHeaders.serializer)
       ..add(ChatGetObjectsSharedInRoomOverviewApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(ChatGetObjectsSharedInRoomOverviewResponseApplicationJson),
@@ -40201,8 +40201,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomGetRoomsNoStatusUpdate.serializer)
       ..add(RoomGetRoomsIncludeStatus.serializer)
       ..add(RoomGetRoomsApiVersion.serializer)
-      ..addBuilderFactory(const FullType(RoomRoomGetRoomsHeaders), RoomRoomGetRoomsHeadersBuilder.new)
-      ..add(RoomRoomGetRoomsHeaders.serializer)
       ..addBuilderFactory(
         const FullType(RoomGetRoomsResponseApplicationJson),
         RoomGetRoomsResponseApplicationJsonBuilder.new,
@@ -40213,6 +40211,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomGetRoomsResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomGetRoomsResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(const FullType(RoomRoomGetRoomsHeaders), RoomRoomGetRoomsHeadersBuilder.new)
+      ..add(RoomRoomGetRoomsHeaders.serializer)
       ..add(RoomCreateRoomApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(RoomCreateRoomResponseApplicationJson),
@@ -40237,11 +40237,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomGetListedRoomsResponseApplicationJson_Ocs.serializer)
       ..add(RoomGetNoteToSelfConversationApiVersion.serializer)
       ..addBuilderFactory(
-        const FullType(RoomRoomGetNoteToSelfConversationHeaders),
-        RoomRoomGetNoteToSelfConversationHeadersBuilder.new,
-      )
-      ..add(RoomRoomGetNoteToSelfConversationHeaders.serializer)
-      ..addBuilderFactory(
         const FullType(RoomGetNoteToSelfConversationResponseApplicationJson),
         RoomGetNoteToSelfConversationResponseApplicationJsonBuilder.new,
       )
@@ -40251,9 +40246,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomGetNoteToSelfConversationResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomRoomGetNoteToSelfConversationHeaders),
+        RoomRoomGetNoteToSelfConversationHeadersBuilder.new,
+      )
+      ..add(RoomRoomGetNoteToSelfConversationHeaders.serializer)
       ..add(RoomGetSingleRoomApiVersion.serializer)
-      ..addBuilderFactory(const FullType(RoomRoomGetSingleRoomHeaders), RoomRoomGetSingleRoomHeadersBuilder.new)
-      ..add(RoomRoomGetSingleRoomHeaders.serializer)
       ..addBuilderFactory(
         const FullType(RoomGetSingleRoomResponseApplicationJson),
         RoomGetSingleRoomResponseApplicationJsonBuilder.new,
@@ -40264,6 +40262,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomGetSingleRoomResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomGetSingleRoomResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(const FullType(RoomRoomGetSingleRoomHeaders), RoomRoomGetSingleRoomHeadersBuilder.new)
+      ..add(RoomRoomGetSingleRoomHeaders.serializer)
       ..add(RoomRenameRoomApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(RoomRenameRoomResponseApplicationJson),
@@ -40380,10 +40380,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomSetPermissionsResponseApplicationJson_Ocs.serializer)
       ..add(RoomGetParticipantsIncludeStatus.serializer)
       ..add(RoomGetParticipantsApiVersion.serializer)
-      ..addBuilderFactory(const FullType(RoomRoomGetParticipantsHeaders), RoomRoomGetParticipantsHeadersBuilder.new)
-      ..add(RoomRoomGetParticipantsHeaders.serializer)
-      ..addBuilderFactory(const FullType(Header, [FullType(bool)]), HeaderBuilder<bool>.new)
-      ..add(Header.serializer)
       ..addBuilderFactory(
         const FullType(RoomGetParticipantsResponseApplicationJson),
         RoomGetParticipantsResponseApplicationJsonBuilder.new,
@@ -40397,6 +40393,10 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(Participant), ParticipantBuilder.new)
       ..add(Participant.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(Participant)]), ListBuilder<Participant>.new)
+      ..addBuilderFactory(const FullType(RoomRoomGetParticipantsHeaders), RoomRoomGetParticipantsHeadersBuilder.new)
+      ..add(RoomRoomGetParticipantsHeaders.serializer)
+      ..addBuilderFactory(const FullType(Header, [FullType(bool)]), HeaderBuilder<bool>.new)
+      ..add(Header.serializer)
       ..add(RoomAddParticipantToRoomSource.serializer)
       ..add(RoomAddParticipantToRoomApiVersion.serializer)
       ..addBuilderFactory(
@@ -40418,11 +40418,6 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomGetBreakoutRoomParticipantsIncludeStatus.serializer)
       ..add(RoomGetBreakoutRoomParticipantsApiVersion.serializer)
       ..addBuilderFactory(
-        const FullType(RoomRoomGetBreakoutRoomParticipantsHeaders),
-        RoomRoomGetBreakoutRoomParticipantsHeadersBuilder.new,
-      )
-      ..add(RoomRoomGetBreakoutRoomParticipantsHeaders.serializer)
-      ..addBuilderFactory(
         const FullType(RoomGetBreakoutRoomParticipantsResponseApplicationJson),
         RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder.new,
       )
@@ -40432,6 +40427,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomRoomGetBreakoutRoomParticipantsHeaders),
+        RoomRoomGetBreakoutRoomParticipantsHeadersBuilder.new,
+      )
+      ..add(RoomRoomGetBreakoutRoomParticipantsHeaders.serializer)
       ..add(RoomRemoveSelfFromRoomApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(RoomRemoveSelfFromRoomResponseApplicationJson),
@@ -40817,7 +40817,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
@@ -7423,38 +7423,38 @@ Serializer<CertificateGetCertificateExpirationResponseApplicationJson_Ocs>
 Serializer<CertificateGetCertificateExpirationResponseApplicationJson>
     _$certificateGetCertificateExpirationResponseApplicationJsonSerializer =
     _$CertificateGetCertificateExpirationResponseApplicationJsonSerializer();
-Serializer<ChatChatReceiveMessagesHeaders> _$chatChatReceiveMessagesHeadersSerializer =
-    _$ChatChatReceiveMessagesHeadersSerializer();
 Serializer<ChatMessageWithParent> _$chatMessageWithParentSerializer = _$ChatMessageWithParentSerializer();
 Serializer<ChatReceiveMessagesResponseApplicationJson_Ocs> _$chatReceiveMessagesResponseApplicationJsonOcsSerializer =
     _$ChatReceiveMessagesResponseApplicationJson_OcsSerializer();
 Serializer<ChatReceiveMessagesResponseApplicationJson> _$chatReceiveMessagesResponseApplicationJsonSerializer =
     _$ChatReceiveMessagesResponseApplicationJsonSerializer();
-Serializer<ChatChatSendMessageHeaders> _$chatChatSendMessageHeadersSerializer =
-    _$ChatChatSendMessageHeadersSerializer();
+Serializer<ChatChatReceiveMessagesHeaders> _$chatChatReceiveMessagesHeadersSerializer =
+    _$ChatChatReceiveMessagesHeadersSerializer();
 Serializer<ChatSendMessageResponseApplicationJson_Ocs> _$chatSendMessageResponseApplicationJsonOcsSerializer =
     _$ChatSendMessageResponseApplicationJson_OcsSerializer();
 Serializer<ChatSendMessageResponseApplicationJson> _$chatSendMessageResponseApplicationJsonSerializer =
     _$ChatSendMessageResponseApplicationJsonSerializer();
-Serializer<ChatChatClearHistoryHeaders> _$chatChatClearHistoryHeadersSerializer =
-    _$ChatChatClearHistoryHeadersSerializer();
+Serializer<ChatChatSendMessageHeaders> _$chatChatSendMessageHeadersSerializer =
+    _$ChatChatSendMessageHeadersSerializer();
 Serializer<ChatClearHistoryResponseApplicationJson_Ocs> _$chatClearHistoryResponseApplicationJsonOcsSerializer =
     _$ChatClearHistoryResponseApplicationJson_OcsSerializer();
 Serializer<ChatClearHistoryResponseApplicationJson> _$chatClearHistoryResponseApplicationJsonSerializer =
     _$ChatClearHistoryResponseApplicationJsonSerializer();
-Serializer<ChatChatDeleteMessageHeaders> _$chatChatDeleteMessageHeadersSerializer =
-    _$ChatChatDeleteMessageHeadersSerializer();
+Serializer<ChatChatClearHistoryHeaders> _$chatChatClearHistoryHeadersSerializer =
+    _$ChatChatClearHistoryHeadersSerializer();
 Serializer<ChatDeleteMessageResponseApplicationJson_Ocs> _$chatDeleteMessageResponseApplicationJsonOcsSerializer =
     _$ChatDeleteMessageResponseApplicationJson_OcsSerializer();
 Serializer<ChatDeleteMessageResponseApplicationJson> _$chatDeleteMessageResponseApplicationJsonSerializer =
     _$ChatDeleteMessageResponseApplicationJsonSerializer();
-Serializer<ChatChatGetMessageContextHeaders> _$chatChatGetMessageContextHeadersSerializer =
-    _$ChatChatGetMessageContextHeadersSerializer();
+Serializer<ChatChatDeleteMessageHeaders> _$chatChatDeleteMessageHeadersSerializer =
+    _$ChatChatDeleteMessageHeadersSerializer();
 Serializer<ChatGetMessageContextResponseApplicationJson_Ocs>
     _$chatGetMessageContextResponseApplicationJsonOcsSerializer =
     _$ChatGetMessageContextResponseApplicationJson_OcsSerializer();
 Serializer<ChatGetMessageContextResponseApplicationJson> _$chatGetMessageContextResponseApplicationJsonSerializer =
     _$ChatGetMessageContextResponseApplicationJsonSerializer();
+Serializer<ChatChatGetMessageContextHeaders> _$chatChatGetMessageContextHeadersSerializer =
+    _$ChatChatGetMessageContextHeadersSerializer();
 Serializer<ChatReminder> _$chatReminderSerializer = _$ChatReminderSerializer();
 Serializer<ChatGetReminderResponseApplicationJson_Ocs> _$chatGetReminderResponseApplicationJsonOcsSerializer =
     _$ChatGetReminderResponseApplicationJson_OcsSerializer();
@@ -7468,37 +7468,37 @@ Serializer<ChatDeleteReminderResponseApplicationJson_Ocs> _$chatDeleteReminderRe
     _$ChatDeleteReminderResponseApplicationJson_OcsSerializer();
 Serializer<ChatDeleteReminderResponseApplicationJson> _$chatDeleteReminderResponseApplicationJsonSerializer =
     _$ChatDeleteReminderResponseApplicationJsonSerializer();
-Serializer<ChatChatSetReadMarkerHeaders> _$chatChatSetReadMarkerHeadersSerializer =
-    _$ChatChatSetReadMarkerHeadersSerializer();
 Serializer<ChatSetReadMarkerResponseApplicationJson_Ocs> _$chatSetReadMarkerResponseApplicationJsonOcsSerializer =
     _$ChatSetReadMarkerResponseApplicationJson_OcsSerializer();
 Serializer<ChatSetReadMarkerResponseApplicationJson> _$chatSetReadMarkerResponseApplicationJsonSerializer =
     _$ChatSetReadMarkerResponseApplicationJsonSerializer();
-Serializer<ChatChatMarkUnreadHeaders> _$chatChatMarkUnreadHeadersSerializer = _$ChatChatMarkUnreadHeadersSerializer();
+Serializer<ChatChatSetReadMarkerHeaders> _$chatChatSetReadMarkerHeadersSerializer =
+    _$ChatChatSetReadMarkerHeadersSerializer();
 Serializer<ChatMarkUnreadResponseApplicationJson_Ocs> _$chatMarkUnreadResponseApplicationJsonOcsSerializer =
     _$ChatMarkUnreadResponseApplicationJson_OcsSerializer();
 Serializer<ChatMarkUnreadResponseApplicationJson> _$chatMarkUnreadResponseApplicationJsonSerializer =
     _$ChatMarkUnreadResponseApplicationJsonSerializer();
+Serializer<ChatChatMarkUnreadHeaders> _$chatChatMarkUnreadHeadersSerializer = _$ChatChatMarkUnreadHeadersSerializer();
 Serializer<ChatMentionSuggestion> _$chatMentionSuggestionSerializer = _$ChatMentionSuggestionSerializer();
 Serializer<ChatMentionsResponseApplicationJson_Ocs> _$chatMentionsResponseApplicationJsonOcsSerializer =
     _$ChatMentionsResponseApplicationJson_OcsSerializer();
 Serializer<ChatMentionsResponseApplicationJson> _$chatMentionsResponseApplicationJsonSerializer =
     _$ChatMentionsResponseApplicationJsonSerializer();
-Serializer<ChatChatGetObjectsSharedInRoomHeaders> _$chatChatGetObjectsSharedInRoomHeadersSerializer =
-    _$ChatChatGetObjectsSharedInRoomHeadersSerializer();
 Serializer<ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs>
     _$chatGetObjectsSharedInRoomResponseApplicationJsonOcsSerializer =
     _$ChatGetObjectsSharedInRoomResponseApplicationJson_OcsSerializer();
 Serializer<ChatGetObjectsSharedInRoomResponseApplicationJson>
     _$chatGetObjectsSharedInRoomResponseApplicationJsonSerializer =
     _$ChatGetObjectsSharedInRoomResponseApplicationJsonSerializer();
-Serializer<ChatChatShareObjectToChatHeaders> _$chatChatShareObjectToChatHeadersSerializer =
-    _$ChatChatShareObjectToChatHeadersSerializer();
+Serializer<ChatChatGetObjectsSharedInRoomHeaders> _$chatChatGetObjectsSharedInRoomHeadersSerializer =
+    _$ChatChatGetObjectsSharedInRoomHeadersSerializer();
 Serializer<ChatShareObjectToChatResponseApplicationJson_Ocs>
     _$chatShareObjectToChatResponseApplicationJsonOcsSerializer =
     _$ChatShareObjectToChatResponseApplicationJson_OcsSerializer();
 Serializer<ChatShareObjectToChatResponseApplicationJson> _$chatShareObjectToChatResponseApplicationJsonSerializer =
     _$ChatShareObjectToChatResponseApplicationJsonSerializer();
+Serializer<ChatChatShareObjectToChatHeaders> _$chatChatShareObjectToChatHeadersSerializer =
+    _$ChatChatShareObjectToChatHeadersSerializer();
 Serializer<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs>
     _$chatGetObjectsSharedInRoomOverviewResponseApplicationJsonOcsSerializer =
     _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsSerializer();
@@ -7653,11 +7653,11 @@ Serializer<RecordingGetWelcomeMessageResponseApplicationJson_Ocs>
 Serializer<RecordingGetWelcomeMessageResponseApplicationJson>
     _$recordingGetWelcomeMessageResponseApplicationJsonSerializer =
     _$RecordingGetWelcomeMessageResponseApplicationJsonSerializer();
-Serializer<RoomRoomGetRoomsHeaders> _$roomRoomGetRoomsHeadersSerializer = _$RoomRoomGetRoomsHeadersSerializer();
 Serializer<RoomGetRoomsResponseApplicationJson_Ocs> _$roomGetRoomsResponseApplicationJsonOcsSerializer =
     _$RoomGetRoomsResponseApplicationJson_OcsSerializer();
 Serializer<RoomGetRoomsResponseApplicationJson> _$roomGetRoomsResponseApplicationJsonSerializer =
     _$RoomGetRoomsResponseApplicationJsonSerializer();
+Serializer<RoomRoomGetRoomsHeaders> _$roomRoomGetRoomsHeadersSerializer = _$RoomRoomGetRoomsHeadersSerializer();
 Serializer<RoomCreateRoomResponseApplicationJson_Ocs> _$roomCreateRoomResponseApplicationJsonOcsSerializer =
     _$RoomCreateRoomResponseApplicationJson_OcsSerializer();
 Serializer<RoomCreateRoomResponseApplicationJson> _$roomCreateRoomResponseApplicationJsonSerializer =
@@ -7666,20 +7666,20 @@ Serializer<RoomGetListedRoomsResponseApplicationJson_Ocs> _$roomGetListedRoomsRe
     _$RoomGetListedRoomsResponseApplicationJson_OcsSerializer();
 Serializer<RoomGetListedRoomsResponseApplicationJson> _$roomGetListedRoomsResponseApplicationJsonSerializer =
     _$RoomGetListedRoomsResponseApplicationJsonSerializer();
-Serializer<RoomRoomGetNoteToSelfConversationHeaders> _$roomRoomGetNoteToSelfConversationHeadersSerializer =
-    _$RoomRoomGetNoteToSelfConversationHeadersSerializer();
 Serializer<RoomGetNoteToSelfConversationResponseApplicationJson_Ocs>
     _$roomGetNoteToSelfConversationResponseApplicationJsonOcsSerializer =
     _$RoomGetNoteToSelfConversationResponseApplicationJson_OcsSerializer();
 Serializer<RoomGetNoteToSelfConversationResponseApplicationJson>
     _$roomGetNoteToSelfConversationResponseApplicationJsonSerializer =
     _$RoomGetNoteToSelfConversationResponseApplicationJsonSerializer();
-Serializer<RoomRoomGetSingleRoomHeaders> _$roomRoomGetSingleRoomHeadersSerializer =
-    _$RoomRoomGetSingleRoomHeadersSerializer();
+Serializer<RoomRoomGetNoteToSelfConversationHeaders> _$roomRoomGetNoteToSelfConversationHeadersSerializer =
+    _$RoomRoomGetNoteToSelfConversationHeadersSerializer();
 Serializer<RoomGetSingleRoomResponseApplicationJson_Ocs> _$roomGetSingleRoomResponseApplicationJsonOcsSerializer =
     _$RoomGetSingleRoomResponseApplicationJson_OcsSerializer();
 Serializer<RoomGetSingleRoomResponseApplicationJson> _$roomGetSingleRoomResponseApplicationJsonSerializer =
     _$RoomGetSingleRoomResponseApplicationJsonSerializer();
+Serializer<RoomRoomGetSingleRoomHeaders> _$roomRoomGetSingleRoomHeadersSerializer =
+    _$RoomRoomGetSingleRoomHeadersSerializer();
 Serializer<RoomRenameRoomResponseApplicationJson_Ocs> _$roomRenameRoomResponseApplicationJsonOcsSerializer =
     _$RoomRenameRoomResponseApplicationJson_OcsSerializer();
 Serializer<RoomRenameRoomResponseApplicationJson> _$roomRenameRoomResponseApplicationJsonSerializer =
@@ -7720,13 +7720,13 @@ Serializer<RoomSetPermissionsResponseApplicationJson_Ocs> _$roomSetPermissionsRe
     _$RoomSetPermissionsResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetPermissionsResponseApplicationJson> _$roomSetPermissionsResponseApplicationJsonSerializer =
     _$RoomSetPermissionsResponseApplicationJsonSerializer();
-Serializer<RoomRoomGetParticipantsHeaders> _$roomRoomGetParticipantsHeadersSerializer =
-    _$RoomRoomGetParticipantsHeadersSerializer();
 Serializer<Participant> _$participantSerializer = _$ParticipantSerializer();
 Serializer<RoomGetParticipantsResponseApplicationJson_Ocs> _$roomGetParticipantsResponseApplicationJsonOcsSerializer =
     _$RoomGetParticipantsResponseApplicationJson_OcsSerializer();
 Serializer<RoomGetParticipantsResponseApplicationJson> _$roomGetParticipantsResponseApplicationJsonSerializer =
     _$RoomGetParticipantsResponseApplicationJsonSerializer();
+Serializer<RoomRoomGetParticipantsHeaders> _$roomRoomGetParticipantsHeadersSerializer =
+    _$RoomRoomGetParticipantsHeadersSerializer();
 Serializer<RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0>
     _$roomAddParticipantToRoomResponseApplicationJsonOcsData0Serializer =
     _$RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Serializer();
@@ -7736,14 +7736,14 @@ Serializer<RoomAddParticipantToRoomResponseApplicationJson_Ocs>
 Serializer<RoomAddParticipantToRoomResponseApplicationJson>
     _$roomAddParticipantToRoomResponseApplicationJsonSerializer =
     _$RoomAddParticipantToRoomResponseApplicationJsonSerializer();
-Serializer<RoomRoomGetBreakoutRoomParticipantsHeaders> _$roomRoomGetBreakoutRoomParticipantsHeadersSerializer =
-    _$RoomRoomGetBreakoutRoomParticipantsHeadersSerializer();
 Serializer<RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs>
     _$roomGetBreakoutRoomParticipantsResponseApplicationJsonOcsSerializer =
     _$RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsSerializer();
 Serializer<RoomGetBreakoutRoomParticipantsResponseApplicationJson>
     _$roomGetBreakoutRoomParticipantsResponseApplicationJsonSerializer =
     _$RoomGetBreakoutRoomParticipantsResponseApplicationJsonSerializer();
+Serializer<RoomRoomGetBreakoutRoomParticipantsHeaders> _$roomRoomGetBreakoutRoomParticipantsHeadersSerializer =
+    _$RoomRoomGetBreakoutRoomParticipantsHeadersSerializer();
 Serializer<RoomRemoveSelfFromRoomResponseApplicationJson_Ocs>
     _$roomRemoveSelfFromRoomResponseApplicationJsonOcsSerializer =
     _$RoomRemoveSelfFromRoomResponseApplicationJson_OcsSerializer();
@@ -11138,56 +11138,6 @@ class _$CertificateGetCertificateExpirationResponseApplicationJsonSerializer
   }
 }
 
-class _$ChatChatReceiveMessagesHeadersSerializer implements StructuredSerializer<ChatChatReceiveMessagesHeaders> {
-  @override
-  final Iterable<Type> types = const [ChatChatReceiveMessagesHeaders, _$ChatChatReceiveMessagesHeaders];
-  @override
-  final String wireName = 'ChatChatReceiveMessagesHeaders';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, ChatChatReceiveMessagesHeaders object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.xChatLastCommonRead;
-    if (value != null) {
-      result
-        ..add('x-chat-last-common-read')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    value = object.xChatLastGiven;
-    if (value != null) {
-      result
-        ..add('x-chat-last-given')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    return result;
-  }
-
-  @override
-  ChatChatReceiveMessagesHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = ChatChatReceiveMessagesHeadersBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'x-chat-last-common-read':
-          result.xChatLastCommonRead = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-        case 'x-chat-last-given':
-          result.xChatLastGiven = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$ChatMessageWithParentSerializer implements StructuredSerializer<ChatMessageWithParent> {
   @override
   final Iterable<Type> types = const [ChatMessageWithParent, _$ChatMessageWithParent];
@@ -11423,14 +11373,14 @@ class _$ChatReceiveMessagesResponseApplicationJsonSerializer
   }
 }
 
-class _$ChatChatSendMessageHeadersSerializer implements StructuredSerializer<ChatChatSendMessageHeaders> {
+class _$ChatChatReceiveMessagesHeadersSerializer implements StructuredSerializer<ChatChatReceiveMessagesHeaders> {
   @override
-  final Iterable<Type> types = const [ChatChatSendMessageHeaders, _$ChatChatSendMessageHeaders];
+  final Iterable<Type> types = const [ChatChatReceiveMessagesHeaders, _$ChatChatReceiveMessagesHeaders];
   @override
-  final String wireName = 'ChatChatSendMessageHeaders';
+  final String wireName = 'ChatChatReceiveMessagesHeaders';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ChatChatSendMessageHeaders object,
+  Iterable<Object?> serialize(Serializers serializers, ChatChatReceiveMessagesHeaders object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
@@ -11440,13 +11390,19 @@ class _$ChatChatSendMessageHeadersSerializer implements StructuredSerializer<Cha
         ..add('x-chat-last-common-read')
         ..add(serializers.serialize(value, specifiedType: const FullType(String)));
     }
+    value = object.xChatLastGiven;
+    if (value != null) {
+      result
+        ..add('x-chat-last-given')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
     return result;
   }
 
   @override
-  ChatChatSendMessageHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ChatChatReceiveMessagesHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ChatChatSendMessageHeadersBuilder();
+    final result = ChatChatReceiveMessagesHeadersBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -11456,6 +11412,9 @@ class _$ChatChatSendMessageHeadersSerializer implements StructuredSerializer<Cha
       switch (key) {
         case 'x-chat-last-common-read':
           result.xChatLastCommonRead = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'x-chat-last-given':
+          result.xChatLastGiven = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -11557,14 +11516,14 @@ class _$ChatSendMessageResponseApplicationJsonSerializer
   }
 }
 
-class _$ChatChatClearHistoryHeadersSerializer implements StructuredSerializer<ChatChatClearHistoryHeaders> {
+class _$ChatChatSendMessageHeadersSerializer implements StructuredSerializer<ChatChatSendMessageHeaders> {
   @override
-  final Iterable<Type> types = const [ChatChatClearHistoryHeaders, _$ChatChatClearHistoryHeaders];
+  final Iterable<Type> types = const [ChatChatSendMessageHeaders, _$ChatChatSendMessageHeaders];
   @override
-  final String wireName = 'ChatChatClearHistoryHeaders';
+  final String wireName = 'ChatChatSendMessageHeaders';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ChatChatClearHistoryHeaders object,
+  Iterable<Object?> serialize(Serializers serializers, ChatChatSendMessageHeaders object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
@@ -11578,9 +11537,9 @@ class _$ChatChatClearHistoryHeadersSerializer implements StructuredSerializer<Ch
   }
 
   @override
-  ChatChatClearHistoryHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ChatChatSendMessageHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ChatChatClearHistoryHeadersBuilder();
+    final result = ChatChatSendMessageHeadersBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -11690,14 +11649,14 @@ class _$ChatClearHistoryResponseApplicationJsonSerializer
   }
 }
 
-class _$ChatChatDeleteMessageHeadersSerializer implements StructuredSerializer<ChatChatDeleteMessageHeaders> {
+class _$ChatChatClearHistoryHeadersSerializer implements StructuredSerializer<ChatChatClearHistoryHeaders> {
   @override
-  final Iterable<Type> types = const [ChatChatDeleteMessageHeaders, _$ChatChatDeleteMessageHeaders];
+  final Iterable<Type> types = const [ChatChatClearHistoryHeaders, _$ChatChatClearHistoryHeaders];
   @override
-  final String wireName = 'ChatChatDeleteMessageHeaders';
+  final String wireName = 'ChatChatClearHistoryHeaders';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ChatChatDeleteMessageHeaders object,
+  Iterable<Object?> serialize(Serializers serializers, ChatChatClearHistoryHeaders object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
@@ -11711,9 +11670,9 @@ class _$ChatChatDeleteMessageHeadersSerializer implements StructuredSerializer<C
   }
 
   @override
-  ChatChatDeleteMessageHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ChatChatClearHistoryHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ChatChatDeleteMessageHeadersBuilder();
+    final result = ChatChatClearHistoryHeadersBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -11823,14 +11782,14 @@ class _$ChatDeleteMessageResponseApplicationJsonSerializer
   }
 }
 
-class _$ChatChatGetMessageContextHeadersSerializer implements StructuredSerializer<ChatChatGetMessageContextHeaders> {
+class _$ChatChatDeleteMessageHeadersSerializer implements StructuredSerializer<ChatChatDeleteMessageHeaders> {
   @override
-  final Iterable<Type> types = const [ChatChatGetMessageContextHeaders, _$ChatChatGetMessageContextHeaders];
+  final Iterable<Type> types = const [ChatChatDeleteMessageHeaders, _$ChatChatDeleteMessageHeaders];
   @override
-  final String wireName = 'ChatChatGetMessageContextHeaders';
+  final String wireName = 'ChatChatDeleteMessageHeaders';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ChatChatGetMessageContextHeaders object,
+  Iterable<Object?> serialize(Serializers serializers, ChatChatDeleteMessageHeaders object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
@@ -11840,19 +11799,13 @@ class _$ChatChatGetMessageContextHeadersSerializer implements StructuredSerializ
         ..add('x-chat-last-common-read')
         ..add(serializers.serialize(value, specifiedType: const FullType(String)));
     }
-    value = object.xChatLastGiven;
-    if (value != null) {
-      result
-        ..add('x-chat-last-given')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
     return result;
   }
 
   @override
-  ChatChatGetMessageContextHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ChatChatDeleteMessageHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ChatChatGetMessageContextHeadersBuilder();
+    final result = ChatChatDeleteMessageHeadersBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -11862,9 +11815,6 @@ class _$ChatChatGetMessageContextHeadersSerializer implements StructuredSerializ
       switch (key) {
         case 'x-chat-last-common-read':
           result.xChatLastCommonRead = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-        case 'x-chat-last-given':
-          result.xChatLastGiven = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -11958,6 +11908,56 @@ class _$ChatGetMessageContextResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ChatGetMessageContextResponseApplicationJson_Ocs))!
               as ChatGetMessageContextResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ChatChatGetMessageContextHeadersSerializer implements StructuredSerializer<ChatChatGetMessageContextHeaders> {
+  @override
+  final Iterable<Type> types = const [ChatChatGetMessageContextHeaders, _$ChatChatGetMessageContextHeaders];
+  @override
+  final String wireName = 'ChatChatGetMessageContextHeaders';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatChatGetMessageContextHeaders object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.xChatLastCommonRead;
+    if (value != null) {
+      result
+        ..add('x-chat-last-common-read')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.xChatLastGiven;
+    if (value != null) {
+      result
+        ..add('x-chat-last-given')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ChatChatGetMessageContextHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatChatGetMessageContextHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'x-chat-last-common-read':
+          result.xChatLastCommonRead = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'x-chat-last-given':
+          result.xChatLastGiven = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -12288,47 +12288,6 @@ class _$ChatDeleteReminderResponseApplicationJsonSerializer
   }
 }
 
-class _$ChatChatSetReadMarkerHeadersSerializer implements StructuredSerializer<ChatChatSetReadMarkerHeaders> {
-  @override
-  final Iterable<Type> types = const [ChatChatSetReadMarkerHeaders, _$ChatChatSetReadMarkerHeaders];
-  @override
-  final String wireName = 'ChatChatSetReadMarkerHeaders';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, ChatChatSetReadMarkerHeaders object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.xChatLastCommonRead;
-    if (value != null) {
-      result
-        ..add('x-chat-last-common-read')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    return result;
-  }
-
-  @override
-  ChatChatSetReadMarkerHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = ChatChatSetReadMarkerHeadersBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'x-chat-last-common-read':
-          result.xChatLastCommonRead = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$ChatSetReadMarkerResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ChatSetReadMarkerResponseApplicationJson_Ocs> {
   @override
@@ -12420,14 +12379,14 @@ class _$ChatSetReadMarkerResponseApplicationJsonSerializer
   }
 }
 
-class _$ChatChatMarkUnreadHeadersSerializer implements StructuredSerializer<ChatChatMarkUnreadHeaders> {
+class _$ChatChatSetReadMarkerHeadersSerializer implements StructuredSerializer<ChatChatSetReadMarkerHeaders> {
   @override
-  final Iterable<Type> types = const [ChatChatMarkUnreadHeaders, _$ChatChatMarkUnreadHeaders];
+  final Iterable<Type> types = const [ChatChatSetReadMarkerHeaders, _$ChatChatSetReadMarkerHeaders];
   @override
-  final String wireName = 'ChatChatMarkUnreadHeaders';
+  final String wireName = 'ChatChatSetReadMarkerHeaders';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ChatChatMarkUnreadHeaders object,
+  Iterable<Object?> serialize(Serializers serializers, ChatChatSetReadMarkerHeaders object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
@@ -12441,9 +12400,9 @@ class _$ChatChatMarkUnreadHeadersSerializer implements StructuredSerializer<Chat
   }
 
   @override
-  ChatChatMarkUnreadHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ChatChatSetReadMarkerHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ChatChatMarkUnreadHeadersBuilder();
+    final result = ChatChatSetReadMarkerHeadersBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -12541,6 +12500,47 @@ class _$ChatMarkUnreadResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(ChatMarkUnreadResponseApplicationJson_Ocs))!
                   as ChatMarkUnreadResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ChatChatMarkUnreadHeadersSerializer implements StructuredSerializer<ChatChatMarkUnreadHeaders> {
+  @override
+  final Iterable<Type> types = const [ChatChatMarkUnreadHeaders, _$ChatChatMarkUnreadHeaders];
+  @override
+  final String wireName = 'ChatChatMarkUnreadHeaders';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatChatMarkUnreadHeaders object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.xChatLastCommonRead;
+    if (value != null) {
+      result
+        ..add('x-chat-last-common-read')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ChatChatMarkUnreadHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatChatMarkUnreadHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'x-chat-last-common-read':
+          result.xChatLastCommonRead = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -12722,48 +12722,6 @@ class _$ChatMentionsResponseApplicationJsonSerializer
   }
 }
 
-class _$ChatChatGetObjectsSharedInRoomHeadersSerializer
-    implements StructuredSerializer<ChatChatGetObjectsSharedInRoomHeaders> {
-  @override
-  final Iterable<Type> types = const [ChatChatGetObjectsSharedInRoomHeaders, _$ChatChatGetObjectsSharedInRoomHeaders];
-  @override
-  final String wireName = 'ChatChatGetObjectsSharedInRoomHeaders';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, ChatChatGetObjectsSharedInRoomHeaders object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.xChatLastGiven;
-    if (value != null) {
-      result
-        ..add('x-chat-last-given')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    return result;
-  }
-
-  @override
-  ChatChatGetObjectsSharedInRoomHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = ChatChatGetObjectsSharedInRoomHeadersBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'x-chat-last-given':
-          result.xChatLastGiven = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$ChatGetObjectsSharedInRoomResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs> {
   @override
@@ -12858,30 +12816,31 @@ class _$ChatGetObjectsSharedInRoomResponseApplicationJsonSerializer
   }
 }
 
-class _$ChatChatShareObjectToChatHeadersSerializer implements StructuredSerializer<ChatChatShareObjectToChatHeaders> {
+class _$ChatChatGetObjectsSharedInRoomHeadersSerializer
+    implements StructuredSerializer<ChatChatGetObjectsSharedInRoomHeaders> {
   @override
-  final Iterable<Type> types = const [ChatChatShareObjectToChatHeaders, _$ChatChatShareObjectToChatHeaders];
+  final Iterable<Type> types = const [ChatChatGetObjectsSharedInRoomHeaders, _$ChatChatGetObjectsSharedInRoomHeaders];
   @override
-  final String wireName = 'ChatChatShareObjectToChatHeaders';
+  final String wireName = 'ChatChatGetObjectsSharedInRoomHeaders';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, ChatChatShareObjectToChatHeaders object,
+  Iterable<Object?> serialize(Serializers serializers, ChatChatGetObjectsSharedInRoomHeaders object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
-    value = object.xChatLastCommonRead;
+    value = object.xChatLastGiven;
     if (value != null) {
       result
-        ..add('x-chat-last-common-read')
+        ..add('x-chat-last-given')
         ..add(serializers.serialize(value, specifiedType: const FullType(String)));
     }
     return result;
   }
 
   @override
-  ChatChatShareObjectToChatHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+  ChatChatGetObjectsSharedInRoomHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = ChatChatShareObjectToChatHeadersBuilder();
+    final result = ChatChatGetObjectsSharedInRoomHeadersBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -12889,8 +12848,8 @@ class _$ChatChatShareObjectToChatHeadersSerializer implements StructuredSerializ
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'x-chat-last-common-read':
-          result.xChatLastCommonRead = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+        case 'x-chat-last-given':
+          result.xChatLastGiven = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -12988,6 +12947,47 @@ class _$ChatShareObjectToChatResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ChatShareObjectToChatResponseApplicationJson_Ocs))!
               as ChatShareObjectToChatResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ChatChatShareObjectToChatHeadersSerializer implements StructuredSerializer<ChatChatShareObjectToChatHeaders> {
+  @override
+  final Iterable<Type> types = const [ChatChatShareObjectToChatHeaders, _$ChatChatShareObjectToChatHeaders];
+  @override
+  final String wireName = 'ChatChatShareObjectToChatHeaders';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatChatShareObjectToChatHeaders object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.xChatLastCommonRead;
+    if (value != null) {
+      result
+        ..add('x-chat-last-common-read')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ChatChatShareObjectToChatHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatChatShareObjectToChatHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'x-chat-last-common-read':
+          result.xChatLastCommonRead = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -16058,57 +16058,6 @@ class _$RecordingGetWelcomeMessageResponseApplicationJsonSerializer
   }
 }
 
-class _$RoomRoomGetRoomsHeadersSerializer implements StructuredSerializer<RoomRoomGetRoomsHeaders> {
-  @override
-  final Iterable<Type> types = const [RoomRoomGetRoomsHeaders, _$RoomRoomGetRoomsHeaders];
-  @override
-  final String wireName = 'RoomRoomGetRoomsHeaders';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, RoomRoomGetRoomsHeaders object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.xNextcloudTalkHash;
-    if (value != null) {
-      result
-        ..add('x-nextcloud-talk-hash')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    value = object.xNextcloudTalkModifiedBefore;
-    if (value != null) {
-      result
-        ..add('x-nextcloud-talk-modified-before')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    return result;
-  }
-
-  @override
-  RoomRoomGetRoomsHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = RoomRoomGetRoomsHeadersBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'x-nextcloud-talk-hash':
-          result.xNextcloudTalkHash = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-        case 'x-nextcloud-talk-modified-before':
-          result.xNextcloudTalkModifiedBefore =
-              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$RoomGetRoomsResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomGetRoomsResponseApplicationJson_Ocs> {
   @override
@@ -16190,6 +16139,57 @@ class _$RoomGetRoomsResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(RoomGetRoomsResponseApplicationJson_Ocs))!
                   as RoomGetRoomsResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomRoomGetRoomsHeadersSerializer implements StructuredSerializer<RoomRoomGetRoomsHeaders> {
+  @override
+  final Iterable<Type> types = const [RoomRoomGetRoomsHeaders, _$RoomRoomGetRoomsHeaders];
+  @override
+  final String wireName = 'RoomRoomGetRoomsHeaders';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomRoomGetRoomsHeaders object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.xNextcloudTalkHash;
+    if (value != null) {
+      result
+        ..add('x-nextcloud-talk-hash')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.xNextcloudTalkModifiedBefore;
+    if (value != null) {
+      result
+        ..add('x-nextcloud-talk-modified-before')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  RoomRoomGetRoomsHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomRoomGetRoomsHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'x-nextcloud-talk-hash':
+          result.xNextcloudTalkHash = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'x-nextcloud-talk-modified-before':
+          result.xNextcloudTalkModifiedBefore =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -16378,51 +16378,6 @@ class _$RoomGetListedRoomsResponseApplicationJsonSerializer
   }
 }
 
-class _$RoomRoomGetNoteToSelfConversationHeadersSerializer
-    implements StructuredSerializer<RoomRoomGetNoteToSelfConversationHeaders> {
-  @override
-  final Iterable<Type> types = const [
-    RoomRoomGetNoteToSelfConversationHeaders,
-    _$RoomRoomGetNoteToSelfConversationHeaders
-  ];
-  @override
-  final String wireName = 'RoomRoomGetNoteToSelfConversationHeaders';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, RoomRoomGetNoteToSelfConversationHeaders object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.xNextcloudTalkHash;
-    if (value != null) {
-      result
-        ..add('x-nextcloud-talk-hash')
-        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
-    }
-    return result;
-  }
-
-  @override
-  RoomRoomGetNoteToSelfConversationHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = RoomRoomGetNoteToSelfConversationHeadersBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'x-nextcloud-talk-hash':
-          result.xNextcloudTalkHash = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$RoomGetNoteToSelfConversationResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomGetNoteToSelfConversationResponseApplicationJson_Ocs> {
   @override
@@ -16517,14 +16472,18 @@ class _$RoomGetNoteToSelfConversationResponseApplicationJsonSerializer
   }
 }
 
-class _$RoomRoomGetSingleRoomHeadersSerializer implements StructuredSerializer<RoomRoomGetSingleRoomHeaders> {
+class _$RoomRoomGetNoteToSelfConversationHeadersSerializer
+    implements StructuredSerializer<RoomRoomGetNoteToSelfConversationHeaders> {
   @override
-  final Iterable<Type> types = const [RoomRoomGetSingleRoomHeaders, _$RoomRoomGetSingleRoomHeaders];
+  final Iterable<Type> types = const [
+    RoomRoomGetNoteToSelfConversationHeaders,
+    _$RoomRoomGetNoteToSelfConversationHeaders
+  ];
   @override
-  final String wireName = 'RoomRoomGetSingleRoomHeaders';
+  final String wireName = 'RoomRoomGetNoteToSelfConversationHeaders';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, RoomRoomGetSingleRoomHeaders object,
+  Iterable<Object?> serialize(Serializers serializers, RoomRoomGetNoteToSelfConversationHeaders object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
@@ -16538,9 +16497,9 @@ class _$RoomRoomGetSingleRoomHeadersSerializer implements StructuredSerializer<R
   }
 
   @override
-  RoomRoomGetSingleRoomHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+  RoomRoomGetNoteToSelfConversationHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = RoomRoomGetSingleRoomHeadersBuilder();
+    final result = RoomRoomGetNoteToSelfConversationHeadersBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -16641,6 +16600,47 @@ class _$RoomGetSingleRoomResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomGetSingleRoomResponseApplicationJson_Ocs))!
               as RoomGetSingleRoomResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomRoomGetSingleRoomHeadersSerializer implements StructuredSerializer<RoomRoomGetSingleRoomHeaders> {
+  @override
+  final Iterable<Type> types = const [RoomRoomGetSingleRoomHeaders, _$RoomRoomGetSingleRoomHeaders];
+  @override
+  final String wireName = 'RoomRoomGetSingleRoomHeaders';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomRoomGetSingleRoomHeaders object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.xNextcloudTalkHash;
+    if (value != null) {
+      result
+        ..add('x-nextcloud-talk-hash')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  RoomRoomGetSingleRoomHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomRoomGetSingleRoomHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'x-nextcloud-talk-hash':
+          result.xNextcloudTalkHash = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -17539,48 +17539,6 @@ class _$RoomSetPermissionsResponseApplicationJsonSerializer
   }
 }
 
-class _$RoomRoomGetParticipantsHeadersSerializer implements StructuredSerializer<RoomRoomGetParticipantsHeaders> {
-  @override
-  final Iterable<Type> types = const [RoomRoomGetParticipantsHeaders, _$RoomRoomGetParticipantsHeaders];
-  @override
-  final String wireName = 'RoomRoomGetParticipantsHeaders';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, RoomRoomGetParticipantsHeaders object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.xNextcloudHasUserStatuses;
-    if (value != null) {
-      result
-        ..add('x-nextcloud-has-user-statuses')
-        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType(bool)])));
-    }
-    return result;
-  }
-
-  @override
-  RoomRoomGetParticipantsHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = RoomRoomGetParticipantsHeadersBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'x-nextcloud-has-user-statuses':
-          result.xNextcloudHasUserStatuses.replace(
-              serializers.deserialize(value, specifiedType: const FullType(Header, [FullType(bool)]))! as Header<bool>);
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$ParticipantSerializer implements StructuredSerializer<Participant> {
   @override
   final Iterable<Type> types = const [Participant, _$Participant];
@@ -17821,6 +17779,48 @@ class _$RoomGetParticipantsResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomRoomGetParticipantsHeadersSerializer implements StructuredSerializer<RoomRoomGetParticipantsHeaders> {
+  @override
+  final Iterable<Type> types = const [RoomRoomGetParticipantsHeaders, _$RoomRoomGetParticipantsHeaders];
+  @override
+  final String wireName = 'RoomRoomGetParticipantsHeaders';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomRoomGetParticipantsHeaders object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.xNextcloudHasUserStatuses;
+    if (value != null) {
+      result
+        ..add('x-nextcloud-has-user-statuses')
+        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType(bool)])));
+    }
+    return result;
+  }
+
+  @override
+  RoomRoomGetParticipantsHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomRoomGetParticipantsHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'x-nextcloud-has-user-statuses':
+          result.xNextcloudHasUserStatuses.replace(
+              serializers.deserialize(value, specifiedType: const FullType(Header, [FullType(bool)]))! as Header<bool>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Serializer
     implements StructuredSerializer<RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0> {
   @override
@@ -17959,52 +17959,6 @@ class _$RoomAddParticipantToRoomResponseApplicationJsonSerializer
   }
 }
 
-class _$RoomRoomGetBreakoutRoomParticipantsHeadersSerializer
-    implements StructuredSerializer<RoomRoomGetBreakoutRoomParticipantsHeaders> {
-  @override
-  final Iterable<Type> types = const [
-    RoomRoomGetBreakoutRoomParticipantsHeaders,
-    _$RoomRoomGetBreakoutRoomParticipantsHeaders
-  ];
-  @override
-  final String wireName = 'RoomRoomGetBreakoutRoomParticipantsHeaders';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, RoomRoomGetBreakoutRoomParticipantsHeaders object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.xNextcloudHasUserStatuses;
-    if (value != null) {
-      result
-        ..add('x-nextcloud-has-user-statuses')
-        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType(bool)])));
-    }
-    return result;
-  }
-
-  @override
-  RoomRoomGetBreakoutRoomParticipantsHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = RoomRoomGetBreakoutRoomParticipantsHeadersBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'x-nextcloud-has-user-statuses':
-          result.xNextcloudHasUserStatuses.replace(
-              serializers.deserialize(value, specifiedType: const FullType(Header, [FullType(bool)]))! as Header<bool>);
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs> {
   @override
@@ -18093,6 +18047,52 @@ class _$RoomGetBreakoutRoomParticipantsResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs))!
               as RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomRoomGetBreakoutRoomParticipantsHeadersSerializer
+    implements StructuredSerializer<RoomRoomGetBreakoutRoomParticipantsHeaders> {
+  @override
+  final Iterable<Type> types = const [
+    RoomRoomGetBreakoutRoomParticipantsHeaders,
+    _$RoomRoomGetBreakoutRoomParticipantsHeaders
+  ];
+  @override
+  final String wireName = 'RoomRoomGetBreakoutRoomParticipantsHeaders';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomRoomGetBreakoutRoomParticipantsHeaders object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.xNextcloudHasUserStatuses;
+    if (value != null) {
+      result
+        ..add('x-nextcloud-has-user-statuses')
+        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType(bool)])));
+    }
+    return result;
+  }
+
+  @override
+  RoomRoomGetBreakoutRoomParticipantsHeaders deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomRoomGetBreakoutRoomParticipantsHeadersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'x-nextcloud-has-user-statuses':
+          result.xNextcloudHasUserStatuses.replace(
+              serializers.deserialize(value, specifiedType: const FullType(Header, [FullType(bool)]))! as Header<bool>);
           break;
       }
     }
@@ -29648,108 +29648,6 @@ class CertificateGetCertificateExpirationResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $ChatChatReceiveMessagesHeadersInterfaceBuilder {
-  void replace($ChatChatReceiveMessagesHeadersInterface other);
-  void update(void Function($ChatChatReceiveMessagesHeadersInterfaceBuilder) updates);
-  String? get xChatLastCommonRead;
-  set xChatLastCommonRead(String? xChatLastCommonRead);
-
-  String? get xChatLastGiven;
-  set xChatLastGiven(String? xChatLastGiven);
-}
-
-class _$ChatChatReceiveMessagesHeaders extends ChatChatReceiveMessagesHeaders {
-  @override
-  final String? xChatLastCommonRead;
-  @override
-  final String? xChatLastGiven;
-
-  factory _$ChatChatReceiveMessagesHeaders([void Function(ChatChatReceiveMessagesHeadersBuilder)? updates]) =>
-      (ChatChatReceiveMessagesHeadersBuilder()..update(updates))._build();
-
-  _$ChatChatReceiveMessagesHeaders._({this.xChatLastCommonRead, this.xChatLastGiven}) : super._();
-
-  @override
-  ChatChatReceiveMessagesHeaders rebuild(void Function(ChatChatReceiveMessagesHeadersBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  ChatChatReceiveMessagesHeadersBuilder toBuilder() => ChatChatReceiveMessagesHeadersBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is ChatChatReceiveMessagesHeaders &&
-        xChatLastCommonRead == other.xChatLastCommonRead &&
-        xChatLastGiven == other.xChatLastGiven;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, xChatLastCommonRead.hashCode);
-    _$hash = $jc(_$hash, xChatLastGiven.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'ChatChatReceiveMessagesHeaders')
-          ..add('xChatLastCommonRead', xChatLastCommonRead)
-          ..add('xChatLastGiven', xChatLastGiven))
-        .toString();
-  }
-}
-
-class ChatChatReceiveMessagesHeadersBuilder
-    implements
-        Builder<ChatChatReceiveMessagesHeaders, ChatChatReceiveMessagesHeadersBuilder>,
-        $ChatChatReceiveMessagesHeadersInterfaceBuilder {
-  _$ChatChatReceiveMessagesHeaders? _$v;
-
-  String? _xChatLastCommonRead;
-  String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
-  set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
-
-  String? _xChatLastGiven;
-  String? get xChatLastGiven => _$this._xChatLastGiven;
-  set xChatLastGiven(covariant String? xChatLastGiven) => _$this._xChatLastGiven = xChatLastGiven;
-
-  ChatChatReceiveMessagesHeadersBuilder();
-
-  ChatChatReceiveMessagesHeadersBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _xChatLastCommonRead = $v.xChatLastCommonRead;
-      _xChatLastGiven = $v.xChatLastGiven;
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant ChatChatReceiveMessagesHeaders other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ChatChatReceiveMessagesHeaders;
-  }
-
-  @override
-  void update(void Function(ChatChatReceiveMessagesHeadersBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  ChatChatReceiveMessagesHeaders build() => _build();
-
-  _$ChatChatReceiveMessagesHeaders _build() {
-    final _$result = _$v ??
-        _$ChatChatReceiveMessagesHeaders._(xChatLastCommonRead: xChatLastCommonRead, xChatLastGiven: xChatLastGiven);
-    replace(_$result);
-    return _$result;
-  }
-}
-
 abstract mixin class $ChatMessageWithParentInterfaceBuilder implements $ChatMessageInterfaceBuilder {
   void replace(covariant $ChatMessageWithParentInterface other);
   void update(void Function($ChatMessageWithParentInterfaceBuilder) updates);
@@ -30341,87 +30239,103 @@ class ChatReceiveMessagesResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $ChatChatSendMessageHeadersInterfaceBuilder {
-  void replace($ChatChatSendMessageHeadersInterface other);
-  void update(void Function($ChatChatSendMessageHeadersInterfaceBuilder) updates);
+abstract mixin class $ChatChatReceiveMessagesHeadersInterfaceBuilder {
+  void replace($ChatChatReceiveMessagesHeadersInterface other);
+  void update(void Function($ChatChatReceiveMessagesHeadersInterfaceBuilder) updates);
   String? get xChatLastCommonRead;
   set xChatLastCommonRead(String? xChatLastCommonRead);
+
+  String? get xChatLastGiven;
+  set xChatLastGiven(String? xChatLastGiven);
 }
 
-class _$ChatChatSendMessageHeaders extends ChatChatSendMessageHeaders {
+class _$ChatChatReceiveMessagesHeaders extends ChatChatReceiveMessagesHeaders {
   @override
   final String? xChatLastCommonRead;
+  @override
+  final String? xChatLastGiven;
 
-  factory _$ChatChatSendMessageHeaders([void Function(ChatChatSendMessageHeadersBuilder)? updates]) =>
-      (ChatChatSendMessageHeadersBuilder()..update(updates))._build();
+  factory _$ChatChatReceiveMessagesHeaders([void Function(ChatChatReceiveMessagesHeadersBuilder)? updates]) =>
+      (ChatChatReceiveMessagesHeadersBuilder()..update(updates))._build();
 
-  _$ChatChatSendMessageHeaders._({this.xChatLastCommonRead}) : super._();
+  _$ChatChatReceiveMessagesHeaders._({this.xChatLastCommonRead, this.xChatLastGiven}) : super._();
 
   @override
-  ChatChatSendMessageHeaders rebuild(void Function(ChatChatSendMessageHeadersBuilder) updates) =>
+  ChatChatReceiveMessagesHeaders rebuild(void Function(ChatChatReceiveMessagesHeadersBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ChatChatSendMessageHeadersBuilder toBuilder() => ChatChatSendMessageHeadersBuilder()..replace(this);
+  ChatChatReceiveMessagesHeadersBuilder toBuilder() => ChatChatReceiveMessagesHeadersBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ChatChatSendMessageHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
+    return other is ChatChatReceiveMessagesHeaders &&
+        xChatLastCommonRead == other.xChatLastCommonRead &&
+        xChatLastGiven == other.xChatLastGiven;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, xChatLastCommonRead.hashCode);
+    _$hash = $jc(_$hash, xChatLastGiven.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ChatChatSendMessageHeaders')..add('xChatLastCommonRead', xChatLastCommonRead))
+    return (newBuiltValueToStringHelper(r'ChatChatReceiveMessagesHeaders')
+          ..add('xChatLastCommonRead', xChatLastCommonRead)
+          ..add('xChatLastGiven', xChatLastGiven))
         .toString();
   }
 }
 
-class ChatChatSendMessageHeadersBuilder
+class ChatChatReceiveMessagesHeadersBuilder
     implements
-        Builder<ChatChatSendMessageHeaders, ChatChatSendMessageHeadersBuilder>,
-        $ChatChatSendMessageHeadersInterfaceBuilder {
-  _$ChatChatSendMessageHeaders? _$v;
+        Builder<ChatChatReceiveMessagesHeaders, ChatChatReceiveMessagesHeadersBuilder>,
+        $ChatChatReceiveMessagesHeadersInterfaceBuilder {
+  _$ChatChatReceiveMessagesHeaders? _$v;
 
   String? _xChatLastCommonRead;
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  ChatChatSendMessageHeadersBuilder();
+  String? _xChatLastGiven;
+  String? get xChatLastGiven => _$this._xChatLastGiven;
+  set xChatLastGiven(covariant String? xChatLastGiven) => _$this._xChatLastGiven = xChatLastGiven;
 
-  ChatChatSendMessageHeadersBuilder get _$this {
+  ChatChatReceiveMessagesHeadersBuilder();
+
+  ChatChatReceiveMessagesHeadersBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _xChatLastCommonRead = $v.xChatLastCommonRead;
+      _xChatLastGiven = $v.xChatLastGiven;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(covariant ChatChatSendMessageHeaders other) {
+  void replace(covariant ChatChatReceiveMessagesHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ChatChatSendMessageHeaders;
+    _$v = other as _$ChatChatReceiveMessagesHeaders;
   }
 
   @override
-  void update(void Function(ChatChatSendMessageHeadersBuilder)? updates) {
+  void update(void Function(ChatChatReceiveMessagesHeadersBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ChatChatSendMessageHeaders build() => _build();
+  ChatChatReceiveMessagesHeaders build() => _build();
 
-  _$ChatChatSendMessageHeaders _build() {
-    final _$result = _$v ?? _$ChatChatSendMessageHeaders._(xChatLastCommonRead: xChatLastCommonRead);
+  _$ChatChatReceiveMessagesHeaders _build() {
+    final _$result = _$v ??
+        _$ChatChatReceiveMessagesHeaders._(xChatLastCommonRead: xChatLastCommonRead, xChatLastGiven: xChatLastGiven);
     replace(_$result);
     return _$result;
   }
@@ -30648,33 +30562,33 @@ class ChatSendMessageResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $ChatChatClearHistoryHeadersInterfaceBuilder {
-  void replace($ChatChatClearHistoryHeadersInterface other);
-  void update(void Function($ChatChatClearHistoryHeadersInterfaceBuilder) updates);
+abstract mixin class $ChatChatSendMessageHeadersInterfaceBuilder {
+  void replace($ChatChatSendMessageHeadersInterface other);
+  void update(void Function($ChatChatSendMessageHeadersInterfaceBuilder) updates);
   String? get xChatLastCommonRead;
   set xChatLastCommonRead(String? xChatLastCommonRead);
 }
 
-class _$ChatChatClearHistoryHeaders extends ChatChatClearHistoryHeaders {
+class _$ChatChatSendMessageHeaders extends ChatChatSendMessageHeaders {
   @override
   final String? xChatLastCommonRead;
 
-  factory _$ChatChatClearHistoryHeaders([void Function(ChatChatClearHistoryHeadersBuilder)? updates]) =>
-      (ChatChatClearHistoryHeadersBuilder()..update(updates))._build();
+  factory _$ChatChatSendMessageHeaders([void Function(ChatChatSendMessageHeadersBuilder)? updates]) =>
+      (ChatChatSendMessageHeadersBuilder()..update(updates))._build();
 
-  _$ChatChatClearHistoryHeaders._({this.xChatLastCommonRead}) : super._();
+  _$ChatChatSendMessageHeaders._({this.xChatLastCommonRead}) : super._();
 
   @override
-  ChatChatClearHistoryHeaders rebuild(void Function(ChatChatClearHistoryHeadersBuilder) updates) =>
+  ChatChatSendMessageHeaders rebuild(void Function(ChatChatSendMessageHeadersBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ChatChatClearHistoryHeadersBuilder toBuilder() => ChatChatClearHistoryHeadersBuilder()..replace(this);
+  ChatChatSendMessageHeadersBuilder toBuilder() => ChatChatSendMessageHeadersBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ChatChatClearHistoryHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
+    return other is ChatChatSendMessageHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
   }
 
   @override
@@ -30687,25 +30601,24 @@ class _$ChatChatClearHistoryHeaders extends ChatChatClearHistoryHeaders {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ChatChatClearHistoryHeaders')
-          ..add('xChatLastCommonRead', xChatLastCommonRead))
+    return (newBuiltValueToStringHelper(r'ChatChatSendMessageHeaders')..add('xChatLastCommonRead', xChatLastCommonRead))
         .toString();
   }
 }
 
-class ChatChatClearHistoryHeadersBuilder
+class ChatChatSendMessageHeadersBuilder
     implements
-        Builder<ChatChatClearHistoryHeaders, ChatChatClearHistoryHeadersBuilder>,
-        $ChatChatClearHistoryHeadersInterfaceBuilder {
-  _$ChatChatClearHistoryHeaders? _$v;
+        Builder<ChatChatSendMessageHeaders, ChatChatSendMessageHeadersBuilder>,
+        $ChatChatSendMessageHeadersInterfaceBuilder {
+  _$ChatChatSendMessageHeaders? _$v;
 
   String? _xChatLastCommonRead;
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  ChatChatClearHistoryHeadersBuilder();
+  ChatChatSendMessageHeadersBuilder();
 
-  ChatChatClearHistoryHeadersBuilder get _$this {
+  ChatChatSendMessageHeadersBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _xChatLastCommonRead = $v.xChatLastCommonRead;
@@ -30715,21 +30628,21 @@ class ChatChatClearHistoryHeadersBuilder
   }
 
   @override
-  void replace(covariant ChatChatClearHistoryHeaders other) {
+  void replace(covariant ChatChatSendMessageHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ChatChatClearHistoryHeaders;
+    _$v = other as _$ChatChatSendMessageHeaders;
   }
 
   @override
-  void update(void Function(ChatChatClearHistoryHeadersBuilder)? updates) {
+  void update(void Function(ChatChatSendMessageHeadersBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ChatChatClearHistoryHeaders build() => _build();
+  ChatChatSendMessageHeaders build() => _build();
 
-  _$ChatChatClearHistoryHeaders _build() {
-    final _$result = _$v ?? _$ChatChatClearHistoryHeaders._(xChatLastCommonRead: xChatLastCommonRead);
+  _$ChatChatSendMessageHeaders _build() {
+    final _$result = _$v ?? _$ChatChatSendMessageHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
   }
@@ -30957,33 +30870,33 @@ class ChatClearHistoryResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $ChatChatDeleteMessageHeadersInterfaceBuilder {
-  void replace($ChatChatDeleteMessageHeadersInterface other);
-  void update(void Function($ChatChatDeleteMessageHeadersInterfaceBuilder) updates);
+abstract mixin class $ChatChatClearHistoryHeadersInterfaceBuilder {
+  void replace($ChatChatClearHistoryHeadersInterface other);
+  void update(void Function($ChatChatClearHistoryHeadersInterfaceBuilder) updates);
   String? get xChatLastCommonRead;
   set xChatLastCommonRead(String? xChatLastCommonRead);
 }
 
-class _$ChatChatDeleteMessageHeaders extends ChatChatDeleteMessageHeaders {
+class _$ChatChatClearHistoryHeaders extends ChatChatClearHistoryHeaders {
   @override
   final String? xChatLastCommonRead;
 
-  factory _$ChatChatDeleteMessageHeaders([void Function(ChatChatDeleteMessageHeadersBuilder)? updates]) =>
-      (ChatChatDeleteMessageHeadersBuilder()..update(updates))._build();
+  factory _$ChatChatClearHistoryHeaders([void Function(ChatChatClearHistoryHeadersBuilder)? updates]) =>
+      (ChatChatClearHistoryHeadersBuilder()..update(updates))._build();
 
-  _$ChatChatDeleteMessageHeaders._({this.xChatLastCommonRead}) : super._();
+  _$ChatChatClearHistoryHeaders._({this.xChatLastCommonRead}) : super._();
 
   @override
-  ChatChatDeleteMessageHeaders rebuild(void Function(ChatChatDeleteMessageHeadersBuilder) updates) =>
+  ChatChatClearHistoryHeaders rebuild(void Function(ChatChatClearHistoryHeadersBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ChatChatDeleteMessageHeadersBuilder toBuilder() => ChatChatDeleteMessageHeadersBuilder()..replace(this);
+  ChatChatClearHistoryHeadersBuilder toBuilder() => ChatChatClearHistoryHeadersBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ChatChatDeleteMessageHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
+    return other is ChatChatClearHistoryHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
   }
 
   @override
@@ -30996,25 +30909,25 @@ class _$ChatChatDeleteMessageHeaders extends ChatChatDeleteMessageHeaders {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ChatChatDeleteMessageHeaders')
+    return (newBuiltValueToStringHelper(r'ChatChatClearHistoryHeaders')
           ..add('xChatLastCommonRead', xChatLastCommonRead))
         .toString();
   }
 }
 
-class ChatChatDeleteMessageHeadersBuilder
+class ChatChatClearHistoryHeadersBuilder
     implements
-        Builder<ChatChatDeleteMessageHeaders, ChatChatDeleteMessageHeadersBuilder>,
-        $ChatChatDeleteMessageHeadersInterfaceBuilder {
-  _$ChatChatDeleteMessageHeaders? _$v;
+        Builder<ChatChatClearHistoryHeaders, ChatChatClearHistoryHeadersBuilder>,
+        $ChatChatClearHistoryHeadersInterfaceBuilder {
+  _$ChatChatClearHistoryHeaders? _$v;
 
   String? _xChatLastCommonRead;
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  ChatChatDeleteMessageHeadersBuilder();
+  ChatChatClearHistoryHeadersBuilder();
 
-  ChatChatDeleteMessageHeadersBuilder get _$this {
+  ChatChatClearHistoryHeadersBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _xChatLastCommonRead = $v.xChatLastCommonRead;
@@ -31024,21 +30937,21 @@ class ChatChatDeleteMessageHeadersBuilder
   }
 
   @override
-  void replace(covariant ChatChatDeleteMessageHeaders other) {
+  void replace(covariant ChatChatClearHistoryHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ChatChatDeleteMessageHeaders;
+    _$v = other as _$ChatChatClearHistoryHeaders;
   }
 
   @override
-  void update(void Function(ChatChatDeleteMessageHeadersBuilder)? updates) {
+  void update(void Function(ChatChatClearHistoryHeadersBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ChatChatDeleteMessageHeaders build() => _build();
+  ChatChatClearHistoryHeaders build() => _build();
 
-  _$ChatChatDeleteMessageHeaders _build() {
-    final _$result = _$v ?? _$ChatChatDeleteMessageHeaders._(xChatLastCommonRead: xChatLastCommonRead);
+  _$ChatChatClearHistoryHeaders _build() {
+    final _$result = _$v ?? _$ChatChatClearHistoryHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
   }
@@ -31266,103 +31179,88 @@ class ChatDeleteMessageResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $ChatChatGetMessageContextHeadersInterfaceBuilder {
-  void replace($ChatChatGetMessageContextHeadersInterface other);
-  void update(void Function($ChatChatGetMessageContextHeadersInterfaceBuilder) updates);
+abstract mixin class $ChatChatDeleteMessageHeadersInterfaceBuilder {
+  void replace($ChatChatDeleteMessageHeadersInterface other);
+  void update(void Function($ChatChatDeleteMessageHeadersInterfaceBuilder) updates);
   String? get xChatLastCommonRead;
   set xChatLastCommonRead(String? xChatLastCommonRead);
-
-  String? get xChatLastGiven;
-  set xChatLastGiven(String? xChatLastGiven);
 }
 
-class _$ChatChatGetMessageContextHeaders extends ChatChatGetMessageContextHeaders {
+class _$ChatChatDeleteMessageHeaders extends ChatChatDeleteMessageHeaders {
   @override
   final String? xChatLastCommonRead;
-  @override
-  final String? xChatLastGiven;
 
-  factory _$ChatChatGetMessageContextHeaders([void Function(ChatChatGetMessageContextHeadersBuilder)? updates]) =>
-      (ChatChatGetMessageContextHeadersBuilder()..update(updates))._build();
+  factory _$ChatChatDeleteMessageHeaders([void Function(ChatChatDeleteMessageHeadersBuilder)? updates]) =>
+      (ChatChatDeleteMessageHeadersBuilder()..update(updates))._build();
 
-  _$ChatChatGetMessageContextHeaders._({this.xChatLastCommonRead, this.xChatLastGiven}) : super._();
+  _$ChatChatDeleteMessageHeaders._({this.xChatLastCommonRead}) : super._();
 
   @override
-  ChatChatGetMessageContextHeaders rebuild(void Function(ChatChatGetMessageContextHeadersBuilder) updates) =>
+  ChatChatDeleteMessageHeaders rebuild(void Function(ChatChatDeleteMessageHeadersBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ChatChatGetMessageContextHeadersBuilder toBuilder() => ChatChatGetMessageContextHeadersBuilder()..replace(this);
+  ChatChatDeleteMessageHeadersBuilder toBuilder() => ChatChatDeleteMessageHeadersBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ChatChatGetMessageContextHeaders &&
-        xChatLastCommonRead == other.xChatLastCommonRead &&
-        xChatLastGiven == other.xChatLastGiven;
+    return other is ChatChatDeleteMessageHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, xChatLastCommonRead.hashCode);
-    _$hash = $jc(_$hash, xChatLastGiven.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ChatChatGetMessageContextHeaders')
-          ..add('xChatLastCommonRead', xChatLastCommonRead)
-          ..add('xChatLastGiven', xChatLastGiven))
+    return (newBuiltValueToStringHelper(r'ChatChatDeleteMessageHeaders')
+          ..add('xChatLastCommonRead', xChatLastCommonRead))
         .toString();
   }
 }
 
-class ChatChatGetMessageContextHeadersBuilder
+class ChatChatDeleteMessageHeadersBuilder
     implements
-        Builder<ChatChatGetMessageContextHeaders, ChatChatGetMessageContextHeadersBuilder>,
-        $ChatChatGetMessageContextHeadersInterfaceBuilder {
-  _$ChatChatGetMessageContextHeaders? _$v;
+        Builder<ChatChatDeleteMessageHeaders, ChatChatDeleteMessageHeadersBuilder>,
+        $ChatChatDeleteMessageHeadersInterfaceBuilder {
+  _$ChatChatDeleteMessageHeaders? _$v;
 
   String? _xChatLastCommonRead;
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  String? _xChatLastGiven;
-  String? get xChatLastGiven => _$this._xChatLastGiven;
-  set xChatLastGiven(covariant String? xChatLastGiven) => _$this._xChatLastGiven = xChatLastGiven;
+  ChatChatDeleteMessageHeadersBuilder();
 
-  ChatChatGetMessageContextHeadersBuilder();
-
-  ChatChatGetMessageContextHeadersBuilder get _$this {
+  ChatChatDeleteMessageHeadersBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _xChatLastCommonRead = $v.xChatLastCommonRead;
-      _xChatLastGiven = $v.xChatLastGiven;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(covariant ChatChatGetMessageContextHeaders other) {
+  void replace(covariant ChatChatDeleteMessageHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ChatChatGetMessageContextHeaders;
+    _$v = other as _$ChatChatDeleteMessageHeaders;
   }
 
   @override
-  void update(void Function(ChatChatGetMessageContextHeadersBuilder)? updates) {
+  void update(void Function(ChatChatDeleteMessageHeadersBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ChatChatGetMessageContextHeaders build() => _build();
+  ChatChatDeleteMessageHeaders build() => _build();
 
-  _$ChatChatGetMessageContextHeaders _build() {
-    final _$result = _$v ??
-        _$ChatChatGetMessageContextHeaders._(xChatLastCommonRead: xChatLastCommonRead, xChatLastGiven: xChatLastGiven);
+  _$ChatChatDeleteMessageHeaders _build() {
+    final _$result = _$v ?? _$ChatChatDeleteMessageHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
   }
@@ -31587,6 +31485,108 @@ class ChatGetMessageContextResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ChatChatGetMessageContextHeadersInterfaceBuilder {
+  void replace($ChatChatGetMessageContextHeadersInterface other);
+  void update(void Function($ChatChatGetMessageContextHeadersInterfaceBuilder) updates);
+  String? get xChatLastCommonRead;
+  set xChatLastCommonRead(String? xChatLastCommonRead);
+
+  String? get xChatLastGiven;
+  set xChatLastGiven(String? xChatLastGiven);
+}
+
+class _$ChatChatGetMessageContextHeaders extends ChatChatGetMessageContextHeaders {
+  @override
+  final String? xChatLastCommonRead;
+  @override
+  final String? xChatLastGiven;
+
+  factory _$ChatChatGetMessageContextHeaders([void Function(ChatChatGetMessageContextHeadersBuilder)? updates]) =>
+      (ChatChatGetMessageContextHeadersBuilder()..update(updates))._build();
+
+  _$ChatChatGetMessageContextHeaders._({this.xChatLastCommonRead, this.xChatLastGiven}) : super._();
+
+  @override
+  ChatChatGetMessageContextHeaders rebuild(void Function(ChatChatGetMessageContextHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatChatGetMessageContextHeadersBuilder toBuilder() => ChatChatGetMessageContextHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatChatGetMessageContextHeaders &&
+        xChatLastCommonRead == other.xChatLastCommonRead &&
+        xChatLastGiven == other.xChatLastGiven;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, xChatLastCommonRead.hashCode);
+    _$hash = $jc(_$hash, xChatLastGiven.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatChatGetMessageContextHeaders')
+          ..add('xChatLastCommonRead', xChatLastCommonRead)
+          ..add('xChatLastGiven', xChatLastGiven))
+        .toString();
+  }
+}
+
+class ChatChatGetMessageContextHeadersBuilder
+    implements
+        Builder<ChatChatGetMessageContextHeaders, ChatChatGetMessageContextHeadersBuilder>,
+        $ChatChatGetMessageContextHeadersInterfaceBuilder {
+  _$ChatChatGetMessageContextHeaders? _$v;
+
+  String? _xChatLastCommonRead;
+  String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
+  set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
+
+  String? _xChatLastGiven;
+  String? get xChatLastGiven => _$this._xChatLastGiven;
+  set xChatLastGiven(covariant String? xChatLastGiven) => _$this._xChatLastGiven = xChatLastGiven;
+
+  ChatChatGetMessageContextHeadersBuilder();
+
+  ChatChatGetMessageContextHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _xChatLastCommonRead = $v.xChatLastCommonRead;
+      _xChatLastGiven = $v.xChatLastGiven;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatChatGetMessageContextHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatChatGetMessageContextHeaders;
+  }
+
+  @override
+  void update(void Function(ChatChatGetMessageContextHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatChatGetMessageContextHeaders build() => _build();
+
+  _$ChatChatGetMessageContextHeaders _build() {
+    final _$result = _$v ??
+        _$ChatChatGetMessageContextHeaders._(xChatLastCommonRead: xChatLastCommonRead, xChatLastGiven: xChatLastGiven);
     replace(_$result);
     return _$result;
   }
@@ -32394,93 +32394,6 @@ class ChatDeleteReminderResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $ChatChatSetReadMarkerHeadersInterfaceBuilder {
-  void replace($ChatChatSetReadMarkerHeadersInterface other);
-  void update(void Function($ChatChatSetReadMarkerHeadersInterfaceBuilder) updates);
-  String? get xChatLastCommonRead;
-  set xChatLastCommonRead(String? xChatLastCommonRead);
-}
-
-class _$ChatChatSetReadMarkerHeaders extends ChatChatSetReadMarkerHeaders {
-  @override
-  final String? xChatLastCommonRead;
-
-  factory _$ChatChatSetReadMarkerHeaders([void Function(ChatChatSetReadMarkerHeadersBuilder)? updates]) =>
-      (ChatChatSetReadMarkerHeadersBuilder()..update(updates))._build();
-
-  _$ChatChatSetReadMarkerHeaders._({this.xChatLastCommonRead}) : super._();
-
-  @override
-  ChatChatSetReadMarkerHeaders rebuild(void Function(ChatChatSetReadMarkerHeadersBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  ChatChatSetReadMarkerHeadersBuilder toBuilder() => ChatChatSetReadMarkerHeadersBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is ChatChatSetReadMarkerHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, xChatLastCommonRead.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'ChatChatSetReadMarkerHeaders')
-          ..add('xChatLastCommonRead', xChatLastCommonRead))
-        .toString();
-  }
-}
-
-class ChatChatSetReadMarkerHeadersBuilder
-    implements
-        Builder<ChatChatSetReadMarkerHeaders, ChatChatSetReadMarkerHeadersBuilder>,
-        $ChatChatSetReadMarkerHeadersInterfaceBuilder {
-  _$ChatChatSetReadMarkerHeaders? _$v;
-
-  String? _xChatLastCommonRead;
-  String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
-  set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
-
-  ChatChatSetReadMarkerHeadersBuilder();
-
-  ChatChatSetReadMarkerHeadersBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _xChatLastCommonRead = $v.xChatLastCommonRead;
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant ChatChatSetReadMarkerHeaders other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ChatChatSetReadMarkerHeaders;
-  }
-
-  @override
-  void update(void Function(ChatChatSetReadMarkerHeadersBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  ChatChatSetReadMarkerHeaders build() => _build();
-
-  _$ChatChatSetReadMarkerHeaders _build() {
-    final _$result = _$v ?? _$ChatChatSetReadMarkerHeaders._(xChatLastCommonRead: xChatLastCommonRead);
-    replace(_$result);
-    return _$result;
-  }
-}
-
 abstract mixin class $ChatSetReadMarkerResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ChatSetReadMarkerResponseApplicationJson_OcsInterface other);
   void update(void Function($ChatSetReadMarkerResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -32705,33 +32618,33 @@ class ChatSetReadMarkerResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $ChatChatMarkUnreadHeadersInterfaceBuilder {
-  void replace($ChatChatMarkUnreadHeadersInterface other);
-  void update(void Function($ChatChatMarkUnreadHeadersInterfaceBuilder) updates);
+abstract mixin class $ChatChatSetReadMarkerHeadersInterfaceBuilder {
+  void replace($ChatChatSetReadMarkerHeadersInterface other);
+  void update(void Function($ChatChatSetReadMarkerHeadersInterfaceBuilder) updates);
   String? get xChatLastCommonRead;
   set xChatLastCommonRead(String? xChatLastCommonRead);
 }
 
-class _$ChatChatMarkUnreadHeaders extends ChatChatMarkUnreadHeaders {
+class _$ChatChatSetReadMarkerHeaders extends ChatChatSetReadMarkerHeaders {
   @override
   final String? xChatLastCommonRead;
 
-  factory _$ChatChatMarkUnreadHeaders([void Function(ChatChatMarkUnreadHeadersBuilder)? updates]) =>
-      (ChatChatMarkUnreadHeadersBuilder()..update(updates))._build();
+  factory _$ChatChatSetReadMarkerHeaders([void Function(ChatChatSetReadMarkerHeadersBuilder)? updates]) =>
+      (ChatChatSetReadMarkerHeadersBuilder()..update(updates))._build();
 
-  _$ChatChatMarkUnreadHeaders._({this.xChatLastCommonRead}) : super._();
+  _$ChatChatSetReadMarkerHeaders._({this.xChatLastCommonRead}) : super._();
 
   @override
-  ChatChatMarkUnreadHeaders rebuild(void Function(ChatChatMarkUnreadHeadersBuilder) updates) =>
+  ChatChatSetReadMarkerHeaders rebuild(void Function(ChatChatSetReadMarkerHeadersBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ChatChatMarkUnreadHeadersBuilder toBuilder() => ChatChatMarkUnreadHeadersBuilder()..replace(this);
+  ChatChatSetReadMarkerHeadersBuilder toBuilder() => ChatChatSetReadMarkerHeadersBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ChatChatMarkUnreadHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
+    return other is ChatChatSetReadMarkerHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
   }
 
   @override
@@ -32744,24 +32657,25 @@ class _$ChatChatMarkUnreadHeaders extends ChatChatMarkUnreadHeaders {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ChatChatMarkUnreadHeaders')..add('xChatLastCommonRead', xChatLastCommonRead))
+    return (newBuiltValueToStringHelper(r'ChatChatSetReadMarkerHeaders')
+          ..add('xChatLastCommonRead', xChatLastCommonRead))
         .toString();
   }
 }
 
-class ChatChatMarkUnreadHeadersBuilder
+class ChatChatSetReadMarkerHeadersBuilder
     implements
-        Builder<ChatChatMarkUnreadHeaders, ChatChatMarkUnreadHeadersBuilder>,
-        $ChatChatMarkUnreadHeadersInterfaceBuilder {
-  _$ChatChatMarkUnreadHeaders? _$v;
+        Builder<ChatChatSetReadMarkerHeaders, ChatChatSetReadMarkerHeadersBuilder>,
+        $ChatChatSetReadMarkerHeadersInterfaceBuilder {
+  _$ChatChatSetReadMarkerHeaders? _$v;
 
   String? _xChatLastCommonRead;
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  ChatChatMarkUnreadHeadersBuilder();
+  ChatChatSetReadMarkerHeadersBuilder();
 
-  ChatChatMarkUnreadHeadersBuilder get _$this {
+  ChatChatSetReadMarkerHeadersBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _xChatLastCommonRead = $v.xChatLastCommonRead;
@@ -32771,21 +32685,21 @@ class ChatChatMarkUnreadHeadersBuilder
   }
 
   @override
-  void replace(covariant ChatChatMarkUnreadHeaders other) {
+  void replace(covariant ChatChatSetReadMarkerHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ChatChatMarkUnreadHeaders;
+    _$v = other as _$ChatChatSetReadMarkerHeaders;
   }
 
   @override
-  void update(void Function(ChatChatMarkUnreadHeadersBuilder)? updates) {
+  void update(void Function(ChatChatSetReadMarkerHeadersBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ChatChatMarkUnreadHeaders build() => _build();
+  ChatChatSetReadMarkerHeaders build() => _build();
 
-  _$ChatChatMarkUnreadHeaders _build() {
-    final _$result = _$v ?? _$ChatChatMarkUnreadHeaders._(xChatLastCommonRead: xChatLastCommonRead);
+  _$ChatChatSetReadMarkerHeaders _build() {
+    final _$result = _$v ?? _$ChatChatSetReadMarkerHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
   }
@@ -33008,6 +32922,92 @@ class ChatMarkUnreadResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ChatChatMarkUnreadHeadersInterfaceBuilder {
+  void replace($ChatChatMarkUnreadHeadersInterface other);
+  void update(void Function($ChatChatMarkUnreadHeadersInterfaceBuilder) updates);
+  String? get xChatLastCommonRead;
+  set xChatLastCommonRead(String? xChatLastCommonRead);
+}
+
+class _$ChatChatMarkUnreadHeaders extends ChatChatMarkUnreadHeaders {
+  @override
+  final String? xChatLastCommonRead;
+
+  factory _$ChatChatMarkUnreadHeaders([void Function(ChatChatMarkUnreadHeadersBuilder)? updates]) =>
+      (ChatChatMarkUnreadHeadersBuilder()..update(updates))._build();
+
+  _$ChatChatMarkUnreadHeaders._({this.xChatLastCommonRead}) : super._();
+
+  @override
+  ChatChatMarkUnreadHeaders rebuild(void Function(ChatChatMarkUnreadHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatChatMarkUnreadHeadersBuilder toBuilder() => ChatChatMarkUnreadHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatChatMarkUnreadHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, xChatLastCommonRead.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatChatMarkUnreadHeaders')..add('xChatLastCommonRead', xChatLastCommonRead))
+        .toString();
+  }
+}
+
+class ChatChatMarkUnreadHeadersBuilder
+    implements
+        Builder<ChatChatMarkUnreadHeaders, ChatChatMarkUnreadHeadersBuilder>,
+        $ChatChatMarkUnreadHeadersInterfaceBuilder {
+  _$ChatChatMarkUnreadHeaders? _$v;
+
+  String? _xChatLastCommonRead;
+  String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
+  set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
+
+  ChatChatMarkUnreadHeadersBuilder();
+
+  ChatChatMarkUnreadHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _xChatLastCommonRead = $v.xChatLastCommonRead;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatChatMarkUnreadHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatChatMarkUnreadHeaders;
+  }
+
+  @override
+  void update(void Function(ChatChatMarkUnreadHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatChatMarkUnreadHeaders build() => _build();
+
+  _$ChatChatMarkUnreadHeaders _build() {
+    final _$result = _$v ?? _$ChatChatMarkUnreadHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
   }
@@ -33416,95 +33416,6 @@ class ChatMentionsResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder {
-  void replace($ChatChatGetObjectsSharedInRoomHeadersInterface other);
-  void update(void Function($ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder) updates);
-  String? get xChatLastGiven;
-  set xChatLastGiven(String? xChatLastGiven);
-}
-
-class _$ChatChatGetObjectsSharedInRoomHeaders extends ChatChatGetObjectsSharedInRoomHeaders {
-  @override
-  final String? xChatLastGiven;
-
-  factory _$ChatChatGetObjectsSharedInRoomHeaders(
-          [void Function(ChatChatGetObjectsSharedInRoomHeadersBuilder)? updates]) =>
-      (ChatChatGetObjectsSharedInRoomHeadersBuilder()..update(updates))._build();
-
-  _$ChatChatGetObjectsSharedInRoomHeaders._({this.xChatLastGiven}) : super._();
-
-  @override
-  ChatChatGetObjectsSharedInRoomHeaders rebuild(void Function(ChatChatGetObjectsSharedInRoomHeadersBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  ChatChatGetObjectsSharedInRoomHeadersBuilder toBuilder() =>
-      ChatChatGetObjectsSharedInRoomHeadersBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is ChatChatGetObjectsSharedInRoomHeaders && xChatLastGiven == other.xChatLastGiven;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, xChatLastGiven.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'ChatChatGetObjectsSharedInRoomHeaders')
-          ..add('xChatLastGiven', xChatLastGiven))
-        .toString();
-  }
-}
-
-class ChatChatGetObjectsSharedInRoomHeadersBuilder
-    implements
-        Builder<ChatChatGetObjectsSharedInRoomHeaders, ChatChatGetObjectsSharedInRoomHeadersBuilder>,
-        $ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder {
-  _$ChatChatGetObjectsSharedInRoomHeaders? _$v;
-
-  String? _xChatLastGiven;
-  String? get xChatLastGiven => _$this._xChatLastGiven;
-  set xChatLastGiven(covariant String? xChatLastGiven) => _$this._xChatLastGiven = xChatLastGiven;
-
-  ChatChatGetObjectsSharedInRoomHeadersBuilder();
-
-  ChatChatGetObjectsSharedInRoomHeadersBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _xChatLastGiven = $v.xChatLastGiven;
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant ChatChatGetObjectsSharedInRoomHeaders other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ChatChatGetObjectsSharedInRoomHeaders;
-  }
-
-  @override
-  void update(void Function(ChatChatGetObjectsSharedInRoomHeadersBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  ChatChatGetObjectsSharedInRoomHeaders build() => _build();
-
-  _$ChatChatGetObjectsSharedInRoomHeaders _build() {
-    final _$result = _$v ?? _$ChatChatGetObjectsSharedInRoomHeaders._(xChatLastGiven: xChatLastGiven);
-    replace(_$result);
-    return _$result;
-  }
-}
-
 abstract mixin class $ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterface other);
   void update(void Function($ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -33734,88 +33645,90 @@ class ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $ChatChatShareObjectToChatHeadersInterfaceBuilder {
-  void replace($ChatChatShareObjectToChatHeadersInterface other);
-  void update(void Function($ChatChatShareObjectToChatHeadersInterfaceBuilder) updates);
-  String? get xChatLastCommonRead;
-  set xChatLastCommonRead(String? xChatLastCommonRead);
+abstract mixin class $ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder {
+  void replace($ChatChatGetObjectsSharedInRoomHeadersInterface other);
+  void update(void Function($ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder) updates);
+  String? get xChatLastGiven;
+  set xChatLastGiven(String? xChatLastGiven);
 }
 
-class _$ChatChatShareObjectToChatHeaders extends ChatChatShareObjectToChatHeaders {
+class _$ChatChatGetObjectsSharedInRoomHeaders extends ChatChatGetObjectsSharedInRoomHeaders {
   @override
-  final String? xChatLastCommonRead;
+  final String? xChatLastGiven;
 
-  factory _$ChatChatShareObjectToChatHeaders([void Function(ChatChatShareObjectToChatHeadersBuilder)? updates]) =>
-      (ChatChatShareObjectToChatHeadersBuilder()..update(updates))._build();
+  factory _$ChatChatGetObjectsSharedInRoomHeaders(
+          [void Function(ChatChatGetObjectsSharedInRoomHeadersBuilder)? updates]) =>
+      (ChatChatGetObjectsSharedInRoomHeadersBuilder()..update(updates))._build();
 
-  _$ChatChatShareObjectToChatHeaders._({this.xChatLastCommonRead}) : super._();
+  _$ChatChatGetObjectsSharedInRoomHeaders._({this.xChatLastGiven}) : super._();
 
   @override
-  ChatChatShareObjectToChatHeaders rebuild(void Function(ChatChatShareObjectToChatHeadersBuilder) updates) =>
+  ChatChatGetObjectsSharedInRoomHeaders rebuild(void Function(ChatChatGetObjectsSharedInRoomHeadersBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ChatChatShareObjectToChatHeadersBuilder toBuilder() => ChatChatShareObjectToChatHeadersBuilder()..replace(this);
+  ChatChatGetObjectsSharedInRoomHeadersBuilder toBuilder() =>
+      ChatChatGetObjectsSharedInRoomHeadersBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is ChatChatShareObjectToChatHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
+    return other is ChatChatGetObjectsSharedInRoomHeaders && xChatLastGiven == other.xChatLastGiven;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, xChatLastCommonRead.hashCode);
+    _$hash = $jc(_$hash, xChatLastGiven.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ChatChatShareObjectToChatHeaders')
-          ..add('xChatLastCommonRead', xChatLastCommonRead))
+    return (newBuiltValueToStringHelper(r'ChatChatGetObjectsSharedInRoomHeaders')
+          ..add('xChatLastGiven', xChatLastGiven))
         .toString();
   }
 }
 
-class ChatChatShareObjectToChatHeadersBuilder
+class ChatChatGetObjectsSharedInRoomHeadersBuilder
     implements
-        Builder<ChatChatShareObjectToChatHeaders, ChatChatShareObjectToChatHeadersBuilder>,
-        $ChatChatShareObjectToChatHeadersInterfaceBuilder {
-  _$ChatChatShareObjectToChatHeaders? _$v;
+        Builder<ChatChatGetObjectsSharedInRoomHeaders, ChatChatGetObjectsSharedInRoomHeadersBuilder>,
+        $ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder {
+  _$ChatChatGetObjectsSharedInRoomHeaders? _$v;
 
-  String? _xChatLastCommonRead;
-  String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
-  set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
+  String? _xChatLastGiven;
+  String? get xChatLastGiven => _$this._xChatLastGiven;
+  set xChatLastGiven(covariant String? xChatLastGiven) => _$this._xChatLastGiven = xChatLastGiven;
 
-  ChatChatShareObjectToChatHeadersBuilder();
+  ChatChatGetObjectsSharedInRoomHeadersBuilder();
 
-  ChatChatShareObjectToChatHeadersBuilder get _$this {
+  ChatChatGetObjectsSharedInRoomHeadersBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _xChatLastCommonRead = $v.xChatLastCommonRead;
+      _xChatLastGiven = $v.xChatLastGiven;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(covariant ChatChatShareObjectToChatHeaders other) {
+  void replace(covariant ChatChatGetObjectsSharedInRoomHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$ChatChatShareObjectToChatHeaders;
+    _$v = other as _$ChatChatGetObjectsSharedInRoomHeaders;
   }
 
   @override
-  void update(void Function(ChatChatShareObjectToChatHeadersBuilder)? updates) {
+  void update(void Function(ChatChatGetObjectsSharedInRoomHeadersBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  ChatChatShareObjectToChatHeaders build() => _build();
+  ChatChatGetObjectsSharedInRoomHeaders build() => _build();
 
-  _$ChatChatShareObjectToChatHeaders _build() {
-    final _$result = _$v ?? _$ChatChatShareObjectToChatHeaders._(xChatLastCommonRead: xChatLastCommonRead);
+  _$ChatChatGetObjectsSharedInRoomHeaders _build() {
+    final _$result = _$v ?? _$ChatChatGetObjectsSharedInRoomHeaders._(xChatLastGiven: xChatLastGiven);
     replace(_$result);
     return _$result;
   }
@@ -34039,6 +33952,93 @@ class ChatShareObjectToChatResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ChatChatShareObjectToChatHeadersInterfaceBuilder {
+  void replace($ChatChatShareObjectToChatHeadersInterface other);
+  void update(void Function($ChatChatShareObjectToChatHeadersInterfaceBuilder) updates);
+  String? get xChatLastCommonRead;
+  set xChatLastCommonRead(String? xChatLastCommonRead);
+}
+
+class _$ChatChatShareObjectToChatHeaders extends ChatChatShareObjectToChatHeaders {
+  @override
+  final String? xChatLastCommonRead;
+
+  factory _$ChatChatShareObjectToChatHeaders([void Function(ChatChatShareObjectToChatHeadersBuilder)? updates]) =>
+      (ChatChatShareObjectToChatHeadersBuilder()..update(updates))._build();
+
+  _$ChatChatShareObjectToChatHeaders._({this.xChatLastCommonRead}) : super._();
+
+  @override
+  ChatChatShareObjectToChatHeaders rebuild(void Function(ChatChatShareObjectToChatHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatChatShareObjectToChatHeadersBuilder toBuilder() => ChatChatShareObjectToChatHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatChatShareObjectToChatHeaders && xChatLastCommonRead == other.xChatLastCommonRead;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, xChatLastCommonRead.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatChatShareObjectToChatHeaders')
+          ..add('xChatLastCommonRead', xChatLastCommonRead))
+        .toString();
+  }
+}
+
+class ChatChatShareObjectToChatHeadersBuilder
+    implements
+        Builder<ChatChatShareObjectToChatHeaders, ChatChatShareObjectToChatHeadersBuilder>,
+        $ChatChatShareObjectToChatHeadersInterfaceBuilder {
+  _$ChatChatShareObjectToChatHeaders? _$v;
+
+  String? _xChatLastCommonRead;
+  String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
+  set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
+
+  ChatChatShareObjectToChatHeadersBuilder();
+
+  ChatChatShareObjectToChatHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _xChatLastCommonRead = $v.xChatLastCommonRead;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatChatShareObjectToChatHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatChatShareObjectToChatHeaders;
+  }
+
+  @override
+  void update(void Function(ChatChatShareObjectToChatHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatChatShareObjectToChatHeaders build() => _build();
+
+  _$ChatChatShareObjectToChatHeaders _build() {
+    final _$result = _$v ?? _$ChatChatShareObjectToChatHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
   }
@@ -41512,110 +41512,6 @@ class RecordingGetWelcomeMessageResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $RoomRoomGetRoomsHeadersInterfaceBuilder {
-  void replace($RoomRoomGetRoomsHeadersInterface other);
-  void update(void Function($RoomRoomGetRoomsHeadersInterfaceBuilder) updates);
-  String? get xNextcloudTalkHash;
-  set xNextcloudTalkHash(String? xNextcloudTalkHash);
-
-  String? get xNextcloudTalkModifiedBefore;
-  set xNextcloudTalkModifiedBefore(String? xNextcloudTalkModifiedBefore);
-}
-
-class _$RoomRoomGetRoomsHeaders extends RoomRoomGetRoomsHeaders {
-  @override
-  final String? xNextcloudTalkHash;
-  @override
-  final String? xNextcloudTalkModifiedBefore;
-
-  factory _$RoomRoomGetRoomsHeaders([void Function(RoomRoomGetRoomsHeadersBuilder)? updates]) =>
-      (RoomRoomGetRoomsHeadersBuilder()..update(updates))._build();
-
-  _$RoomRoomGetRoomsHeaders._({this.xNextcloudTalkHash, this.xNextcloudTalkModifiedBefore}) : super._();
-
-  @override
-  RoomRoomGetRoomsHeaders rebuild(void Function(RoomRoomGetRoomsHeadersBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  RoomRoomGetRoomsHeadersBuilder toBuilder() => RoomRoomGetRoomsHeadersBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is RoomRoomGetRoomsHeaders &&
-        xNextcloudTalkHash == other.xNextcloudTalkHash &&
-        xNextcloudTalkModifiedBefore == other.xNextcloudTalkModifiedBefore;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, xNextcloudTalkHash.hashCode);
-    _$hash = $jc(_$hash, xNextcloudTalkModifiedBefore.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'RoomRoomGetRoomsHeaders')
-          ..add('xNextcloudTalkHash', xNextcloudTalkHash)
-          ..add('xNextcloudTalkModifiedBefore', xNextcloudTalkModifiedBefore))
-        .toString();
-  }
-}
-
-class RoomRoomGetRoomsHeadersBuilder
-    implements
-        Builder<RoomRoomGetRoomsHeaders, RoomRoomGetRoomsHeadersBuilder>,
-        $RoomRoomGetRoomsHeadersInterfaceBuilder {
-  _$RoomRoomGetRoomsHeaders? _$v;
-
-  String? _xNextcloudTalkHash;
-  String? get xNextcloudTalkHash => _$this._xNextcloudTalkHash;
-  set xNextcloudTalkHash(covariant String? xNextcloudTalkHash) => _$this._xNextcloudTalkHash = xNextcloudTalkHash;
-
-  String? _xNextcloudTalkModifiedBefore;
-  String? get xNextcloudTalkModifiedBefore => _$this._xNextcloudTalkModifiedBefore;
-  set xNextcloudTalkModifiedBefore(covariant String? xNextcloudTalkModifiedBefore) =>
-      _$this._xNextcloudTalkModifiedBefore = xNextcloudTalkModifiedBefore;
-
-  RoomRoomGetRoomsHeadersBuilder();
-
-  RoomRoomGetRoomsHeadersBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _xNextcloudTalkHash = $v.xNextcloudTalkHash;
-      _xNextcloudTalkModifiedBefore = $v.xNextcloudTalkModifiedBefore;
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant RoomRoomGetRoomsHeaders other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$RoomRoomGetRoomsHeaders;
-  }
-
-  @override
-  void update(void Function(RoomRoomGetRoomsHeadersBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  RoomRoomGetRoomsHeaders build() => _build();
-
-  _$RoomRoomGetRoomsHeaders _build() {
-    final _$result = _$v ??
-        _$RoomRoomGetRoomsHeaders._(
-            xNextcloudTalkHash: xNextcloudTalkHash, xNextcloudTalkModifiedBefore: xNextcloudTalkModifiedBefore);
-    replace(_$result);
-    return _$result;
-  }
-}
-
 abstract mixin class $RoomGetRoomsResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomGetRoomsResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomGetRoomsResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -41830,6 +41726,110 @@ class RoomGetRoomsResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomRoomGetRoomsHeadersInterfaceBuilder {
+  void replace($RoomRoomGetRoomsHeadersInterface other);
+  void update(void Function($RoomRoomGetRoomsHeadersInterfaceBuilder) updates);
+  String? get xNextcloudTalkHash;
+  set xNextcloudTalkHash(String? xNextcloudTalkHash);
+
+  String? get xNextcloudTalkModifiedBefore;
+  set xNextcloudTalkModifiedBefore(String? xNextcloudTalkModifiedBefore);
+}
+
+class _$RoomRoomGetRoomsHeaders extends RoomRoomGetRoomsHeaders {
+  @override
+  final String? xNextcloudTalkHash;
+  @override
+  final String? xNextcloudTalkModifiedBefore;
+
+  factory _$RoomRoomGetRoomsHeaders([void Function(RoomRoomGetRoomsHeadersBuilder)? updates]) =>
+      (RoomRoomGetRoomsHeadersBuilder()..update(updates))._build();
+
+  _$RoomRoomGetRoomsHeaders._({this.xNextcloudTalkHash, this.xNextcloudTalkModifiedBefore}) : super._();
+
+  @override
+  RoomRoomGetRoomsHeaders rebuild(void Function(RoomRoomGetRoomsHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomRoomGetRoomsHeadersBuilder toBuilder() => RoomRoomGetRoomsHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomRoomGetRoomsHeaders &&
+        xNextcloudTalkHash == other.xNextcloudTalkHash &&
+        xNextcloudTalkModifiedBefore == other.xNextcloudTalkModifiedBefore;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, xNextcloudTalkHash.hashCode);
+    _$hash = $jc(_$hash, xNextcloudTalkModifiedBefore.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomRoomGetRoomsHeaders')
+          ..add('xNextcloudTalkHash', xNextcloudTalkHash)
+          ..add('xNextcloudTalkModifiedBefore', xNextcloudTalkModifiedBefore))
+        .toString();
+  }
+}
+
+class RoomRoomGetRoomsHeadersBuilder
+    implements
+        Builder<RoomRoomGetRoomsHeaders, RoomRoomGetRoomsHeadersBuilder>,
+        $RoomRoomGetRoomsHeadersInterfaceBuilder {
+  _$RoomRoomGetRoomsHeaders? _$v;
+
+  String? _xNextcloudTalkHash;
+  String? get xNextcloudTalkHash => _$this._xNextcloudTalkHash;
+  set xNextcloudTalkHash(covariant String? xNextcloudTalkHash) => _$this._xNextcloudTalkHash = xNextcloudTalkHash;
+
+  String? _xNextcloudTalkModifiedBefore;
+  String? get xNextcloudTalkModifiedBefore => _$this._xNextcloudTalkModifiedBefore;
+  set xNextcloudTalkModifiedBefore(covariant String? xNextcloudTalkModifiedBefore) =>
+      _$this._xNextcloudTalkModifiedBefore = xNextcloudTalkModifiedBefore;
+
+  RoomRoomGetRoomsHeadersBuilder();
+
+  RoomRoomGetRoomsHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _xNextcloudTalkHash = $v.xNextcloudTalkHash;
+      _xNextcloudTalkModifiedBefore = $v.xNextcloudTalkModifiedBefore;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomRoomGetRoomsHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomRoomGetRoomsHeaders;
+  }
+
+  @override
+  void update(void Function(RoomRoomGetRoomsHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomRoomGetRoomsHeaders build() => _build();
+
+  _$RoomRoomGetRoomsHeaders _build() {
+    final _$result = _$v ??
+        _$RoomRoomGetRoomsHeaders._(
+            xNextcloudTalkHash: xNextcloudTalkHash, xNextcloudTalkModifiedBefore: xNextcloudTalkModifiedBefore);
     replace(_$result);
     return _$result;
   }
@@ -42278,96 +42278,6 @@ class RoomGetListedRoomsResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder {
-  void replace($RoomRoomGetNoteToSelfConversationHeadersInterface other);
-  void update(void Function($RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder) updates);
-  String? get xNextcloudTalkHash;
-  set xNextcloudTalkHash(String? xNextcloudTalkHash);
-}
-
-class _$RoomRoomGetNoteToSelfConversationHeaders extends RoomRoomGetNoteToSelfConversationHeaders {
-  @override
-  final String? xNextcloudTalkHash;
-
-  factory _$RoomRoomGetNoteToSelfConversationHeaders(
-          [void Function(RoomRoomGetNoteToSelfConversationHeadersBuilder)? updates]) =>
-      (RoomRoomGetNoteToSelfConversationHeadersBuilder()..update(updates))._build();
-
-  _$RoomRoomGetNoteToSelfConversationHeaders._({this.xNextcloudTalkHash}) : super._();
-
-  @override
-  RoomRoomGetNoteToSelfConversationHeaders rebuild(
-          void Function(RoomRoomGetNoteToSelfConversationHeadersBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  RoomRoomGetNoteToSelfConversationHeadersBuilder toBuilder() =>
-      RoomRoomGetNoteToSelfConversationHeadersBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is RoomRoomGetNoteToSelfConversationHeaders && xNextcloudTalkHash == other.xNextcloudTalkHash;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, xNextcloudTalkHash.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'RoomRoomGetNoteToSelfConversationHeaders')
-          ..add('xNextcloudTalkHash', xNextcloudTalkHash))
-        .toString();
-  }
-}
-
-class RoomRoomGetNoteToSelfConversationHeadersBuilder
-    implements
-        Builder<RoomRoomGetNoteToSelfConversationHeaders, RoomRoomGetNoteToSelfConversationHeadersBuilder>,
-        $RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder {
-  _$RoomRoomGetNoteToSelfConversationHeaders? _$v;
-
-  String? _xNextcloudTalkHash;
-  String? get xNextcloudTalkHash => _$this._xNextcloudTalkHash;
-  set xNextcloudTalkHash(covariant String? xNextcloudTalkHash) => _$this._xNextcloudTalkHash = xNextcloudTalkHash;
-
-  RoomRoomGetNoteToSelfConversationHeadersBuilder();
-
-  RoomRoomGetNoteToSelfConversationHeadersBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _xNextcloudTalkHash = $v.xNextcloudTalkHash;
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant RoomRoomGetNoteToSelfConversationHeaders other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$RoomRoomGetNoteToSelfConversationHeaders;
-  }
-
-  @override
-  void update(void Function(RoomRoomGetNoteToSelfConversationHeadersBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  RoomRoomGetNoteToSelfConversationHeaders build() => _build();
-
-  _$RoomRoomGetNoteToSelfConversationHeaders _build() {
-    final _$result = _$v ?? _$RoomRoomGetNoteToSelfConversationHeaders._(xNextcloudTalkHash: xNextcloudTalkHash);
-    replace(_$result);
-    return _$result;
-  }
-}
-
 abstract mixin class $RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -42600,33 +42510,36 @@ class RoomGetNoteToSelfConversationResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $RoomRoomGetSingleRoomHeadersInterfaceBuilder {
-  void replace($RoomRoomGetSingleRoomHeadersInterface other);
-  void update(void Function($RoomRoomGetSingleRoomHeadersInterfaceBuilder) updates);
+abstract mixin class $RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder {
+  void replace($RoomRoomGetNoteToSelfConversationHeadersInterface other);
+  void update(void Function($RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder) updates);
   String? get xNextcloudTalkHash;
   set xNextcloudTalkHash(String? xNextcloudTalkHash);
 }
 
-class _$RoomRoomGetSingleRoomHeaders extends RoomRoomGetSingleRoomHeaders {
+class _$RoomRoomGetNoteToSelfConversationHeaders extends RoomRoomGetNoteToSelfConversationHeaders {
   @override
   final String? xNextcloudTalkHash;
 
-  factory _$RoomRoomGetSingleRoomHeaders([void Function(RoomRoomGetSingleRoomHeadersBuilder)? updates]) =>
-      (RoomRoomGetSingleRoomHeadersBuilder()..update(updates))._build();
+  factory _$RoomRoomGetNoteToSelfConversationHeaders(
+          [void Function(RoomRoomGetNoteToSelfConversationHeadersBuilder)? updates]) =>
+      (RoomRoomGetNoteToSelfConversationHeadersBuilder()..update(updates))._build();
 
-  _$RoomRoomGetSingleRoomHeaders._({this.xNextcloudTalkHash}) : super._();
+  _$RoomRoomGetNoteToSelfConversationHeaders._({this.xNextcloudTalkHash}) : super._();
 
   @override
-  RoomRoomGetSingleRoomHeaders rebuild(void Function(RoomRoomGetSingleRoomHeadersBuilder) updates) =>
+  RoomRoomGetNoteToSelfConversationHeaders rebuild(
+          void Function(RoomRoomGetNoteToSelfConversationHeadersBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  RoomRoomGetSingleRoomHeadersBuilder toBuilder() => RoomRoomGetSingleRoomHeadersBuilder()..replace(this);
+  RoomRoomGetNoteToSelfConversationHeadersBuilder toBuilder() =>
+      RoomRoomGetNoteToSelfConversationHeadersBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is RoomRoomGetSingleRoomHeaders && xNextcloudTalkHash == other.xNextcloudTalkHash;
+    return other is RoomRoomGetNoteToSelfConversationHeaders && xNextcloudTalkHash == other.xNextcloudTalkHash;
   }
 
   @override
@@ -42639,24 +42552,25 @@ class _$RoomRoomGetSingleRoomHeaders extends RoomRoomGetSingleRoomHeaders {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'RoomRoomGetSingleRoomHeaders')..add('xNextcloudTalkHash', xNextcloudTalkHash))
+    return (newBuiltValueToStringHelper(r'RoomRoomGetNoteToSelfConversationHeaders')
+          ..add('xNextcloudTalkHash', xNextcloudTalkHash))
         .toString();
   }
 }
 
-class RoomRoomGetSingleRoomHeadersBuilder
+class RoomRoomGetNoteToSelfConversationHeadersBuilder
     implements
-        Builder<RoomRoomGetSingleRoomHeaders, RoomRoomGetSingleRoomHeadersBuilder>,
-        $RoomRoomGetSingleRoomHeadersInterfaceBuilder {
-  _$RoomRoomGetSingleRoomHeaders? _$v;
+        Builder<RoomRoomGetNoteToSelfConversationHeaders, RoomRoomGetNoteToSelfConversationHeadersBuilder>,
+        $RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder {
+  _$RoomRoomGetNoteToSelfConversationHeaders? _$v;
 
   String? _xNextcloudTalkHash;
   String? get xNextcloudTalkHash => _$this._xNextcloudTalkHash;
   set xNextcloudTalkHash(covariant String? xNextcloudTalkHash) => _$this._xNextcloudTalkHash = xNextcloudTalkHash;
 
-  RoomRoomGetSingleRoomHeadersBuilder();
+  RoomRoomGetNoteToSelfConversationHeadersBuilder();
 
-  RoomRoomGetSingleRoomHeadersBuilder get _$this {
+  RoomRoomGetNoteToSelfConversationHeadersBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _xNextcloudTalkHash = $v.xNextcloudTalkHash;
@@ -42666,21 +42580,21 @@ class RoomRoomGetSingleRoomHeadersBuilder
   }
 
   @override
-  void replace(covariant RoomRoomGetSingleRoomHeaders other) {
+  void replace(covariant RoomRoomGetNoteToSelfConversationHeaders other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$RoomRoomGetSingleRoomHeaders;
+    _$v = other as _$RoomRoomGetNoteToSelfConversationHeaders;
   }
 
   @override
-  void update(void Function(RoomRoomGetSingleRoomHeadersBuilder)? updates) {
+  void update(void Function(RoomRoomGetNoteToSelfConversationHeadersBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  RoomRoomGetSingleRoomHeaders build() => _build();
+  RoomRoomGetNoteToSelfConversationHeaders build() => _build();
 
-  _$RoomRoomGetSingleRoomHeaders _build() {
-    final _$result = _$v ?? _$RoomRoomGetSingleRoomHeaders._(xNextcloudTalkHash: xNextcloudTalkHash);
+  _$RoomRoomGetNoteToSelfConversationHeaders _build() {
+    final _$result = _$v ?? _$RoomRoomGetNoteToSelfConversationHeaders._(xNextcloudTalkHash: xNextcloudTalkHash);
     replace(_$result);
     return _$result;
   }
@@ -42903,6 +42817,92 @@ class RoomGetSingleRoomResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomRoomGetSingleRoomHeadersInterfaceBuilder {
+  void replace($RoomRoomGetSingleRoomHeadersInterface other);
+  void update(void Function($RoomRoomGetSingleRoomHeadersInterfaceBuilder) updates);
+  String? get xNextcloudTalkHash;
+  set xNextcloudTalkHash(String? xNextcloudTalkHash);
+}
+
+class _$RoomRoomGetSingleRoomHeaders extends RoomRoomGetSingleRoomHeaders {
+  @override
+  final String? xNextcloudTalkHash;
+
+  factory _$RoomRoomGetSingleRoomHeaders([void Function(RoomRoomGetSingleRoomHeadersBuilder)? updates]) =>
+      (RoomRoomGetSingleRoomHeadersBuilder()..update(updates))._build();
+
+  _$RoomRoomGetSingleRoomHeaders._({this.xNextcloudTalkHash}) : super._();
+
+  @override
+  RoomRoomGetSingleRoomHeaders rebuild(void Function(RoomRoomGetSingleRoomHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomRoomGetSingleRoomHeadersBuilder toBuilder() => RoomRoomGetSingleRoomHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomRoomGetSingleRoomHeaders && xNextcloudTalkHash == other.xNextcloudTalkHash;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, xNextcloudTalkHash.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomRoomGetSingleRoomHeaders')..add('xNextcloudTalkHash', xNextcloudTalkHash))
+        .toString();
+  }
+}
+
+class RoomRoomGetSingleRoomHeadersBuilder
+    implements
+        Builder<RoomRoomGetSingleRoomHeaders, RoomRoomGetSingleRoomHeadersBuilder>,
+        $RoomRoomGetSingleRoomHeadersInterfaceBuilder {
+  _$RoomRoomGetSingleRoomHeaders? _$v;
+
+  String? _xNextcloudTalkHash;
+  String? get xNextcloudTalkHash => _$this._xNextcloudTalkHash;
+  set xNextcloudTalkHash(covariant String? xNextcloudTalkHash) => _$this._xNextcloudTalkHash = xNextcloudTalkHash;
+
+  RoomRoomGetSingleRoomHeadersBuilder();
+
+  RoomRoomGetSingleRoomHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _xNextcloudTalkHash = $v.xNextcloudTalkHash;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomRoomGetSingleRoomHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomRoomGetSingleRoomHeaders;
+  }
+
+  @override
+  void update(void Function(RoomRoomGetSingleRoomHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomRoomGetSingleRoomHeaders build() => _build();
+
+  _$RoomRoomGetSingleRoomHeaders _build() {
+    final _$result = _$v ?? _$RoomRoomGetSingleRoomHeaders._(xNextcloudTalkHash: xNextcloudTalkHash);
     replace(_$result);
     return _$result;
   }
@@ -45136,107 +45136,6 @@ class RoomSetPermissionsResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $RoomRoomGetParticipantsHeadersInterfaceBuilder {
-  void replace($RoomRoomGetParticipantsHeadersInterface other);
-  void update(void Function($RoomRoomGetParticipantsHeadersInterfaceBuilder) updates);
-  HeaderBuilder<bool> get xNextcloudHasUserStatuses;
-  set xNextcloudHasUserStatuses(HeaderBuilder<bool>? xNextcloudHasUserStatuses);
-}
-
-class _$RoomRoomGetParticipantsHeaders extends RoomRoomGetParticipantsHeaders {
-  @override
-  final Header<bool>? xNextcloudHasUserStatuses;
-
-  factory _$RoomRoomGetParticipantsHeaders([void Function(RoomRoomGetParticipantsHeadersBuilder)? updates]) =>
-      (RoomRoomGetParticipantsHeadersBuilder()..update(updates))._build();
-
-  _$RoomRoomGetParticipantsHeaders._({this.xNextcloudHasUserStatuses}) : super._();
-
-  @override
-  RoomRoomGetParticipantsHeaders rebuild(void Function(RoomRoomGetParticipantsHeadersBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  RoomRoomGetParticipantsHeadersBuilder toBuilder() => RoomRoomGetParticipantsHeadersBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is RoomRoomGetParticipantsHeaders && xNextcloudHasUserStatuses == other.xNextcloudHasUserStatuses;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, xNextcloudHasUserStatuses.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'RoomRoomGetParticipantsHeaders')
-          ..add('xNextcloudHasUserStatuses', xNextcloudHasUserStatuses))
-        .toString();
-  }
-}
-
-class RoomRoomGetParticipantsHeadersBuilder
-    implements
-        Builder<RoomRoomGetParticipantsHeaders, RoomRoomGetParticipantsHeadersBuilder>,
-        $RoomRoomGetParticipantsHeadersInterfaceBuilder {
-  _$RoomRoomGetParticipantsHeaders? _$v;
-
-  HeaderBuilder<bool>? _xNextcloudHasUserStatuses;
-  HeaderBuilder<bool> get xNextcloudHasUserStatuses => _$this._xNextcloudHasUserStatuses ??= HeaderBuilder<bool>();
-  set xNextcloudHasUserStatuses(covariant HeaderBuilder<bool>? xNextcloudHasUserStatuses) =>
-      _$this._xNextcloudHasUserStatuses = xNextcloudHasUserStatuses;
-
-  RoomRoomGetParticipantsHeadersBuilder();
-
-  RoomRoomGetParticipantsHeadersBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _xNextcloudHasUserStatuses = $v.xNextcloudHasUserStatuses?.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant RoomRoomGetParticipantsHeaders other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$RoomRoomGetParticipantsHeaders;
-  }
-
-  @override
-  void update(void Function(RoomRoomGetParticipantsHeadersBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  RoomRoomGetParticipantsHeaders build() => _build();
-
-  _$RoomRoomGetParticipantsHeaders _build() {
-    _$RoomRoomGetParticipantsHeaders _$result;
-    try {
-      _$result =
-          _$v ?? _$RoomRoomGetParticipantsHeaders._(xNextcloudHasUserStatuses: _xNextcloudHasUserStatuses?.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'xNextcloudHasUserStatuses';
-        _xNextcloudHasUserStatuses?.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'RoomRoomGetParticipantsHeaders', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
 abstract mixin class $ParticipantInterfaceBuilder {
   void replace($ParticipantInterface other);
   void update(void Function($ParticipantInterfaceBuilder) updates);
@@ -45830,6 +45729,107 @@ class RoomGetParticipantsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomRoomGetParticipantsHeadersInterfaceBuilder {
+  void replace($RoomRoomGetParticipantsHeadersInterface other);
+  void update(void Function($RoomRoomGetParticipantsHeadersInterfaceBuilder) updates);
+  HeaderBuilder<bool> get xNextcloudHasUserStatuses;
+  set xNextcloudHasUserStatuses(HeaderBuilder<bool>? xNextcloudHasUserStatuses);
+}
+
+class _$RoomRoomGetParticipantsHeaders extends RoomRoomGetParticipantsHeaders {
+  @override
+  final Header<bool>? xNextcloudHasUserStatuses;
+
+  factory _$RoomRoomGetParticipantsHeaders([void Function(RoomRoomGetParticipantsHeadersBuilder)? updates]) =>
+      (RoomRoomGetParticipantsHeadersBuilder()..update(updates))._build();
+
+  _$RoomRoomGetParticipantsHeaders._({this.xNextcloudHasUserStatuses}) : super._();
+
+  @override
+  RoomRoomGetParticipantsHeaders rebuild(void Function(RoomRoomGetParticipantsHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomRoomGetParticipantsHeadersBuilder toBuilder() => RoomRoomGetParticipantsHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomRoomGetParticipantsHeaders && xNextcloudHasUserStatuses == other.xNextcloudHasUserStatuses;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, xNextcloudHasUserStatuses.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomRoomGetParticipantsHeaders')
+          ..add('xNextcloudHasUserStatuses', xNextcloudHasUserStatuses))
+        .toString();
+  }
+}
+
+class RoomRoomGetParticipantsHeadersBuilder
+    implements
+        Builder<RoomRoomGetParticipantsHeaders, RoomRoomGetParticipantsHeadersBuilder>,
+        $RoomRoomGetParticipantsHeadersInterfaceBuilder {
+  _$RoomRoomGetParticipantsHeaders? _$v;
+
+  HeaderBuilder<bool>? _xNextcloudHasUserStatuses;
+  HeaderBuilder<bool> get xNextcloudHasUserStatuses => _$this._xNextcloudHasUserStatuses ??= HeaderBuilder<bool>();
+  set xNextcloudHasUserStatuses(covariant HeaderBuilder<bool>? xNextcloudHasUserStatuses) =>
+      _$this._xNextcloudHasUserStatuses = xNextcloudHasUserStatuses;
+
+  RoomRoomGetParticipantsHeadersBuilder();
+
+  RoomRoomGetParticipantsHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _xNextcloudHasUserStatuses = $v.xNextcloudHasUserStatuses?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomRoomGetParticipantsHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomRoomGetParticipantsHeaders;
+  }
+
+  @override
+  void update(void Function(RoomRoomGetParticipantsHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomRoomGetParticipantsHeaders build() => _build();
+
+  _$RoomRoomGetParticipantsHeaders _build() {
+    _$RoomRoomGetParticipantsHeaders _$result;
+    try {
+      _$result =
+          _$v ?? _$RoomRoomGetParticipantsHeaders._(xNextcloudHasUserStatuses: _xNextcloudHasUserStatuses?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'xNextcloudHasUserStatuses';
+        _xNextcloudHasUserStatuses?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'RoomRoomGetParticipantsHeaders', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder {
   void replace($RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Interface other);
   void update(void Function($RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder) updates);
@@ -46161,112 +46161,6 @@ class RoomAddParticipantToRoomResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder {
-  void replace($RoomRoomGetBreakoutRoomParticipantsHeadersInterface other);
-  void update(void Function($RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder) updates);
-  HeaderBuilder<bool> get xNextcloudHasUserStatuses;
-  set xNextcloudHasUserStatuses(HeaderBuilder<bool>? xNextcloudHasUserStatuses);
-}
-
-class _$RoomRoomGetBreakoutRoomParticipantsHeaders extends RoomRoomGetBreakoutRoomParticipantsHeaders {
-  @override
-  final Header<bool>? xNextcloudHasUserStatuses;
-
-  factory _$RoomRoomGetBreakoutRoomParticipantsHeaders(
-          [void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder)? updates]) =>
-      (RoomRoomGetBreakoutRoomParticipantsHeadersBuilder()..update(updates))._build();
-
-  _$RoomRoomGetBreakoutRoomParticipantsHeaders._({this.xNextcloudHasUserStatuses}) : super._();
-
-  @override
-  RoomRoomGetBreakoutRoomParticipantsHeaders rebuild(
-          void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
-
-  @override
-  RoomRoomGetBreakoutRoomParticipantsHeadersBuilder toBuilder() =>
-      RoomRoomGetBreakoutRoomParticipantsHeadersBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is RoomRoomGetBreakoutRoomParticipantsHeaders &&
-        xNextcloudHasUserStatuses == other.xNextcloudHasUserStatuses;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, xNextcloudHasUserStatuses.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'RoomRoomGetBreakoutRoomParticipantsHeaders')
-          ..add('xNextcloudHasUserStatuses', xNextcloudHasUserStatuses))
-        .toString();
-  }
-}
-
-class RoomRoomGetBreakoutRoomParticipantsHeadersBuilder
-    implements
-        Builder<RoomRoomGetBreakoutRoomParticipantsHeaders, RoomRoomGetBreakoutRoomParticipantsHeadersBuilder>,
-        $RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder {
-  _$RoomRoomGetBreakoutRoomParticipantsHeaders? _$v;
-
-  HeaderBuilder<bool>? _xNextcloudHasUserStatuses;
-  HeaderBuilder<bool> get xNextcloudHasUserStatuses => _$this._xNextcloudHasUserStatuses ??= HeaderBuilder<bool>();
-  set xNextcloudHasUserStatuses(covariant HeaderBuilder<bool>? xNextcloudHasUserStatuses) =>
-      _$this._xNextcloudHasUserStatuses = xNextcloudHasUserStatuses;
-
-  RoomRoomGetBreakoutRoomParticipantsHeadersBuilder();
-
-  RoomRoomGetBreakoutRoomParticipantsHeadersBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _xNextcloudHasUserStatuses = $v.xNextcloudHasUserStatuses?.toBuilder();
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(covariant RoomRoomGetBreakoutRoomParticipantsHeaders other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$RoomRoomGetBreakoutRoomParticipantsHeaders;
-  }
-
-  @override
-  void update(void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder)? updates) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  RoomRoomGetBreakoutRoomParticipantsHeaders build() => _build();
-
-  _$RoomRoomGetBreakoutRoomParticipantsHeaders _build() {
-    _$RoomRoomGetBreakoutRoomParticipantsHeaders _$result;
-    try {
-      _$result = _$v ??
-          _$RoomRoomGetBreakoutRoomParticipantsHeaders._(
-              xNextcloudHasUserStatuses: _xNextcloudHasUserStatuses?.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'xNextcloudHasUserStatuses';
-        _xNextcloudHasUserStatuses?.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(r'RoomRoomGetBreakoutRoomParticipantsHeaders', _$failedField, e.toString());
-      }
-      rethrow;
-    }
-    replace(_$result);
-    return _$result;
-  }
-}
-
 abstract mixin class $RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -46491,6 +46385,112 @@ class RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder
       } catch (e) {
         throw BuiltValueNestedFieldError(
             r'RoomGetBreakoutRoomParticipantsResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder {
+  void replace($RoomRoomGetBreakoutRoomParticipantsHeadersInterface other);
+  void update(void Function($RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder) updates);
+  HeaderBuilder<bool> get xNextcloudHasUserStatuses;
+  set xNextcloudHasUserStatuses(HeaderBuilder<bool>? xNextcloudHasUserStatuses);
+}
+
+class _$RoomRoomGetBreakoutRoomParticipantsHeaders extends RoomRoomGetBreakoutRoomParticipantsHeaders {
+  @override
+  final Header<bool>? xNextcloudHasUserStatuses;
+
+  factory _$RoomRoomGetBreakoutRoomParticipantsHeaders(
+          [void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder)? updates]) =>
+      (RoomRoomGetBreakoutRoomParticipantsHeadersBuilder()..update(updates))._build();
+
+  _$RoomRoomGetBreakoutRoomParticipantsHeaders._({this.xNextcloudHasUserStatuses}) : super._();
+
+  @override
+  RoomRoomGetBreakoutRoomParticipantsHeaders rebuild(
+          void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomRoomGetBreakoutRoomParticipantsHeadersBuilder toBuilder() =>
+      RoomRoomGetBreakoutRoomParticipantsHeadersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomRoomGetBreakoutRoomParticipantsHeaders &&
+        xNextcloudHasUserStatuses == other.xNextcloudHasUserStatuses;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, xNextcloudHasUserStatuses.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomRoomGetBreakoutRoomParticipantsHeaders')
+          ..add('xNextcloudHasUserStatuses', xNextcloudHasUserStatuses))
+        .toString();
+  }
+}
+
+class RoomRoomGetBreakoutRoomParticipantsHeadersBuilder
+    implements
+        Builder<RoomRoomGetBreakoutRoomParticipantsHeaders, RoomRoomGetBreakoutRoomParticipantsHeadersBuilder>,
+        $RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder {
+  _$RoomRoomGetBreakoutRoomParticipantsHeaders? _$v;
+
+  HeaderBuilder<bool>? _xNextcloudHasUserStatuses;
+  HeaderBuilder<bool> get xNextcloudHasUserStatuses => _$this._xNextcloudHasUserStatuses ??= HeaderBuilder<bool>();
+  set xNextcloudHasUserStatuses(covariant HeaderBuilder<bool>? xNextcloudHasUserStatuses) =>
+      _$this._xNextcloudHasUserStatuses = xNextcloudHasUserStatuses;
+
+  RoomRoomGetBreakoutRoomParticipantsHeadersBuilder();
+
+  RoomRoomGetBreakoutRoomParticipantsHeadersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _xNextcloudHasUserStatuses = $v.xNextcloudHasUserStatuses?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomRoomGetBreakoutRoomParticipantsHeaders other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomRoomGetBreakoutRoomParticipantsHeaders;
+  }
+
+  @override
+  void update(void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomRoomGetBreakoutRoomParticipantsHeaders build() => _build();
+
+  _$RoomRoomGetBreakoutRoomParticipantsHeaders _build() {
+    _$RoomRoomGetBreakoutRoomParticipantsHeaders _$result;
+    try {
+      _$result = _$v ??
+          _$RoomRoomGetBreakoutRoomParticipantsHeaders._(
+              xNextcloudHasUserStatuses: _xNextcloudHasUserStatuses?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'xNextcloudHasUserStatuses';
+        _xNextcloudHasUserStatuses?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'RoomRoomGetBreakoutRoomParticipantsHeaders', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -24,9 +24,9 @@ import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i3;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i2;
+import 'package:dynamite_runtime/utils.dart' as _i4;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i3;
 
 part 'theming.openapi.g.dart';
 
@@ -105,7 +105,7 @@ class $IconClient {
   ///
   /// See:
   ///  * [getFavicon] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getFaviconRaw({String? app}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'image/x-icon'};
@@ -129,7 +129,7 @@ class $IconClient {
     $app ??= 'core';
     _parameters['app'] = $app;
 
-    final _path = _i2.UriTemplate('/index.php/apps/theming/favicon/{app}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/theming/favicon/{app}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -183,7 +183,7 @@ class $IconClient {
   ///
   /// See:
   ///  * [getTouchIcon] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getTouchIconRaw({String? app}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'image/png'};
@@ -207,7 +207,7 @@ class $IconClient {
     $app ??= 'core';
     _parameters['app'] = $app;
 
-    final _path = _i2.UriTemplate('/index.php/apps/theming/icon/{app}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/theming/icon/{app}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -267,7 +267,7 @@ class $IconClient {
   ///
   /// See:
   ///  * [getThemedIcon] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getThemedIconRaw({
     required String app,
     required String image,
@@ -294,14 +294,14 @@ class $IconClient {
     _parameters['app'] = $app;
 
     final $image = _$jsonSerializers.serialize(image, specifiedType: const FullType(String));
-    _i3.checkPattern(
+    _i4.checkPattern(
       $image as String?,
       RegExp(r'^.+$'),
       'image',
     );
     _parameters['image'] = $image;
 
-    final _path = _i2.UriTemplate('/index.php/apps/theming/img/{app}/{image}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/theming/img/{app}/{image}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -372,7 +372,7 @@ class $ThemingClient {
   ///
   /// See:
   ///  * [getThemeStylesheet] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<String, void> getThemeStylesheetRaw({
     required String themeId,
     ThemingGetThemeStylesheetPlain? plain,
@@ -411,7 +411,7 @@ class $ThemingClient {
     _parameters['withCustomCss'] = $withCustomCss;
 
     final _path =
-        _i2.UriTemplate('/index.php/apps/theming/theme/{themeId}.css{?plain*,withCustomCss*}').expand(_parameters);
+        _i3.UriTemplate('/index.php/apps/theming/theme/{themeId}.css{?plain*,withCustomCss*}').expand(_parameters);
     return _i1.DynamiteRawResponse<String, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -471,7 +471,7 @@ class $ThemingClient {
   ///
   /// See:
   ///  * [getImage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getImageRaw({
     required String key,
     ThemingGetImageUseSvg? useSvg,
@@ -501,7 +501,7 @@ class $ThemingClient {
     $useSvg ??= 1;
     _parameters['useSvg'] = $useSvg;
 
-    final _path = _i2.UriTemplate('/index.php/apps/theming/image/{key}{?useSvg*}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/theming/image/{key}{?useSvg*}').expand(_parameters);
     return _i1.DynamiteRawResponse<Uint8List, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -553,7 +553,7 @@ class $ThemingClient {
   ///
   /// See:
   ///  * [getManifest] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ThemingGetManifestResponseApplicationJson, void> getManifestRaw({String? app}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -577,7 +577,7 @@ class $ThemingClient {
     $app ??= 'core';
     _parameters['app'] = $app;
 
-    final _path = _i2.UriTemplate('/index.php/apps/theming/manifest/{app}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/theming/manifest/{app}').expand(_parameters);
     return _i1.DynamiteRawResponse<ThemingGetManifestResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -628,7 +628,7 @@ class $UserThemeClient {
   ///
   /// See:
   ///  * [getBackground] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<Uint8List, void> getBackgroundRaw() {
     final _headers = <String, String>{'Accept': '*/*'};
 
@@ -709,7 +709,7 @@ class $UserThemeClient {
   ///
   /// See:
   ///  * [enableTheme] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UserThemeEnableThemeResponseApplicationJson, void> enableThemeRaw({
     required String themeId,
     bool? oCSAPIRequest,
@@ -739,9 +739,9 @@ class $UserThemeClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i2.UriTemplate('/ocs/v2.php/apps/theming/api/v1/theme/{themeId}/enable').expand(_parameters);
+    final _path = _i3.UriTemplate('/ocs/v2.php/apps/theming/api/v1/theme/{themeId}/enable').expand(_parameters);
     return _i1.DynamiteRawResponse<UserThemeEnableThemeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -801,7 +801,7 @@ class $UserThemeClient {
   ///
   /// See:
   ///  * [disableTheme] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UserThemeDisableThemeResponseApplicationJson, void> disableThemeRaw({
     required String themeId,
     bool? oCSAPIRequest,
@@ -831,9 +831,9 @@ class $UserThemeClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i2.UriTemplate('/ocs/v2.php/apps/theming/api/v1/theme/{themeId}').expand(_parameters);
+    final _path = _i3.UriTemplate('/ocs/v2.php/apps/theming/api/v1/theme/{themeId}').expand(_parameters);
     return _i1.DynamiteRawResponse<UserThemeDisableThemeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -1084,7 +1084,7 @@ abstract class ThemingGetManifestResponseApplicationJson_Icons
 
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(ThemingGetManifestResponseApplicationJson_IconsBuilder b) {
-    _i3.checkMinLength(
+    _i4.checkMinLength(
       b.src,
       1,
       'src',
@@ -1424,7 +1424,7 @@ abstract class PublicCapabilities
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ThemingGetThemeStylesheetPlain.serializer)
@@ -1476,7 +1476,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
@@ -21,9 +21,9 @@ import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'updatenotification.openapi.g.dart';
 
@@ -108,7 +108,7 @@ class $ApiClient {
   ///
   /// See:
   ///  * [getAppList] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<ApiGetAppListResponseApplicationJson, void> getAppListRaw({
     required String newVersion,
     ApiGetAppListApiVersion? apiVersion,
@@ -143,9 +143,9 @@ class $ApiClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/updatenotification/api/{apiVersion}/applist/{newVersion}')
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/updatenotification/api/{apiVersion}/applist/{newVersion}')
         .expand(_parameters);
     return _i1.DynamiteRawResponse<ApiGetAppListResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -404,7 +404,7 @@ abstract class ApiGetAppListResponseApplicationJson
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ApiGetAppListApiVersion.serializer)
@@ -434,7 +434,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/uppush.openapi.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.dart
@@ -11,7 +11,7 @@
 /// Use Nextcloud as a push provider for mobile phones' notifications.
 ///
 /// Use of this source code is governed by a agpl license.
-@_i3.experimental
+@_i2.experimental
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:built_collection/built_collection.dart';
@@ -21,8 +21,8 @@ import 'package:built_value/standard_json_plugin.dart' as _i5;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i4;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:meta/meta.dart' as _i3;
-import 'package:uri/uri.dart' as _i2;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i3;
 
 part 'uppush.openapi.g.dart';
 
@@ -74,7 +74,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [check] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CheckResponseApplicationJson, void> checkRaw() {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -149,7 +149,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [setKeepalive] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SetKeepaliveResponseApplicationJson, void> setKeepaliveRaw({required int keepalive}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -174,7 +174,7 @@ class $Client extends _i1.DynamiteClient {
     final $keepalive = _$jsonSerializers.serialize(keepalive, specifiedType: const FullType(int));
     _parameters['keepalive'] = $keepalive;
 
-    final _path = _i2.UriTemplate('/index.php/apps/uppush/keepalive{?keepalive*}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/uppush/keepalive{?keepalive*}').expand(_parameters);
     return _i1.DynamiteRawResponse<SetKeepaliveResponseApplicationJson, void>(
       response: executeRequest(
         'put',
@@ -226,7 +226,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [createDevice] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CreateDeviceResponseApplicationJson, void> createDeviceRaw({required String deviceName}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -251,7 +251,7 @@ class $Client extends _i1.DynamiteClient {
     final $deviceName = _$jsonSerializers.serialize(deviceName, specifiedType: const FullType(String));
     _parameters['deviceName'] = $deviceName;
 
-    final _path = _i2.UriTemplate('/index.php/apps/uppush/device{?deviceName*}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/uppush/device{?deviceName*}').expand(_parameters);
     return _i1.DynamiteRawResponse<CreateDeviceResponseApplicationJson, void>(
       response: executeRequest(
         'put',
@@ -299,7 +299,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [syncDevice] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<SyncDeviceResponseApplicationJson, void> syncDeviceRaw({required String deviceId}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -324,7 +324,7 @@ class $Client extends _i1.DynamiteClient {
     final $deviceId = _$jsonSerializers.serialize(deviceId, specifiedType: const FullType(String));
     _parameters['deviceId'] = $deviceId;
 
-    final _path = _i2.UriTemplate('/index.php/apps/uppush/device/{deviceId}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/uppush/device/{deviceId}').expand(_parameters);
     return _i1.DynamiteRawResponse<SyncDeviceResponseApplicationJson, void>(
       response: executeRequest(
         'get',
@@ -370,7 +370,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [deleteDevice] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DeleteDeviceResponseApplicationJson, void> deleteDeviceRaw({required String deviceId}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -395,7 +395,7 @@ class $Client extends _i1.DynamiteClient {
     final $deviceId = _$jsonSerializers.serialize(deviceId, specifiedType: const FullType(String));
     _parameters['deviceId'] = $deviceId;
 
-    final _path = _i2.UriTemplate('/index.php/apps/uppush/device/{deviceId}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/uppush/device/{deviceId}').expand(_parameters);
     return _i1.DynamiteRawResponse<DeleteDeviceResponseApplicationJson, void>(
       response: executeRequest(
         'delete',
@@ -451,7 +451,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [createApp] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<CreateAppResponseApplicationJson, void> createAppRaw({
     required String deviceId,
     required String appName,
@@ -482,7 +482,7 @@ class $Client extends _i1.DynamiteClient {
     final $appName = _$jsonSerializers.serialize(appName, specifiedType: const FullType(String));
     _parameters['appName'] = $appName;
 
-    final _path = _i2.UriTemplate('/index.php/apps/uppush/app{?deviceId*,appName*}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/uppush/app{?deviceId*,appName*}').expand(_parameters);
     return _i1.DynamiteRawResponse<CreateAppResponseApplicationJson, void>(
       response: executeRequest(
         'put',
@@ -526,7 +526,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [deleteApp] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<DeleteAppResponseApplicationJson, void> deleteAppRaw({required String token}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -551,7 +551,7 @@ class $Client extends _i1.DynamiteClient {
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _parameters['token'] = $token;
 
-    final _path = _i2.UriTemplate('/index.php/apps/uppush/app/{token}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/uppush/app/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<DeleteAppResponseApplicationJson, void>(
       response: executeRequest(
         'delete',
@@ -597,7 +597,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [unifiedpushDiscovery] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UnifiedpushDiscoveryResponseApplicationJson, void> unifiedpushDiscoveryRaw({
     required String token,
   }) {
@@ -624,7 +624,7 @@ class $Client extends _i1.DynamiteClient {
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _parameters['token'] = $token;
 
-    final _path = _i2.UriTemplate('/index.php/apps/uppush/push/{token}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/uppush/push/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<UnifiedpushDiscoveryResponseApplicationJson, void>(
       response: executeRequest(
         'get',
@@ -668,7 +668,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [push] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PushResponseApplicationJson, void> pushRaw({required String token}) {
     final _parameters = <String, dynamic>{};
     final _headers = <String, String>{'Accept': 'application/json'};
@@ -693,7 +693,7 @@ class $Client extends _i1.DynamiteClient {
     final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _parameters['token'] = $token;
 
-    final _path = _i2.UriTemplate('/index.php/apps/uppush/push/{token}').expand(_parameters);
+    final _path = _i3.UriTemplate('/index.php/apps/uppush/push/{token}').expand(_parameters);
     return _i1.DynamiteRawResponse<PushResponseApplicationJson, void>(
       response: executeRequest(
         'post',
@@ -735,7 +735,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [gatewayMatrixDiscovery] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<GatewayMatrixDiscoveryResponseApplicationJson, void> gatewayMatrixDiscoveryRaw() {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -798,7 +798,7 @@ class $Client extends _i1.DynamiteClient {
   ///
   /// See:
   ///  * [gatewayMatrix] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i3.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<GatewayMatrixResponseApplicationJson, void> gatewayMatrixRaw() {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -1323,7 +1323,7 @@ abstract class GatewayMatrixResponseApplicationJson
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(CheckResponseApplicationJson), CheckResponseApplicationJsonBuilder.new)
@@ -1386,7 +1386,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i3.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i4.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -22,9 +22,9 @@ import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'user_status.openapi.g.dart';
 
@@ -111,7 +111,7 @@ class $HeartbeatClient {
   ///
   /// See:
   ///  * [heartbeat] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<HeartbeatHeartbeatResponseApplicationJson, void> heartbeatRaw({
     required String status,
     bool? oCSAPIRequest,
@@ -141,9 +141,9 @@ class $HeartbeatClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/heartbeat{?status*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/heartbeat{?status*}').expand(_parameters);
     return _i1.DynamiteRawResponse<HeartbeatHeartbeatResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -202,7 +202,7 @@ class $PredefinedStatusClient {
   ///
   /// See:
   ///  * [findAll] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<PredefinedStatusFindAllResponseApplicationJson, void> findAllRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -225,7 +225,7 @@ class $PredefinedStatusClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/user_status/api/v1/predefined_statuses';
     return _i1.DynamiteRawResponse<PredefinedStatusFindAllResponseApplicationJson, void>(
@@ -294,7 +294,7 @@ class $StatusesClient {
   ///
   /// See:
   ///  * [findAll] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<StatusesFindAllResponseApplicationJson, void> findAllRaw({
     int? limit,
     int? offset,
@@ -328,9 +328,9 @@ class $StatusesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses{?limit*,offset*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses{?limit*,offset*}').expand(_parameters);
     return _i1.DynamiteRawResponse<StatusesFindAllResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -388,7 +388,7 @@ class $StatusesClient {
   ///
   /// See:
   ///  * [find] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<StatusesFindResponseApplicationJson, void> findRaw({
     required String userId,
     bool? oCSAPIRequest,
@@ -418,9 +418,9 @@ class $StatusesClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses/{userId}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses/{userId}').expand(_parameters);
     return _i1.DynamiteRawResponse<StatusesFindResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'get',
@@ -481,7 +481,7 @@ class $UserStatusClient {
   ///
   /// See:
   ///  * [getStatus] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UserStatusGetStatusResponseApplicationJson, void> getStatusRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -504,7 +504,7 @@ class $UserStatusClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/user_status/api/v1/user_status';
     return _i1.DynamiteRawResponse<UserStatusGetStatusResponseApplicationJson, void>(
@@ -564,7 +564,7 @@ class $UserStatusClient {
   ///
   /// See:
   ///  * [setStatus] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UserStatusSetStatusResponseApplicationJson, void> setStatusRaw({
     required String statusType,
     bool? oCSAPIRequest,
@@ -594,10 +594,10 @@ class $UserStatusClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/status{?statusType*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/status{?statusType*}').expand(_parameters);
     return _i1.DynamiteRawResponse<UserStatusSetStatusResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -659,7 +659,7 @@ class $UserStatusClient {
   ///
   /// See:
   ///  * [setPredefinedMessage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UserStatusSetPredefinedMessageResponseApplicationJson, void> setPredefinedMessageRaw({
     required String messageId,
     int? clearAt,
@@ -693,10 +693,10 @@ class $UserStatusClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/message/predefined{?messageId*,clearAt*}')
+        _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/message/predefined{?messageId*,clearAt*}')
             .expand(_parameters);
     return _i1.DynamiteRawResponse<UserStatusSetPredefinedMessageResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
@@ -763,7 +763,7 @@ class $UserStatusClient {
   ///
   /// See:
   ///  * [setCustomMessage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UserStatusSetCustomMessageResponseApplicationJson, void> setCustomMessageRaw({
     String? statusIcon,
     String? message,
@@ -801,9 +801,9 @@ class $UserStatusClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate(
+    final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/user_status/api/v1/user_status/message/custom{?statusIcon*,message*,clearAt*}',
     ).expand(_parameters);
     return _i1.DynamiteRawResponse<UserStatusSetCustomMessageResponseApplicationJson, void>(
@@ -857,7 +857,7 @@ class $UserStatusClient {
   ///
   /// See:
   ///  * [clearMessage] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UserStatusClearMessageResponseApplicationJson, void> clearMessageRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -880,7 +880,7 @@ class $UserStatusClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/user_status/api/v1/user_status/message';
     return _i1.DynamiteRawResponse<UserStatusClearMessageResponseApplicationJson, void>(
@@ -938,7 +938,7 @@ class $UserStatusClient {
   ///
   /// See:
   ///  * [revertStatus] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<UserStatusRevertStatusResponseApplicationJson, void> revertStatusRaw({
     required String messageId,
     bool? oCSAPIRequest,
@@ -968,10 +968,10 @@ class $UserStatusClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/revert/{messageId}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/revert/{messageId}').expand(_parameters);
     return _i1.DynamiteRawResponse<UserStatusRevertStatusResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'delete',
@@ -2252,13 +2252,13 @@ extension $557344b3ba734aacc7109e5420fcb6c5Extension on _$557344b3ba734aacc7109e
   List<String> get _names => const ['clearAtTimeType', r'$int'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -2329,13 +2329,13 @@ extension $d77829de8b7590d2e16cdb714800f5beExtension on _$d77829de8b7590d2e16cdb
   List<String> get _names => const ['builtListNever', 'private'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -2402,7 +2402,7 @@ class _$d77829de8b7590d2e16cdb714800f5beSerializer implements PrimitiveSerialize
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
@@ -2533,7 +2533,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -21,9 +21,9 @@ import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:collection/collection.dart';
 import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i2;
-import 'package:meta/meta.dart' as _i4;
-import 'package:uri/uri.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i3;
+import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 part 'weather_status.openapi.g.dart';
 
@@ -98,7 +98,7 @@ class $WeatherStatusClient {
   ///
   /// See:
   ///  * [setMode] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<WeatherStatusSetModeResponseApplicationJson, void> setModeRaw({
     required int mode,
     bool? oCSAPIRequest,
@@ -128,9 +128,9 @@ class $WeatherStatusClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
-    final _path = _i3.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/mode{?mode*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/mode{?mode*}').expand(_parameters);
     return _i1.DynamiteRawResponse<WeatherStatusSetModeResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -182,7 +182,7 @@ class $WeatherStatusClient {
   ///
   /// See:
   ///  * [usePersonalAddress] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<WeatherStatusUsePersonalAddressResponseApplicationJson, void> usePersonalAddressRaw({
     bool? oCSAPIRequest,
   }) {
@@ -207,7 +207,7 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/weather_status/api/v1/use-personal';
     return _i1.DynamiteRawResponse<WeatherStatusUsePersonalAddressResponseApplicationJson, void>(
@@ -261,7 +261,7 @@ class $WeatherStatusClient {
   ///
   /// See:
   ///  * [getLocation] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<WeatherStatusGetLocationResponseApplicationJson, void> getLocationRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -284,7 +284,7 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/weather_status/api/v1/location';
     return _i1.DynamiteRawResponse<WeatherStatusGetLocationResponseApplicationJson, void>(
@@ -350,7 +350,7 @@ class $WeatherStatusClient {
   ///
   /// See:
   ///  * [setLocation] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<WeatherStatusSetLocationResponseApplicationJson, void> setLocationRaw({
     String? address,
     double? lat,
@@ -388,10 +388,10 @@ class $WeatherStatusClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/location{?address*,lat*,lon*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/location{?address*,lat*,lon*}').expand(_parameters);
     return _i1.DynamiteRawResponse<WeatherStatusSetLocationResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -445,7 +445,7 @@ class $WeatherStatusClient {
   ///
   /// See:
   ///  * [getForecast] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<WeatherStatusGetForecastResponseApplicationJson, void> getForecastRaw({bool? oCSAPIRequest}) {
     final _headers = <String, String>{'Accept': 'application/json'};
 
@@ -468,7 +468,7 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/weather_status/api/v1/forecast';
     return _i1.DynamiteRawResponse<WeatherStatusGetForecastResponseApplicationJson, void>(
@@ -522,7 +522,7 @@ class $WeatherStatusClient {
   ///
   /// See:
   ///  * [getFavorites] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<WeatherStatusGetFavoritesResponseApplicationJson, void> getFavoritesRaw({
     bool? oCSAPIRequest,
   }) {
@@ -547,7 +547,7 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     const _path = '/ocs/v2.php/apps/weather_status/api/v1/favorites';
     return _i1.DynamiteRawResponse<WeatherStatusGetFavoritesResponseApplicationJson, void>(
@@ -605,7 +605,7 @@ class $WeatherStatusClient {
   ///
   /// See:
   ///  * [setFavorites] for an operation that returns a `DynamiteResponse` with a stable API.
-  @_i4.experimental
+  @_i2.experimental
   _i1.DynamiteRawResponse<WeatherStatusSetFavoritesResponseApplicationJson, void> setFavoritesRaw({
     required BuiltList<String> favorites,
     bool? oCSAPIRequest,
@@ -636,10 +636,10 @@ class $WeatherStatusClient {
 
     var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     $oCSAPIRequest ??= true;
-    _headers['OCS-APIRequest'] = const _i2.HeaderEncoder().convert($oCSAPIRequest);
+    _headers['OCS-APIRequest'] = const _i3.HeaderEncoder().convert($oCSAPIRequest);
 
     final _path =
-        _i3.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/favorites{?favorites%5B%5D*}').expand(_parameters);
+        _i4.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/favorites{?favorites%5B%5D*}').expand(_parameters);
     return _i1.DynamiteRawResponse<WeatherStatusSetFavoritesResponseApplicationJson, void>(
       response: _rootClient.executeRequest(
         'put',
@@ -2010,13 +2010,13 @@ extension $20fe3de793aed6fbf929c9b82b472b1aExtension on _$20fe3de793aed6fbf929c9
   List<String> get _names => const ['builtListForecast', 'weatherStatusGetForecastResponseApplicationJsonOcsData1'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i2.validateOneOf(
+  void validateOneOf() => _i3.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i2.validateAnyOf(
+  void validateAnyOf() => _i3.validateAnyOf(
         _values,
         _names,
       );
@@ -2092,7 +2092,7 @@ class _$20fe3de793aed6fbf929c9b82b472b1aSerializer implements PrimitiveSerialize
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
@@ -2227,7 +2227,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i4.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
       ..add(_i5.DynamiteDoubleSerializer())


### PR DESCRIPTION
refactors extracted from: #1580
Motivation:
This decouples the resolving and generation of our parameter code.
The new code first resolves everything into a collections that can later be used to generate code.
```dart
      final operationParameters = <Parameter>[];
      final pathParameters = <openapi.Parameter, TypeResult>{};
      final headerParameters = <openapi.Parameter, TypeResult>{};
```
This is needed to keep further behavior changing changes easy to review.