### PR TITLE
fix(dynamite): build config to allow built_value_generator running inside dynamite

### DIFF
--- a/packages/dynamite/dynamite/build.yaml
+++ b/packages/dynamite/dynamite/build.yaml
@@ -1,9 +1,8 @@
 builders:
   dynamite:
-    import: "package:dynamite/builder.dart"
-    builder_factories: ["openAPIBuilder"]
-    build_extensions: {'.openapi.json': ['openapi.dart']}
-    auto_apply: root_package
+    import: 'package:dynamite/builder.dart'
+    builder_factories: ['openAPIBuilder']
+    build_extensions: { '.openapi.json': ['openapi.dart'] }
+    auto_apply: dependents
     build_to: source
-    runs_before: ["built_value_generator|built_value"]
-    applies_builders: ["built_value_generator|built_value"]
+    runs_before: ['built_value_generator|built_value']


### PR DESCRIPTION
before that running build_runner inside dynamite also tried to execute dynamite itself.
Also formats the build.yaml to use single quotes. The same we have everywhere else in the project.