### PR TITLE
Revert "chore: Add pubspec_overrides.yaml to .gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,10 @@ packages/**/build
 packages/**/build-dir
 packages/**/.flatpak-builder
 packages/**/doc/api
-packages/**/pubspec_overrides.yaml
 
 !packages/app/pubspec.lock
+
+# Melos reccomends not adding them to vcs but we need them as we don't use melos in CI
+# **/pubspec_overrides.yaml
 
 .fvm/

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ packages/**/doc/api
 
 !packages/app/pubspec.lock
 
-# Melos reccomends not adding them to vcs but we need them as we don't use melos in CI
+# Melos recommends adding them, but renovate does not generate them which would end up with broken lockfiles
 # **/pubspec_overrides.yaml
 
 .fvm/

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -306,12 +306,11 @@ packages:
     source: hosted
     version: "1.7.0"
   dynamite_runtime:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: dynamite_runtime
-      sha256: "0e416683614460ed2a407bbf1717eb5f756e7a40969319b4192ea0fc01104979"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../dynamite/dynamite_runtime"
+      relative: true
+    source: path
     version: "0.2.0"
   emoji_picker_flutter:
     dependency: transitive
@@ -346,13 +345,11 @@ packages:
     source: hosted
     version: "7.0.0"
   file_icons:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      path: "packages/file_icons"
-      ref: HEAD
-      resolved-ref: "82c4f0254f964a3d3e79befc21c7017ba2c053b8"
-      url: "https://github.com/nextcloud/neon"
-    source: git
+      path: "../file_icons"
+      relative: true
+    source: path
     version: "1.0.0"
   file_picker:
     dependency: transitive
@@ -761,74 +758,58 @@ packages:
   neon_dashboard:
     dependency: "direct main"
     description:
-      path: "packages/neon/neon_dashboard"
-      ref: HEAD
-      resolved-ref: "82c4f0254f964a3d3e79befc21c7017ba2c053b8"
-      url: "https://github.com/nextcloud/neon"
-    source: git
+      path: "../neon/neon_dashboard"
+      relative: true
+    source: path
     version: "1.0.0"
   neon_files:
     dependency: "direct main"
     description:
-      path: "packages/neon/neon_files"
-      ref: HEAD
-      resolved-ref: "82c4f0254f964a3d3e79befc21c7017ba2c053b8"
-      url: "https://github.com/nextcloud/neon"
-    source: git
+      path: "../neon/neon_files"
+      relative: true
+    source: path
     version: "1.0.0"
   neon_framework:
     dependency: "direct main"
     description:
-      path: "packages/neon_framework"
-      ref: HEAD
-      resolved-ref: "82c4f0254f964a3d3e79befc21c7017ba2c053b8"
-      url: "https://github.com/nextcloud/neon"
-    source: git
+      path: "../neon_framework"
+      relative: true
+    source: path
     version: "1.0.0"
   neon_lints:
     dependency: "direct dev"
     description:
-      path: "packages/neon_lints"
-      ref: HEAD
-      resolved-ref: "82c4f0254f964a3d3e79befc21c7017ba2c053b8"
-      url: "https://github.com/nextcloud/neon"
-    source: git
+      path: "../neon_lints"
+      relative: true
+    source: path
     version: "1.0.0"
   neon_news:
     dependency: "direct main"
     description:
-      path: "packages/neon/neon_news"
-      ref: HEAD
-      resolved-ref: "82c4f0254f964a3d3e79befc21c7017ba2c053b8"
-      url: "https://github.com/nextcloud/neon"
-    source: git
+      path: "../neon/neon_news"
+      relative: true
+    source: path
     version: "1.0.0"
   neon_notes:
     dependency: "direct main"
     description:
-      path: "packages/neon/neon_notes"
-      ref: HEAD
-      resolved-ref: "82c4f0254f964a3d3e79befc21c7017ba2c053b8"
-      url: "https://github.com/nextcloud/neon"
-    source: git
+      path: "../neon/neon_notes"
+      relative: true
+    source: path
     version: "1.0.0"
   neon_notifications:
     dependency: "direct main"
     description:
-      path: "packages/neon/neon_notifications"
-      ref: HEAD
-      resolved-ref: "82c4f0254f964a3d3e79befc21c7017ba2c053b8"
-      url: "https://github.com/nextcloud/neon"
-    source: git
+      path: "../neon/neon_notifications"
+      relative: true
+    source: path
     version: "1.0.0"
   neon_talk:
     dependency: "direct main"
     description:
-      path: "packages/neon/neon_talk"
-      ref: HEAD
-      resolved-ref: "82c4f0254f964a3d3e79befc21c7017ba2c053b8"
-      url: "https://github.com/nextcloud/neon"
-    source: git
+      path: "../neon/neon_talk"
+      relative: true
+    source: path
     version: "1.0.0"
   nested:
     dependency: transitive
@@ -839,12 +820,11 @@ packages:
     source: hosted
     version: "1.0.0"
   nextcloud:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: nextcloud
-      sha256: "6c0e0be07c9563cbf99c00ae1ca97657762741d035175e4caf22c4e8d0ceb693"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../nextcloud"
+      relative: true
+    source: path
     version: "5.0.2"
   open_filex:
     dependency: transitive
@@ -1212,13 +1192,11 @@ packages:
     source: sdk
     version: "0.0.99"
   sort_box:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      path: "packages/sort_box"
-      ref: HEAD
-      resolved-ref: "82c4f0254f964a3d3e79befc21c7017ba2c053b8"
-      url: "https://github.com/nextcloud/neon"
-    source: git
+      path: "../sort_box"
+      relative: true
+    source: path
     version: "1.0.0"
   source_span:
     dependency: transitive

--- a/packages/app/pubspec_overrides.yaml
+++ b/packages/app/pubspec_overrides.yaml
@@ -1,0 +1,26 @@
+# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon_dashboard,neon_files,neon_framework,neon_lints,neon_news,neon_notes,neon_notifications,neon_talk,nextcloud,sort_box
+dependency_overrides:
+  dynamite_runtime:
+    path: ../dynamite/dynamite_runtime
+  file_icons:
+    path: ../file_icons
+  neon_dashboard:
+    path: ../neon/neon_dashboard
+  neon_files:
+    path: ../neon/neon_files
+  neon_framework:
+    path: ../neon_framework
+  neon_lints:
+    path: ../neon_lints
+  neon_news:
+    path: ../neon/neon_news
+  neon_notes:
+    path: ../neon/neon_notes
+  neon_notifications:
+    path: ../neon/neon_notifications
+  neon_talk:
+    path: ../neon/neon_talk
+  nextcloud:
+    path: ../nextcloud
+  sort_box:
+    path: ../sort_box

--- a/packages/dynamite/dynamite/example/pubspec_overrides.yaml
+++ b/packages/dynamite/dynamite/example/pubspec_overrides.yaml
@@ -1,0 +1,8 @@
+# melos_managed_dependency_overrides: dynamite,dynamite_runtime,neon_lints
+dependency_overrides:
+  dynamite:
+    path: ..
+  dynamite_runtime:
+    path: ../../dynamite_runtime
+  neon_lints:
+    path: ../../../neon_lints

--- a/packages/dynamite/dynamite/pubspec_overrides.yaml
+++ b/packages/dynamite/dynamite/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: neon_lints
+dependency_overrides:
+  neon_lints:
+    path: ../../neon_lints

--- a/packages/dynamite/dynamite_end_to_end_test/pubspec_overrides.yaml
+++ b/packages/dynamite/dynamite_end_to_end_test/pubspec_overrides.yaml
@@ -1,0 +1,8 @@
+# melos_managed_dependency_overrides: dynamite,dynamite_runtime,neon_lints
+dependency_overrides:
+  dynamite:
+    path: ../dynamite
+  dynamite_runtime:
+    path: ../dynamite_runtime
+  neon_lints:
+    path: ../../neon_lints

--- a/packages/dynamite/dynamite_runtime/pubspec_overrides.yaml
+++ b/packages/dynamite/dynamite_runtime/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: neon_lints
+dependency_overrides:
+  neon_lints:
+    path: ../../neon_lints

--- a/packages/file_icons/pubspec_overrides.yaml
+++ b/packages/file_icons/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: neon_lints
+dependency_overrides:
+  neon_lints:
+    path: ../neon_lints

--- a/packages/neon/neon_dashboard/pubspec_overrides.yaml
+++ b/packages/neon/neon_dashboard/pubspec_overrides.yaml
@@ -1,0 +1,12 @@
+# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  neon_framework:
+    path: ../../neon_framework
+  neon_lints:
+    path: ../../neon_lints
+  nextcloud:
+    path: ../../nextcloud
+  sort_box:
+    path: ../../sort_box

--- a/packages/neon/neon_files/pubspec_overrides.yaml
+++ b/packages/neon/neon_files/pubspec_overrides.yaml
@@ -1,0 +1,14 @@
+# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon_framework,neon_lints,nextcloud,sort_box
+dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  file_icons:
+    path: ../../file_icons
+  neon_framework:
+    path: ../../neon_framework
+  neon_lints:
+    path: ../../neon_lints
+  nextcloud:
+    path: ../../nextcloud
+  sort_box:
+    path: ../../sort_box

--- a/packages/neon/neon_news/pubspec_overrides.yaml
+++ b/packages/neon/neon_news/pubspec_overrides.yaml
@@ -1,0 +1,12 @@
+# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  neon_framework:
+    path: ../../neon_framework
+  neon_lints:
+    path: ../../neon_lints
+  nextcloud:
+    path: ../../nextcloud
+  sort_box:
+    path: ../../sort_box

--- a/packages/neon/neon_notes/pubspec_overrides.yaml
+++ b/packages/neon/neon_notes/pubspec_overrides.yaml
@@ -1,0 +1,12 @@
+# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  neon_framework:
+    path: ../../neon_framework
+  neon_lints:
+    path: ../../neon_lints
+  nextcloud:
+    path: ../../nextcloud
+  sort_box:
+    path: ../../sort_box

--- a/packages/neon/neon_notifications/pubspec_overrides.yaml
+++ b/packages/neon/neon_notifications/pubspec_overrides.yaml
@@ -1,0 +1,12 @@
+# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  neon_framework:
+    path: ../../neon_framework
+  neon_lints:
+    path: ../../neon_lints
+  nextcloud:
+    path: ../../nextcloud
+  sort_box:
+    path: ../../sort_box

--- a/packages/neon/neon_talk/pubspec_overrides.yaml
+++ b/packages/neon/neon_talk/pubspec_overrides.yaml
@@ -1,0 +1,12 @@
+# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  neon_framework:
+    path: ../../neon_framework
+  neon_lints:
+    path: ../../neon_lints
+  nextcloud:
+    path: ../../nextcloud
+  sort_box:
+    path: ../../sort_box

--- a/packages/neon_framework/pubspec_overrides.yaml
+++ b/packages/neon_framework/pubspec_overrides.yaml
@@ -1,0 +1,10 @@
+# melos_managed_dependency_overrides: dynamite_runtime,neon_lints,nextcloud,sort_box
+dependency_overrides:
+  dynamite_runtime:
+    path: ../dynamite/dynamite_runtime
+  neon_lints:
+    path: ../neon_lints
+  nextcloud:
+    path: ../nextcloud
+  sort_box:
+    path: ../sort_box

--- a/packages/neon_lints/example/pubspec_overrides.yaml
+++ b/packages/neon_lints/example/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: neon_lints
+dependency_overrides:
+  neon_lints:
+    path: ..

--- a/packages/nextcloud/pubspec_overrides.yaml
+++ b/packages/nextcloud/pubspec_overrides.yaml
@@ -1,0 +1,10 @@
+# melos_managed_dependency_overrides: dynamite,dynamite_runtime,neon_lints,nextcloud_test
+dependency_overrides:
+  dynamite:
+    path: ../dynamite/dynamite
+  dynamite_runtime:
+    path: ../dynamite/dynamite_runtime
+  neon_lints:
+    path: ../neon_lints
+  nextcloud_test:
+    path: ../nextcloud_test

--- a/packages/nextcloud_test/pubspec_overrides.yaml
+++ b/packages/nextcloud_test/pubspec_overrides.yaml
@@ -1,0 +1,8 @@
+# melos_managed_dependency_overrides: dynamite_runtime,neon_lints,nextcloud
+dependency_overrides:
+  dynamite_runtime:
+    path: ../dynamite/dynamite_runtime
+  neon_lints:
+    path: ../neon_lints
+  nextcloud:
+    path: ../nextcloud

--- a/packages/sort_box/pubspec_overrides.yaml
+++ b/packages/sort_box/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: neon_lints
+dependency_overrides:
+  neon_lints:
+    path: ../neon_lints


### PR DESCRIPTION
With https://github.com/nextcloud/neon/pull/1876 we no longer have the overrides because melos generates them in the CI for us, but renovate doesn't do that so it picks up the git references which lead to https://github.com/nextcloud/neon/pull/1879.