### PR TITLE
test(neon_talk): Test last common read emitted

### DIFF
--- a/packages/neon/neon_talk/test/room_bloc_test.dart
+++ b/packages/neon/neon_talk/test/room_bloc_test.dart
@@ -46,6 +46,9 @@ Account mockTalkAccount() {
               },
             }),
             200,
+            headers: {
+              'x-chat-last-common-read': '0',
+            },
           ),
       'post': (match, queryParameters) => Response(
             json.encode({
@@ -55,6 +58,9 @@ Account mockTalkAccount() {
               },
             }),
             201,
+            headers: {
+              'x-chat-last-common-read': '1',
+            },
           ),
     },
   });
@@ -107,6 +113,11 @@ void main() {
       ]),
     );
 
+    expect(
+      bloc.lastCommonRead,
+      emitsInOrder([0, 0]),
+    );
+
     // The delay is necessary to avoid a race condition with loading twice at the same time
     await Future<void>.delayed(const Duration(milliseconds: 1));
     await bloc.refresh();
@@ -120,6 +131,11 @@ void main() {
         Result.success(BuiltList<int>([2, 1, 0])),
         Result.success(BuiltList<int>([3, 2, 1, 0])),
       ]),
+    );
+
+    expect(
+      bloc.lastCommonRead,
+      emitsInOrder([0, 1]),
     );
 
     // The delay is necessary to avoid a race condition with loading twice at the same time


### PR DESCRIPTION
Forgot to write these tests in https://github.com/nextcloud/neon/pull/1935