### PR TITLE
feat(neon_framework): request cache return CacheParameters on get

### DIFF
--- a/.cspell/tools.txt
+++ b/.cspell/tools.txt
@@ -64,6 +64,7 @@ strfreev
 subprojects
 sysroot
 tsvg
+unixepoch
 werror
 xxxh
 xxxhdpi

--- a/packages/neon/neon_talk/test/room_bloc_test.dart
+++ b/packages/neon/neon_talk/test/room_bloc_test.dart
@@ -79,7 +79,6 @@ void main() {
     expect(
       bloc.room.transformResult((e) => e.token),
       emitsInOrder([
-        Result.success('abcd'),
         Result.success('abcd').asLoading(),
         Result.success('abcd'),
         Result.success('abcd').asLoading(),

--- a/packages/neon_framework/lib/src/storage/request_cache.dart
+++ b/packages/neon_framework/lib/src/storage/request_cache.dart
@@ -73,7 +73,7 @@ final class DefaultRequestCache implements RequestCache {
         // Non breaking migrations should not drop the cache. The next
         // breaking change should remove all non breaking migrations before it.
         await db.transaction((txn) async {
-          if (oldVersion <= 2) {
+          if (oldVersion <= 3) {
             await txn.execute('DROP TABLE cache');
             await onCreate(txn);
           }

--- a/packages/neon_framework/lib/src/storage/request_cache.dart
+++ b/packages/neon_framework/lib/src/storage/request_cache.dart
@@ -15,19 +15,13 @@ final _log = Logger('RequestCache');
 
 /// A storage used to cache a key value pair.
 abstract interface class RequestCache {
-  /// Get's the cached value for the given [key].
-  ///
-  /// Use [getParameters] if you only need to check whether the cache is still
-  /// valid.
-  Future<String?> get(Account account, String key);
+  /// Get's the cached value and parameters for the given [key].
+  Future<({String value, CacheParameters? parameters})?> get(Account account, String key);
 
   /// Set's the cached [value] at the given [key].
   ///
   /// If a value is already present it will be updated with the new one.
   Future<void> set(Account account, String key, String value, CacheParameters? parameters);
-
-  /// Retrieves the cache parameters for the given [key].
-  Future<CacheParameters> getParameters(Account account, String key);
 
   /// Updates the cache [parameters] for a given [key] without modifying the `value`.
   Future<void> updateParameters(Account account, String key, CacheParameters? parameters);
@@ -112,15 +106,15 @@ CREATE TABLE "cache" (
   }
 
   @override
-  Future<String?> get(Account account, String key) async {
+  Future<({String value, CacheParameters? parameters})?> get(Account account, String key) async {
     List<Map<String, Object?>>? result;
     try {
       result = await _requireDatabase.rawQuery(
         '''
-SELECT value
+SELECT value, etag, expires
 FROM cache
 WHERE account = ? AND key = ?
-      ''',
+''',
         [account.id, key],
       );
     } on DatabaseException catch (error, stackTrace) {
@@ -131,7 +125,26 @@ WHERE account = ? AND key = ?
       );
     }
 
-    return result?.firstOrNull?['value'] as String?;
+    final row = result?.singleOrNull;
+    if (row == null) {
+      return null;
+    }
+
+    final value = row['value']! as String;
+    final etag = row['etag'] as String?;
+    final expires = row['expires'] as int?;
+
+    final parameters = CacheParameters(
+      etag: etag,
+      expires: expires != null
+          ? DateTimeUtils.fromSecondsSinceEpoch(
+              tz.UTC,
+              expires,
+            )
+          : null,
+    );
+
+    return (value: value, parameters: parameters);
   }
 
   @override
@@ -174,40 +187,6 @@ WHERE (SELECT changes() = 0)
         stackTrace,
       );
     }
-  }
-
-  @override
-  Future<CacheParameters> getParameters(Account account, String key) async {
-    List<Map<String, Object?>>? result;
-    try {
-      result = await _requireDatabase.rawQuery(
-        '''
-SELECT etag, expires
-FROM cache
-WHERE account = ? AND key = ?
-''',
-        [account.id, key],
-      );
-    } on DatabaseException catch (error, stackTrace) {
-      _log.severe(
-        'Error getting the cache parameters for `$key` from cache.',
-        error,
-        stackTrace,
-      );
-    }
-
-    final row = result?.firstOrNull;
-
-    final expires = row?['expires'] as int?;
-    return CacheParameters(
-      etag: row?['etag'] as String?,
-      expires: expires != null
-          ? DateTimeUtils.fromSecondsSinceEpoch(
-              tz.UTC,
-              expires,
-            )
-          : null,
-    );
   }
 
   @override

--- a/packages/neon_framework/test/persistence_test.dart
+++ b/packages/neon_framework/test/persistence_test.dart
@@ -55,9 +55,11 @@ void main() {
         expires: now,
       );
       await cache.updateParameters(account, 'key', parameters);
-      final cachedParameters = await cache.getParameters(account, 'key');
-      expect(cachedParameters.etag, 'etag');
-      expect(cachedParameters.expires?.secondsSinceEpoch, now.secondsSinceEpoch);
+
+      result = await cache.getParameters(account, 'key');
+      result as CacheParameters;
+      expect(result.etag, 'etag');
+      expect(result.expires?.secondsSinceEpoch, now.secondsSinceEpoch);
     });
 
     group('SQLitePersistence', () {

--- a/packages/neon_framework/test/persistence_test.dart
+++ b/packages/neon_framework/test/persistence_test.dart
@@ -14,52 +14,62 @@ import 'package:timezone/timezone.dart' as tz;
 
 void main() {
   group('Persistences', () {
-    test('RequestCache', () async {
+    group('RequestCache', () {
       final account = MockAccount();
       when(() => account.id).thenReturn('clientID');
 
       final cache = DefaultRequestCache();
-      sqfliteFfiInit();
-      databaseFactory = databaseFactoryFfi;
 
-      expect(() async => cache.get(account, 'key'), throwsA(isA<StateError>()));
+      setUpAll(() {
+        sqfliteFfiInit();
+        databaseFactory = databaseFactoryFfi;
+      });
 
-      cache.database = await openDatabase(
-        inMemoryDatabasePath,
-        version: 1,
-        onCreate: DefaultRequestCache.onCreate,
-      );
+      setUp(() async {
+        cache.database = await openDatabase(
+          inMemoryDatabasePath,
+          version: 1,
+          onCreate: DefaultRequestCache.onCreate,
+          singleInstance: false,
+        );
+      });
 
-      dynamic result = await cache.get(account, 'key');
-      expect(result, isNull);
+      test('init', () {
+        cache.database = null;
+        expect(() async => cache.get(account, 'key'), throwsA(isA<StateError>()));
+      });
 
-      await cache.set(account, 'key', 'value', null);
-      result = await cache.get(account, 'key');
-      expect(result, equals('value'));
+      test('RequestCache', () async {
+        var result = await cache.get(account, 'key');
+        expect(result, isNull);
 
-      await cache.set(account, 'key', 'upsert', null);
-      result = await cache.get(account, 'key');
-      expect(result, equals('upsert'));
+        await cache.set(account, 'key', 'value', null);
+        result = await cache.get(account, 'key');
+        expect(result?.value, equals('value'));
 
-      var parameters = const CacheParameters(etag: null, expires: null);
-      result = await cache.getParameters(account, 'newKey');
-      expect(result, equals(parameters));
+        await cache.set(account, 'key', 'upsert', null);
+        result = await cache.get(account, 'key');
+        expect(result?.value, equals('upsert'));
 
-      await cache.set(account, 'key', 'value', parameters);
-      result = await cache.getParameters(account, 'key');
-      expect(result, equals(parameters));
+        var parameters = const CacheParameters(etag: null, expires: null);
+        result = await cache.get(account, 'newKey');
+        expect(result?.parameters, isNull);
 
-      final now = tz.TZDateTime.now(tz.UTC);
-      parameters = CacheParameters(
-        etag: 'etag',
-        expires: now,
-      );
-      await cache.updateParameters(account, 'key', parameters);
+        await cache.set(account, 'key', 'value', parameters);
+        result = await cache.get(account, 'key');
+        expect(result?.parameters, equals(parameters));
 
-      result = await cache.getParameters(account, 'key');
-      result as CacheParameters;
-      expect(result.etag, 'etag');
-      expect(result.expires?.secondsSinceEpoch, now.secondsSinceEpoch);
+        final now = tz.TZDateTime.now(tz.UTC);
+        parameters = CacheParameters(
+          etag: 'etag',
+          expires: now,
+        );
+
+        await cache.updateParameters(account, 'key', parameters);
+        result = await cache.get(account, 'key');
+        expect(result?.parameters?.etag, 'etag');
+        expect(result?.parameters?.expires?.secondsSinceEpoch, now.secondsSinceEpoch);
+      });
     });
 
     group('SQLitePersistence', () {

--- a/packages/neon_framework/test/request_manager_test.dart
+++ b/packages/neon_framework/test/request_manager_test.dart
@@ -279,15 +279,11 @@ void main() {
         cache = MockRequestCache();
 
         when(() => cache.get(any(), any())).thenAnswer(
-          (_) => Future.value('Cached value'),
+          (_) => Future.value((value: 'Cached value', parameters: null)),
         );
 
         when(() => cache.set(any(), any(), any(), any())).thenAnswer(
           (_) => Future.value(),
-        );
-
-        when(() => cache.getParameters(any(), any())).thenAnswer(
-          (_) => Future.value(const CacheParameters(etag: null, expires: null)),
         );
 
         when(() => cache.updateParameters(any(), any(), any())).thenAnswer(
@@ -500,16 +496,16 @@ void main() {
       });
 
       test('cached Expires', () async {
-        when(() => cache.getParameters(any(), any())).thenAnswer(
+        when(() => cache.get(any(), any())).thenAnswer(
           (_) => Future.value(
-            CacheParameters(
-              etag: null,
-              expires: tz.TZDateTime.now(tz.UTC).add(const Duration(hours: 1)),
+            (
+              value: 'Cached value',
+              parameters: CacheParameters(
+                etag: null,
+                expires: tz.TZDateTime.now(tz.UTC).add(const Duration(hours: 1)),
+              )
             ),
           ),
-        );
-        when(() => cache.get(any(), any())).thenAnswer(
-          (_) => Future.value('Cached value'),
         );
 
         var subject = BehaviorSubject<Result<String>>();
@@ -538,16 +534,16 @@ void main() {
         verify(() => cache.get(account, 'key')).called(1);
         verifyNever(() => cache.set(any(), any(), any(), any()));
 
-        when(() => cache.getParameters(any(), any())).thenAnswer(
+        when(() => cache.get(any(), any())).thenAnswer(
           (_) => Future.value(
-            CacheParameters(
-              etag: null,
-              expires: tz.TZDateTime.now(tz.UTC).subtract(const Duration(hours: 1)),
+            (
+              value: 'Cached value',
+              parameters: CacheParameters(
+                etag: null,
+                expires: tz.TZDateTime.now(tz.UTC).subtract(const Duration(hours: 1)),
+              )
             ),
           ),
-        );
-        when(() => cache.get(any(), any())).thenAnswer(
-          (_) => Future.value('Cached value'),
         );
 
         subject = BehaviorSubject<Result<String>>();
@@ -585,16 +581,16 @@ void main() {
           tz.UTC,
         );
 
-        when(() => cache.getParameters(any(), any())).thenAnswer(
+        when(() => cache.get(any(), any())).thenAnswer(
           (_) => Future.value(
-            const CacheParameters(
-              etag: 'a',
-              expires: null,
+            (
+              value: 'Cached value',
+              parameters: const CacheParameters(
+                etag: 'a',
+                expires: null,
+              ),
             ),
           ),
-        );
-        when(() => cache.get(any(), any())).thenAnswer(
-          (_) => Future.value('Cached value'),
         );
         when(callback.call).thenAnswer(
           (_) async => CacheParameters(
@@ -632,16 +628,16 @@ void main() {
         verify(() => cache.updateParameters(account, 'key', CacheParameters(etag: 'a', expires: newExpires))).called(1);
         verifyNever(() => cache.set(any(), any(), any(), any()));
 
-        when(() => cache.getParameters(any(), any())).thenAnswer(
+        when(() => cache.get(any(), any())).thenAnswer(
           (_) => Future.value(
-            const CacheParameters(
-              etag: 'a',
-              expires: null,
+            (
+              value: 'Cached value',
+              parameters: const CacheParameters(
+                etag: 'a',
+                expires: null,
+              ),
             ),
           ),
-        );
-        when(() => cache.get(any(), any())).thenAnswer(
-          (_) => Future.value('Cached value'),
         );
         when(callback.call).thenAnswer(
           (_) async => CacheParameters(


### PR DESCRIPTION
No matter what the cache parameters are we will always also query the cached data.
Doing both in one go saves us a round trip to the DB and imo also makes the request manager a bit easier to read.

This is the result of my effort to validate the `etag` and `expires` field in DB which turned out to not be viable.