### PR TITLE
feat(neon_framework): emit cached data before fetching new cache parameters

### DIFF
--- a/packages/neon_framework/test/request_manager_test.dart
+++ b/packages/neon_framework/test/request_manager_test.dart
@@ -606,6 +606,7 @@ void main() {
           subject.stream,
           emitsInOrder([
             equals(Result<String>.loading()),
+            equals(Result(base64String('Cached value'), null, isLoading: true, isCached: true)),
             equals(Result(base64String('Cached value'), null, isLoading: false, isCached: true)),
             emitsDone,
           ]),


### PR DESCRIPTION
Signed-off-by: Nikolas Rimikis <leptopoda@users.noreply.github.com>

As discussed in: https://github.com/nextcloud/neon/pull/1787#discussion_r1540738969
This will result in faster loading of the cached data with an extra ui refresh when the loading is done.