### PR TITLE
fix(neon_framework): Correctly scale status loading indicator in NeonUserAvatar

### DIFF
--- a/packages/neon_framework/lib/src/widgets/user_avatar.dart
+++ b/packages/neon_framework/lib/src/widgets/user_avatar.dart
@@ -138,9 +138,12 @@ class NeonUserStatusIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     Widget? child;
     if (result.isLoading) {
-      child = CircularProgressIndicator(
-        strokeWidth: 1.5,
-        color: Theme.of(context).colorScheme.onPrimary,
+      child = SizedBox.square(
+        dimension: size / 2.5,
+        child: CircularProgressIndicator(
+          strokeWidth: 1.5,
+          color: Theme.of(context).colorScheme.onPrimary,
+        ),
       );
     } else if (result.hasError) {
       child = Icon(


### PR DESCRIPTION
It should only take up the size of the status indicator and not the whole avatar.