### PR TITLE
chore(neon_talk): Remove TalkTheme from coverage

### DIFF
--- a/packages/neon/neon_talk/lib/src/theme.dart
+++ b/packages/neon/neon_talk/lib/src/theme.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 import 'package:flutter/material.dart';
 
 /// Defines the custom Talk theme.


### PR DESCRIPTION
This file is not relevant for testing and coverage, so it can just be ignore to avoid dragging down the coverage rate.