### PR TITLE
fix(neon_framework): Catch FormatExceptions when parsing Http-dates in RequestManager

### DIFF
--- a/packages/neon_framework/lib/src/utils/request_manager.dart
+++ b/packages/neon_framework/lib/src/utils/request_manager.dart
@@ -395,6 +395,8 @@ class CacheParameters {
   });
 
   /// Parse the cache parameters from HTTP response headers.
+  ///
+  /// It will throw a [FormatException] if the expiry date is invalid.
   factory CacheParameters.parseHeaders(Map<String, dynamic> headers) {
     tz.TZDateTime? expiry;
     if (headers.containsKey('expires')) {

--- a/packages/neon_framework/lib/src/utils/request_manager.dart
+++ b/packages/neon_framework/lib/src/utils/request_manager.dart
@@ -244,6 +244,11 @@ class RequestManager {
             'Fetching cache parameters timed out. Assuming expired.',
             error,
           );
+        } on FormatException catch (error) {
+          _log.info(
+            'Invalid format when parsing cache parameters. Assuming expired.',
+            error,
+          );
         } on http.ClientException catch (error, stackTrace) {
           _log.warning(
             'Error fetching cache parameters. Assuming expired.',
@@ -303,7 +308,14 @@ class RequestManager {
 
         CacheParameters? cacheParameters;
         if (response case DynamiteRawResponse(:final rawHeaders) when rawHeaders != null) {
-          cacheParameters = CacheParameters.parseHeaders(rawHeaders);
+          try {
+            cacheParameters = CacheParameters.parseHeaders(rawHeaders);
+          } on FormatException catch (error) {
+            _log.info(
+              'Invalid format when parsing cache parameters.',
+              error,
+            );
+          }
         }
 
         await _cache?.set(account, cacheKey, serialized, cacheParameters);

--- a/packages/nextcloud/lib/src/webdav/file.dart
+++ b/packages/nextcloud/lib/src/webdav/file.dart
@@ -62,7 +62,9 @@ class WebDavFile {
   /// Share note
   late final String? note = props.ncnote;
 
-  /// Last modified date of the file
+  /// Last modified date of the file.
+  ///
+  /// It will throw a [FormatException] if the date is invalid.
   late final tz.TZDateTime? lastModified = () {
     if (props.davgetlastmodified != null) {
       return parseHttpDate(props.davgetlastmodified!);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/1762