### PR TITLE
fix(neon_framework): Use broadcast stream in maintenance mode bloc

### DIFF
--- a/packages/neon_framework/lib/src/blocs/maintenance_mode.dart
+++ b/packages/neon_framework/lib/src/blocs/maintenance_mode.dart
@@ -35,8 +35,9 @@ class _MaintenanceModeBloc extends InteractiveBloc implements MaintenanceModeBlo
     super.dispose();
   }
 
+  // Broadcast stream is necessary because the Stream might be listened to multiple times (e.g. switching accounts).
   @override
-  late final onMaintenanceMode = controller.stream;
+  late final onMaintenanceMode = controller.stream.asBroadcastStream();
 
   @override
   Future<void> refresh() async {


### PR DESCRIPTION
When switching to another account and back will throw an error because the home page listens to the same stream again.