### PR TITLE
refactor(dynamite_runtime)!: Remove executeRequest and executeRawRequest methods

### DIFF
--- a/packages/dynamite/dynamite/lib/src/helpers/dart_helpers.dart
+++ b/packages/dynamite/dynamite/lib/src/helpers/dart_helpers.dart
@@ -122,8 +122,6 @@ extension StringUtils on String {
 }
 
 const _reservedMethodNames = [
-  'executeRequest',
-  'executeRawRequest',
   'send',
   'head',
   'get',

--- a/packages/dynamite/dynamite_runtime/lib/src/client/client.dart
+++ b/packages/dynamite/dynamite_runtime/lib/src/client/client.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dynamite_runtime/src/client/authentication.dart';
@@ -54,47 +53,6 @@ class DynamiteClient with http.BaseClient {
   ///
   /// The first one matching the required authentication type will be used.
   final List<DynamiteAuthentication>? authentications;
-
-  /// Makes a request against a given [path].
-  ///
-  /// The query parameters of the [baseURL] are added.
-  /// The [path] is resolved against the path of the [baseURL].
-  /// All [baseHeaders] are added to the request.
-  Future<http.StreamedResponse> executeRequest(
-    String method,
-    String path, {
-    Map<String, String>? headers,
-    Uint8List? body,
-  }) {
-    final uri = Uri.parse('$baseURL$path');
-
-    return executeRawRequest(
-      method,
-      uri,
-      headers: headers,
-      body: body,
-    );
-  }
-
-  /// Executes a HTTP request against give full [uri].
-  Future<http.StreamedResponse> executeRawRequest(
-    String method,
-    Uri uri, {
-    Map<String, String>? headers,
-    Uint8List? body,
-  }) async {
-    final request = http.Request(method, uri);
-
-    if (headers != null) {
-      request.headers.addAll(headers);
-    }
-
-    if (body != null) {
-      request.bodyBytes = body;
-    }
-
-    return send(request);
-  }
 
   /// Sends an HTTP request and asynchronously returns the response.
   ///

--- a/packages/dynamite/dynamite_runtime/test/client_test.dart
+++ b/packages/dynamite/dynamite_runtime/test/client_test.dart
@@ -33,7 +33,7 @@ void main() {
       );
 
       await cookieJar.saveFromResponse(uri, [Cookie('a', 'b')]);
-      await client.executeRequest('GET', '');
+      await client.get(uri);
 
       final cookies = await cookieJar.loadForRequest(uri);
       expect(cookies, hasLength(2));
@@ -55,7 +55,7 @@ void main() {
         cookieJar: cookieJar,
       );
 
-      await client.executeRequest('GET', '');
+      await client.get(uri);
     });
   });
 
@@ -83,7 +83,7 @@ void main() {
         },
       );
 
-      await client.executeRawRequest('GET', uri);
+      await client.get(uri);
     });
 
     test('request overwrites base headers', () async {
@@ -109,7 +109,12 @@ void main() {
         },
       );
 
-      await client.executeRawRequest('GET', uri, headers: {'some-key': 'some-other-value'});
+      await client.get(
+        uri,
+        headers: {
+          'some-key': 'some-other-value',
+        },
+      );
     });
   });
 }

--- a/packages/neon_framework/lib/src/utils/request_manager.dart
+++ b/packages/neon_framework/lib/src/utils/request_manager.dart
@@ -181,8 +181,7 @@ class RequestManager {
       account: account,
       cacheKey: uri.toString(),
       getCacheParameters: () async {
-        final response = await account.client.executeRawRequest(
-          'HEAD',
+        final response = await account.client.head(
           uri,
           headers: headers,
         );

--- a/tool/find-untested-neon-apis.sh
+++ b/tool/find-untested-neon-apis.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")/.."
 
 function find_apis() {
     # shellcheck disable=SC2068
-    grep -r $@ --include "*\.dart" -e "client\([0-9]\)\?\.[^.]*.[^(]*(" -oh | sed "s/^client\([0-9]\)\?\.//" | sed "s/($//" | sed "s/Raw$//" | grep -v "_Serializer" | grep -v "send" | grep -v "_Request" | grep -v "^executeRawRequest" | sort | uniq
+    grep -r $@ --include "*\.dart" -e "client\([0-9]\)\?\.[^.]*.[^(]*(" -oh | sed "s/^client\([0-9]\)\?\.//" | sed "s/($//" | grep -v "_Serializer" | grep -v "send" | grep -v "head" | grep -v "_Request" | sort | uniq
 }
 
 used_apis=("$(find_apis "packages/neon_framework" "packages/neon/"*)")


### PR DESCRIPTION
I noticed these tests are no longer used by any generated code and can be replaced by just using the send method.