### PR TITLE
feat(neon_talk): Show user status on room page

### DIFF
--- a/packages/neon/neon_talk/lib/src/pages/room.dart
+++ b/packages/neon/neon_talk/lib/src/pages/room.dart
@@ -57,13 +57,29 @@ class _TalkRoomPageState extends State<TalkRoomPage> {
     return ResultBuilder.behaviorSubject(
       subject: bloc.room,
       builder: (context, result) {
+        Widget title = Text(result.requireData.displayName);
+
+        final statusMessage = result.requireData.statusMessage;
+        if (statusMessage != null) {
+          title = Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              title,
+              Text(
+                statusMessage,
+                style: Theme.of(context).textTheme.labelSmall,
+              ),
+            ],
+          );
+        }
+
         final appBar = AppBar(
           title: Row(
             children: <Widget>[
               TalkRoomAvatar(
                 room: widget.room,
               ),
-              Text(result.requireData.displayName),
+              title,
               NeonError(
                 result.error,
                 onRetry: bloc.refresh,


### PR DESCRIPTION
Closes https://github.com/nextcloud/neon/issues/1778

No extra check for the room type is necessary because the status will just be null for rooms that are not 1:1s.