### PR TITLE
chore(nextcloud): Remove test skip on spreed 16

### DIFF
--- a/packages/nextcloud/test/spreed_test.dart
+++ b/packages/nextcloud/test/spreed_test.dart
@@ -9,7 +9,6 @@ import 'package:nextcloud/src/utils/date_time.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
-import 'package:version/version.dart';
 
 void main() {
   presets(
@@ -176,64 +175,60 @@ void main() {
         });
       });
 
-      group(
-        'Avatar',
-        () {
-          test('Set emoji avatar', () async {
-            final room = await createTestRoom();
+      group('Avatar', () {
+        test('Set emoji avatar', () async {
+          final room = await createTestRoom();
 
-            final response = await client1.spreed.avatar.emojiAvatar(
-              emoji: '😀',
-              token: room.token,
-            );
-            expect(response.statusCode, 200);
-            expect(response.body.ocs.data.isCustomAvatar, true);
-          });
+          final response = await client1.spreed.avatar.emojiAvatar(
+            emoji: '😀',
+            token: room.token,
+          );
+          expect(response.statusCode, 200);
+          expect(response.body.ocs.data.isCustomAvatar, true);
+        });
 
-          test('Get avatar', () async {
-            final room = await createTestRoom();
-            await client1.spreed.avatar.emojiAvatar(
-              emoji: '😀',
-              token: room.token,
-            );
+        test('Get avatar', () async {
+          final room = await createTestRoom();
+          await client1.spreed.avatar.emojiAvatar(
+            emoji: '😀',
+            token: room.token,
+          );
 
-            final response = await client1.spreed.avatar.getAvatar(
-              token: room.token,
-            );
-            expect(response.statusCode, 200);
-            expect(response.body, isNotEmpty);
-          });
+          final response = await client1.spreed.avatar.getAvatar(
+            token: room.token,
+          );
+          expect(response.statusCode, 200);
+          expect(response.body, isNotEmpty);
+        });
 
-          test('Get avatar dark', () async {
-            final room = await createTestRoom();
-            await client1.spreed.avatar.emojiAvatar(
-              emoji: '😀',
-              token: room.token,
-            );
+        test('Get avatar dark', () async {
+          final room = await createTestRoom();
+          await client1.spreed.avatar.emojiAvatar(
+            emoji: '😀',
+            token: room.token,
+          );
 
-            final response = await client1.spreed.avatar.getAvatarDark(
-              token: room.token,
-            );
-            expect(response.statusCode, 200);
-            expect(response.body, isNotEmpty);
-          });
+          final response = await client1.spreed.avatar.getAvatarDark(
+            token: room.token,
+          );
+          expect(response.statusCode, 200);
+          expect(response.body, isNotEmpty);
+        });
 
-          test('Delete avatar', () async {
-            final room = await createTestRoom();
-            await client1.spreed.avatar.emojiAvatar(
-              emoji: '😀',
-              token: room.token,
-            );
+        test('Delete avatar', () async {
+          final room = await createTestRoom();
+          await client1.spreed.avatar.emojiAvatar(
+            emoji: '😀',
+            token: room.token,
+          );
 
-            final response = await client1.spreed.avatar.deleteAvatar(
-              token: room.token,
-            );
-            expect(response.statusCode, 200);
-            expect(response.body.ocs.data.isCustomAvatar, false);
-          });
-        },
-        skip: preset.version < Version(17, 0, 0),
-      );
+          final response = await client1.spreed.avatar.deleteAvatar(
+            token: room.token,
+          );
+          expect(response.statusCode, 200);
+          expect(response.body.ocs.data.isCustomAvatar, false);
+        });
+      });
 
       group('Chat', () {
         test('Send message', () async {


### PR DESCRIPTION
Should have been removed in https://github.com/nextcloud/neon/pull/1832 because we no longer test against spreed 16.