### PR TITLE
chore(nextcloud): Advertise drop_account 2.5 compatibility

### DIFF
--- a/packages/nextcloud/README.md
+++ b/packages/nextcloud/README.md
@@ -55,7 +55,7 @@ These OpenAPI specifications are [generated](https://github.com/nextcloud/openap
 | [Notifications app](https://github.com/nextcloud/notifications)                    | 26 - 28                |
 | [Talk app](https://github.com/nextcloud/spreed)                                    | 16 - 18                |
 | [NextPush app](https://codeberg.org/NextPush/uppush)                               | 1.3 - 1.4              |
-| [User account deletion app](https://framagit.org/framasoft/nextcloud/drop_account) | 2.3 - 2.4              |
+| [User account deletion app](https://framagit.org/framasoft/nextcloud/drop_account) | 2.3 - 2.5              |
 
 1: Other versions might be supported too or at least mostly working, but we do not test against those.  
 2: Server includes the following apps: comments, core, dashboard, dav, files, files_external, files_reminders, files_sharing, files_trashbin, files_versions, provisioning_api, settings, sharebymail, theming, updatenotification, user_status, weather_status and WebDAV.  


### PR DESCRIPTION
Forgot to add it in https://github.com/nextcloud/neon/pull/1775