### PR TITLE
fix(neon_talk): Improve message list constraints

### DIFF
--- a/packages/neon/neon_talk/lib/neon_talk.dart
+++ b/packages/neon/neon_talk/lib/neon_talk.dart
@@ -13,6 +13,7 @@ import 'package:neon_talk/src/blocs/talk.dart';
 import 'package:neon_talk/src/options.dart';
 import 'package:neon_talk/src/pages/main.dart';
 import 'package:neon_talk/src/routes.dart';
+import 'package:neon_talk/src/theme.dart';
 import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/spreed.dart';
@@ -49,6 +50,9 @@ class TalkApp extends AppImplementation<TalkBloc, TalkOptions> {
 
   @override
   final RouteBase route = $talkAppRoute;
+
+  @override
+  final theme = const TalkTheme();
 
   @override
   BehaviorSubject<int> getUnreadCounter(TalkBloc bloc) => bloc.unreadCounter;

--- a/packages/neon/neon_talk/lib/src/pages/room.dart
+++ b/packages/neon/neon_talk/lib/src/pages/room.dart
@@ -7,6 +7,7 @@ import 'package:neon_framework/models.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
 import 'package:neon_talk/src/blocs/room.dart';
+import 'package:neon_talk/src/theme.dart';
 import 'package:neon_talk/src/widgets/message.dart';
 import 'package:neon_talk/src/widgets/room_avatar.dart';
 import 'package:nextcloud/spreed.dart' as spreed;
@@ -104,39 +105,48 @@ class _TalkRoomPageState extends State<TalkRoomPage> {
 
         final body = ResultBuilder.behaviorSubject(
           subject: bloc.messages,
-          builder: (context, result) => NeonListView(
-            scrollKey: 'talk-room-${room.token}',
-            reverse: true,
-            isLoading: result.isLoading,
-            error: result.error,
-            onRefresh: bloc.refresh,
-            itemCount: result.data?.length ?? 0,
-            itemBuilder: (context, index) {
-              final message = result.requireData[index];
+          builder: (context, result) {
+            final sliver = SliverList.builder(
+              itemCount: result.data?.length ?? 0,
+              itemBuilder: (context, index) {
+                final message = result.requireData[index];
 
-              spreed.ChatMessageWithParent? previousMessage;
-              if (result.requireData.length > index + 1) {
-                previousMessage = result.requireData[index + 1];
-              }
+                spreed.ChatMessageWithParent? previousMessage;
+                if (result.requireData.length > index + 1) {
+                  previousMessage = result.requireData[index + 1];
+                }
 
-              return TalkMessage(
-                chatMessage: message,
-                previousChatMessage: previousMessage,
-              );
-            },
-          ),
+                return Center(
+                  child: ConstrainedBox(
+                    constraints: Theme.of(context).extension<TalkTheme>()!.messageConstraints,
+                    child: TalkMessage(
+                      chatMessage: message,
+                      previousChatMessage: previousMessage,
+                    ),
+                  ),
+                );
+              },
+            );
+
+            return NeonListView.custom(
+              scrollKey: 'talk-room-${room.token}',
+              reverse: true,
+              isLoading: result.isLoading,
+              error: result.error,
+              onRefresh: bloc.refresh,
+              sliver: SliverPadding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 20,
+                ),
+                sliver: sliver,
+              ),
+            );
+          },
         );
 
         return Scaffold(
           appBar: appBar,
-          body: Center(
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(
-                maxWidth: 1120,
-              ),
-              child: body,
-            ),
-          ),
+          body: body,
         );
       },
     );

--- a/packages/neon/neon_talk/lib/src/theme.dart
+++ b/packages/neon/neon_talk/lib/src/theme.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+/// Defines the custom Talk theme.
+class TalkTheme extends ThemeExtension<TalkTheme> {
+  /// Creates a new Talk theme.
+  const TalkTheme({
+    this.messageConstraints = const BoxConstraints(
+      maxWidth: 1120,
+    ),
+  });
+
+  /// The constraints that are applied to message widgets.
+  final BoxConstraints messageConstraints;
+
+  @override
+  TalkTheme copyWith({BoxConstraints? messageConstraints}) {
+    return TalkTheme(
+      messageConstraints: messageConstraints ?? this.messageConstraints,
+    );
+  }
+
+  @override
+  TalkTheme lerp(covariant TalkTheme? other, double t) {
+    throw UnimplementedError();
+  }
+}

--- a/packages/neon_framework/lib/src/models/app_implementation.dart
+++ b/packages/neon_framework/lib/src/models/app_implementation.dart
@@ -189,7 +189,7 @@ abstract class AppImplementation<T extends Bloc, R extends AppImplementationOpti
   /// A custom theme that will be injected into the widget tree.
   ///
   /// You can later access it through `Theme.of(context).extension<ThemeName>()`.
-  final ThemeExtension? theme = null;
+  ThemeExtension? get theme => null;
 
   @override
   bool operator ==(Object other) => other is AppImplementation && other.id == id;


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/1740

This not only adds the padding so that the scroll bar never overlaps the message time, but also moves the constraint into the list itself so that the scrollbar is always at the most right position regardless of the list width and you can scroll everywhere.

I didn't find any way to use SliverConstrainedCrossAxis because it aligns everything to the left but the messages should be centered. Maybe @Leptopoda you know what would make this work.