### PR TITLE
fix(neon_framework): Set theme primaryColor to fix markdown rendering

### DIFF
--- a/packages/neon/neon_notes/lib/src/pages/note.dart
+++ b/packages/neon/neon_notes/lib/src/pages/note.dart
@@ -181,6 +181,7 @@ class _NotesNotePageState extends State<NotesNotePage> {
                       )
                     : SingleChildScrollView(
                         child: MarkdownBody(
+                          styleSheetTheme: MarkdownStyleSheetBaseTheme.platform,
                           data: _contentController.text,
                           onTapLink: (text, href, title) async {
                             if (href != null) {

--- a/packages/neon_framework/lib/src/theme/theme.dart
+++ b/packages/neon_framework/lib/src/theme/theme.dart
@@ -106,6 +106,8 @@ class AppTheme {
       useMaterial3: true,
       platform: platform,
       colorScheme: colorScheme,
+      // For Markdown
+      primaryColor: colorScheme.primary,
       scaffoldBackgroundColor: colorScheme.background,
       cardColor: colorScheme.background,
       // For LicensePage


### PR DESCRIPTION
The flutter_markdown package still relies on Theme.primaryColor, so we have to set it.
Previously list items were not readable in dark mode because the primaryColor was set to dark grey on a black background.