### PR TITLE
fix(neon_talk): Add missing TalkTheme.lerp implementation

### DIFF
--- a/packages/neon/neon_talk/lib/src/theme.dart
+++ b/packages/neon/neon_talk/lib/src/theme.dart
@@ -21,6 +21,12 @@ class TalkTheme extends ThemeExtension<TalkTheme> {
 
   @override
   TalkTheme lerp(covariant TalkTheme? other, double t) {
-    throw UnimplementedError();
+    if (other == null) {
+      return this;
+    }
+
+    return TalkTheme(
+      messageConstraints: BoxConstraints.lerp(messageConstraints, other.messageConstraints, t)!,
+    );
   }
 }


### PR DESCRIPTION
I thought this method didn't need to be implement if not called manually, but I just saw the UnimplementedError show up.