### PR TITLE
feat(neon_framework): implement custom cookie store flow 

### DIFF
--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -13,6 +13,7 @@ playstore
 postmarket
 provokateurin
 punycode
+STRFTIME
 subroutes
 testexample
 uncategorized

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -201,6 +201,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.8"
+  cookie_store:
+    dependency: "direct overridden"
+    description:
+      path: "../cookie_store"
+      relative: true
+    source: path
+    version: "0.1.0"
   cross_file:
     dependency: transitive
     description:

--- a/packages/app/pubspec_overrides.yaml
+++ b/packages/app/pubspec_overrides.yaml
@@ -1,5 +1,7 @@
-# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon_dashboard,neon_files,neon_framework,neon_lints,neon_news,neon_notes,neon_notifications,neon_talk,nextcloud,sort_box
+# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,file_icons,neon_dashboard,neon_files,neon_framework,neon_lints,neon_news,neon_notes,neon_notifications,neon_talk,nextcloud,sort_box
 dependency_overrides:
+  cookie_store:
+    path: ../cookie_store
   dynamite_runtime:
     path: ../dynamite/dynamite_runtime
   file_icons:

--- a/packages/cookie_store/lib/cookie_store.dart
+++ b/packages/cookie_store/lib/cookie_store.dart
@@ -6,8 +6,12 @@
 /// This package has an implementation independent api and provides utilities
 /// that make it easy to extend and implemented into existing storage backends
 /// like SQLite databases.
+///
+/// Users of the [cookie_jar](https://pub.dev/packages/cookie_jar) package
+/// can use the provided `CookieJarAdapter`.
 library;
 
+export 'src/cookie_jar_adapter.dart';
 export 'src/cookie_persistence.dart';
 export 'src/cookie_store.dart';
 export 'src/storable_cookie.dart';

--- a/packages/cookie_store/lib/src/cookie_jar_adapter.dart
+++ b/packages/cookie_store/lib/src/cookie_jar_adapter.dart
@@ -1,0 +1,35 @@
+import 'package:cookie_jar/cookie_jar.dart' as cookie_jar;
+import 'package:cookie_store/src/cookie_store.dart';
+import 'package:cookie_store/src/utils.dart';
+
+/// An adapter between the neon [CookieStore] and the [cookie_jar.CookieJar]
+/// from the [cookie_jar](https://pub.dev/packages/cookie_jar) package.
+final class CookieJarAdapter implements cookie_jar.CookieJar {
+  /// Creates a new cookie jar adapter backed by the given [cookieStore].
+  const CookieJarAdapter(this.cookieStore);
+
+  /// The neon cookie store backing the cookie jar.
+  final CookieStore cookieStore;
+
+  @override
+  bool get ignoreExpires => false;
+
+  @override
+  Future<void> delete(Uri uri, [bool withDomainSharedCookie = false]) async {
+    return cookieStore.deleteWhere((cookie) {
+      return isDomainMatch(uri.host, cookie.domain ?? '') && isPathMatch(uri.path, cookie.path ?? '');
+    });
+  }
+
+  @override
+  Future<void> deleteAll() async {
+    return cookieStore.deleteAll();
+  }
+
+  @override
+  Future<List<cookie_jar.Cookie>> loadForRequest(Uri uri) async => cookieStore.loadForRequest(uri);
+
+  @override
+  Future<void> saveFromResponse(Uri uri, List<cookie_jar.Cookie> cookies) async =>
+      cookieStore.saveFromResponse(uri, cookies);
+}

--- a/packages/cookie_store/pubspec.yaml
+++ b/packages/cookie_store/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
+  cookie_jar: ^4.0.0
   meta: ^1.0.0
   timezone: ^0.9.3
   universal_io: ^2.0.0

--- a/packages/neon/neon_dashboard/pubspec_overrides.yaml
+++ b/packages/neon/neon_dashboard/pubspec_overrides.yaml
@@ -1,5 +1,7 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
 dependency_overrides:
+  cookie_store:
+    path: ../../cookie_store
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
   neon_framework:

--- a/packages/neon/neon_files/pubspec_overrides.yaml
+++ b/packages/neon/neon_files/pubspec_overrides.yaml
@@ -1,5 +1,7 @@
-# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,file_icons,neon_framework,neon_lints,nextcloud,sort_box
 dependency_overrides:
+  cookie_store:
+    path: ../../cookie_store
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
   file_icons:

--- a/packages/neon/neon_news/pubspec_overrides.yaml
+++ b/packages/neon/neon_news/pubspec_overrides.yaml
@@ -1,5 +1,7 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
 dependency_overrides:
+  cookie_store:
+    path: ../../cookie_store
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
   neon_framework:

--- a/packages/neon/neon_notes/pubspec_overrides.yaml
+++ b/packages/neon/neon_notes/pubspec_overrides.yaml
@@ -1,5 +1,7 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
 dependency_overrides:
+  cookie_store:
+    path: ../../cookie_store
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
   neon_framework:

--- a/packages/neon/neon_notifications/pubspec_overrides.yaml
+++ b/packages/neon/neon_notifications/pubspec_overrides.yaml
@@ -1,5 +1,7 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,neon_framework,neon_lints,nextcloud,sort_box
 dependency_overrides:
+  cookie_store:
+    path: ../../cookie_store
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
   neon_framework:

--- a/packages/neon/neon_talk/pubspec_overrides.yaml
+++ b/packages/neon/neon_talk/pubspec_overrides.yaml
@@ -1,5 +1,6 @@
-# melos_managed_dependency_overrides: dynamite_runtime,file_icons,neon_framework,neon_lints,nextcloud,sort_box
 dependency_overrides:
+  cookie_store:
+    path: ../../cookie_store
   dynamite_runtime:
     path: ../../dynamite/dynamite_runtime
   file_icons:

--- a/packages/neon_framework/lib/src/models/account.dart
+++ b/packages/neon_framework/lib/src/models/account.dart
@@ -35,7 +35,9 @@ class Account implements Credentials, Findable {
     this.password,
     this.userAgent,
     @visibleForTesting Client? httpClient,
-  }) : client = NextcloudClient(
+  })  : humanReadableID = _buildHumanReadableID(username, serverURL),
+        id = sha1.convert(utf8.encode('$username@$serverURL')).toString(),
+        client = NextcloudClient(
           serverURL,
           loginName: username,
           password: password,
@@ -78,16 +80,14 @@ class Account implements Credentials, Findable {
   /// The unique ID of the account.
   ///
   /// Implemented in a primitive way hashing the [username] and [serverURL].
-  /// IDs are globally cached in [_idCache].
   @override
-  String get id {
-    final key = '$username@$serverURL';
-
-    return _idCache[key] ??= sha1.convert(utf8.encode(key)).toString();
-  }
+  final String id;
 
   /// A human readable representation of [username] and [serverURL].
-  String get humanReadableID {
+  final String humanReadableID;
+
+  /// Builds a human readable id for a user and server pair.
+  static String _buildHumanReadableID(String username, Uri serverURL) {
     // Maybe also show path if it is not '/' ?
     final buffer = StringBuffer()
       ..write(username)
@@ -134,9 +134,6 @@ class Account implements Credentials, Findable {
   /// Should be used when trying to push a [uri] from an API to the router as it might contain the scheme, host and sub path of the instance which will not work with the router.
   Uri stripUri(Uri uri) => Uri.parse(uri.toString().replaceFirst(serverURL.toString(), ''));
 }
-
-/// Global [Account.id] cache.
-Map<String, String> _idCache = {};
 
 /// QRcode Login credentials.
 ///

--- a/packages/neon_framework/lib/src/storage/sqlite_cookie_persistence.dart
+++ b/packages/neon_framework/lib/src/storage/sqlite_cookie_persistence.dart
@@ -1,0 +1,380 @@
+import 'dart:async';
+
+import 'package:cookie_store/cookie_store.dart';
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+import 'package:neon_framework/platform.dart';
+import 'package:nextcloud/utils.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:universal_io/io.dart' show Cookie;
+
+const String _unsupportedCookieManagementMessage =
+    'The neon project does not plan to support individual cookie management.';
+
+const String _lastAccessMaxDuration = "STRFTIME('%s', 'now', '-1 years')";
+
+/// An SQLite backed cookie persistence.
+///
+/// No maximum cookie age is set as mentioned in [RFC6265 section 7.3](https://httpwg.org/specs/rfc6265.html#rfc.section.7.3).
+///
+/// This persistence does not support cookie management through the [deleteAll]
+/// and [deleteWhere] methods. Calling them will throw a [UnsupportedError].
+@internal
+final class SQLiteCookiePersistence implements CookiePersistence {
+  /// Creates a new SQLite backed cookie persistence for the given account.
+  ///
+  /// Optionally [allowedBaseUri] can be used to restrict storage and loading of cookies to a certain domain and path.
+  SQLiteCookiePersistence({
+    required this.accountID,
+    Uri? allowedBaseUri,
+  }) : allowedBaseUri = switch (allowedBaseUri) {
+          null => null,
+          Uri(:final path) when path.endsWith('/') => Uri(
+              host: allowedBaseUri.host,
+              path: path.substring(0, path.length - 1),
+            ),
+          _ => allowedBaseUri,
+        };
+
+  final _log = Logger('SQLiteCookiePersistence');
+
+  /// The allowed cookie base uri.
+  ///
+  /// When not null, only cookies  domain and path matching this uri will be
+  /// persisted.
+  ///
+  /// See:
+  ///   * domain matching [RFC6265 section 5.1.3](https://httpwg.org/specs/rfc6265.html#rfc.section.5.1.3)
+  ///   * path matching [RFC6265 section 5.1.4](https://httpwg.org/specs/rfc6265.html#rfc.section.5.1.4)
+  final Uri? allowedBaseUri;
+
+  /// The id of the requesting account.
+  final String accountID;
+
+  @visibleForTesting
+  static Database? database;
+
+  /// Initializes this cookie persistence by setting up the backing SQLite database.
+  ///
+  /// This must called and completed before accessing other methods of the cache.
+  static Future<void> init() async {
+    if (database != null) {
+      return;
+    }
+
+    assert(
+      NeonPlatform.instance.canUsePaths,
+      'Tried to initialize SQLiteCookiePersistence on a platform without support for paths',
+    );
+    final cacheDir = await getApplicationCacheDirectory();
+    database = await openDatabase(
+      p.join(cacheDir.path, 'cookies.db'),
+      version: 1,
+      onCreate: onCreate,
+    );
+  }
+
+  @visibleForTesting
+  static Future<void> onCreate(Database db, int version) async {
+    // https://httpwg.org/specs/rfc6265.html#storage-model with an extra account key.
+    await db.execute('''
+CREATE TABLE "cookies" (
+  "account"           TEXT NOT NULL,
+  "name"              TEXT NOT NULL,
+  "value"             TEXT NOT NULL,
+  "expiry-time"       INTEGER NOT NULL,
+  "domain"            TEXT NOT NULL,
+  "path"              TEXT NOT NULL,
+  "creation-time"     INTEGER NOT NULL,
+  "last-access-time"  INTEGER NOT NULL,
+  "persistent-flag"   BOOLEAN NOT NULL,
+  "host-only-flag"    BOOLEAN NOT NULL,
+  "secure-only-flag"  BOOLEAN NOT NULL,
+  "http-only-flag"    BOOLEAN NOT NULL,
+  PRIMARY KEY("account", "name", "domain", "path")
+);
+
+CREATE TRIGGER delete_outdated_cookies
+   AFTER UPDATE
+   ON cookies
+BEGIN
+ DELETE FROM cookies
+ WHERE
+   "expiry-time" <= STRFTIME('%s')
+   OR "last-access-time" <= $_lastAccessMaxDuration;
+END;
+''');
+  }
+
+  Database get _requireDatabase {
+    if (database == null) {
+      throw StateError(
+        'Cookie persistence has not been set up yet. Please make sure SQLiteCookiePersistence.init() has been called before and completed.',
+      );
+    }
+
+    return database!;
+  }
+
+  @override
+  Future<List<Cookie>> loadForRequest(Uri uri) async {
+    final requestHost = uri.host;
+    var requestPath = uri.path;
+    if (requestPath.isEmpty) {
+      requestPath = '/';
+    }
+
+    if (!_isAllowedUri(requestHost, requestPath)) {
+      return [];
+    }
+
+    final isHttpRequest = isHttpUri(uri);
+    final isSecureRequest = isSecureUri(uri);
+
+    // domain and patch matching is error prone in SQL;
+    // use the dart helpers for now.
+    try {
+      final results = await _requireDatabase.rawQuery(
+        '''
+SELECT "name", "domain", "path", "value"
+FROM "cookies"
+WHERE "account" = ?
+  AND ("domain" = ? OR "host-only-flag" = 0)
+  AND ("secure-only-flag" = 0 OR ?)
+  AND ("http-only-flag" = 0 OR ?)
+  AND "expiry-time" >= STRFTIME('%s')
+  AND "last-access-time" >= $_lastAccessMaxDuration
+ORDER BY 
+  length("path") DESC,
+  "creation-time" ASC
+''',
+        [
+          accountID,
+          requestHost,
+          if (isSecureRequest) 1 else 0,
+          if (isHttpRequest) 1 else 0,
+        ],
+      );
+
+      final list = <Cookie>[];
+      final batch = _requireDatabase.batch();
+
+      for (final result in results) {
+        final name = result['name']! as String;
+        final domain = result['domain']! as String;
+        final path = result['path']! as String;
+        final value = result['value']! as String;
+
+        if (!isDomainMatch(requestHost, domain) || !isPathMatch(requestPath, path)) {
+          continue;
+        }
+
+        final cookie = Cookie(name, value);
+        list.add(cookie);
+
+        batch.rawUpdate(
+          '''
+UPDATE "cookies"
+SET "last-access-time" = STRFTIME('%s')
+WHERE "account" = ?
+  AND "name" = ?
+  AND "domain" = ?
+  AND "path" = ?
+''',
+          [
+            accountID,
+            name,
+            domain,
+            path,
+          ],
+        );
+      }
+
+      if (batch.length >= 1) {
+        await batch.commit(noResult: true);
+      }
+
+      return list;
+    } on DatabaseException catch (error, stackTrace) {
+      _log.warning(
+        'Error loading cookies.',
+        error,
+        stackTrace,
+      );
+    }
+
+    return [];
+  }
+
+  @override
+  Future<bool> saveFromResponse(Set<StorableCookie> cookies, {required bool isHttpRequest}) async {
+    if (cookies.isEmpty) {
+      return true;
+    }
+
+    final batch = _requireDatabase.batch();
+
+    for (final cookie in cookies) {
+      batch
+        ..update(
+          'cookies',
+          {
+            '"name"': cookie.name,
+            '"value"': cookie.value,
+            '"expiry-time"': cookie.expiryTime.secondsSinceEpoch,
+            '"domain"': cookie.domain,
+            '"path"': cookie.path,
+            // DO NOT update the creation time
+            '"last-access-time"': cookie.lastAccessTime.secondsSinceEpoch,
+            '"persistent-flag"': cookie.persistentFlag ? 1 : 0,
+            '"host-only-flag"': cookie.hostOnlyFlag ? 1 : 0,
+            '"secure-only-flag"': cookie.secureOnlyFlag ? 1 : 0,
+            '"http-only-flag"': cookie.httpOnlyFlag ? 1 : 0,
+          },
+          where: '''
+"account" = ?
+AND "name" = ?
+AND "domain" = ?
+AND "path" = ?
+AND ("http-only-flag" = 0 OR ? = 1)
+''',
+          whereArgs: [
+            accountID,
+            cookie.name,
+            cookie.domain,
+            cookie.path,
+            if (isHttpRequest) 1 else 0,
+          ],
+        )
+        // Ignore already present records.
+        // This happens when the cookie was not updated because of the http-only-flag
+        ..rawInsert(
+          '''
+INSERT OR IGNORE INTO cookies ("account", "name", "value", "expiry-time", "domain", "path", "creation-time", "last-access-time", "persistent-flag", "host-only-flag", "secure-only-flag", "http-only-flag")
+SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+WHERE (SELECT changes() = 0)
+''',
+          [
+            accountID,
+            cookie.name,
+            cookie.value,
+            cookie.expiryTime.secondsSinceEpoch,
+            cookie.domain,
+            cookie.path,
+            cookie.creationTime.secondsSinceEpoch,
+            cookie.lastAccessTime.secondsSinceEpoch,
+            if (cookie.persistentFlag) 1 else 0,
+            if (cookie.hostOnlyFlag) 1 else 0,
+            if (cookie.secureOnlyFlag) 1 else 0,
+            if (cookie.httpOnlyFlag) 1 else 0,
+          ],
+        );
+    }
+
+    try {
+      await batch.commit(noResult: true);
+    } on DatabaseException catch (error, stackTrace) {
+      _log.warning(
+        'Error persisting cookies.',
+        error,
+        stackTrace,
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  Future<bool> endSession() async {
+    try {
+      await _requireDatabase.execute(
+        '''
+DELETE FROM cookies
+WHERE
+  "account" = ?
+  AND ("persistent-flag" = 0
+    OR "expiry-time" <= STRFTIME('%s'))
+''',
+        [accountID],
+      );
+
+      return true;
+    } on DatabaseException catch (error, stackTrace) {
+      _log.warning(
+        'Error removing session cookies.',
+        error,
+        stackTrace,
+      );
+
+      return false;
+    }
+  }
+
+  /// Not implemented by this persistence.
+  @override
+  bool deleteWhere(bool Function(Cookie cookie) test) {
+    throw UnsupportedError(_unsupportedCookieManagementMessage);
+  }
+
+  /// Not implemented by this persistence.
+  @override
+  bool deleteAll() {
+    throw UnsupportedError(_unsupportedCookieManagementMessage);
+  }
+
+  /// This method is only meant for testing.
+  @visibleForTesting
+  @override
+  Future<List<Cookie>> loadAll() async {
+    final list = <Cookie>[];
+
+    try {
+      final results = await _requireDatabase.rawQuery(
+        '''
+SELECT "name", "value"
+FROM "cookies"
+WHERE "account" = ?
+''',
+        [accountID],
+      );
+
+      for (final result in results) {
+        final cookie = Cookie(
+          result['name']! as String,
+          result['value']! as String,
+        );
+
+        list.add(cookie);
+      }
+    } on DatabaseException catch (error, stackTrace) {
+      _log.warning(
+        'Error loading cookies.',
+        error,
+        stackTrace,
+      );
+    }
+
+    return list;
+  }
+
+  bool _isAllowedUri(String domain, String path) {
+    final allowedBaseUri = this.allowedBaseUri;
+    if (allowedBaseUri == null) {
+      return true;
+    }
+
+    if (allowedBaseUri.host != domain) {
+      return false;
+    }
+
+    if (allowedBaseUri.path.isNotEmpty && !isPathMatch(path, allowedBaseUri.path)) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/packages/neon_framework/lib/src/testing/mocks.dart
+++ b/packages/neon_framework/lib/src/testing/mocks.dart
@@ -58,6 +58,9 @@ class FakeNeonStorage extends Fake implements NeonStorage {
 
   @override
   Null get requestCache => null;
+
+  @override
+  Null cookieStore({required String accountID, required Uri serverURL}) => null;
 }
 
 class MockCachedPersistence<T extends Object> extends Mock implements CachedPersistence<T> {}

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -11,6 +11,10 @@ dependencies:
   built_value: ^8.9.0
   collection: ^1.0.0
   cookie_jar: ^4.0.0
+  cookie_store:
+    git:
+      url: https://github.com/nextcloud/neon
+      path: packages/cookie_store
   crypto: ^3.0.0
   crypton: ^2.0.0
   cupertino_icons: ^1.0.0 # Do not remove this, is it needed on iOS/macOS. It will not include icons on other platforms because Apple forbids it.
@@ -65,6 +69,10 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.9
+  cookie_store_conformance_tests:
+    git:
+      url: https://github.com/nextcloud/neon
+      path: packages/cookie_store_conformance_tests
   custom_lint: ^0.6.4
   flutter_test:
     sdk: flutter

--- a/packages/neon_framework/pubspec_overrides.yaml
+++ b/packages/neon_framework/pubspec_overrides.yaml
@@ -1,5 +1,9 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_lints,nextcloud,sort_box
+# melos_managed_dependency_overrides: cookie_store,cookie_store_conformance_tests,dynamite_runtime,neon_lints,nextcloud,sort_box
 dependency_overrides:
+  cookie_store:
+    path: ../cookie_store
+  cookie_store_conformance_tests:
+    path: ../cookie_store_conformance_tests
   dynamite_runtime:
     path: ../dynamite/dynamite_runtime
   neon_lints:

--- a/packages/neon_framework/test/persistence_test.dart
+++ b/packages/neon_framework/test/persistence_test.dart
@@ -2,15 +2,19 @@
 // ignore_for_file: inference_failure_on_collection_literal
 
 import 'package:built_collection/built_collection.dart';
+import 'package:cookie_store/cookie_store.dart';
+import 'package:cookie_store_conformance_tests/cookie_store_conformance_tests.dart' as cookie_jar_conformance;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/src/storage/request_cache.dart';
+import 'package:neon_framework/src/storage/sqlite_cookie_persistence.dart';
 import 'package:neon_framework/src/storage/sqlite_persistence.dart';
 import 'package:neon_framework/src/utils/request_manager.dart';
 import 'package:neon_framework/testing.dart';
 import 'package:nextcloud/utils.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:timezone/timezone.dart' as tz;
+import 'package:universal_io/io.dart' show Cookie;
 
 void main() {
   group('Persistences', () {
@@ -199,6 +203,85 @@ void main() {
         SQLiteCachedPersistence().setCache('key', 'value');
         expect(SQLiteCachedPersistence().containsKey('key'), isTrue);
         expect(SQLiteCachedPersistence(prefix: 'prefix').containsKey('key'), isFalse);
+      });
+    });
+
+    group(SQLiteCookiePersistence, () {
+      setUpAll(() {
+        sqfliteFfiInit();
+        databaseFactory = databaseFactoryFfi;
+      });
+
+      tearDown(() {
+        SQLiteCookiePersistence.database = null;
+      });
+
+      test('Uninitialized', () {
+        SQLiteCookiePersistence.database = null;
+
+        final persistence = SQLiteCookiePersistence(accountID: 'accountID');
+        expect(() async => persistence.loadAll(), throwsA(isA<StateError>()));
+      });
+
+      cookie_jar_conformance.testAll(
+        () async {
+          SQLiteCookiePersistence.database = await openDatabase(
+            inMemoryDatabasePath,
+            version: 1,
+            onCreate: SQLiteCookiePersistence.onCreate,
+            singleInstance: false,
+          );
+
+          final persistence = SQLiteCookiePersistence(accountID: 'accountID');
+          return DefaultCookieStore(persistence);
+        },
+        canDeleteAll: false,
+        canDeleteByTest: false,
+      );
+
+      group('Restrict allowedBaseUri', () {
+        late CookieStore cookieStore;
+
+        setUpAll(() async {
+          SQLiteCookiePersistence.database = await openDatabase(
+            inMemoryDatabasePath,
+            version: 1,
+            onCreate: SQLiteCookiePersistence.onCreate,
+            singleInstance: false,
+          );
+
+          cookieStore = DefaultCookieStore(
+            SQLiteCookiePersistence(
+              accountID: 'accountID',
+              allowedBaseUri: Uri(host: 'example.com', path: '/subpath/'),
+            ),
+          );
+        });
+
+        for (final element in [
+          (Uri(host: 'example.com', path: '/subpath/other'), isNotEmpty),
+          (Uri(host: 'example.com', path: '/subpath'), isNotEmpty),
+          (Uri(host: 'example.com', path: '/subpathTest'), isEmpty),
+          (Uri(host: 'example.com', path: '/'), isEmpty),
+          (Uri(host: 'test.com', path: '/subpath/other'), isEmpty),
+        ]) {
+          final uri = element.$1;
+          test(uri, () async {
+            final cookies = [
+              Cookie(uri.host, 'value')
+                ..domain = uri.host
+                ..path = uri.path
+                ..httpOnly = false
+                ..secure = false,
+            ];
+
+            await cookieStore.saveFromResponse(uri, cookies);
+            expect(
+              await cookieStore.loadForRequest(uri),
+              element.$2,
+            );
+          });
+        }
       });
     });
   });

--- a/packages/nextcloud/pubspec_overrides.yaml
+++ b/packages/nextcloud/pubspec_overrides.yaml
@@ -1,5 +1,7 @@
-# melos_managed_dependency_overrides: dynamite,dynamite_runtime,neon_lints,nextcloud_test
+# melos_managed_dependency_overrides: cookie_store,dynamite,dynamite_runtime,neon_lints,nextcloud_test
 dependency_overrides:
+  cookie_store:
+    path: ../cookie_store
   dynamite:
     path: ../dynamite/dynamite
   dynamite_runtime:

--- a/packages/nextcloud_test/lib/src/test_client.dart
+++ b/packages/nextcloud_test/lib/src/test_client.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:cookie_jar/cookie_jar.dart';
+import 'package:cookie_store/cookie_store.dart';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud_test/src/docker_container.dart';
 import 'package:nextcloud_test/src/fixtures.dart';
@@ -54,7 +54,9 @@ extension TestNextcloudClient on NextcloudClient {
       loginName: username,
       password: username,
       appPassword: appPassword,
-      cookieJar: CookieJar(),
+      cookieJar: CookieJarAdapter(
+        CookieStore(),
+      ),
       httpClient: getProxyHttpClient(
         onRequest: appendFixture,
       ),

--- a/packages/nextcloud_test/pubspec.yaml
+++ b/packages/nextcloud_test/pubspec.yaml
@@ -8,6 +8,10 @@ environment:
 dependencies:
   built_collection: ^5.0.0
   cookie_jar: ^4.0.8
+  cookie_store:
+    git:
+      url: https://github.com/nextcloud/neon
+      path: packages/cookie_store
   dynamite_runtime: ^0.4.0
   http: ^1.2.0
   meta: ^1.0.0

--- a/packages/nextcloud_test/pubspec.yaml
+++ b/packages/nextcloud_test/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
 
 dependencies:
   built_collection: ^5.0.0
-  cookie_jar: ^4.0.8
   cookie_store:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/nextcloud_test/pubspec_overrides.yaml
+++ b/packages/nextcloud_test/pubspec_overrides.yaml
@@ -1,5 +1,7 @@
-# melos_managed_dependency_overrides: dynamite_runtime,neon_lints,nextcloud
+# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,neon_lints,nextcloud
 dependency_overrides:
+  cookie_store:
+    path: ../cookie_store
   dynamite_runtime:
     path: ../dynamite/dynamite_runtime
   neon_lints:


### PR DESCRIPTION
Tests are missing and the `allowedBaseUri` might not be 100% correct yet but an initial feedback would be appreciated.

The code is written in a way that easily allows us to move it into a separate package.
I wonder if we should already do that or even require our interface in the nextcloud package and force other users to use an adapter if they want to use the cookie_jar interface.