### PR TITLE
chore(neon_talk): Ignore irrelevant coverage parts in room avatar

### DIFF
--- a/packages/neon/neon_talk/lib/src/widgets/room_avatar.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/room_avatar.dart
@@ -42,10 +42,12 @@ class TalkRoomAvatar extends StatelessWidget {
           username: room.name,
         ),
       spreed.RoomType.group => _buildIconAvatar(AdaptiveIcons.group),
+      // coverage:ignore-start
       spreed.RoomType.public => _buildIconAvatar(AdaptiveIcons.link),
       spreed.RoomType.changelog => _buildIconAvatar(AdaptiveIcons.text_snippet_outlined),
       spreed.RoomType.oneToOneFormer => _buildIconAvatar(AdaptiveIcons.lock),
       spreed.RoomType.noteToSelf => _buildIconAvatar(AdaptiveIcons.edit_note),
+      // coverage:ignore-end
     };
   }
 


### PR DESCRIPTION
Testing the other cases has no point, so we don't do it. The added ignores bump the coverage to 100%