### PR TITLE
Fix/dynamite/inheritt_defaults_and_vaidation

### DIFF
--- a/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
+++ b/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
@@ -360,9 +360,14 @@ abstract class NewPet implements $NewPetInterface, Built<NewPet, NewPetBuilder> 
 abstract interface class $PetInterface implements $NewPetInterface {
   int get id;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($PetInterfaceBuilder b) {}
+  static void _defaults($PetInterfaceBuilder b) {
+    $NewPetInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($PetInterfaceBuilder b) {}
+  static void _validate($PetInterfaceBuilder b) {
+    $NewPetInterface._validate(b);
+  }
 }
 
 abstract class Pet implements $PetInterface, Built<Pet, PetBuilder> {

--- a/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
+++ b/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
@@ -318,6 +318,10 @@ class $Client extends _i1.DynamiteClient {
 abstract interface class $NewPetInterface {
   String get name;
   String? get tag;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NewPetInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NewPetInterfaceBuilder b) {}
 }
 
 abstract class NewPet implements $NewPetInterface, Built<NewPet, NewPetBuilder> {
@@ -340,11 +344,25 @@ abstract class NewPet implements $NewPetInterface, Built<NewPet, NewPetBuilder> 
 
   /// Serializer for NewPet.
   static Serializer<NewPet> get serializer => _$newPetSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NewPetBuilder b) {
+    $NewPetInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NewPetBuilder b) {
+    $NewPetInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PetInterface implements $NewPetInterface {
   int get id;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PetInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PetInterfaceBuilder b) {}
 }
 
 abstract class Pet implements $PetInterface, Built<Pet, PetBuilder> {
@@ -367,12 +385,26 @@ abstract class Pet implements $PetInterface, Built<Pet, PetBuilder> {
 
   /// Serializer for Pet.
   static Serializer<Pet> get serializer => _$petSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PetBuilder b) {
+    $PetInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PetBuilder b) {
+    $PetInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ErrorInterface {
   int get code;
   String get message;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ErrorInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ErrorInterfaceBuilder b) {}
 }
 
 abstract class Error implements $ErrorInterface, Built<Error, ErrorBuilder> {
@@ -395,6 +427,16 @@ abstract class Error implements $ErrorInterface, Built<Error, ErrorBuilder> {
 
   /// Serializer for Error.
   static Serializer<Error> get serializer => _$errorSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ErrorBuilder b) {
+    $ErrorInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ErrorBuilder b) {
+    $ErrorInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/dynamite/dynamite/example/lib/petstore.openapi.g.dart
+++ b/packages/dynamite/dynamite/example/lib/petstore.openapi.g.dart
@@ -212,7 +212,9 @@ class NewPetBuilder implements Builder<NewPet, NewPetBuilder>, $NewPetInterfaceB
   String? get tag => _$this._tag;
   set tag(covariant String? tag) => _$this._tag = tag;
 
-  NewPetBuilder();
+  NewPetBuilder() {
+    NewPet._defaults(this);
+  }
 
   NewPetBuilder get _$this {
     final $v = _$v;
@@ -239,6 +241,7 @@ class NewPetBuilder implements Builder<NewPet, NewPetBuilder>, $NewPetInterfaceB
   NewPet build() => _build();
 
   _$NewPet _build() {
+    NewPet._validate(this);
     final _$result = _$v ?? _$NewPet._(name: BuiltValueNullFieldError.checkNotNull(name, r'NewPet', 'name'), tag: tag);
     replace(_$result);
     return _$result;
@@ -320,7 +323,9 @@ class PetBuilder implements Builder<Pet, PetBuilder>, $PetInterfaceBuilder {
   String? get tag => _$this._tag;
   set tag(covariant String? tag) => _$this._tag = tag;
 
-  PetBuilder();
+  PetBuilder() {
+    Pet._defaults(this);
+  }
 
   PetBuilder get _$this {
     final $v = _$v;
@@ -348,6 +353,7 @@ class PetBuilder implements Builder<Pet, PetBuilder>, $PetInterfaceBuilder {
   Pet build() => _build();
 
   _$Pet _build() {
+    Pet._validate(this);
     final _$result = _$v ??
         _$Pet._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'Pet', 'id'),
@@ -422,7 +428,9 @@ class ErrorBuilder implements Builder<Error, ErrorBuilder>, $ErrorInterfaceBuild
   String? get message => _$this._message;
   set message(covariant String? message) => _$this._message = message;
 
-  ErrorBuilder();
+  ErrorBuilder() {
+    Error._defaults(this);
+  }
 
   ErrorBuilder get _$this {
     final $v = _$v;
@@ -449,6 +457,7 @@ class ErrorBuilder implements Builder<Error, ErrorBuilder>, $ErrorInterfaceBuild
   Error build() => _build();
 
   _$Error _build() {
+    Error._validate(this);
     final _$result = _$v ??
         _$Error._(
             code: BuiltValueNullFieldError.checkNotNull(code, r'Error', 'code'),

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_object.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_object.dart
@@ -1,13 +1,6 @@
-import 'package:built_collection/built_collection.dart';
-import 'package:code_builder/code_builder.dart';
 import 'package:dynamite/src/builder/resolve_interface.dart';
-import 'package:dynamite/src/builder/resolve_type.dart';
 import 'package:dynamite/src/builder/state.dart';
 import 'package:dynamite/src/helpers/built_value.dart';
-import 'package:dynamite/src/helpers/dart_helpers.dart';
-import 'package:dynamite/src/helpers/dynamite.dart';
-import 'package:dynamite/src/helpers/pattern_check.dart';
-import 'package:dynamite/src/helpers/type_result.dart';
 import 'package:dynamite/src/models/openapi.dart' as openapi;
 import 'package:dynamite/src/models/type_result.dart';
 
@@ -23,78 +16,19 @@ TypeResultObject resolveObject(
     identifier,
     nullable: nullable,
   );
+
   if (state.resolvedTypes.add(result)) {
-    state.resolvedInterfaces.add(result);
-    final properties = schema.properties?.entries;
-
-    if (properties == null || properties.isEmpty) {
-      throw StateError('The schema must have a non empty properties field.');
-    }
-
-    final defaults = ListBuilder<String>();
-    final validators = ListBuilder<Expression>();
-    final methods = ListBuilder<Method>();
-    // resolveInterface is not suitable here as we need the resolved result.
-    for (final property in properties) {
-      final propertyName = property.key;
-      final propertySchema = property.value;
-      final dartName = toDartName(propertyName);
-
-      var result = resolveType(
-        spec,
-        state,
-        toDartName(
-          propertyName,
-          identifier: identifier,
-        ),
-        propertySchema,
-        nullable: isDartParameterNullable(
-          schema.required.contains(propertyName),
-          propertySchema,
-        ),
-      );
-
-      if (isHeader && result.className != 'String') {
-        result = TypeResultObject(
-          'Header',
-          generics: BuiltList([result]),
-          nullable: result.nullable,
-        );
-        state.resolvedTypes.add(result);
-      }
-
-      final method = generateProperty(
-        result,
-        propertyName,
-        propertySchema.formattedDescription,
-      );
-      methods.add(method);
-
-      final $default = propertySchema.$default;
-      if ($default != null) {
-        final value = $default.toString();
-        defaults.add('..$dartName = ${valueToEscapedValue(result, value)}');
-      }
-
-      if (result is TypeResultOneOf && !result.isSingleValue) {
-        validators.add(
-          refer('b').property(dartName).nullSafeProperty('validateOneOf').call([]),
-        );
-      } else if (result is TypeResultAnyOf && !result.isSingleValue) {
-        validators.add(
-          refer('b').property(dartName).nullSafeProperty('validateAnyOf').call([]),
-        );
-      }
-
-      validators.addAll(buildPatternCheck(propertySchema, 'b.$dartName', dartName));
+    if (schema.allOf == null) {
+      state.resolvedInterfaces.add(result);
     }
 
     final $interface = buildInterface(
+      spec,
+      state,
       identifier,
-      methods: methods.build(),
-      documentation: schema.formattedDescription,
-      defaults: defaults.build(),
-      validators: validators.build(),
+      schema,
+      nullable: nullable,
+      isHeader: isHeader,
     );
 
     final $class = buildBuiltClass(

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_object.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_object.dart
@@ -93,12 +93,13 @@ TypeResultObject resolveObject(
       identifier,
       methods: methods.build(),
       documentation: schema.formattedDescription,
+      defaults: defaults.build(),
+      validators: validators.build(),
     );
+
     final $class = buildBuiltClass(
       identifier,
       documentation: schema.formattedDescription,
-      defaults: defaults.build(),
-      validators: validators.build(),
     );
 
     state.output.addAll([

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_ofs.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_ofs.dart
@@ -1,13 +1,9 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
-import 'package:dynamite/src/builder/resolve_interface.dart';
 import 'package:dynamite/src/builder/resolve_type.dart';
 import 'package:dynamite/src/builder/state.dart';
-import 'package:dynamite/src/helpers/built_value.dart';
-import 'package:dynamite/src/helpers/dart_helpers.dart';
 import 'package:dynamite/src/helpers/docs.dart';
-import 'package:dynamite/src/helpers/dynamite.dart';
 import 'package:dynamite/src/models/openapi.dart' as openapi;
 import 'package:dynamite/src/models/type_result.dart';
 
@@ -58,94 +54,5 @@ TypeResult resolveSomeOf(
     state.output.add($typedef);
   }
 
-  return result;
-}
-
-TypeResult resolveAllOf(
-  openapi.OpenAPI spec,
-  State state,
-  String identifier,
-  openapi.Schema schema, {
-  bool nullable = false,
-}) {
-  final result = TypeResultObject(
-    identifier,
-    nullable: nullable,
-  );
-
-  if (state.resolvedTypes.add(result)) {
-    final interfaces = <TypeResultObject>{};
-    final methods = ListBuilder<Method>();
-
-    for (final s in schema.allOf!) {
-      if (s.properties != null) {
-        final properties = s.properties!.entries;
-
-        methods.addAll(
-          properties.map((property) {
-            final propertyName = property.key;
-            final propertySchema = property.value;
-
-            final result = resolveType(
-              spec,
-              state,
-              toDartName(
-                propertyName,
-                identifier: identifier,
-              ),
-              propertySchema,
-              nullable: isDartParameterNullable(
-                s.required.contains(propertyName),
-                propertySchema,
-              ),
-            );
-
-            return generateProperty(
-              result,
-              propertyName,
-              propertySchema.formattedDescription,
-            );
-          }),
-        );
-      } else {
-        final object = resolveType(
-          spec,
-          state,
-          identifier,
-          s,
-          nullable: nullable,
-        );
-
-        if (object is TypeResultObject) {
-          interfaces.add(object);
-        } else {
-          final property = generateProperty(
-            object,
-            object.className,
-            s.formattedDescription,
-          );
-
-          methods.add(property);
-        }
-      }
-    }
-
-    final $interface = buildInterface(
-      identifier,
-      interfaces: interfaces,
-      methods: methods.build(),
-      documentation: schema.formattedDescription,
-    );
-
-    final $class = buildBuiltClass(
-      identifier,
-      documentation: schema.formattedDescription,
-    );
-
-    state.output.addAll([
-      $interface,
-      $class,
-    ]);
-  }
   return result;
 }

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_type.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_type.dart
@@ -57,6 +57,15 @@ TypeResult _resolveType(
         nullable: nullable,
       );
 
+    case openapi.Schema(allOf: != null):
+      return resolveObject(
+        spec,
+        state,
+        identifier,
+        schema,
+        nullable: nullable,
+      );
+
     case openapi.Schema(ref: null, ofs: null, type: null):
       return TypeResultBase(
         'JsonObject',
@@ -74,15 +83,6 @@ TypeResult _resolveType(
       );
 
       return subResult.asTypeDef;
-
-    case openapi.Schema(allOf: != null):
-      return resolveAllOf(
-        spec,
-        state,
-        identifier,
-        schema,
-        nullable: nullable,
-      );
 
     case openapi.Schema(anyOf: != null) || openapi.Schema(oneOf: != null):
       return resolveSomeOf(

--- a/packages/dynamite/dynamite/lib/src/helpers/built_value.dart
+++ b/packages/dynamite/dynamite/lib/src/helpers/built_value.dart
@@ -10,17 +10,16 @@ const interfaceSuffix = 'Interface';
 Spec buildBuiltClass(
   String className, {
   String? documentation,
-  Iterable<String>? defaults,
-  Iterable<Expression>? validators,
-  Iterable<Method>? methods,
 }) =>
     Class(
       (b) {
+        final interfaceClass = '\$$className$interfaceSuffix';
+
         b
           ..name = className
           ..abstract = true
           ..implements.addAll([
-            refer('\$$className$interfaceSuffix'),
+            refer(interfaceClass),
             refer(
               'Built<$className, ${className}Builder>',
             ),
@@ -35,67 +34,53 @@ Spec buildBuiltClass(
             buildSerializer(className),
           ]);
 
-        if (methods != null) {
-          b.methods.addAll(methods);
-        }
-
         if (documentation != null) {
           b.docs.addAll(escapeDescription(documentation));
         }
 
-        if (defaults != null && defaults.isNotEmpty) {
-          b.methods.add(
-            Method(
-              (b) => b
-                ..name = '_defaults'
-                ..returns = refer('void')
-                ..static = true
-                ..lambda = true
-                ..annotations.add(
-                  refer('BuiltValueHook').call([], {
-                    'initializeBuilder': literalTrue,
-                  }),
-                )
-                ..requiredParameters.add(
-                  Parameter(
-                    (b) => b
-                      ..name = 'b'
-                      ..type = refer('${className}Builder'),
-                  ),
-                )
-                ..body = Code(
-                  <String?>[
-                    'b',
-                    ...defaults,
-                  ].join(),
+        b.methods.add(
+          Method((b) {
+            b
+              ..name = '_defaults'
+              ..returns = refer('void')
+              ..static = true
+              ..annotations.add(
+                refer('BuiltValueHook').call([], {
+                  'initializeBuilder': literalTrue,
+                }),
+              )
+              ..requiredParameters.add(
+                Parameter(
+                  (b) => b
+                    ..name = 'b'
+                    ..type = refer('${className}Builder'),
                 ),
-            ),
-          );
-        }
+              )
+              ..body = Code('$interfaceClass._defaults(b);');
+          }),
+        );
 
-        if (validators != null && validators.isNotEmpty) {
-          b.methods.add(
-            Method((b) {
-              b
-                ..name = '_validate'
-                ..returns = refer('void')
-                ..annotations.add(
-                  refer('BuiltValueHook').call([], {'finalizeBuilder': literalTrue}),
-                )
-                ..static = true
-                ..requiredParameters.add(
-                  Parameter(
-                    (b) => b
-                      ..name = 'b'
-                      ..type = refer('${className}Builder'),
-                  ),
-                )
-                ..body = Block.of(
-                  validators.map((v) => v.statement),
-                );
-            }),
-          );
-        }
+        b.methods.add(
+          Method((b) {
+            b
+              ..name = '_validate'
+              ..returns = refer('void')
+              ..annotations.add(
+                refer('BuiltValueHook').call([], {
+                  'finalizeBuilder': literalTrue,
+                }),
+              )
+              ..static = true
+              ..requiredParameters.add(
+                Parameter(
+                  (b) => b
+                    ..name = 'b'
+                    ..type = refer('${className}Builder'),
+                ),
+              )
+              ..body = Code('$interfaceClass._validate(b);');
+          }),
+        );
       },
     );
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.dart
@@ -23,6 +23,10 @@ abstract interface class $ObjectAllOfInterface {
   String get attribute1AllOf;
   @BuiltValueField(wireName: 'attribute2-allOf')
   String get attribute2AllOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ObjectAllOfInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ObjectAllOfInterfaceBuilder b) {}
 }
 
 /// All of with objects only.
@@ -44,6 +48,16 @@ abstract class ObjectAllOf implements $ObjectAllOfInterface, Built<ObjectAllOf, 
 
   /// Serializer for ObjectAllOf.
   static Serializer<ObjectAllOf> get serializer => _$objectAllOfSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ObjectAllOfBuilder b) {
+    $ObjectAllOfInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ObjectAllOfBuilder b) {
+    $ObjectAllOfInterface._validate(b);
+  }
 }
 
 /// All of with one object value.
@@ -51,6 +65,10 @@ abstract class ObjectAllOf implements $ObjectAllOfInterface, Built<ObjectAllOf, 
 abstract interface class $OneObjectAllOfInterface {
   @BuiltValueField(wireName: 'attribute-allOf')
   String get attributeAllOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OneObjectAllOfInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OneObjectAllOfInterfaceBuilder b) {}
 }
 
 /// All of with one object value.
@@ -72,6 +90,16 @@ abstract class OneObjectAllOf implements $OneObjectAllOfInterface, Built<OneObje
 
   /// Serializer for OneObjectAllOf.
   static Serializer<OneObjectAllOf> get serializer => _$oneObjectAllOfSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OneObjectAllOfBuilder b) {
+    $OneObjectAllOfInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OneObjectAllOfBuilder b) {
+    $OneObjectAllOfInterface._validate(b);
+  }
 }
 
 /// All of with an primitive values.
@@ -81,6 +109,10 @@ abstract interface class $PrimitiveAllOfInterface {
   int get $int;
   @BuiltValueField(wireName: 'String')
   String get string;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PrimitiveAllOfInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PrimitiveAllOfInterfaceBuilder b) {}
 }
 
 /// All of with an primitive values.
@@ -102,6 +134,16 @@ abstract class PrimitiveAllOf implements $PrimitiveAllOfInterface, Built<Primiti
 
   /// Serializer for PrimitiveAllOf.
   static Serializer<PrimitiveAllOf> get serializer => _$primitiveAllOfSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PrimitiveAllOfBuilder b) {
+    $PrimitiveAllOfInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PrimitiveAllOfBuilder b) {
+    $PrimitiveAllOfInterface._validate(b);
+  }
 }
 
 /// All of with object and primitive value.
@@ -111,6 +153,10 @@ abstract interface class $MixedAllOfInterface {
   String get string;
   @BuiltValueField(wireName: 'attribute-allOf')
   String get attributeAllOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MixedAllOfInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MixedAllOfInterfaceBuilder b) {}
 }
 
 /// All of with object and primitive value.
@@ -132,6 +178,16 @@ abstract class MixedAllOf implements $MixedAllOfInterface, Built<MixedAllOf, Mix
 
   /// Serializer for MixedAllOf.
   static Serializer<MixedAllOf> get serializer => _$mixedAllOfSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MixedAllOfBuilder b) {
+    $MixedAllOfInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MixedAllOfBuilder b) {
+    $MixedAllOfInterface._validate(b);
+  }
 }
 
 /// All of with one primitive value.
@@ -139,6 +195,10 @@ abstract class MixedAllOf implements $MixedAllOfInterface, Built<MixedAllOf, Mix
 abstract interface class $OneValueAllOfInterface {
   @BuiltValueField(wireName: 'String')
   String get string;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OneValueAllOfInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OneValueAllOfInterfaceBuilder b) {}
 }
 
 /// All of with one primitive value.
@@ -160,6 +220,16 @@ abstract class OneValueAllOf implements $OneValueAllOfInterface, Built<OneValueA
 
   /// Serializer for OneValueAllOf.
   static Serializer<OneValueAllOf> get serializer => _$oneValueAllOfSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OneValueAllOfBuilder b) {
+    $OneValueAllOfInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OneValueAllOfBuilder b) {
+    $OneValueAllOfInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.dart
@@ -10,9 +10,10 @@ library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:built_value/standard_json_plugin.dart' as _i3;
-import 'package:dynamite_runtime/built_value.dart' as _i2;
-import 'package:meta/meta.dart' as _i1;
+import 'package:built_value/standard_json_plugin.dart' as _i4;
+import 'package:dynamite_runtime/built_value.dart' as _i3;
+import 'package:dynamite_runtime/utils.dart' as _i1;
+import 'package:meta/meta.dart' as _i2;
 
 part 'all_of.openapi.g.dart';
 
@@ -232,12 +233,113 @@ abstract class OneValueAllOf implements $OneValueAllOfInterface, Built<OneValueA
   }
 }
 
+@BuiltValue(instantiable: false)
+abstract interface class $SuperObjectInterface {
+  String get value;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SuperObjectInterfaceBuilder b) {
+    b.value = '123';
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SuperObjectInterfaceBuilder b) {
+    _i1.checkPattern(
+      b.value,
+      RegExp(r'^[0-9]*$'),
+      'value',
+    );
+    _i1.checkMinLength(
+      b.value,
+      3,
+      'value',
+    );
+    _i1.checkMaxLength(
+      b.value,
+      20,
+      'value',
+    );
+  }
+}
+
+abstract class SuperObject implements $SuperObjectInterface, Built<SuperObject, SuperObjectBuilder> {
+  /// Creates a new SuperObject object using the builder pattern.
+  factory SuperObject([void Function(SuperObjectBuilder)? b]) = _$SuperObject;
+
+  const SuperObject._();
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  factory SuperObject.fromJson(Map<String, dynamic> json) => _$jsonSerializers.deserializeWith(serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+
+  /// Serializer for SuperObject.
+  static Serializer<SuperObject> get serializer => _$superObjectSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SuperObjectBuilder b) {
+    $SuperObjectInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SuperObjectBuilder b) {
+    $SuperObjectInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+abstract interface class $SubObjectInterface implements $SuperObjectInterface {
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SubObjectInterfaceBuilder b) {
+    $SuperObjectInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SubObjectInterfaceBuilder b) {
+    $SuperObjectInterface._validate(b);
+  }
+}
+
+abstract class SubObject implements $SubObjectInterface, Built<SubObject, SubObjectBuilder> {
+  /// Creates a new SubObject object using the builder pattern.
+  factory SubObject([void Function(SubObjectBuilder)? b]) = _$SubObject;
+
+  const SubObject._();
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  factory SubObject.fromJson(Map<String, dynamic> json) => _$jsonSerializers.deserializeWith(serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+
+  /// Serializer for SubObject.
+  static Serializer<SubObject> get serializer => _$subObjectSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SubObjectBuilder b) {
+    $SubObjectInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SubObjectBuilder b) {
+    $SubObjectInterface._validate(b);
+  }
+}
+
 // coverage:ignore-start
 /// Serializer for all values in this library.
 ///
 /// Serializes values into the `built_value` wire format.
 /// See: [$jsonSerializers] for serializing into json.
-@_i1.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(ObjectAllOf), ObjectAllOfBuilder.new)
@@ -249,19 +351,23 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(MixedAllOf), MixedAllOfBuilder.new)
       ..add(MixedAllOf.serializer)
       ..addBuilderFactory(const FullType(OneValueAllOf), OneValueAllOfBuilder.new)
-      ..add(OneValueAllOf.serializer))
+      ..add(OneValueAllOf.serializer)
+      ..addBuilderFactory(const FullType(SuperObject), SuperObjectBuilder.new)
+      ..add(SuperObject.serializer)
+      ..addBuilderFactory(const FullType(SubObject), SubObjectBuilder.new)
+      ..add(SubObject.serializer))
     .build();
 
 /// Serializer for all values in this library.
 ///
 /// Serializes values into the json. Json serialization is more expensive than the built_value wire format.
 /// See: [$serializers] for serializing into the `built_value` wire format.
-@_i1.visibleForTesting
+@_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
-      ..add(_i2.DynamiteDoubleSerializer())
-      ..addPlugin(_i3.StandardJsonPlugin())
-      ..addPlugin(const _i2.HeaderPlugin())
-      ..addPlugin(const _i2.ContentStringPlugin()))
+      ..add(_i3.DynamiteDoubleSerializer())
+      ..addPlugin(_i4.StandardJsonPlugin())
+      ..addPlugin(const _i3.HeaderPlugin())
+      ..addPlugin(const _i3.ContentStringPlugin()))
     .build();
 // coverage:ignore-end

--- a/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.g.dart
@@ -11,6 +11,8 @@ Serializer<OneObjectAllOf> _$oneObjectAllOfSerializer = _$OneObjectAllOfSerializ
 Serializer<PrimitiveAllOf> _$primitiveAllOfSerializer = _$PrimitiveAllOfSerializer();
 Serializer<MixedAllOf> _$mixedAllOfSerializer = _$MixedAllOfSerializer();
 Serializer<OneValueAllOf> _$oneValueAllOfSerializer = _$OneValueAllOfSerializer();
+Serializer<SuperObject> _$superObjectSerializer = _$SuperObjectSerializer();
+Serializer<SubObject> _$subObjectSerializer = _$SubObjectSerializer();
 
 class _$ObjectAllOfSerializer implements StructuredSerializer<ObjectAllOf> {
   @override
@@ -209,6 +211,82 @@ class _$OneValueAllOfSerializer implements StructuredSerializer<OneValueAllOf> {
       switch (key) {
         case 'String':
           result.string = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SuperObjectSerializer implements StructuredSerializer<SuperObject> {
+  @override
+  final Iterable<Type> types = const [SuperObject, _$SuperObject];
+  @override
+  final String wireName = 'SuperObject';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, SuperObject object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  SuperObject deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = SuperObjectBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SubObjectSerializer implements StructuredSerializer<SubObject> {
+  @override
+  final Iterable<Type> types = const [SubObject, _$SubObject];
+  @override
+  final String wireName = 'SubObject';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, SubObject object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  SubObject deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = SubObjectBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -698,6 +776,178 @@ class OneValueAllOfBuilder implements Builder<OneValueAllOf, OneValueAllOfBuilde
     OneValueAllOf._validate(this);
     final _$result =
         _$v ?? _$OneValueAllOf._(string: BuiltValueNullFieldError.checkNotNull(string, r'OneValueAllOf', 'string'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $SuperObjectInterfaceBuilder {
+  void replace($SuperObjectInterface other);
+  void update(void Function($SuperObjectInterfaceBuilder) updates);
+  String? get value;
+  set value(String? value);
+}
+
+class _$SuperObject extends SuperObject {
+  @override
+  final String value;
+
+  factory _$SuperObject([void Function(SuperObjectBuilder)? updates]) =>
+      (SuperObjectBuilder()..update(updates))._build();
+
+  _$SuperObject._({required this.value}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(value, r'SuperObject', 'value');
+  }
+
+  @override
+  SuperObject rebuild(void Function(SuperObjectBuilder) updates) => (toBuilder()..update(updates)).build();
+
+  @override
+  SuperObjectBuilder toBuilder() => SuperObjectBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SuperObject && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SuperObject')..add('value', value)).toString();
+  }
+}
+
+class SuperObjectBuilder implements Builder<SuperObject, SuperObjectBuilder>, $SuperObjectInterfaceBuilder {
+  _$SuperObject? _$v;
+
+  String? _value;
+  String? get value => _$this._value;
+  set value(covariant String? value) => _$this._value = value;
+
+  SuperObjectBuilder() {
+    SuperObject._defaults(this);
+  }
+
+  SuperObjectBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant SuperObject other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$SuperObject;
+  }
+
+  @override
+  void update(void Function(SuperObjectBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SuperObject build() => _build();
+
+  _$SuperObject _build() {
+    SuperObject._validate(this);
+    final _$result =
+        _$v ?? _$SuperObject._(value: BuiltValueNullFieldError.checkNotNull(value, r'SuperObject', 'value'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $SubObjectInterfaceBuilder implements $SuperObjectInterfaceBuilder {
+  void replace(covariant $SubObjectInterface other);
+  void update(void Function($SubObjectInterfaceBuilder) updates);
+  String? get value;
+  set value(covariant String? value);
+}
+
+class _$SubObject extends SubObject {
+  @override
+  final String value;
+
+  factory _$SubObject([void Function(SubObjectBuilder)? updates]) => (SubObjectBuilder()..update(updates))._build();
+
+  _$SubObject._({required this.value}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(value, r'SubObject', 'value');
+  }
+
+  @override
+  SubObject rebuild(void Function(SubObjectBuilder) updates) => (toBuilder()..update(updates)).build();
+
+  @override
+  SubObjectBuilder toBuilder() => SubObjectBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SubObject && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SubObject')..add('value', value)).toString();
+  }
+}
+
+class SubObjectBuilder implements Builder<SubObject, SubObjectBuilder>, $SubObjectInterfaceBuilder {
+  _$SubObject? _$v;
+
+  String? _value;
+  String? get value => _$this._value;
+  set value(covariant String? value) => _$this._value = value;
+
+  SubObjectBuilder() {
+    SubObject._defaults(this);
+  }
+
+  SubObjectBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant SubObject other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$SubObject;
+  }
+
+  @override
+  void update(void Function(SubObjectBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SubObject build() => _build();
+
+  _$SubObject _build() {
+    SubObject._validate(this);
+    final _$result = _$v ?? _$SubObject._(value: BuiltValueNullFieldError.checkNotNull(value, r'SubObject', 'value'));
     replace(_$result);
     return _$result;
   }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.g.dart
@@ -282,7 +282,9 @@ class ObjectAllOfBuilder implements Builder<ObjectAllOf, ObjectAllOfBuilder>, $O
   String? get attribute2AllOf => _$this._attribute2AllOf;
   set attribute2AllOf(covariant String? attribute2AllOf) => _$this._attribute2AllOf = attribute2AllOf;
 
-  ObjectAllOfBuilder();
+  ObjectAllOfBuilder() {
+    ObjectAllOf._defaults(this);
+  }
 
   ObjectAllOfBuilder get _$this {
     final $v = _$v;
@@ -309,6 +311,7 @@ class ObjectAllOfBuilder implements Builder<ObjectAllOf, ObjectAllOfBuilder>, $O
   ObjectAllOf build() => _build();
 
   _$ObjectAllOf _build() {
+    ObjectAllOf._validate(this);
     final _$result = _$v ??
         _$ObjectAllOf._(
             attribute1AllOf: BuiltValueNullFieldError.checkNotNull(attribute1AllOf, r'ObjectAllOf', 'attribute1AllOf'),
@@ -369,7 +372,9 @@ class OneObjectAllOfBuilder implements Builder<OneObjectAllOf, OneObjectAllOfBui
   String? get attributeAllOf => _$this._attributeAllOf;
   set attributeAllOf(covariant String? attributeAllOf) => _$this._attributeAllOf = attributeAllOf;
 
-  OneObjectAllOfBuilder();
+  OneObjectAllOfBuilder() {
+    OneObjectAllOf._defaults(this);
+  }
 
   OneObjectAllOfBuilder get _$this {
     final $v = _$v;
@@ -395,6 +400,7 @@ class OneObjectAllOfBuilder implements Builder<OneObjectAllOf, OneObjectAllOfBui
   OneObjectAllOf build() => _build();
 
   _$OneObjectAllOf _build() {
+    OneObjectAllOf._validate(this);
     final _$result = _$v ??
         _$OneObjectAllOf._(
             attributeAllOf: BuiltValueNullFieldError.checkNotNull(attributeAllOf, r'OneObjectAllOf', 'attributeAllOf'));
@@ -468,7 +474,9 @@ class PrimitiveAllOfBuilder implements Builder<PrimitiveAllOf, PrimitiveAllOfBui
   String? get string => _$this._string;
   set string(covariant String? string) => _$this._string = string;
 
-  PrimitiveAllOfBuilder();
+  PrimitiveAllOfBuilder() {
+    PrimitiveAllOf._defaults(this);
+  }
 
   PrimitiveAllOfBuilder get _$this {
     final $v = _$v;
@@ -495,6 +503,7 @@ class PrimitiveAllOfBuilder implements Builder<PrimitiveAllOf, PrimitiveAllOfBui
   PrimitiveAllOf build() => _build();
 
   _$PrimitiveAllOf _build() {
+    PrimitiveAllOf._validate(this);
     final _$result = _$v ??
         _$PrimitiveAllOf._(
             $int: BuiltValueNullFieldError.checkNotNull($int, r'PrimitiveAllOf', '\$int'),
@@ -568,7 +577,9 @@ class MixedAllOfBuilder implements Builder<MixedAllOf, MixedAllOfBuilder>, $Mixe
   String? get attributeAllOf => _$this._attributeAllOf;
   set attributeAllOf(covariant String? attributeAllOf) => _$this._attributeAllOf = attributeAllOf;
 
-  MixedAllOfBuilder();
+  MixedAllOfBuilder() {
+    MixedAllOf._defaults(this);
+  }
 
   MixedAllOfBuilder get _$this {
     final $v = _$v;
@@ -595,6 +606,7 @@ class MixedAllOfBuilder implements Builder<MixedAllOf, MixedAllOfBuilder>, $Mixe
   MixedAllOf build() => _build();
 
   _$MixedAllOf _build() {
+    MixedAllOf._validate(this);
     final _$result = _$v ??
         _$MixedAllOf._(
             string: BuiltValueNullFieldError.checkNotNull(string, r'MixedAllOf', 'string'),
@@ -655,7 +667,9 @@ class OneValueAllOfBuilder implements Builder<OneValueAllOf, OneValueAllOfBuilde
   String? get string => _$this._string;
   set string(covariant String? string) => _$this._string = string;
 
-  OneValueAllOfBuilder();
+  OneValueAllOfBuilder() {
+    OneValueAllOf._defaults(this);
+  }
 
   OneValueAllOfBuilder get _$this {
     final $v = _$v;
@@ -681,6 +695,7 @@ class OneValueAllOfBuilder implements Builder<OneValueAllOf, OneValueAllOfBuilde
   OneValueAllOf build() => _build();
 
   _$OneValueAllOf _build() {
+    OneValueAllOf._validate(this);
     final _$result =
         _$v ?? _$OneValueAllOf._(string: BuiltValueNullFieldError.checkNotNull(string, r'OneValueAllOf', 'string'));
     replace(_$result);

--- a/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.json
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.json
@@ -86,6 +86,29 @@
                         "type": "string"
                     }
                 ]
+            },
+            "SuperObject": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "pattern": "^[0-9]*$",
+                        "minLength": 3,
+                        "maxLength": 20,
+                        "default": "123"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "SubObject": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SuperObject"
+                    }
+                ]
             }
         }
     },

--- a/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.dart
@@ -26,6 +26,10 @@ typedef AnyOfIntDoubleNum = num;
 abstract interface class $ObjectAnyOf0Interface {
   @BuiltValueField(wireName: 'attribute1-anyOf')
   String get attribute1AnyOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ObjectAnyOf0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ObjectAnyOf0InterfaceBuilder b) {}
 }
 
 abstract class ObjectAnyOf0 implements $ObjectAnyOf0Interface, Built<ObjectAnyOf0, ObjectAnyOf0Builder> {
@@ -46,12 +50,26 @@ abstract class ObjectAnyOf0 implements $ObjectAnyOf0Interface, Built<ObjectAnyOf
 
   /// Serializer for ObjectAnyOf0.
   static Serializer<ObjectAnyOf0> get serializer => _$objectAnyOf0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ObjectAnyOf0Builder b) {
+    $ObjectAnyOf0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ObjectAnyOf0Builder b) {
+    $ObjectAnyOf0Interface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ObjectAnyOf1Interface {
   @BuiltValueField(wireName: 'attribute2-anyOf')
   String get attribute2AnyOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ObjectAnyOf1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ObjectAnyOf1InterfaceBuilder b) {}
 }
 
 abstract class ObjectAnyOf1 implements $ObjectAnyOf1Interface, Built<ObjectAnyOf1, ObjectAnyOf1Builder> {
@@ -72,6 +90,16 @@ abstract class ObjectAnyOf1 implements $ObjectAnyOf1Interface, Built<ObjectAnyOf
 
   /// Serializer for ObjectAnyOf1.
   static Serializer<ObjectAnyOf1> get serializer => _$objectAnyOf1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ObjectAnyOf1Builder b) {
+    $ObjectAnyOf1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ObjectAnyOf1Builder b) {
+    $ObjectAnyOf1Interface._validate(b);
+  }
 }
 
 /// Any of with objects only.
@@ -81,6 +109,10 @@ typedef ObjectAnyOf = ({ObjectAnyOf0? objectAnyOf0, ObjectAnyOf1? objectAnyOf1})
 abstract interface class $MixedAnyOf1Interface {
   @BuiltValueField(wireName: 'attribute-anyOf')
   String get attributeAnyOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MixedAnyOf1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MixedAnyOf1InterfaceBuilder b) {}
 }
 
 abstract class MixedAnyOf1 implements $MixedAnyOf1Interface, Built<MixedAnyOf1, MixedAnyOf1Builder> {
@@ -101,6 +133,16 @@ abstract class MixedAnyOf1 implements $MixedAnyOf1Interface, Built<MixedAnyOf1, 
 
   /// Serializer for MixedAnyOf1.
   static Serializer<MixedAnyOf1> get serializer => _$mixedAnyOf1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MixedAnyOf1Builder b) {
+    $MixedAnyOf1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MixedAnyOf1Builder b) {
+    $MixedAnyOf1Interface._validate(b);
+  }
 }
 
 /// Any of with object and primitive value.
@@ -110,6 +152,10 @@ typedef MixedAnyOf = ({MixedAnyOf1? mixedAnyOf1, String? string});
 abstract interface class $OneObjectAnyOf0Interface {
   @BuiltValueField(wireName: 'attribute-anyOf')
   String get attributeAnyOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OneObjectAnyOf0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OneObjectAnyOf0InterfaceBuilder b) {}
 }
 
 abstract class OneObjectAnyOf0 implements $OneObjectAnyOf0Interface, Built<OneObjectAnyOf0, OneObjectAnyOf0Builder> {
@@ -130,6 +176,16 @@ abstract class OneObjectAnyOf0 implements $OneObjectAnyOf0Interface, Built<OneOb
 
   /// Serializer for OneObjectAnyOf0.
   static Serializer<OneObjectAnyOf0> get serializer => _$oneObjectAnyOf0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OneObjectAnyOf0Builder b) {
+    $OneObjectAnyOf0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OneObjectAnyOf0Builder b) {
+    $OneObjectAnyOf0Interface._validate(b);
+  }
 }
 
 /// Any of with an integer, double and other value.

--- a/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.g.dart
@@ -214,7 +214,9 @@ class ObjectAnyOf0Builder implements Builder<ObjectAnyOf0, ObjectAnyOf0Builder>,
   String? get attribute1AnyOf => _$this._attribute1AnyOf;
   set attribute1AnyOf(covariant String? attribute1AnyOf) => _$this._attribute1AnyOf = attribute1AnyOf;
 
-  ObjectAnyOf0Builder();
+  ObjectAnyOf0Builder() {
+    ObjectAnyOf0._defaults(this);
+  }
 
   ObjectAnyOf0Builder get _$this {
     final $v = _$v;
@@ -240,6 +242,7 @@ class ObjectAnyOf0Builder implements Builder<ObjectAnyOf0, ObjectAnyOf0Builder>,
   ObjectAnyOf0 build() => _build();
 
   _$ObjectAnyOf0 _build() {
+    ObjectAnyOf0._validate(this);
     final _$result = _$v ??
         _$ObjectAnyOf0._(
             attribute1AnyOf:
@@ -300,7 +303,9 @@ class ObjectAnyOf1Builder implements Builder<ObjectAnyOf1, ObjectAnyOf1Builder>,
   String? get attribute2AnyOf => _$this._attribute2AnyOf;
   set attribute2AnyOf(covariant String? attribute2AnyOf) => _$this._attribute2AnyOf = attribute2AnyOf;
 
-  ObjectAnyOf1Builder();
+  ObjectAnyOf1Builder() {
+    ObjectAnyOf1._defaults(this);
+  }
 
   ObjectAnyOf1Builder get _$this {
     final $v = _$v;
@@ -326,6 +331,7 @@ class ObjectAnyOf1Builder implements Builder<ObjectAnyOf1, ObjectAnyOf1Builder>,
   ObjectAnyOf1 build() => _build();
 
   _$ObjectAnyOf1 _build() {
+    ObjectAnyOf1._validate(this);
     final _$result = _$v ??
         _$ObjectAnyOf1._(
             attribute2AnyOf:
@@ -386,7 +392,9 @@ class MixedAnyOf1Builder implements Builder<MixedAnyOf1, MixedAnyOf1Builder>, $M
   String? get attributeAnyOf => _$this._attributeAnyOf;
   set attributeAnyOf(covariant String? attributeAnyOf) => _$this._attributeAnyOf = attributeAnyOf;
 
-  MixedAnyOf1Builder();
+  MixedAnyOf1Builder() {
+    MixedAnyOf1._defaults(this);
+  }
 
   MixedAnyOf1Builder get _$this {
     final $v = _$v;
@@ -412,6 +420,7 @@ class MixedAnyOf1Builder implements Builder<MixedAnyOf1, MixedAnyOf1Builder>, $M
   MixedAnyOf1 build() => _build();
 
   _$MixedAnyOf1 _build() {
+    MixedAnyOf1._validate(this);
     final _$result = _$v ??
         _$MixedAnyOf1._(
             attributeAnyOf: BuiltValueNullFieldError.checkNotNull(attributeAnyOf, r'MixedAnyOf1', 'attributeAnyOf'));
@@ -472,7 +481,9 @@ class OneObjectAnyOf0Builder
   String? get attributeAnyOf => _$this._attributeAnyOf;
   set attributeAnyOf(covariant String? attributeAnyOf) => _$this._attributeAnyOf = attributeAnyOf;
 
-  OneObjectAnyOf0Builder();
+  OneObjectAnyOf0Builder() {
+    OneObjectAnyOf0._defaults(this);
+  }
 
   OneObjectAnyOf0Builder get _$this {
     final $v = _$v;
@@ -498,6 +509,7 @@ class OneObjectAnyOf0Builder
   OneObjectAnyOf0 build() => _build();
 
   _$OneObjectAnyOf0 _build() {
+    OneObjectAnyOf0._validate(this);
     final _$result = _$v ??
         _$OneObjectAnyOf0._(
             attributeAnyOf:

--- a/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
@@ -441,9 +441,14 @@ abstract interface class $Object1Interface implements $Object2Interface {
   /// The uuid in an UUIDv4 format.
   int get id;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($Object1InterfaceBuilder b) {}
+  static void _defaults($Object1InterfaceBuilder b) {
+    $Object2Interface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($Object1InterfaceBuilder b) {}
+  static void _validate($Object1InterfaceBuilder b) {
+    $Object2Interface._validate(b);
+  }
 }
 
 /// A representation of the main object.

--- a/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
@@ -398,6 +398,10 @@ abstract interface class $Object2Interface {
 
   /// The tag of an Object2 object.
   String? get tag;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Object2InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Object2InterfaceBuilder b) {}
 }
 
 /// A representation of the second Object type.
@@ -419,6 +423,16 @@ abstract class Object2 implements $Object2Interface, Built<Object2, Object2Build
 
   /// Serializer for Object2.
   static Serializer<Object2> get serializer => _$object2Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Object2Builder b) {
+    $Object2Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Object2Builder b) {
+    $Object2Interface._validate(b);
+  }
 }
 
 /// A representation of the main object.
@@ -426,6 +440,10 @@ abstract class Object2 implements $Object2Interface, Built<Object2, Object2Build
 abstract interface class $Object1Interface implements $Object2Interface {
   /// The uuid in an UUIDv4 format.
   int get id;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Object1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Object1InterfaceBuilder b) {}
 }
 
 /// A representation of the main object.
@@ -447,6 +465,16 @@ abstract class Object1 implements $Object1Interface, Built<Object1, Object1Build
 
   /// Serializer for Object1.
   static Serializer<Object1> get serializer => _$object1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Object1Builder b) {
+    $Object1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Object1Builder b) {
+    $Object1Interface._validate(b);
+  }
 }
 
 /// An Object to test the documentation of someOf extension methods and typdefs.

--- a/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.g.dart
@@ -198,7 +198,9 @@ class Object2Builder implements Builder<Object2, Object2Builder>, $Object2Interf
   String? get tag => _$this._tag;
   set tag(covariant String? tag) => _$this._tag = tag;
 
-  Object2Builder();
+  Object2Builder() {
+    Object2._defaults(this);
+  }
 
   Object2Builder get _$this {
     final $v = _$v;
@@ -225,6 +227,7 @@ class Object2Builder implements Builder<Object2, Object2Builder>, $Object2Interf
   Object2 build() => _build();
 
   _$Object2 _build() {
+    Object2._validate(this);
     final _$result =
         _$v ?? _$Object2._(name: BuiltValueNullFieldError.checkNotNull(name, r'Object2', 'name'), tag: tag);
     replace(_$result);
@@ -307,7 +310,9 @@ class Object1Builder implements Builder<Object1, Object1Builder>, $Object1Interf
   String? get tag => _$this._tag;
   set tag(covariant String? tag) => _$this._tag = tag;
 
-  Object1Builder();
+  Object1Builder() {
+    Object1._defaults(this);
+  }
 
   Object1Builder get _$this {
     final $v = _$v;
@@ -335,6 +340,7 @@ class Object1Builder implements Builder<Object1, Object1Builder>, $Object1Interf
   Object1 build() => _build();
 
   _$Object1 _build() {
+    Object1._validate(this);
     final _$result = _$v ??
         _$Object1._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'Object1', 'id'),

--- a/packages/dynamite/dynamite_end_to_end_test/lib/enum.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/enum.openapi.dart
@@ -348,6 +348,10 @@ abstract interface class $WrappedEnumInterface {
   @BuiltValueField(wireName: 'String')
   WrappedEnum_String get string;
   WrappedEnum_Integer get integer;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WrappedEnumInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WrappedEnumInterfaceBuilder b) {}
 }
 
 abstract class WrappedEnum implements $WrappedEnumInterface, Built<WrappedEnum, WrappedEnumBuilder> {
@@ -368,11 +372,25 @@ abstract class WrappedEnum implements $WrappedEnumInterface, Built<WrappedEnum, 
 
   /// Serializer for WrappedEnum.
   static Serializer<WrappedEnum> get serializer => _$wrappedEnumSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WrappedEnumBuilder b) {
+    $WrappedEnumInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WrappedEnumBuilder b) {
+    $WrappedEnumInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EnumReferenceInterface {
   EnumString get string;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EnumReferenceInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EnumReferenceInterfaceBuilder b) {}
 }
 
 abstract class EnumReference implements $EnumReferenceInterface, Built<EnumReference, EnumReferenceBuilder> {
@@ -393,6 +411,16 @@ abstract class EnumReference implements $EnumReferenceInterface, Built<EnumRefer
 
   /// Serializer for EnumReference.
   static Serializer<EnumReference> get serializer => _$enumReferenceSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EnumReferenceBuilder b) {
+    $EnumReferenceInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EnumReferenceBuilder b) {
+    $EnumReferenceInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/dynamite/dynamite_end_to_end_test/lib/enum.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/enum.openapi.g.dart
@@ -269,7 +269,9 @@ class WrappedEnumBuilder implements Builder<WrappedEnum, WrappedEnumBuilder>, $W
   WrappedEnum_Integer? get integer => _$this._integer;
   set integer(covariant WrappedEnum_Integer? integer) => _$this._integer = integer;
 
-  WrappedEnumBuilder();
+  WrappedEnumBuilder() {
+    WrappedEnum._defaults(this);
+  }
 
   WrappedEnumBuilder get _$this {
     final $v = _$v;
@@ -296,6 +298,7 @@ class WrappedEnumBuilder implements Builder<WrappedEnum, WrappedEnumBuilder>, $W
   WrappedEnum build() => _build();
 
   _$WrappedEnum _build() {
+    WrappedEnum._validate(this);
     final _$result = _$v ??
         _$WrappedEnum._(
             string: BuiltValueNullFieldError.checkNotNull(string, r'WrappedEnum', 'string'),
@@ -356,7 +359,9 @@ class EnumReferenceBuilder implements Builder<EnumReference, EnumReferenceBuilde
   EnumString? get string => _$this._string;
   set string(covariant EnumString? string) => _$this._string = string;
 
-  EnumReferenceBuilder();
+  EnumReferenceBuilder() {
+    EnumReference._defaults(this);
+  }
 
   EnumReferenceBuilder get _$this {
     final $v = _$v;
@@ -382,6 +387,7 @@ class EnumReferenceBuilder implements Builder<EnumReference, EnumReferenceBuilde
   EnumReference build() => _build();
 
   _$EnumReference _build() {
+    EnumReference._validate(this);
     final _$result =
         _$v ?? _$EnumReference._(string: BuiltValueNullFieldError.checkNotNull(string, r'EnumReference', 'string'));
     replace(_$result);

--- a/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
@@ -175,6 +175,10 @@ class $Client extends _i1.DynamiteClient {
 abstract interface class $GetHeadersInterface {
   @BuiltValueField(wireName: 'my-header')
   String? get myHeader;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GetHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GetHeadersInterfaceBuilder b) {}
 }
 
 abstract class GetHeaders implements $GetHeadersInterface, Built<GetHeaders, GetHeadersBuilder> {
@@ -195,12 +199,26 @@ abstract class GetHeaders implements $GetHeadersInterface, Built<GetHeaders, Get
 
   /// Serializer for GetHeaders.
   static Serializer<GetHeaders> get serializer => _$getHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GetHeadersBuilder b) {
+    $GetHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GetHeadersBuilder b) {
+    $GetHeadersInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WithContentOperationIdHeadersInterface {
   @BuiltValueField(wireName: 'my-header')
   String? get myHeader;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WithContentOperationIdHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WithContentOperationIdHeadersInterfaceBuilder b) {}
 }
 
 abstract class WithContentOperationIdHeaders
@@ -226,12 +244,26 @@ abstract class WithContentOperationIdHeaders
 
   /// Serializer for WithContentOperationIdHeaders.
   static Serializer<WithContentOperationIdHeaders> get serializer => _$withContentOperationIdHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WithContentOperationIdHeadersBuilder b) {
+    $WithContentOperationIdHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WithContentOperationIdHeadersBuilder b) {
+    $WithContentOperationIdHeadersInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GetWithContentHeadersInterface {
   @BuiltValueField(wireName: 'my-header')
   String? get myHeader;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GetWithContentHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GetWithContentHeadersInterfaceBuilder b) {}
 }
 
 abstract class GetWithContentHeaders
@@ -254,6 +286,16 @@ abstract class GetWithContentHeaders
 
   /// Serializer for GetWithContentHeaders.
   static Serializer<GetWithContentHeaders> get serializer => _$getWithContentHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GetWithContentHeadersBuilder b) {
+    $GetWithContentHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GetWithContentHeadersBuilder b) {
+    $GetWithContentHeadersInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.g.dart
@@ -182,7 +182,9 @@ class GetHeadersBuilder implements Builder<GetHeaders, GetHeadersBuilder>, $GetH
   String? get myHeader => _$this._myHeader;
   set myHeader(covariant String? myHeader) => _$this._myHeader = myHeader;
 
-  GetHeadersBuilder();
+  GetHeadersBuilder() {
+    GetHeaders._defaults(this);
+  }
 
   GetHeadersBuilder get _$this {
     final $v = _$v;
@@ -208,6 +210,7 @@ class GetHeadersBuilder implements Builder<GetHeaders, GetHeadersBuilder>, $GetH
   GetHeaders build() => _build();
 
   _$GetHeaders _build() {
+    GetHeaders._validate(this);
     final _$result = _$v ?? _$GetHeaders._(myHeader: myHeader);
     replace(_$result);
     return _$result;
@@ -267,7 +270,9 @@ class WithContentOperationIdHeadersBuilder
   String? get myHeader => _$this._myHeader;
   set myHeader(covariant String? myHeader) => _$this._myHeader = myHeader;
 
-  WithContentOperationIdHeadersBuilder();
+  WithContentOperationIdHeadersBuilder() {
+    WithContentOperationIdHeaders._defaults(this);
+  }
 
   WithContentOperationIdHeadersBuilder get _$this {
     final $v = _$v;
@@ -293,6 +298,7 @@ class WithContentOperationIdHeadersBuilder
   WithContentOperationIdHeaders build() => _build();
 
   _$WithContentOperationIdHeaders _build() {
+    WithContentOperationIdHeaders._validate(this);
     final _$result = _$v ?? _$WithContentOperationIdHeaders._(myHeader: myHeader);
     replace(_$result);
     return _$result;
@@ -350,7 +356,9 @@ class GetWithContentHeadersBuilder
   String? get myHeader => _$this._myHeader;
   set myHeader(covariant String? myHeader) => _$this._myHeader = myHeader;
 
-  GetWithContentHeadersBuilder();
+  GetWithContentHeadersBuilder() {
+    GetWithContentHeaders._defaults(this);
+  }
 
   GetWithContentHeadersBuilder get _$this {
     final $v = _$v;
@@ -376,6 +384,7 @@ class GetWithContentHeadersBuilder
   GetWithContentHeaders build() => _build();
 
   _$GetWithContentHeaders _build() {
+    GetWithContentHeaders._validate(this);
     final _$result = _$v ?? _$GetWithContentHeaders._(myHeader: myHeader);
     replace(_$result);
     return _$result;

--- a/packages/dynamite/dynamite_end_to_end_test/lib/interfaces.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/interfaces.openapi.dart
@@ -19,6 +19,10 @@ part 'interfaces.openapi.g.dart';
 @BuiltValue(instantiable: false)
 abstract interface class $BaseInterface {
   String? get attribute;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BaseInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BaseInterfaceBuilder b) {}
 }
 
 abstract class Base implements $BaseInterface, Built<Base, BaseBuilder> {
@@ -39,11 +43,25 @@ abstract class Base implements $BaseInterface, Built<Base, BaseBuilder> {
 
   /// Serializer for Base.
   static Serializer<Base> get serializer => _$baseSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BaseBuilder b) {
+    $BaseInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BaseBuilder b) {
+    $BaseInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BaseInterfaceInterface {
   String? get attribute;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BaseInterfaceInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BaseInterfaceInterfaceBuilder b) {}
 }
 
 abstract class BaseInterface implements $BaseInterfaceInterface, Built<BaseInterface, BaseInterfaceBuilder> {
@@ -64,6 +82,16 @@ abstract class BaseInterface implements $BaseInterfaceInterface, Built<BaseInter
 
   /// Serializer for BaseInterface.
   static Serializer<BaseInterface> get serializer => _$baseInterfaceSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BaseInterfaceBuilder b) {
+    $BaseInterfaceInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BaseInterfaceBuilder b) {
+    $BaseInterfaceInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/dynamite/dynamite_end_to_end_test/lib/interfaces.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/interfaces.openapi.g.dart
@@ -138,7 +138,9 @@ class BaseBuilder implements Builder<Base, BaseBuilder>, $BaseInterfaceBuilder {
   String? get attribute => _$this._attribute;
   set attribute(covariant String? attribute) => _$this._attribute = attribute;
 
-  BaseBuilder();
+  BaseBuilder() {
+    Base._defaults(this);
+  }
 
   BaseBuilder get _$this {
     final $v = _$v;
@@ -164,6 +166,7 @@ class BaseBuilder implements Builder<Base, BaseBuilder>, $BaseInterfaceBuilder {
   Base build() => _build();
 
   _$Base _build() {
+    Base._validate(this);
     final _$result = _$v ?? _$Base._(attribute: attribute);
     replace(_$result);
     return _$result;
@@ -219,7 +222,9 @@ class BaseInterfaceBuilder implements Builder<BaseInterface, BaseInterfaceBuilde
   String? get attribute => _$this._attribute;
   set attribute(covariant String? attribute) => _$this._attribute = attribute;
 
-  BaseInterfaceBuilder();
+  BaseInterfaceBuilder() {
+    BaseInterface._defaults(this);
+  }
 
   BaseInterfaceBuilder get _$this {
     final $v = _$v;
@@ -245,6 +250,7 @@ class BaseInterfaceBuilder implements Builder<BaseInterface, BaseInterfaceBuilde
   BaseInterface build() => _build();
 
   _$BaseInterface _build() {
+    BaseInterface._validate(this);
     final _$result = _$v ?? _$BaseInterface._(attribute: attribute);
     replace(_$result);
     return _$result;

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
@@ -23,6 +23,10 @@ abstract interface class $BaseAllOfInterface {
   String get string;
   @BuiltValueField(wireName: 'attribute-allOf')
   String get attributeAllOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BaseAllOfInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BaseAllOfInterfaceBuilder b) {}
 }
 
 abstract class BaseAllOf implements $BaseAllOfInterface, Built<BaseAllOf, BaseAllOfBuilder> {
@@ -43,12 +47,26 @@ abstract class BaseAllOf implements $BaseAllOfInterface, Built<BaseAllOf, BaseAl
 
   /// Serializer for BaseAllOf.
   static Serializer<BaseAllOf> get serializer => _$baseAllOfSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BaseAllOfBuilder b) {
+    $BaseAllOfInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BaseAllOfBuilder b) {
+    $BaseAllOfInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BaseOneOf1Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
   String get attributeOneOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BaseOneOf1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BaseOneOf1InterfaceBuilder b) {}
 }
 
 abstract class BaseOneOf1 implements $BaseOneOf1Interface, Built<BaseOneOf1, BaseOneOf1Builder> {
@@ -69,6 +87,16 @@ abstract class BaseOneOf1 implements $BaseOneOf1Interface, Built<BaseOneOf1, Bas
 
   /// Serializer for BaseOneOf1.
   static Serializer<BaseOneOf1> get serializer => _$baseOneOf1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BaseOneOf1Builder b) {
+    $BaseOneOf1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BaseOneOf1Builder b) {
+    $BaseOneOf1Interface._validate(b);
+  }
 }
 
 typedef BaseOneOf = ({BaseOneOf1? baseOneOf1, double? $double});
@@ -77,6 +105,10 @@ typedef BaseOneOf = ({BaseOneOf1? baseOneOf1, double? $double});
 abstract interface class $BaseAnyOf1Interface {
   @BuiltValueField(wireName: 'attribute-anyOf')
   String get attributeAnyOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BaseAnyOf1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BaseAnyOf1InterfaceBuilder b) {}
 }
 
 abstract class BaseAnyOf1 implements $BaseAnyOf1Interface, Built<BaseAnyOf1, BaseAnyOf1Builder> {
@@ -97,6 +129,16 @@ abstract class BaseAnyOf1 implements $BaseAnyOf1Interface, Built<BaseAnyOf1, Bas
 
   /// Serializer for BaseAnyOf1.
   static Serializer<BaseAnyOf1> get serializer => _$baseAnyOf1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BaseAnyOf1Builder b) {
+    $BaseAnyOf1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BaseAnyOf1Builder b) {
+    $BaseAnyOf1Interface._validate(b);
+  }
 }
 
 typedef BaseAnyOf = ({BaseAnyOf1? baseAnyOf1, int? $int});
@@ -109,6 +151,10 @@ abstract interface class $BaseNestedAllOfInterface implements $BaseAllOfInterfac
   BaseAnyOf get baseAnyOf;
   @BuiltValueField(wireName: 'attribute-nested-allOf')
   String get attributeNestedAllOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BaseNestedAllOfInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BaseNestedAllOfInterfaceBuilder b) {}
 }
 
 abstract class BaseNestedAllOf implements $BaseNestedAllOfInterface, Built<BaseNestedAllOf, BaseNestedAllOfBuilder> {
@@ -129,12 +175,26 @@ abstract class BaseNestedAllOf implements $BaseNestedAllOfInterface, Built<BaseN
 
   /// Serializer for BaseNestedAllOf.
   static Serializer<BaseNestedAllOf> get serializer => _$baseNestedAllOfSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BaseNestedAllOfBuilder b) {
+    $BaseNestedAllOfInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BaseNestedAllOfBuilder b) {
+    $BaseNestedAllOfInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BaseNestedOneOf3Interface {
   @BuiltValueField(wireName: 'attribute-nested-oneOf')
   String get attributeNestedOneOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BaseNestedOneOf3InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BaseNestedOneOf3InterfaceBuilder b) {}
 }
 
 abstract class BaseNestedOneOf3
@@ -156,6 +216,16 @@ abstract class BaseNestedOneOf3
 
   /// Serializer for BaseNestedOneOf3.
   static Serializer<BaseNestedOneOf3> get serializer => _$baseNestedOneOf3Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BaseNestedOneOf3Builder b) {
+    $BaseNestedOneOf3Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BaseNestedOneOf3Builder b) {
+    $BaseNestedOneOf3Interface._validate(b);
+  }
 }
 
 typedef BaseNestedOneOf = ({
@@ -170,6 +240,10 @@ typedef BaseNestedOneOf = ({
 abstract interface class $BaseNestedAnyOf3Interface {
   @BuiltValueField(wireName: 'attribute-nested-anyOf')
   String get attributeNestedAnyOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BaseNestedAnyOf3InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BaseNestedAnyOf3InterfaceBuilder b) {}
 }
 
 abstract class BaseNestedAnyOf3
@@ -191,6 +265,16 @@ abstract class BaseNestedAnyOf3
 
   /// Serializer for BaseNestedAnyOf3.
   static Serializer<BaseNestedAnyOf3> get serializer => _$baseNestedAnyOf3Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BaseNestedAnyOf3Builder b) {
+    $BaseNestedAnyOf3Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BaseNestedAnyOf3Builder b) {
+    $BaseNestedAnyOf3Interface._validate(b);
+  }
 }
 
 typedef BaseNestedAnyOf = ({

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
@@ -152,9 +152,14 @@ abstract interface class $BaseNestedAllOfInterface implements $BaseAllOfInterfac
   @BuiltValueField(wireName: 'attribute-nested-allOf')
   String get attributeNestedAllOf;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($BaseNestedAllOfInterfaceBuilder b) {}
+  static void _defaults($BaseNestedAllOfInterfaceBuilder b) {
+    $BaseAllOfInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($BaseNestedAllOfInterfaceBuilder b) {}
+  static void _validate($BaseNestedAllOfInterfaceBuilder b) {
+    $BaseAllOfInterface._validate(b);
+  }
 }
 
 abstract class BaseNestedAllOf implements $BaseNestedAllOfInterface, Built<BaseNestedAllOf, BaseNestedAllOfBuilder> {

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.g.dart
@@ -333,7 +333,9 @@ class BaseAllOfBuilder implements Builder<BaseAllOf, BaseAllOfBuilder>, $BaseAll
   String? get attributeAllOf => _$this._attributeAllOf;
   set attributeAllOf(covariant String? attributeAllOf) => _$this._attributeAllOf = attributeAllOf;
 
-  BaseAllOfBuilder();
+  BaseAllOfBuilder() {
+    BaseAllOf._defaults(this);
+  }
 
   BaseAllOfBuilder get _$this {
     final $v = _$v;
@@ -360,6 +362,7 @@ class BaseAllOfBuilder implements Builder<BaseAllOf, BaseAllOfBuilder>, $BaseAll
   BaseAllOf build() => _build();
 
   _$BaseAllOf _build() {
+    BaseAllOf._validate(this);
     final _$result = _$v ??
         _$BaseAllOf._(
             string: BuiltValueNullFieldError.checkNotNull(string, r'BaseAllOf', 'string'),
@@ -419,7 +422,9 @@ class BaseOneOf1Builder implements Builder<BaseOneOf1, BaseOneOf1Builder>, $Base
   String? get attributeOneOf => _$this._attributeOneOf;
   set attributeOneOf(covariant String? attributeOneOf) => _$this._attributeOneOf = attributeOneOf;
 
-  BaseOneOf1Builder();
+  BaseOneOf1Builder() {
+    BaseOneOf1._defaults(this);
+  }
 
   BaseOneOf1Builder get _$this {
     final $v = _$v;
@@ -445,6 +450,7 @@ class BaseOneOf1Builder implements Builder<BaseOneOf1, BaseOneOf1Builder>, $Base
   BaseOneOf1 build() => _build();
 
   _$BaseOneOf1 _build() {
+    BaseOneOf1._validate(this);
     final _$result = _$v ??
         _$BaseOneOf1._(
             attributeOneOf: BuiltValueNullFieldError.checkNotNull(attributeOneOf, r'BaseOneOf1', 'attributeOneOf'));
@@ -503,7 +509,9 @@ class BaseAnyOf1Builder implements Builder<BaseAnyOf1, BaseAnyOf1Builder>, $Base
   String? get attributeAnyOf => _$this._attributeAnyOf;
   set attributeAnyOf(covariant String? attributeAnyOf) => _$this._attributeAnyOf = attributeAnyOf;
 
-  BaseAnyOf1Builder();
+  BaseAnyOf1Builder() {
+    BaseAnyOf1._defaults(this);
+  }
 
   BaseAnyOf1Builder get _$this {
     final $v = _$v;
@@ -529,6 +537,7 @@ class BaseAnyOf1Builder implements Builder<BaseAnyOf1, BaseAnyOf1Builder>, $Base
   BaseAnyOf1 build() => _build();
 
   _$BaseAnyOf1 _build() {
+    BaseAnyOf1._validate(this);
     final _$result = _$v ??
         _$BaseAnyOf1._(
             attributeAnyOf: BuiltValueNullFieldError.checkNotNull(attributeAnyOf, r'BaseAnyOf1', 'attributeAnyOf'));
@@ -652,7 +661,9 @@ class BaseNestedAllOfBuilder
   String? get attributeAllOf => _$this._attributeAllOf;
   set attributeAllOf(covariant String? attributeAllOf) => _$this._attributeAllOf = attributeAllOf;
 
-  BaseNestedAllOfBuilder();
+  BaseNestedAllOfBuilder() {
+    BaseNestedAllOf._defaults(this);
+  }
 
   BaseNestedAllOfBuilder get _$this {
     final $v = _$v;
@@ -682,6 +693,7 @@ class BaseNestedAllOfBuilder
   BaseNestedAllOf build() => _build();
 
   _$BaseNestedAllOf _build() {
+    BaseNestedAllOf._validate(this);
     final _$result = _$v ??
         _$BaseNestedAllOf._(
             baseOneOf: BuiltValueNullFieldError.checkNotNull(baseOneOf, r'BaseNestedAllOf', 'baseOneOf'),
@@ -750,7 +762,9 @@ class BaseNestedOneOf3Builder
   set attributeNestedOneOf(covariant String? attributeNestedOneOf) =>
       _$this._attributeNestedOneOf = attributeNestedOneOf;
 
-  BaseNestedOneOf3Builder();
+  BaseNestedOneOf3Builder() {
+    BaseNestedOneOf3._defaults(this);
+  }
 
   BaseNestedOneOf3Builder get _$this {
     final $v = _$v;
@@ -776,6 +790,7 @@ class BaseNestedOneOf3Builder
   BaseNestedOneOf3 build() => _build();
 
   _$BaseNestedOneOf3 _build() {
+    BaseNestedOneOf3._validate(this);
     final _$result = _$v ??
         _$BaseNestedOneOf3._(
             attributeNestedOneOf: BuiltValueNullFieldError.checkNotNull(
@@ -839,7 +854,9 @@ class BaseNestedAnyOf3Builder
   set attributeNestedAnyOf(covariant String? attributeNestedAnyOf) =>
       _$this._attributeNestedAnyOf = attributeNestedAnyOf;
 
-  BaseNestedAnyOf3Builder();
+  BaseNestedAnyOf3Builder() {
+    BaseNestedAnyOf3._defaults(this);
+  }
 
   BaseNestedAnyOf3Builder get _$this {
     final $v = _$v;
@@ -865,6 +882,7 @@ class BaseNestedAnyOf3Builder
   BaseNestedAnyOf3 build() => _build();
 
   _$BaseNestedAnyOf3 _build() {
+    BaseNestedAnyOf3._validate(this);
     final _$result = _$v ??
         _$BaseNestedAnyOf3._(
             attributeNestedAnyOf: BuiltValueNullFieldError.checkNotNull(

--- a/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.dart
@@ -28,6 +28,10 @@ typedef OneOfIntDoubleNum = num;
 abstract interface class $ObjectOneOf0Interface {
   @BuiltValueField(wireName: 'attribute1-oneOf')
   String get attribute1OneOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ObjectOneOf0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ObjectOneOf0InterfaceBuilder b) {}
 }
 
 abstract class ObjectOneOf0 implements $ObjectOneOf0Interface, Built<ObjectOneOf0, ObjectOneOf0Builder> {
@@ -48,12 +52,26 @@ abstract class ObjectOneOf0 implements $ObjectOneOf0Interface, Built<ObjectOneOf
 
   /// Serializer for ObjectOneOf0.
   static Serializer<ObjectOneOf0> get serializer => _$objectOneOf0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ObjectOneOf0Builder b) {
+    $ObjectOneOf0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ObjectOneOf0Builder b) {
+    $ObjectOneOf0Interface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ObjectOneOf1Interface {
   @BuiltValueField(wireName: 'attribute2-oneOf')
   String get attribute2OneOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ObjectOneOf1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ObjectOneOf1InterfaceBuilder b) {}
 }
 
 abstract class ObjectOneOf1 implements $ObjectOneOf1Interface, Built<ObjectOneOf1, ObjectOneOf1Builder> {
@@ -74,6 +92,16 @@ abstract class ObjectOneOf1 implements $ObjectOneOf1Interface, Built<ObjectOneOf
 
   /// Serializer for ObjectOneOf1.
   static Serializer<ObjectOneOf1> get serializer => _$objectOneOf1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ObjectOneOf1Builder b) {
+    $ObjectOneOf1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ObjectOneOf1Builder b) {
+    $ObjectOneOf1Interface._validate(b);
+  }
 }
 
 /// One of with objects only.
@@ -83,6 +111,10 @@ typedef ObjectOneOf = ({ObjectOneOf0? objectOneOf0, ObjectOneOf1? objectOneOf1})
 abstract interface class $MixedOneOf1Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
   String get attributeOneOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MixedOneOf1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MixedOneOf1InterfaceBuilder b) {}
 }
 
 abstract class MixedOneOf1 implements $MixedOneOf1Interface, Built<MixedOneOf1, MixedOneOf1Builder> {
@@ -103,6 +135,16 @@ abstract class MixedOneOf1 implements $MixedOneOf1Interface, Built<MixedOneOf1, 
 
   /// Serializer for MixedOneOf1.
   static Serializer<MixedOneOf1> get serializer => _$mixedOneOf1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MixedOneOf1Builder b) {
+    $MixedOneOf1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MixedOneOf1Builder b) {
+    $MixedOneOf1Interface._validate(b);
+  }
 }
 
 /// One of with object and primitive value.
@@ -112,6 +154,10 @@ typedef MixedOneOf = ({MixedOneOf1? mixedOneOf1, String? string});
 abstract interface class $OneObjectOneOf0Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
   String get attributeOneOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OneObjectOneOf0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OneObjectOneOf0InterfaceBuilder b) {}
 }
 
 abstract class OneObjectOneOf0 implements $OneObjectOneOf0Interface, Built<OneObjectOneOf0, OneObjectOneOf0Builder> {
@@ -132,6 +178,16 @@ abstract class OneObjectOneOf0 implements $OneObjectOneOf0Interface, Built<OneOb
 
   /// Serializer for OneObjectOneOf0.
   static Serializer<OneObjectOneOf0> get serializer => _$oneObjectOneOf0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OneObjectOneOf0Builder b) {
+    $OneObjectOneOf0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OneObjectOneOf0Builder b) {
+    $OneObjectOneOf0Interface._validate(b);
+  }
 }
 
 /// One of with an integer, double and other value.
@@ -141,6 +197,10 @@ typedef OneOfIntDoubleOther = ({num? $num, String? string});
 abstract interface class $OneOfUnspecifiedArray0Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
   String get attributeOneOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OneOfUnspecifiedArray0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OneOfUnspecifiedArray0InterfaceBuilder b) {}
 }
 
 abstract class OneOfUnspecifiedArray0
@@ -163,6 +223,16 @@ abstract class OneOfUnspecifiedArray0
 
   /// Serializer for OneOfUnspecifiedArray0.
   static Serializer<OneOfUnspecifiedArray0> get serializer => _$oneOfUnspecifiedArray0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OneOfUnspecifiedArray0Builder b) {
+    $OneOfUnspecifiedArray0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OneOfUnspecifiedArray0Builder b) {
+    $OneOfUnspecifiedArray0Interface._validate(b);
+  }
 }
 
 typedef OneOfUnspecifiedArray = ({
@@ -174,6 +244,10 @@ typedef OneOfUnspecifiedArray = ({
 abstract interface class $OneOfStringArray0Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
   String get attributeOneOf;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OneOfStringArray0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OneOfStringArray0InterfaceBuilder b) {}
 }
 
 abstract class OneOfStringArray0
@@ -195,6 +269,16 @@ abstract class OneOfStringArray0
 
   /// Serializer for OneOfStringArray0.
   static Serializer<OneOfStringArray0> get serializer => _$oneOfStringArray0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OneOfStringArray0Builder b) {
+    $OneOfStringArray0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OneOfStringArray0Builder b) {
+    $OneOfStringArray0Interface._validate(b);
+  }
 }
 
 typedef OneOfStringArray = ({BuiltList<String>? builtListString, OneOfStringArray0? oneOfStringArray0});

--- a/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.g.dart
@@ -292,7 +292,9 @@ class ObjectOneOf0Builder implements Builder<ObjectOneOf0, ObjectOneOf0Builder>,
   String? get attribute1OneOf => _$this._attribute1OneOf;
   set attribute1OneOf(covariant String? attribute1OneOf) => _$this._attribute1OneOf = attribute1OneOf;
 
-  ObjectOneOf0Builder();
+  ObjectOneOf0Builder() {
+    ObjectOneOf0._defaults(this);
+  }
 
   ObjectOneOf0Builder get _$this {
     final $v = _$v;
@@ -318,6 +320,7 @@ class ObjectOneOf0Builder implements Builder<ObjectOneOf0, ObjectOneOf0Builder>,
   ObjectOneOf0 build() => _build();
 
   _$ObjectOneOf0 _build() {
+    ObjectOneOf0._validate(this);
     final _$result = _$v ??
         _$ObjectOneOf0._(
             attribute1OneOf:
@@ -378,7 +381,9 @@ class ObjectOneOf1Builder implements Builder<ObjectOneOf1, ObjectOneOf1Builder>,
   String? get attribute2OneOf => _$this._attribute2OneOf;
   set attribute2OneOf(covariant String? attribute2OneOf) => _$this._attribute2OneOf = attribute2OneOf;
 
-  ObjectOneOf1Builder();
+  ObjectOneOf1Builder() {
+    ObjectOneOf1._defaults(this);
+  }
 
   ObjectOneOf1Builder get _$this {
     final $v = _$v;
@@ -404,6 +409,7 @@ class ObjectOneOf1Builder implements Builder<ObjectOneOf1, ObjectOneOf1Builder>,
   ObjectOneOf1 build() => _build();
 
   _$ObjectOneOf1 _build() {
+    ObjectOneOf1._validate(this);
     final _$result = _$v ??
         _$ObjectOneOf1._(
             attribute2OneOf:
@@ -464,7 +470,9 @@ class MixedOneOf1Builder implements Builder<MixedOneOf1, MixedOneOf1Builder>, $M
   String? get attributeOneOf => _$this._attributeOneOf;
   set attributeOneOf(covariant String? attributeOneOf) => _$this._attributeOneOf = attributeOneOf;
 
-  MixedOneOf1Builder();
+  MixedOneOf1Builder() {
+    MixedOneOf1._defaults(this);
+  }
 
   MixedOneOf1Builder get _$this {
     final $v = _$v;
@@ -490,6 +498,7 @@ class MixedOneOf1Builder implements Builder<MixedOneOf1, MixedOneOf1Builder>, $M
   MixedOneOf1 build() => _build();
 
   _$MixedOneOf1 _build() {
+    MixedOneOf1._validate(this);
     final _$result = _$v ??
         _$MixedOneOf1._(
             attributeOneOf: BuiltValueNullFieldError.checkNotNull(attributeOneOf, r'MixedOneOf1', 'attributeOneOf'));
@@ -550,7 +559,9 @@ class OneObjectOneOf0Builder
   String? get attributeOneOf => _$this._attributeOneOf;
   set attributeOneOf(covariant String? attributeOneOf) => _$this._attributeOneOf = attributeOneOf;
 
-  OneObjectOneOf0Builder();
+  OneObjectOneOf0Builder() {
+    OneObjectOneOf0._defaults(this);
+  }
 
   OneObjectOneOf0Builder get _$this {
     final $v = _$v;
@@ -576,6 +587,7 @@ class OneObjectOneOf0Builder
   OneObjectOneOf0 build() => _build();
 
   _$OneObjectOneOf0 _build() {
+    OneObjectOneOf0._validate(this);
     final _$result = _$v ??
         _$OneObjectOneOf0._(
             attributeOneOf:
@@ -638,7 +650,9 @@ class OneOfUnspecifiedArray0Builder
   String? get attributeOneOf => _$this._attributeOneOf;
   set attributeOneOf(covariant String? attributeOneOf) => _$this._attributeOneOf = attributeOneOf;
 
-  OneOfUnspecifiedArray0Builder();
+  OneOfUnspecifiedArray0Builder() {
+    OneOfUnspecifiedArray0._defaults(this);
+  }
 
   OneOfUnspecifiedArray0Builder get _$this {
     final $v = _$v;
@@ -664,6 +678,7 @@ class OneOfUnspecifiedArray0Builder
   OneOfUnspecifiedArray0 build() => _build();
 
   _$OneOfUnspecifiedArray0 _build() {
+    OneOfUnspecifiedArray0._validate(this);
     final _$result = _$v ??
         _$OneOfUnspecifiedArray0._(
             attributeOneOf:
@@ -725,7 +740,9 @@ class OneOfStringArray0Builder
   String? get attributeOneOf => _$this._attributeOneOf;
   set attributeOneOf(covariant String? attributeOneOf) => _$this._attributeOneOf = attributeOneOf;
 
-  OneOfStringArray0Builder();
+  OneOfStringArray0Builder() {
+    OneOfStringArray0._defaults(this);
+  }
 
   OneOfStringArray0Builder get _$this {
     final $v = _$v;
@@ -751,6 +768,7 @@ class OneOfStringArray0Builder
   OneOfStringArray0 build() => _build();
 
   _$OneOfStringArray0 _build() {
+    OneOfStringArray0._validate(this);
     final _$result = _$v ??
         _$OneOfStringArray0._(
             attributeOneOf:

--- a/packages/dynamite/dynamite_end_to_end_test/lib/pattern_check.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/pattern_check.openapi.dart
@@ -27,29 +27,10 @@ abstract interface class $TestObjectInterface {
   String? get maxLength;
   @BuiltValueField(wireName: 'multiple-checks')
   String? get multipleChecks;
-}
-
-abstract class TestObject implements $TestObjectInterface, Built<TestObject, TestObjectBuilder> {
-  /// Creates a new TestObject object using the builder pattern.
-  factory TestObject([void Function(TestObjectBuilder)? b]) = _$TestObject;
-
-  const TestObject._();
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  factory TestObject.fromJson(Map<String, dynamic> json) => _$jsonSerializers.deserializeWith(serializer, json)!;
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-
-  /// Serializer for TestObject.
-  static Serializer<TestObject> get serializer => _$testObjectSerializer;
-
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TestObjectInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(TestObjectBuilder b) {
+  static void _validate($TestObjectInterfaceBuilder b) {
     _i1.checkPattern(
       b.onlyNumbers,
       RegExp(r'^[0-9]*$'),
@@ -80,6 +61,36 @@ abstract class TestObject implements $TestObjectInterface, Built<TestObject, Tes
       20,
       'multipleChecks',
     );
+  }
+}
+
+abstract class TestObject implements $TestObjectInterface, Built<TestObject, TestObjectBuilder> {
+  /// Creates a new TestObject object using the builder pattern.
+  factory TestObject([void Function(TestObjectBuilder)? b]) = _$TestObject;
+
+  const TestObject._();
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  factory TestObject.fromJson(Map<String, dynamic> json) => _$jsonSerializers.deserializeWith(serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+
+  /// Serializer for TestObject.
+  static Serializer<TestObject> get serializer => _$testObjectSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TestObjectBuilder b) {
+    $TestObjectInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TestObjectBuilder b) {
+    $TestObjectInterface._validate(b);
   }
 }
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/pattern_check.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/pattern_check.openapi.g.dart
@@ -163,7 +163,9 @@ class TestObjectBuilder implements Builder<TestObject, TestObjectBuilder>, $Test
   String? get multipleChecks => _$this._multipleChecks;
   set multipleChecks(covariant String? multipleChecks) => _$this._multipleChecks = multipleChecks;
 
-  TestObjectBuilder();
+  TestObjectBuilder() {
+    TestObject._defaults(this);
+  }
 
   TestObjectBuilder get _$this {
     final $v = _$v;

--- a/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.dart
@@ -34,6 +34,12 @@ abstract interface class $OneValueSomeOfInObjectInterface {
   num get intDouble;
   @BuiltValueField(wireName: 'IntDoubleString')
   OneValueSomeOfInObject_IntDoubleString? get intDoubleString;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OneValueSomeOfInObjectInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OneValueSomeOfInObjectInterfaceBuilder b) {
+    b.intDoubleString?.validateOneOf();
+  }
 }
 
 /// Object with someOfs that only contain a single value (or are optimized to such).
@@ -59,9 +65,14 @@ abstract class OneValueSomeOfInObject
   /// Serializer for OneValueSomeOfInObject.
   static Serializer<OneValueSomeOfInObject> get serializer => _$oneValueSomeOfInObjectSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OneValueSomeOfInObjectBuilder b) {
+    $OneValueSomeOfInObjectInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(OneValueSomeOfInObjectBuilder b) {
-    b.intDoubleString?.validateOneOf();
+    $OneValueSomeOfInObjectInterface._validate(b);
   }
 }
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.g.dart
@@ -145,7 +145,9 @@ class OneValueSomeOfInObjectBuilder
   set intDoubleString(covariant OneValueSomeOfInObject_IntDoubleString? intDoubleString) =>
       _$this._intDoubleString = intDoubleString;
 
-  OneValueSomeOfInObjectBuilder();
+  OneValueSomeOfInObjectBuilder() {
+    OneValueSomeOfInObject._defaults(this);
+  }
 
   OneValueSomeOfInObjectBuilder get _$this {
     final $v = _$v;

--- a/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.dart
@@ -27,6 +27,10 @@ typedef RedirectEmptyType = dynamic;
 @BuiltValue(instantiable: false)
 abstract interface class $BaseInterface {
   String? get attribute;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BaseInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BaseInterfaceBuilder b) {}
 }
 
 abstract class Base implements $BaseInterface, Built<Base, BaseBuilder> {
@@ -47,6 +51,16 @@ abstract class Base implements $BaseInterface, Built<Base, BaseBuilder> {
 
   /// Serializer for Base.
   static Serializer<Base> get serializer => _$baseSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BaseBuilder b) {
+    $BaseInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BaseBuilder b) {
+    $BaseInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -54,6 +68,10 @@ abstract interface class $NestedRedirectInterface {
   Base? get redirect;
   int? get redirectBaseType;
   JsonObject? get redirectEmptyType;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NestedRedirectInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NestedRedirectInterfaceBuilder b) {}
 }
 
 abstract class NestedRedirect implements $NestedRedirectInterface, Built<NestedRedirect, NestedRedirectBuilder> {
@@ -74,6 +92,16 @@ abstract class NestedRedirect implements $NestedRedirectInterface, Built<NestedR
 
   /// Serializer for NestedRedirect.
   static Serializer<NestedRedirect> get serializer => _$nestedRedirectSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NestedRedirectBuilder b) {
+    $NestedRedirectInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NestedRedirectBuilder b) {
+    $NestedRedirectInterface._validate(b);
+  }
 }
 
 typedef SomeOfRedirect = ({Base? base, int? $int, JsonObject? jsonObject});

--- a/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.g.dart
@@ -157,7 +157,9 @@ class BaseBuilder implements Builder<Base, BaseBuilder>, $BaseInterfaceBuilder {
   String? get attribute => _$this._attribute;
   set attribute(covariant String? attribute) => _$this._attribute = attribute;
 
-  BaseBuilder();
+  BaseBuilder() {
+    Base._defaults(this);
+  }
 
   BaseBuilder get _$this {
     final $v = _$v;
@@ -183,6 +185,7 @@ class BaseBuilder implements Builder<Base, BaseBuilder>, $BaseInterfaceBuilder {
   Base build() => _build();
 
   _$Base _build() {
+    Base._validate(this);
     final _$result = _$v ?? _$Base._(attribute: attribute);
     replace(_$result);
     return _$result;
@@ -265,7 +268,9 @@ class NestedRedirectBuilder implements Builder<NestedRedirect, NestedRedirectBui
   JsonObject? get redirectEmptyType => _$this._redirectEmptyType;
   set redirectEmptyType(covariant JsonObject? redirectEmptyType) => _$this._redirectEmptyType = redirectEmptyType;
 
-  NestedRedirectBuilder();
+  NestedRedirectBuilder() {
+    NestedRedirect._defaults(this);
+  }
 
   NestedRedirectBuilder get _$this {
     final $v = _$v;
@@ -293,6 +298,7 @@ class NestedRedirectBuilder implements Builder<NestedRedirect, NestedRedirectBui
   NestedRedirect build() => _build();
 
   _$NestedRedirect _build() {
+    NestedRedirect._validate(this);
     _$NestedRedirect _$result;
     try {
       _$result = _$v ??

--- a/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.dart
@@ -48,6 +48,10 @@ abstract interface class $BaseInterface {
   BuiltList<Never>? get listNever;
   @BuiltValueField(wireName: 'list-string')
   BuiltList<String>? get listString;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BaseInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BaseInterfaceBuilder b) {}
 }
 
 abstract class Base implements $BaseInterface, Built<Base, BaseBuilder> {
@@ -68,6 +72,16 @@ abstract class Base implements $BaseInterface, Built<Base, BaseBuilder> {
 
   /// Serializer for Base.
   static Serializer<Base> get serializer => _$baseSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BaseBuilder b) {
+    $BaseInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BaseBuilder b) {
+    $BaseInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -96,6 +110,10 @@ abstract interface class $AdditionalPropertiesInterface {
   BuiltMap<String, BuiltList<Never>>? get listNever;
   @BuiltValueField(wireName: 'list-string')
   BuiltMap<String, BuiltList<String>>? get listString;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AdditionalPropertiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AdditionalPropertiesInterfaceBuilder b) {}
 }
 
 abstract class AdditionalProperties
@@ -118,6 +136,16 @@ abstract class AdditionalProperties
 
   /// Serializer for AdditionalProperties.
   static Serializer<AdditionalProperties> get serializer => _$additionalPropertiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AdditionalPropertiesBuilder b) {
+    $AdditionalPropertiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AdditionalPropertiesBuilder b) {
+    $AdditionalPropertiesInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.g.dart
@@ -518,7 +518,9 @@ class BaseBuilder implements Builder<Base, BaseBuilder>, $BaseInterfaceBuilder {
   ListBuilder<String> get listString => _$this._listString ??= ListBuilder<String>();
   set listString(covariant ListBuilder<String>? listString) => _$this._listString = listString;
 
-  BaseBuilder();
+  BaseBuilder() {
+    Base._defaults(this);
+  }
 
   BaseBuilder get _$this {
     final $v = _$v;
@@ -553,6 +555,7 @@ class BaseBuilder implements Builder<Base, BaseBuilder>, $BaseInterfaceBuilder {
   Base build() => _build();
 
   _$Base _build() {
+    Base._validate(this);
     _$Base _$result;
     try {
       _$result = _$v ??
@@ -819,7 +822,9 @@ class AdditionalPropertiesBuilder
       _$this._listString ??= MapBuilder<String, BuiltList<String>>();
   set listString(covariant MapBuilder<String, BuiltList<String>>? listString) => _$this._listString = listString;
 
-  AdditionalPropertiesBuilder();
+  AdditionalPropertiesBuilder() {
+    AdditionalProperties._defaults(this);
+  }
 
   AdditionalPropertiesBuilder get _$this {
     final $v = _$v;
@@ -858,6 +863,7 @@ class AdditionalPropertiesBuilder
   AdditionalProperties build() => _build();
 
   _$AdditionalProperties _build() {
+    AdditionalProperties._validate(this);
     _$AdditionalProperties _$result;
     try {
       _$result = _$v ??

--- a/packages/dynamite/dynamite_end_to_end_test/test/all_of_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/all_of_test.dart
@@ -75,4 +75,23 @@ void main() {
     expect(object.toJson(), equals(json));
     expect(OneValueAllOf.fromJson(json), equals(object));
   });
+
+  test('default value inheritance', () {
+    var object = SubObject();
+
+    expect(object.value, '123');
+
+    object = object.rebuild((b) {
+      b.value = '1234';
+    });
+
+    expect(object.value, '1234');
+  });
+
+  test('validation inheritance', () {
+    expect(
+      () => SubObject((b) => b..value = 'abcd'),
+      throwsA(isA<FormatException>()),
+    );
+  });
 }

--- a/packages/nextcloud/lib/src/api/comments.openapi.dart
+++ b/packages/nextcloud/lib/src/api/comments.openapi.dart
@@ -26,6 +26,10 @@ part 'comments.openapi.g.dart';
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities_FilesInterface {
   bool get comments;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_Files
@@ -54,11 +58,25 @@ abstract class Capabilities_Files
 
   /// Serializer for Capabilities_Files.
   static Serializer<Capabilities_Files> get serializer => _$capabilitiesFilesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesBuilder b) {
+    $Capabilities_FilesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesBuilder b) {
+    $Capabilities_FilesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   Capabilities_Files get files;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -85,6 +103,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/comments.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/comments.openapi.g.dart
@@ -139,7 +139,9 @@ class Capabilities_FilesBuilder
   bool? get comments => _$this._comments;
   set comments(covariant bool? comments) => _$this._comments = comments;
 
-  Capabilities_FilesBuilder();
+  Capabilities_FilesBuilder() {
+    Capabilities_Files._defaults(this);
+  }
 
   Capabilities_FilesBuilder get _$this {
     final $v = _$v;
@@ -165,6 +167,7 @@ class Capabilities_FilesBuilder
   Capabilities_Files build() => _build();
 
   _$Capabilities_Files _build() {
+    Capabilities_Files._validate(this);
     final _$result = _$v ??
         _$Capabilities_Files._(
             comments: BuiltValueNullFieldError.checkNotNull(comments, r'Capabilities_Files', 'comments'));
@@ -224,7 +227,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities_FilesBuilder get files => _$this._files ??= Capabilities_FilesBuilder();
   set files(covariant Capabilities_FilesBuilder? files) => _$this._files = files;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -250,6 +255,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(files: files.build());

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -5247,6 +5247,10 @@ abstract interface class $StatusInterface {
   String get edition;
   String get productname;
   bool get extendedSupport;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($StatusInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($StatusInterfaceBuilder b) {}
 }
 
 abstract class Status implements $StatusInterface, Built<Status, StatusBuilder> {
@@ -5273,6 +5277,16 @@ abstract class Status implements $StatusInterface, Built<Status, StatusBuilder> 
 
   /// Serializer for Status.
   static Serializer<Status> get serializer => _$statusSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(StatusBuilder b) {
+    $StatusInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(StatusBuilder b) {
+    $StatusInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5282,6 +5296,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -5308,11 +5326,25 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterface {
   String get apppassword;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data
@@ -5347,12 +5379,26 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data
   /// Serializer for AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data.
   static Serializer<AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data> get serializer =>
       _$appPasswordGetAppPasswordResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder b) {
+    $AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder b) {
+    $AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppPasswordGetAppPasswordResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppPasswordGetAppPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppPasswordGetAppPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AppPasswordGetAppPasswordResponseApplicationJson_Ocs
@@ -5387,11 +5433,25 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson_Ocs
   /// Serializer for AppPasswordGetAppPasswordResponseApplicationJson_Ocs.
   static Serializer<AppPasswordGetAppPasswordResponseApplicationJson_Ocs> get serializer =>
       _$appPasswordGetAppPasswordResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder b) {
+    $AppPasswordGetAppPasswordResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder b) {
+    $AppPasswordGetAppPasswordResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppPasswordGetAppPasswordResponseApplicationJsonInterface {
   AppPasswordGetAppPasswordResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppPasswordGetAppPasswordResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppPasswordGetAppPasswordResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AppPasswordGetAppPasswordResponseApplicationJson
@@ -5426,11 +5486,25 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson
   /// Serializer for AppPasswordGetAppPasswordResponseApplicationJson.
   static Serializer<AppPasswordGetAppPasswordResponseApplicationJson> get serializer =>
       _$appPasswordGetAppPasswordResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppPasswordGetAppPasswordResponseApplicationJsonBuilder b) {
+    $AppPasswordGetAppPasswordResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppPasswordGetAppPasswordResponseApplicationJsonBuilder b) {
+    $AppPasswordGetAppPasswordResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterface {
   String get apppassword;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data
@@ -5465,12 +5539,26 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data
   /// Serializer for AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data.
   static Serializer<AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data> get serializer =>
       _$appPasswordRotateAppPasswordResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder b) {
+    $AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder b) {
+    $AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs
@@ -5505,11 +5593,25 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs
   /// Serializer for AppPasswordRotateAppPasswordResponseApplicationJson_Ocs.
   static Serializer<AppPasswordRotateAppPasswordResponseApplicationJson_Ocs> get serializer =>
       _$appPasswordRotateAppPasswordResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder b) {
+    $AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder b) {
+    $AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppPasswordRotateAppPasswordResponseApplicationJsonInterface {
   AppPasswordRotateAppPasswordResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppPasswordRotateAppPasswordResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppPasswordRotateAppPasswordResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AppPasswordRotateAppPasswordResponseApplicationJson
@@ -5544,12 +5646,26 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson
   /// Serializer for AppPasswordRotateAppPasswordResponseApplicationJson.
   static Serializer<AppPasswordRotateAppPasswordResponseApplicationJson> get serializer =>
       _$appPasswordRotateAppPasswordResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppPasswordRotateAppPasswordResponseApplicationJsonBuilder b) {
+    $AppPasswordRotateAppPasswordResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppPasswordRotateAppPasswordResponseApplicationJsonBuilder b) {
+    $AppPasswordRotateAppPasswordResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs
@@ -5584,11 +5700,25 @@ abstract class AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs
   /// Serializer for AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs.
   static Serializer<AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs> get serializer =>
       _$appPasswordDeleteAppPasswordResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder b) {
+    $AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder b) {
+    $AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppPasswordDeleteAppPasswordResponseApplicationJsonInterface {
   AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppPasswordDeleteAppPasswordResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppPasswordDeleteAppPasswordResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AppPasswordDeleteAppPasswordResponseApplicationJson
@@ -5623,6 +5753,16 @@ abstract class AppPasswordDeleteAppPasswordResponseApplicationJson
   /// Serializer for AppPasswordDeleteAppPasswordResponseApplicationJson.
   static Serializer<AppPasswordDeleteAppPasswordResponseApplicationJson> get serializer =>
       _$appPasswordDeleteAppPasswordResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppPasswordDeleteAppPasswordResponseApplicationJsonBuilder b) {
+    $AppPasswordDeleteAppPasswordResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppPasswordDeleteAppPasswordResponseApplicationJsonBuilder b) {
+    $AppPasswordDeleteAppPasswordResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5631,6 +5771,10 @@ abstract interface class $AutocompleteResult_Status0Interface {
   String? get message;
   String? get icon;
   int? get clearAt;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AutocompleteResult_Status0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AutocompleteResult_Status0InterfaceBuilder b) {}
 }
 
 abstract class AutocompleteResult_Status0
@@ -5662,6 +5806,16 @@ abstract class AutocompleteResult_Status0
 
   /// Serializer for AutocompleteResult_Status0.
   static Serializer<AutocompleteResult_Status0> get serializer => _$autocompleteResultStatus0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AutocompleteResult_Status0Builder b) {
+    $AutocompleteResult_Status0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AutocompleteResult_Status0Builder b) {
+    $AutocompleteResult_Status0Interface._validate(b);
+  }
 }
 
 typedef AutocompleteResult_Status = ({AutocompleteResult_Status0? autocompleteResultStatus0, String? string});
@@ -5675,6 +5829,12 @@ abstract interface class $AutocompleteResultInterface {
   AutocompleteResult_Status get status;
   String get subline;
   String get shareWithDisplayNameUnique;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AutocompleteResultInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AutocompleteResultInterfaceBuilder b) {
+    b.status?.validateOneOf();
+  }
 }
 
 abstract class AutocompleteResult
@@ -5704,9 +5864,14 @@ abstract class AutocompleteResult
   /// Serializer for AutocompleteResult.
   static Serializer<AutocompleteResult> get serializer => _$autocompleteResultSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AutocompleteResultBuilder b) {
+    $AutocompleteResultInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(AutocompleteResultBuilder b) {
-    b.status?.validateOneOf();
+    $AutocompleteResultInterface._validate(b);
   }
 }
 
@@ -5714,6 +5879,10 @@ abstract class AutocompleteResult
 abstract interface class $AutoCompleteGetResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<AutocompleteResult> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AutoCompleteGetResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AutoCompleteGetResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AutoCompleteGetResponseApplicationJson_Ocs
@@ -5747,11 +5916,25 @@ abstract class AutoCompleteGetResponseApplicationJson_Ocs
   /// Serializer for AutoCompleteGetResponseApplicationJson_Ocs.
   static Serializer<AutoCompleteGetResponseApplicationJson_Ocs> get serializer =>
       _$autoCompleteGetResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AutoCompleteGetResponseApplicationJson_OcsBuilder b) {
+    $AutoCompleteGetResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AutoCompleteGetResponseApplicationJson_OcsBuilder b) {
+    $AutoCompleteGetResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AutoCompleteGetResponseApplicationJsonInterface {
   AutoCompleteGetResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AutoCompleteGetResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AutoCompleteGetResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AutoCompleteGetResponseApplicationJson
@@ -5784,12 +5967,26 @@ abstract class AutoCompleteGetResponseApplicationJson
   /// Serializer for AutoCompleteGetResponseApplicationJson.
   static Serializer<AutoCompleteGetResponseApplicationJson> get serializer =>
       _$autoCompleteGetResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AutoCompleteGetResponseApplicationJsonBuilder b) {
+    $AutoCompleteGetResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AutoCompleteGetResponseApplicationJsonBuilder b) {
+    $AutoCompleteGetResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AvatarAvatarGetAvatarDarkHeadersInterface {
   @BuiltValueField(wireName: 'x-nc-iscustomavatar')
   Header<int>? get xNcIscustomavatar;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder b) {}
 }
 
 abstract class AvatarAvatarGetAvatarDarkHeaders
@@ -5821,12 +6018,26 @@ abstract class AvatarAvatarGetAvatarDarkHeaders
 
   /// Serializer for AvatarAvatarGetAvatarDarkHeaders.
   static Serializer<AvatarAvatarGetAvatarDarkHeaders> get serializer => _$avatarAvatarGetAvatarDarkHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarAvatarGetAvatarDarkHeadersBuilder b) {
+    $AvatarAvatarGetAvatarDarkHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarAvatarGetAvatarDarkHeadersBuilder b) {
+    $AvatarAvatarGetAvatarDarkHeadersInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AvatarAvatarGetAvatarHeadersInterface {
   @BuiltValueField(wireName: 'x-nc-iscustomavatar')
   Header<int>? get xNcIscustomavatar;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarAvatarGetAvatarHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarAvatarGetAvatarHeadersInterfaceBuilder b) {}
 }
 
 abstract class AvatarAvatarGetAvatarHeaders
@@ -5858,6 +6069,16 @@ abstract class AvatarAvatarGetAvatarHeaders
 
   /// Serializer for AvatarAvatarGetAvatarHeaders.
   static Serializer<AvatarAvatarGetAvatarHeaders> get serializer => _$avatarAvatarGetAvatarHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarAvatarGetAvatarHeadersBuilder b) {
+    $AvatarAvatarGetAvatarHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarAvatarGetAvatarHeadersBuilder b) {
+    $AvatarAvatarGetAvatarHeadersInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5865,6 +6086,10 @@ abstract interface class $LoginFlowV2CredentialsInterface {
   String get server;
   String get loginName;
   String get appPassword;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($LoginFlowV2CredentialsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($LoginFlowV2CredentialsInterfaceBuilder b) {}
 }
 
 abstract class LoginFlowV2Credentials
@@ -5893,12 +6118,26 @@ abstract class LoginFlowV2Credentials
 
   /// Serializer for LoginFlowV2Credentials.
   static Serializer<LoginFlowV2Credentials> get serializer => _$loginFlowV2CredentialsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(LoginFlowV2CredentialsBuilder b) {
+    $LoginFlowV2CredentialsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(LoginFlowV2CredentialsBuilder b) {
+    $LoginFlowV2CredentialsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $LoginFlowV2_PollInterface {
   String get token;
   String get endpoint;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($LoginFlowV2_PollInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($LoginFlowV2_PollInterfaceBuilder b) {}
 }
 
 abstract class LoginFlowV2_Poll
@@ -5926,12 +6165,26 @@ abstract class LoginFlowV2_Poll
 
   /// Serializer for LoginFlowV2_Poll.
   static Serializer<LoginFlowV2_Poll> get serializer => _$loginFlowV2PollSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(LoginFlowV2_PollBuilder b) {
+    $LoginFlowV2_PollInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(LoginFlowV2_PollBuilder b) {
+    $LoginFlowV2_PollInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $LoginFlowV2Interface {
   LoginFlowV2_Poll get poll;
   String get login;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($LoginFlowV2InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($LoginFlowV2InterfaceBuilder b) {}
 }
 
 abstract class LoginFlowV2 implements $LoginFlowV2Interface, Built<LoginFlowV2, LoginFlowV2Builder> {
@@ -5958,6 +6211,16 @@ abstract class LoginFlowV2 implements $LoginFlowV2Interface, Built<LoginFlowV2, 
 
   /// Serializer for LoginFlowV2.
   static Serializer<LoginFlowV2> get serializer => _$loginFlowV2Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(LoginFlowV2Builder b) {
+    $LoginFlowV2Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(LoginFlowV2Builder b) {
+    $LoginFlowV2Interface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5967,6 +6230,10 @@ abstract interface class $OpenGraphObjectInterface {
   String? get description;
   String? get thumb;
   String get link;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OpenGraphObjectInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OpenGraphObjectInterfaceBuilder b) {}
 }
 
 abstract class OpenGraphObject implements $OpenGraphObjectInterface, Built<OpenGraphObject, OpenGraphObjectBuilder> {
@@ -5993,6 +6260,16 @@ abstract class OpenGraphObject implements $OpenGraphObjectInterface, Built<OpenG
 
   /// Serializer for OpenGraphObject.
   static Serializer<OpenGraphObject> get serializer => _$openGraphObjectSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OpenGraphObjectBuilder b) {
+    $OpenGraphObjectInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenGraphObjectBuilder b) {
+    $OpenGraphObjectInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -6001,6 +6278,10 @@ abstract interface class $ResourceInterface {
   BuiltMap<String, JsonObject> get richObject;
   OpenGraphObject get openGraphObject;
   bool get accessible;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ResourceInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ResourceInterfaceBuilder b) {}
 }
 
 abstract class Resource implements $ResourceInterface, Built<Resource, ResourceBuilder> {
@@ -6027,6 +6308,16 @@ abstract class Resource implements $ResourceInterface, Built<Resource, ResourceB
 
   /// Serializer for Resource.
   static Serializer<Resource> get serializer => _$resourceSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ResourceBuilder b) {
+    $ResourceInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ResourceBuilder b) {
+    $ResourceInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -6034,6 +6325,10 @@ abstract interface class $CollectionInterface {
   int get id;
   String get name;
   BuiltList<Resource> get resources;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollectionInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollectionInterfaceBuilder b) {}
 }
 
 abstract class Collection implements $CollectionInterface, Built<Collection, CollectionBuilder> {
@@ -6060,12 +6355,26 @@ abstract class Collection implements $CollectionInterface, Built<Collection, Col
 
   /// Serializer for Collection.
   static Serializer<Collection> get serializer => _$collectionSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollectionBuilder b) {
+    $CollectionInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollectionBuilder b) {
+    $CollectionInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Collection> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs
@@ -6100,11 +6409,25 @@ abstract class CollaborationResourcesSearchCollectionsResponseApplicationJson_Oc
   /// Serializer for CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs.
   static Serializer<CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs> get serializer =>
       _$collaborationResourcesSearchCollectionsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesSearchCollectionsResponseApplicationJsonInterface {
   CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesSearchCollectionsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesSearchCollectionsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesSearchCollectionsResponseApplicationJson
@@ -6139,12 +6462,26 @@ abstract class CollaborationResourcesSearchCollectionsResponseApplicationJson
   /// Serializer for CollaborationResourcesSearchCollectionsResponseApplicationJson.
   static Serializer<CollaborationResourcesSearchCollectionsResponseApplicationJson> get serializer =>
       _$collaborationResourcesSearchCollectionsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesSearchCollectionsResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesSearchCollectionsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesSearchCollectionsResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesSearchCollectionsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesListCollectionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesListCollectionResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesListCollectionResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesListCollectionResponseApplicationJson_Ocs
@@ -6179,11 +6516,25 @@ abstract class CollaborationResourcesListCollectionResponseApplicationJson_Ocs
   /// Serializer for CollaborationResourcesListCollectionResponseApplicationJson_Ocs.
   static Serializer<CollaborationResourcesListCollectionResponseApplicationJson_Ocs> get serializer =>
       _$collaborationResourcesListCollectionResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesListCollectionResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesListCollectionResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesListCollectionResponseApplicationJsonInterface {
   CollaborationResourcesListCollectionResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesListCollectionResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesListCollectionResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesListCollectionResponseApplicationJson
@@ -6218,12 +6569,26 @@ abstract class CollaborationResourcesListCollectionResponseApplicationJson
   /// Serializer for CollaborationResourcesListCollectionResponseApplicationJson.
   static Serializer<CollaborationResourcesListCollectionResponseApplicationJson> get serializer =>
       _$collaborationResourcesListCollectionResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesListCollectionResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesListCollectionResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesListCollectionResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesListCollectionResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs
@@ -6258,11 +6623,25 @@ abstract class CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs
   /// Serializer for CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs.
   static Serializer<CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs> get serializer =>
       _$collaborationResourcesRenameCollectionResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesRenameCollectionResponseApplicationJsonInterface {
   CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesRenameCollectionResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesRenameCollectionResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesRenameCollectionResponseApplicationJson
@@ -6297,12 +6676,26 @@ abstract class CollaborationResourcesRenameCollectionResponseApplicationJson
   /// Serializer for CollaborationResourcesRenameCollectionResponseApplicationJson.
   static Serializer<CollaborationResourcesRenameCollectionResponseApplicationJson> get serializer =>
       _$collaborationResourcesRenameCollectionResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesRenameCollectionResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesRenameCollectionResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesAddResourceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesAddResourceResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesAddResourceResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesAddResourceResponseApplicationJson_Ocs
@@ -6337,11 +6730,25 @@ abstract class CollaborationResourcesAddResourceResponseApplicationJson_Ocs
   /// Serializer for CollaborationResourcesAddResourceResponseApplicationJson_Ocs.
   static Serializer<CollaborationResourcesAddResourceResponseApplicationJson_Ocs> get serializer =>
       _$collaborationResourcesAddResourceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesAddResourceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesAddResourceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesAddResourceResponseApplicationJsonInterface {
   CollaborationResourcesAddResourceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesAddResourceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesAddResourceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesAddResourceResponseApplicationJson
@@ -6376,12 +6783,26 @@ abstract class CollaborationResourcesAddResourceResponseApplicationJson
   /// Serializer for CollaborationResourcesAddResourceResponseApplicationJson.
   static Serializer<CollaborationResourcesAddResourceResponseApplicationJson> get serializer =>
       _$collaborationResourcesAddResourceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesAddResourceResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesAddResourceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesAddResourceResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesAddResourceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs
@@ -6416,11 +6837,25 @@ abstract class CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs
   /// Serializer for CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs.
   static Serializer<CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs> get serializer =>
       _$collaborationResourcesRemoveResourceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesRemoveResourceResponseApplicationJsonInterface {
   CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesRemoveResourceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesRemoveResourceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesRemoveResourceResponseApplicationJson
@@ -6455,12 +6890,26 @@ abstract class CollaborationResourcesRemoveResourceResponseApplicationJson
   /// Serializer for CollaborationResourcesRemoveResourceResponseApplicationJson.
   static Serializer<CollaborationResourcesRemoveResourceResponseApplicationJson> get serializer =>
       _$collaborationResourcesRemoveResourceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesRemoveResourceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesRemoveResourceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Collection> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs
@@ -6497,11 +6946,25 @@ abstract class CollaborationResourcesGetCollectionsByResourceResponseApplication
   /// Serializer for CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs.
   static Serializer<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs> get serializer =>
       _$collaborationResourcesGetCollectionsByResourceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterface {
   CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesGetCollectionsByResourceResponseApplicationJson
@@ -6536,12 +6999,30 @@ abstract class CollaborationResourcesGetCollectionsByResourceResponseApplication
   /// Serializer for CollaborationResourcesGetCollectionsByResourceResponseApplicationJson.
   static Serializer<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson> get serializer =>
       _$collaborationResourcesGetCollectionsByResourceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(
+    $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterfaceBuilder b,
+  ) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(
+    $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterfaceBuilder b,
+  ) {}
 }
 
 abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs
@@ -6578,11 +7059,25 @@ abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicati
   /// Serializer for CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs.
   static Serializer<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs> get serializer =>
       _$collaborationResourcesCreateCollectionOnResourceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder b) {
+    $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterface {
   CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson
@@ -6617,6 +7112,16 @@ abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicati
   /// Serializer for CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson.
   static Serializer<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson> get serializer =>
       _$collaborationResourcesCreateCollectionOnResourceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBuilder b) {
+    $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class GuestAvatarGetAvatarDarkTheme extends EnumClass {
@@ -6688,6 +7193,10 @@ abstract interface class $ContactsActionInterface {
   String get icon;
   String get hyperlink;
   String get appId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ContactsActionInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ContactsActionInterfaceBuilder b) {}
 }
 
 abstract class ContactsAction implements $ContactsActionInterface, Built<ContactsAction, ContactsActionBuilder> {
@@ -6714,6 +7223,16 @@ abstract class ContactsAction implements $ContactsActionInterface, Built<Contact
 
   /// Serializer for ContactsAction.
   static Serializer<ContactsAction> get serializer => _$contactsActionSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ContactsActionBuilder b) {
+    $ContactsActionInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ContactsActionBuilder b) {
+    $ContactsActionInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -6721,6 +7240,10 @@ abstract interface class $HoverCardGetUserResponseApplicationJson_Ocs_DataInterf
   String get userId;
   String get displayName;
   BuiltList<ContactsAction> get actions;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HoverCardGetUserResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HoverCardGetUserResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class HoverCardGetUserResponseApplicationJson_Ocs_Data
@@ -6755,12 +7278,26 @@ abstract class HoverCardGetUserResponseApplicationJson_Ocs_Data
   /// Serializer for HoverCardGetUserResponseApplicationJson_Ocs_Data.
   static Serializer<HoverCardGetUserResponseApplicationJson_Ocs_Data> get serializer =>
       _$hoverCardGetUserResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder b) {
+    $HoverCardGetUserResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder b) {
+    $HoverCardGetUserResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $HoverCardGetUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   HoverCardGetUserResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HoverCardGetUserResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HoverCardGetUserResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class HoverCardGetUserResponseApplicationJson_Ocs
@@ -6794,11 +7331,25 @@ abstract class HoverCardGetUserResponseApplicationJson_Ocs
   /// Serializer for HoverCardGetUserResponseApplicationJson_Ocs.
   static Serializer<HoverCardGetUserResponseApplicationJson_Ocs> get serializer =>
       _$hoverCardGetUserResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HoverCardGetUserResponseApplicationJson_OcsBuilder b) {
+    $HoverCardGetUserResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HoverCardGetUserResponseApplicationJson_OcsBuilder b) {
+    $HoverCardGetUserResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $HoverCardGetUserResponseApplicationJsonInterface {
   HoverCardGetUserResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HoverCardGetUserResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HoverCardGetUserResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class HoverCardGetUserResponseApplicationJson
@@ -6831,6 +7382,16 @@ abstract class HoverCardGetUserResponseApplicationJson
   /// Serializer for HoverCardGetUserResponseApplicationJson.
   static Serializer<HoverCardGetUserResponseApplicationJson> get serializer =>
       _$hoverCardGetUserResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HoverCardGetUserResponseApplicationJsonBuilder b) {
+    $HoverCardGetUserResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HoverCardGetUserResponseApplicationJsonBuilder b) {
+    $HoverCardGetUserResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class NavigationGetAppsNavigationAbsolute extends EnumClass {
@@ -6912,6 +7473,12 @@ abstract interface class $NavigationEntryInterface {
   bool get active;
   String get classes;
   int get unread;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NavigationEntryInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NavigationEntryInterfaceBuilder b) {
+    b.order?.validateOneOf();
+  }
 }
 
 abstract class NavigationEntry implements $NavigationEntryInterface, Built<NavigationEntry, NavigationEntryBuilder> {
@@ -6939,9 +7506,14 @@ abstract class NavigationEntry implements $NavigationEntryInterface, Built<Navig
   /// Serializer for NavigationEntry.
   static Serializer<NavigationEntry> get serializer => _$navigationEntrySerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NavigationEntryBuilder b) {
+    $NavigationEntryInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(NavigationEntryBuilder b) {
-    b.order?.validateOneOf();
+    $NavigationEntryInterface._validate(b);
   }
 }
 
@@ -6949,6 +7521,10 @@ abstract class NavigationEntry implements $NavigationEntryInterface, Built<Navig
 abstract interface class $NavigationGetAppsNavigationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<NavigationEntry> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NavigationGetAppsNavigationResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NavigationGetAppsNavigationResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class NavigationGetAppsNavigationResponseApplicationJson_Ocs
@@ -6983,11 +7559,25 @@ abstract class NavigationGetAppsNavigationResponseApplicationJson_Ocs
   /// Serializer for NavigationGetAppsNavigationResponseApplicationJson_Ocs.
   static Serializer<NavigationGetAppsNavigationResponseApplicationJson_Ocs> get serializer =>
       _$navigationGetAppsNavigationResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder b) {
+    $NavigationGetAppsNavigationResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder b) {
+    $NavigationGetAppsNavigationResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $NavigationGetAppsNavigationResponseApplicationJsonInterface {
   NavigationGetAppsNavigationResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NavigationGetAppsNavigationResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NavigationGetAppsNavigationResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class NavigationGetAppsNavigationResponseApplicationJson
@@ -7022,6 +7612,16 @@ abstract class NavigationGetAppsNavigationResponseApplicationJson
   /// Serializer for NavigationGetAppsNavigationResponseApplicationJson.
   static Serializer<NavigationGetAppsNavigationResponseApplicationJson> get serializer =>
       _$navigationGetAppsNavigationResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NavigationGetAppsNavigationResponseApplicationJsonBuilder b) {
+    $NavigationGetAppsNavigationResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NavigationGetAppsNavigationResponseApplicationJsonBuilder b) {
+    $NavigationGetAppsNavigationResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class NavigationGetSettingsNavigationAbsolute extends EnumClass {
@@ -7097,6 +7697,10 @@ class _$NavigationGetSettingsNavigationAbsoluteSerializer
 abstract interface class $NavigationGetSettingsNavigationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<NavigationEntry> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NavigationGetSettingsNavigationResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NavigationGetSettingsNavigationResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class NavigationGetSettingsNavigationResponseApplicationJson_Ocs
@@ -7131,11 +7735,25 @@ abstract class NavigationGetSettingsNavigationResponseApplicationJson_Ocs
   /// Serializer for NavigationGetSettingsNavigationResponseApplicationJson_Ocs.
   static Serializer<NavigationGetSettingsNavigationResponseApplicationJson_Ocs> get serializer =>
       _$navigationGetSettingsNavigationResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder b) {
+    $NavigationGetSettingsNavigationResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder b) {
+    $NavigationGetSettingsNavigationResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $NavigationGetSettingsNavigationResponseApplicationJsonInterface {
   NavigationGetSettingsNavigationResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NavigationGetSettingsNavigationResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NavigationGetSettingsNavigationResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class NavigationGetSettingsNavigationResponseApplicationJson
@@ -7170,11 +7788,25 @@ abstract class NavigationGetSettingsNavigationResponseApplicationJson
   /// Serializer for NavigationGetSettingsNavigationResponseApplicationJson.
   static Serializer<NavigationGetSettingsNavigationResponseApplicationJson> get serializer =>
       _$navigationGetSettingsNavigationResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NavigationGetSettingsNavigationResponseApplicationJsonBuilder b) {
+    $NavigationGetSettingsNavigationResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NavigationGetSettingsNavigationResponseApplicationJsonBuilder b) {
+    $NavigationGetSettingsNavigationResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterface {
   String get webdav;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterfaceBuilder b) {}
 }
 
 abstract class OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols
@@ -7209,6 +7841,16 @@ abstract class OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols
   /// Serializer for OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols.
   static Serializer<OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols> get serializer =>
       _$ocmDiscoveryResponseApplicationJsonResourceTypesProtocolsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder b) {
+    $OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder b) {
+    $OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7216,6 +7858,10 @@ abstract interface class $OcmDiscoveryResponseApplicationJson_ResourceTypesInter
   String get name;
   BuiltList<String> get shareTypes;
   OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols get protocols;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OcmDiscoveryResponseApplicationJson_ResourceTypesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OcmDiscoveryResponseApplicationJson_ResourceTypesInterfaceBuilder b) {}
 }
 
 abstract class OcmDiscoveryResponseApplicationJson_ResourceTypes
@@ -7250,6 +7896,16 @@ abstract class OcmDiscoveryResponseApplicationJson_ResourceTypes
   /// Serializer for OcmDiscoveryResponseApplicationJson_ResourceTypes.
   static Serializer<OcmDiscoveryResponseApplicationJson_ResourceTypes> get serializer =>
       _$ocmDiscoveryResponseApplicationJsonResourceTypesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OcmDiscoveryResponseApplicationJson_ResourceTypesBuilder b) {
+    $OcmDiscoveryResponseApplicationJson_ResourceTypesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OcmDiscoveryResponseApplicationJson_ResourceTypesBuilder b) {
+    $OcmDiscoveryResponseApplicationJson_ResourceTypesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7258,6 +7914,10 @@ abstract interface class $OcmDiscoveryResponseApplicationJsonInterface {
   String get apiVersion;
   String get endPoint;
   BuiltList<OcmDiscoveryResponseApplicationJson_ResourceTypes> get resourceTypes;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OcmDiscoveryResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OcmDiscoveryResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class OcmDiscoveryResponseApplicationJson
@@ -7290,6 +7950,16 @@ abstract class OcmDiscoveryResponseApplicationJson
   /// Serializer for OcmDiscoveryResponseApplicationJson.
   static Serializer<OcmDiscoveryResponseApplicationJson> get serializer =>
       _$ocmDiscoveryResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OcmDiscoveryResponseApplicationJsonBuilder b) {
+    $OcmDiscoveryResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OcmDiscoveryResponseApplicationJsonBuilder b) {
+    $OcmDiscoveryResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class OcmOcmDiscoveryHeaders_XNextcloudOcmProviders extends EnumClass {
@@ -7360,6 +8030,10 @@ class _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer
 abstract interface class $OcmOcmDiscoveryHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-ocm-providers')
   Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? get xNextcloudOcmProviders;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OcmOcmDiscoveryHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OcmOcmDiscoveryHeadersInterfaceBuilder b) {}
 }
 
 abstract class OcmOcmDiscoveryHeaders
@@ -7388,6 +8062,16 @@ abstract class OcmOcmDiscoveryHeaders
 
   /// Serializer for OcmOcmDiscoveryHeaders.
   static Serializer<OcmOcmDiscoveryHeaders> get serializer => _$ocmOcmDiscoveryHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OcmOcmDiscoveryHeadersBuilder b) {
+    $OcmOcmDiscoveryHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OcmOcmDiscoveryHeadersBuilder b) {
+    $OcmOcmDiscoveryHeadersInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7398,6 +8082,10 @@ abstract interface class $OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Ver
   String get string;
   String get edition;
   bool get extendedSupport;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterfaceBuilder b) {}
 }
 
 abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version
@@ -7432,11 +8120,25 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version
   /// Serializer for OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version.
   static Serializer<OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version> get serializer =>
       _$ocsGetCapabilitiesResponseApplicationJsonOcsDataVersionSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionBuilder b) {
+    $OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionBuilder b) {
+    $OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CommentsCapabilities_FilesInterface {
   bool get comments;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CommentsCapabilities_FilesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CommentsCapabilities_FilesInterfaceBuilder b) {}
 }
 
 abstract class CommentsCapabilities_Files
@@ -7468,11 +8170,25 @@ abstract class CommentsCapabilities_Files
 
   /// Serializer for CommentsCapabilities_Files.
   static Serializer<CommentsCapabilities_Files> get serializer => _$commentsCapabilitiesFilesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CommentsCapabilities_FilesBuilder b) {
+    $CommentsCapabilities_FilesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CommentsCapabilities_FilesBuilder b) {
+    $CommentsCapabilities_FilesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CommentsCapabilitiesInterface {
   CommentsCapabilities_Files get files;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CommentsCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CommentsCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class CommentsCapabilities
@@ -7501,12 +8217,26 @@ abstract class CommentsCapabilities
 
   /// Serializer for CommentsCapabilities.
   static Serializer<CommentsCapabilities> get serializer => _$commentsCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CommentsCapabilitiesBuilder b) {
+    $CommentsCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CommentsCapabilitiesBuilder b) {
+    $CommentsCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DavCapabilities_DavInterface {
   String get chunking;
   String? get bulkupload;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DavCapabilities_DavInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DavCapabilities_DavInterfaceBuilder b) {}
 }
 
 abstract class DavCapabilities_Dav
@@ -7535,11 +8265,25 @@ abstract class DavCapabilities_Dav
 
   /// Serializer for DavCapabilities_Dav.
   static Serializer<DavCapabilities_Dav> get serializer => _$davCapabilitiesDavSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DavCapabilities_DavBuilder b) {
+    $DavCapabilities_DavInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DavCapabilities_DavBuilder b) {
+    $DavCapabilities_DavInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DavCapabilitiesInterface {
   DavCapabilities_Dav get dav;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DavCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DavCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class DavCapabilities implements $DavCapabilitiesInterface, Built<DavCapabilities, DavCapabilitiesBuilder> {
@@ -7566,12 +8310,26 @@ abstract class DavCapabilities implements $DavCapabilitiesInterface, Built<DavCa
 
   /// Serializer for DavCapabilities.
   static Serializer<DavCapabilities> get serializer => _$davCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DavCapabilitiesBuilder b) {
+    $DavCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DavCapabilitiesBuilder b) {
+    $DavCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DropAccountCapabilities_DropAccount_DelayInterface {
   bool get enabled;
   int get hours;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DropAccountCapabilities_DropAccount_DelayInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DropAccountCapabilities_DropAccount_DelayInterfaceBuilder b) {}
 }
 
 abstract class DropAccountCapabilities_DropAccount_Delay
@@ -7605,6 +8363,16 @@ abstract class DropAccountCapabilities_DropAccount_Delay
   /// Serializer for DropAccountCapabilities_DropAccount_Delay.
   static Serializer<DropAccountCapabilities_DropAccount_Delay> get serializer =>
       _$dropAccountCapabilitiesDropAccountDelaySerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DropAccountCapabilities_DropAccount_DelayBuilder b) {
+    $DropAccountCapabilities_DropAccount_DelayInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DropAccountCapabilities_DropAccount_DelayBuilder b) {
+    $DropAccountCapabilities_DropAccount_DelayInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7614,6 +8382,10 @@ abstract interface class $DropAccountCapabilities_DropAccountInterface {
   String get apiVersion;
   DropAccountCapabilities_DropAccount_Delay get delay;
   String? get details;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DropAccountCapabilities_DropAccountInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DropAccountCapabilities_DropAccountInterfaceBuilder b) {}
 }
 
 abstract class DropAccountCapabilities_DropAccount
@@ -7646,12 +8418,26 @@ abstract class DropAccountCapabilities_DropAccount
   /// Serializer for DropAccountCapabilities_DropAccount.
   static Serializer<DropAccountCapabilities_DropAccount> get serializer =>
       _$dropAccountCapabilitiesDropAccountSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DropAccountCapabilities_DropAccountBuilder b) {
+    $DropAccountCapabilities_DropAccountInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DropAccountCapabilities_DropAccountBuilder b) {
+    $DropAccountCapabilities_DropAccountInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DropAccountCapabilitiesInterface {
   @BuiltValueField(wireName: 'drop-account')
   DropAccountCapabilities_DropAccount get dropAccount;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DropAccountCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DropAccountCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class DropAccountCapabilities
@@ -7680,6 +8466,16 @@ abstract class DropAccountCapabilities
 
   /// Serializer for DropAccountCapabilities.
   static Serializer<DropAccountCapabilities> get serializer => _$dropAccountCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DropAccountCapabilitiesBuilder b) {
+    $DropAccountCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DropAccountCapabilitiesBuilder b) {
+    $DropAccountCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7687,6 +8483,10 @@ abstract interface class $FilesCapabilities_Files_DirectEditingInterface {
   String get url;
   String get etag;
   bool get supportsFileId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesCapabilities_Files_DirectEditingInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesCapabilities_Files_DirectEditingInterfaceBuilder b) {}
 }
 
 abstract class FilesCapabilities_Files_DirectEditing
@@ -7719,6 +8519,16 @@ abstract class FilesCapabilities_Files_DirectEditing
   /// Serializer for FilesCapabilities_Files_DirectEditing.
   static Serializer<FilesCapabilities_Files_DirectEditing> get serializer =>
       _$filesCapabilitiesFilesDirectEditingSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesCapabilities_Files_DirectEditingBuilder b) {
+    $FilesCapabilities_Files_DirectEditingInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesCapabilities_Files_DirectEditingBuilder b) {
+    $FilesCapabilities_Files_DirectEditingInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7727,6 +8537,10 @@ abstract interface class $FilesCapabilities_FilesInterface {
   @BuiltValueField(wireName: 'blacklisted_files')
   BuiltList<JsonObject> get blacklistedFiles;
   FilesCapabilities_Files_DirectEditing get directEditing;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesCapabilities_FilesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesCapabilities_FilesInterfaceBuilder b) {}
 }
 
 abstract class FilesCapabilities_Files
@@ -7755,11 +8569,25 @@ abstract class FilesCapabilities_Files
 
   /// Serializer for FilesCapabilities_Files.
   static Serializer<FilesCapabilities_Files> get serializer => _$filesCapabilitiesFilesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesCapabilities_FilesBuilder b) {
+    $FilesCapabilities_FilesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesCapabilities_FilesBuilder b) {
+    $FilesCapabilities_FilesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesCapabilitiesInterface {
   FilesCapabilities_Files get files;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class FilesCapabilities
@@ -7787,12 +8615,26 @@ abstract class FilesCapabilities
 
   /// Serializer for FilesCapabilities.
   static Serializer<FilesCapabilities> get serializer => _$filesCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesCapabilitiesBuilder b) {
+    $FilesCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesCapabilitiesBuilder b) {
+    $FilesCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesSharingCapabilities_FilesSharing_Public_PasswordInterface {
   bool get enforced;
   bool get askForOptionalPassword;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Public_Password
@@ -7827,6 +8669,16 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_Password
   /// Serializer for FilesSharingCapabilities_FilesSharing_Public_Password.
   static Serializer<FilesSharingCapabilities_FilesSharing_Public_Password> get serializer =>
       _$filesSharingCapabilitiesFilesSharingPublicPasswordSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Public_PasswordInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Public_PasswordInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7834,6 +8686,10 @@ abstract interface class $FilesSharingCapabilities_FilesSharing_Public_ExpireDat
   bool get enabled;
   int? get days;
   bool? get enforced;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDate
@@ -7868,6 +8724,16 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDate
   /// Serializer for FilesSharingCapabilities_FilesSharing_Public_ExpireDate.
   static Serializer<FilesSharingCapabilities_FilesSharing_Public_ExpireDate> get serializer =>
       _$filesSharingCapabilitiesFilesSharingPublicExpireDateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7875,6 +8741,10 @@ abstract interface class $FilesSharingCapabilities_FilesSharing_Public_ExpireDat
   bool get enabled;
   int? get days;
   bool? get enforced;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
@@ -7909,6 +8779,16 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal
   /// Serializer for FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal.
   static Serializer<FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal> get serializer =>
       _$filesSharingCapabilitiesFilesSharingPublicExpireDateInternalSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7916,6 +8796,10 @@ abstract interface class $FilesSharingCapabilities_FilesSharing_Public_ExpireDat
   bool get enabled;
   int? get days;
   bool? get enforced;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
@@ -7950,6 +8834,16 @@ abstract class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote
   /// Serializer for FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote.
   static Serializer<FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote> get serializer =>
       _$filesSharingCapabilitiesFilesSharingPublicExpireDateRemoteSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7969,6 +8863,10 @@ abstract interface class $FilesSharingCapabilities_FilesSharing_PublicInterface 
   bool? get upload;
   @BuiltValueField(wireName: 'upload_files_drop')
   bool? get uploadFilesDrop;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Public
@@ -8002,11 +8900,25 @@ abstract class FilesSharingCapabilities_FilesSharing_Public
   /// Serializer for FilesSharingCapabilities_FilesSharing_Public.
   static Serializer<FilesSharingCapabilities_FilesSharing_Public> get serializer =>
       _$filesSharingCapabilitiesFilesSharingPublicSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_PublicBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_PublicInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_PublicBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_PublicInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesSharingCapabilities_FilesSharing_User_ExpireDateInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_User_ExpireDate
@@ -8041,6 +8953,16 @@ abstract class FilesSharingCapabilities_FilesSharing_User_ExpireDate
   /// Serializer for FilesSharingCapabilities_FilesSharing_User_ExpireDate.
   static Serializer<FilesSharingCapabilities_FilesSharing_User_ExpireDate> get serializer =>
       _$filesSharingCapabilitiesFilesSharingUserExpireDateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_User_ExpireDateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_User_ExpireDateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -8049,6 +8971,10 @@ abstract interface class $FilesSharingCapabilities_FilesSharing_UserInterface {
   bool get sendMail;
   @BuiltValueField(wireName: 'expire_date')
   FilesSharingCapabilities_FilesSharing_User_ExpireDate? get expireDate;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_User
@@ -8082,11 +9008,25 @@ abstract class FilesSharingCapabilities_FilesSharing_User
   /// Serializer for FilesSharingCapabilities_FilesSharing_User.
   static Serializer<FilesSharingCapabilities_FilesSharing_User> get serializer =>
       _$filesSharingCapabilitiesFilesSharingUserSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_UserBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_UserInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_UserBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_UserInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Group_ExpireDate
@@ -8121,6 +9061,16 @@ abstract class FilesSharingCapabilities_FilesSharing_Group_ExpireDate
   /// Serializer for FilesSharingCapabilities_FilesSharing_Group_ExpireDate.
   static Serializer<FilesSharingCapabilities_FilesSharing_Group_ExpireDate> get serializer =>
       _$filesSharingCapabilitiesFilesSharingGroupExpireDateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -8128,6 +9078,10 @@ abstract interface class $FilesSharingCapabilities_FilesSharing_GroupInterface {
   bool get enabled;
   @BuiltValueField(wireName: 'expire_date')
   FilesSharingCapabilities_FilesSharing_Group_ExpireDate? get expireDate;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Group
@@ -8161,11 +9115,25 @@ abstract class FilesSharingCapabilities_FilesSharing_Group
   /// Serializer for FilesSharingCapabilities_FilesSharing_Group.
   static Serializer<FilesSharingCapabilities_FilesSharing_Group> get serializer =>
       _$filesSharingCapabilitiesFilesSharingGroupSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_GroupBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_GroupInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_GroupBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_GroupInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDate
@@ -8200,11 +9168,25 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDate
   /// Serializer for FilesSharingCapabilities_FilesSharing_Federation_ExpireDate.
   static Serializer<FilesSharingCapabilities_FilesSharing_Federation_ExpireDate> get serializer =>
       _$filesSharingCapabilitiesFilesSharingFederationExpireDateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported
@@ -8239,6 +9221,16 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSuppor
   /// Serializer for FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported.
   static Serializer<FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported> get serializer =>
       _$filesSharingCapabilitiesFilesSharingFederationExpireDateSupportedSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -8249,6 +9241,10 @@ abstract interface class $FilesSharingCapabilities_FilesSharing_FederationInterf
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDate get expireDate;
   @BuiltValueField(wireName: 'expire_date_supported')
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported get expireDateSupported;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Federation
@@ -8283,6 +9279,16 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation
   /// Serializer for FilesSharingCapabilities_FilesSharing_Federation.
   static Serializer<FilesSharingCapabilities_FilesSharing_Federation> get serializer =>
       _$filesSharingCapabilitiesFilesSharingFederationSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_FederationBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_FederationInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_FederationBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_FederationInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -8291,6 +9297,10 @@ abstract interface class $FilesSharingCapabilities_FilesSharing_ShareeInterface 
   bool get queryLookupDefault;
   @BuiltValueField(wireName: 'always_show_unique')
   bool get alwaysShowUnique;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing_Sharee
@@ -8324,6 +9334,16 @@ abstract class FilesSharingCapabilities_FilesSharing_Sharee
   /// Serializer for FilesSharingCapabilities_FilesSharing_Sharee.
   static Serializer<FilesSharingCapabilities_FilesSharing_Sharee> get serializer =>
       _$filesSharingCapabilitiesFilesSharingShareeSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharing_ShareeBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_ShareeInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharing_ShareeBuilder b) {
+    $FilesSharingCapabilities_FilesSharing_ShareeInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -8340,6 +9360,10 @@ abstract interface class $FilesSharingCapabilities_FilesSharingInterface {
   int? get defaultPermissions;
   FilesSharingCapabilities_FilesSharing_Federation get federation;
   FilesSharingCapabilities_FilesSharing_Sharee get sharee;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilities_FilesSharingInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilities_FilesSharingInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities_FilesSharing
@@ -8372,12 +9396,26 @@ abstract class FilesSharingCapabilities_FilesSharing
   /// Serializer for FilesSharingCapabilities_FilesSharing.
   static Serializer<FilesSharingCapabilities_FilesSharing> get serializer =>
       _$filesSharingCapabilitiesFilesSharingSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilities_FilesSharingBuilder b) {
+    $FilesSharingCapabilities_FilesSharingInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilities_FilesSharingBuilder b) {
+    $FilesSharingCapabilities_FilesSharingInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesSharingCapabilitiesInterface {
   @BuiltValueField(wireName: 'files_sharing')
   FilesSharingCapabilities_FilesSharing get filesSharing;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesSharingCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesSharingCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class FilesSharingCapabilities
@@ -8406,11 +9444,25 @@ abstract class FilesSharingCapabilities
 
   /// Serializer for FilesSharingCapabilities.
   static Serializer<FilesSharingCapabilities> get serializer => _$filesSharingCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesSharingCapabilitiesBuilder b) {
+    $FilesSharingCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesSharingCapabilitiesBuilder b) {
+    $FilesSharingCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesTrashbinCapabilities_FilesInterface {
   bool get undelete;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesTrashbinCapabilities_FilesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesTrashbinCapabilities_FilesInterfaceBuilder b) {}
 }
 
 abstract class FilesTrashbinCapabilities_Files
@@ -8442,11 +9494,25 @@ abstract class FilesTrashbinCapabilities_Files
 
   /// Serializer for FilesTrashbinCapabilities_Files.
   static Serializer<FilesTrashbinCapabilities_Files> get serializer => _$filesTrashbinCapabilitiesFilesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesTrashbinCapabilities_FilesBuilder b) {
+    $FilesTrashbinCapabilities_FilesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesTrashbinCapabilities_FilesBuilder b) {
+    $FilesTrashbinCapabilities_FilesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesTrashbinCapabilitiesInterface {
   FilesTrashbinCapabilities_Files get files;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesTrashbinCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesTrashbinCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class FilesTrashbinCapabilities
@@ -8475,6 +9541,16 @@ abstract class FilesTrashbinCapabilities
 
   /// Serializer for FilesTrashbinCapabilities.
   static Serializer<FilesTrashbinCapabilities> get serializer => _$filesTrashbinCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesTrashbinCapabilitiesBuilder b) {
+    $FilesTrashbinCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesTrashbinCapabilitiesBuilder b) {
+    $FilesTrashbinCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -8484,6 +9560,10 @@ abstract interface class $FilesVersionsCapabilities_FilesInterface {
   bool get versionLabeling;
   @BuiltValueField(wireName: 'version_deletion')
   bool get versionDeletion;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesVersionsCapabilities_FilesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesVersionsCapabilities_FilesInterfaceBuilder b) {}
 }
 
 abstract class FilesVersionsCapabilities_Files
@@ -8515,11 +9595,25 @@ abstract class FilesVersionsCapabilities_Files
 
   /// Serializer for FilesVersionsCapabilities_Files.
   static Serializer<FilesVersionsCapabilities_Files> get serializer => _$filesVersionsCapabilitiesFilesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesVersionsCapabilities_FilesBuilder b) {
+    $FilesVersionsCapabilities_FilesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesVersionsCapabilities_FilesBuilder b) {
+    $FilesVersionsCapabilities_FilesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesVersionsCapabilitiesInterface {
   FilesVersionsCapabilities_Files get files;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesVersionsCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesVersionsCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class FilesVersionsCapabilities
@@ -8548,6 +9642,16 @@ abstract class FilesVersionsCapabilities
 
   /// Serializer for FilesVersionsCapabilities.
   static Serializer<FilesVersionsCapabilities> get serializer => _$filesVersionsCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesVersionsCapabilitiesBuilder b) {
+    $FilesVersionsCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesVersionsCapabilitiesBuilder b) {
+    $FilesVersionsCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -8557,6 +9661,10 @@ abstract interface class $NotificationsCapabilities_NotificationsInterface {
   BuiltList<String> get push;
   @BuiltValueField(wireName: 'admin-notifications')
   BuiltList<String> get adminNotifications;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NotificationsCapabilities_NotificationsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NotificationsCapabilities_NotificationsInterfaceBuilder b) {}
 }
 
 abstract class NotificationsCapabilities_Notifications
@@ -8589,11 +9697,25 @@ abstract class NotificationsCapabilities_Notifications
   /// Serializer for NotificationsCapabilities_Notifications.
   static Serializer<NotificationsCapabilities_Notifications> get serializer =>
       _$notificationsCapabilitiesNotificationsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NotificationsCapabilities_NotificationsBuilder b) {
+    $NotificationsCapabilities_NotificationsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NotificationsCapabilities_NotificationsBuilder b) {
+    $NotificationsCapabilities_NotificationsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $NotificationsCapabilitiesInterface {
   NotificationsCapabilities_Notifications get notifications;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NotificationsCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NotificationsCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class NotificationsCapabilities
@@ -8622,6 +9744,16 @@ abstract class NotificationsCapabilities
 
   /// Serializer for NotificationsCapabilities.
   static Serializer<NotificationsCapabilities> get serializer => _$notificationsCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NotificationsCapabilitiesBuilder b) {
+    $NotificationsCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NotificationsCapabilitiesBuilder b) {
+    $NotificationsCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -8633,6 +9765,10 @@ abstract interface class $ProvisioningApiCapabilities_ProvisioningApiInterface {
   bool get accountPropertyScopesFederatedEnabled;
   @BuiltValueField(wireName: 'AccountPropertyScopesPublishedEnabled')
   bool get accountPropertyScopesPublishedEnabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder b) {}
 }
 
 abstract class ProvisioningApiCapabilities_ProvisioningApi
@@ -8666,12 +9802,26 @@ abstract class ProvisioningApiCapabilities_ProvisioningApi
   /// Serializer for ProvisioningApiCapabilities_ProvisioningApi.
   static Serializer<ProvisioningApiCapabilities_ProvisioningApi> get serializer =>
       _$provisioningApiCapabilitiesProvisioningApiSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ProvisioningApiCapabilities_ProvisioningApiBuilder b) {
+    $ProvisioningApiCapabilities_ProvisioningApiInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ProvisioningApiCapabilities_ProvisioningApiBuilder b) {
+    $ProvisioningApiCapabilities_ProvisioningApiInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ProvisioningApiCapabilitiesInterface {
   @BuiltValueField(wireName: 'provisioning_api')
   ProvisioningApiCapabilities_ProvisioningApi get provisioningApi;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ProvisioningApiCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ProvisioningApiCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class ProvisioningApiCapabilities
@@ -8703,11 +9853,25 @@ abstract class ProvisioningApiCapabilities
 
   /// Serializer for ProvisioningApiCapabilities.
   static Serializer<ProvisioningApiCapabilities> get serializer => _$provisioningApiCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ProvisioningApiCapabilitiesBuilder b) {
+    $ProvisioningApiCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ProvisioningApiCapabilitiesBuilder b) {
+    $ProvisioningApiCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder b) {}
 }
 
 abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop
@@ -8742,12 +9906,26 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop
   /// Serializer for SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop.
   static Serializer<SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop> get serializer =>
       _$sharebymailCapabilities0FilesSharingSharebymailUploadFilesDropSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder b) {
+    $SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder b) {
+    $SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterface {
   bool get enabled;
   bool get enforced;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder b) {}
 }
 
 abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_Password
@@ -8782,12 +9960,26 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_Password
   /// Serializer for SharebymailCapabilities0_FilesSharing_Sharebymail_Password.
   static Serializer<SharebymailCapabilities0_FilesSharing_Sharebymail_Password> get serializer =>
       _$sharebymailCapabilities0FilesSharingSharebymailPasswordSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordBuilder b) {
+    $SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordBuilder b) {
+    $SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterface {
   bool get enabled;
   bool get enforced;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder b) {}
 }
 
 abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate
@@ -8822,6 +10014,16 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate
   /// Serializer for SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate.
   static Serializer<SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate> get serializer =>
       _$sharebymailCapabilities0FilesSharingSharebymailExpireDateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder b) {
+    $SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder b) {
+    $SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -8834,6 +10036,10 @@ abstract interface class $SharebymailCapabilities0_FilesSharing_SharebymailInter
   SharebymailCapabilities0_FilesSharing_Sharebymail_Password get password;
   @BuiltValueField(wireName: 'expire_date')
   SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate get expireDate;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SharebymailCapabilities0_FilesSharing_SharebymailInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SharebymailCapabilities0_FilesSharing_SharebymailInterfaceBuilder b) {}
 }
 
 abstract class SharebymailCapabilities0_FilesSharing_Sharebymail
@@ -8868,11 +10074,25 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail
   /// Serializer for SharebymailCapabilities0_FilesSharing_Sharebymail.
   static Serializer<SharebymailCapabilities0_FilesSharing_Sharebymail> get serializer =>
       _$sharebymailCapabilities0FilesSharingSharebymailSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SharebymailCapabilities0_FilesSharing_SharebymailBuilder b) {
+    $SharebymailCapabilities0_FilesSharing_SharebymailInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SharebymailCapabilities0_FilesSharing_SharebymailBuilder b) {
+    $SharebymailCapabilities0_FilesSharing_SharebymailInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SharebymailCapabilities0_FilesSharingInterface {
   SharebymailCapabilities0_FilesSharing_Sharebymail get sharebymail;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SharebymailCapabilities0_FilesSharingInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SharebymailCapabilities0_FilesSharingInterfaceBuilder b) {}
 }
 
 abstract class SharebymailCapabilities0_FilesSharing
@@ -8905,12 +10125,26 @@ abstract class SharebymailCapabilities0_FilesSharing
   /// Serializer for SharebymailCapabilities0_FilesSharing.
   static Serializer<SharebymailCapabilities0_FilesSharing> get serializer =>
       _$sharebymailCapabilities0FilesSharingSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SharebymailCapabilities0_FilesSharingBuilder b) {
+    $SharebymailCapabilities0_FilesSharingInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SharebymailCapabilities0_FilesSharingBuilder b) {
+    $SharebymailCapabilities0_FilesSharingInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SharebymailCapabilities0Interface {
   @BuiltValueField(wireName: 'files_sharing')
   SharebymailCapabilities0_FilesSharing get filesSharing;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SharebymailCapabilities0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SharebymailCapabilities0InterfaceBuilder b) {}
 }
 
 abstract class SharebymailCapabilities0
@@ -8939,6 +10173,16 @@ abstract class SharebymailCapabilities0
 
   /// Serializer for SharebymailCapabilities0.
   static Serializer<SharebymailCapabilities0> get serializer => _$sharebymailCapabilities0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SharebymailCapabilities0Builder b) {
+    $SharebymailCapabilities0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SharebymailCapabilities0Builder b) {
+    $SharebymailCapabilities0Interface._validate(b);
+  }
 }
 
 typedef SharebymailCapabilities = ({
@@ -8950,6 +10194,10 @@ typedef SharebymailCapabilities = ({
 abstract interface class $SpreedPublicCapabilities0_Spreed_Config_AttachmentsInterface {
   bool get allowed;
   String? get folder;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SpreedPublicCapabilities0_Spreed_Config_AttachmentsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SpreedPublicCapabilities0_Spreed_Config_AttachmentsInterfaceBuilder b) {}
 }
 
 abstract class SpreedPublicCapabilities0_Spreed_Config_Attachments
@@ -8984,6 +10232,16 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Attachments
   /// Serializer for SpreedPublicCapabilities0_Spreed_Config_Attachments.
   static Serializer<SpreedPublicCapabilities0_Spreed_Config_Attachments> get serializer =>
       _$spreedPublicCapabilities0SpreedConfigAttachmentsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SpreedPublicCapabilities0_Spreed_Config_AttachmentsBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_AttachmentsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SpreedPublicCapabilities0_Spreed_Config_AttachmentsBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_AttachmentsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -9006,6 +10264,10 @@ abstract interface class $SpreedPublicCapabilities0_Spreed_Config_CallInterface 
   bool? get sipDialoutEnabled;
   @BuiltValueField(wireName: 'can-enable-sip')
   bool? get canEnableSip;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SpreedPublicCapabilities0_Spreed_Config_CallInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SpreedPublicCapabilities0_Spreed_Config_CallInterfaceBuilder b) {}
 }
 
 abstract class SpreedPublicCapabilities0_Spreed_Config_Call
@@ -9039,6 +10301,16 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Call
   /// Serializer for SpreedPublicCapabilities0_Spreed_Config_Call.
   static Serializer<SpreedPublicCapabilities0_Spreed_Config_Call> get serializer =>
       _$spreedPublicCapabilities0SpreedConfigCallSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SpreedPublicCapabilities0_Spreed_Config_CallBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_CallInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SpreedPublicCapabilities0_Spreed_Config_CallBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_CallInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -9052,6 +10324,10 @@ abstract interface class $SpreedPublicCapabilities0_Spreed_Config_ChatInterface 
   @BuiltValueField(wireName: 'typing-privacy')
   int get typingPrivacy;
   BuiltList<String>? get translations;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SpreedPublicCapabilities0_Spreed_Config_ChatInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SpreedPublicCapabilities0_Spreed_Config_ChatInterfaceBuilder b) {}
 }
 
 abstract class SpreedPublicCapabilities0_Spreed_Config_Chat
@@ -9085,12 +10361,26 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Chat
   /// Serializer for SpreedPublicCapabilities0_Spreed_Config_Chat.
   static Serializer<SpreedPublicCapabilities0_Spreed_Config_Chat> get serializer =>
       _$spreedPublicCapabilities0SpreedConfigChatSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SpreedPublicCapabilities0_Spreed_Config_ChatBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_ChatInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SpreedPublicCapabilities0_Spreed_Config_ChatBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_ChatInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SpreedPublicCapabilities0_Spreed_Config_ConversationsInterface {
   @BuiltValueField(wireName: 'can-create')
   bool get canCreate;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SpreedPublicCapabilities0_Spreed_Config_ConversationsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SpreedPublicCapabilities0_Spreed_Config_ConversationsInterfaceBuilder b) {}
 }
 
 abstract class SpreedPublicCapabilities0_Spreed_Config_Conversations
@@ -9125,12 +10415,26 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Conversations
   /// Serializer for SpreedPublicCapabilities0_Spreed_Config_Conversations.
   static Serializer<SpreedPublicCapabilities0_Spreed_Config_Conversations> get serializer =>
       _$spreedPublicCapabilities0SpreedConfigConversationsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SpreedPublicCapabilities0_Spreed_Config_ConversationsBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_ConversationsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SpreedPublicCapabilities0_Spreed_Config_ConversationsBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_ConversationsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SpreedPublicCapabilities0_Spreed_Config_PreviewsInterface {
   @BuiltValueField(wireName: 'max-gif-size')
   int get maxGifSize;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SpreedPublicCapabilities0_Spreed_Config_PreviewsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SpreedPublicCapabilities0_Spreed_Config_PreviewsInterfaceBuilder b) {}
 }
 
 abstract class SpreedPublicCapabilities0_Spreed_Config_Previews
@@ -9165,6 +10469,16 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Previews
   /// Serializer for SpreedPublicCapabilities0_Spreed_Config_Previews.
   static Serializer<SpreedPublicCapabilities0_Spreed_Config_Previews> get serializer =>
       _$spreedPublicCapabilities0SpreedConfigPreviewsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SpreedPublicCapabilities0_Spreed_Config_PreviewsBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_PreviewsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SpreedPublicCapabilities0_Spreed_Config_PreviewsBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_PreviewsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -9173,6 +10487,10 @@ abstract interface class $SpreedPublicCapabilities0_Spreed_Config_SignalingInter
   int get sessionPingLimit;
   @BuiltValueField(wireName: 'hello-v2-token-key')
   String? get helloV2TokenKey;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SpreedPublicCapabilities0_Spreed_Config_SignalingInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SpreedPublicCapabilities0_Spreed_Config_SignalingInterfaceBuilder b) {}
 }
 
 abstract class SpreedPublicCapabilities0_Spreed_Config_Signaling
@@ -9207,6 +10525,16 @@ abstract class SpreedPublicCapabilities0_Spreed_Config_Signaling
   /// Serializer for SpreedPublicCapabilities0_Spreed_Config_Signaling.
   static Serializer<SpreedPublicCapabilities0_Spreed_Config_Signaling> get serializer =>
       _$spreedPublicCapabilities0SpreedConfigSignalingSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_SignalingInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_Config_SignalingInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -9217,6 +10545,10 @@ abstract interface class $SpreedPublicCapabilities0_Spreed_ConfigInterface {
   SpreedPublicCapabilities0_Spreed_Config_Conversations get conversations;
   SpreedPublicCapabilities0_Spreed_Config_Previews get previews;
   SpreedPublicCapabilities0_Spreed_Config_Signaling get signaling;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SpreedPublicCapabilities0_Spreed_ConfigInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SpreedPublicCapabilities0_Spreed_ConfigInterfaceBuilder b) {}
 }
 
 abstract class SpreedPublicCapabilities0_Spreed_Config
@@ -9249,6 +10581,16 @@ abstract class SpreedPublicCapabilities0_Spreed_Config
   /// Serializer for SpreedPublicCapabilities0_Spreed_Config.
   static Serializer<SpreedPublicCapabilities0_Spreed_Config> get serializer =>
       _$spreedPublicCapabilities0SpreedConfigSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SpreedPublicCapabilities0_Spreed_ConfigBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_ConfigInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SpreedPublicCapabilities0_Spreed_ConfigBuilder b) {
+    $SpreedPublicCapabilities0_Spreed_ConfigInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -9256,6 +10598,10 @@ abstract interface class $SpreedPublicCapabilities0_SpreedInterface {
   BuiltList<String> get features;
   SpreedPublicCapabilities0_Spreed_Config get config;
   String get version;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SpreedPublicCapabilities0_SpreedInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SpreedPublicCapabilities0_SpreedInterfaceBuilder b) {}
 }
 
 abstract class SpreedPublicCapabilities0_Spreed
@@ -9287,11 +10633,25 @@ abstract class SpreedPublicCapabilities0_Spreed
 
   /// Serializer for SpreedPublicCapabilities0_Spreed.
   static Serializer<SpreedPublicCapabilities0_Spreed> get serializer => _$spreedPublicCapabilities0SpreedSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SpreedPublicCapabilities0_SpreedBuilder b) {
+    $SpreedPublicCapabilities0_SpreedInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SpreedPublicCapabilities0_SpreedBuilder b) {
+    $SpreedPublicCapabilities0_SpreedInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SpreedPublicCapabilities0Interface {
   SpreedPublicCapabilities0_Spreed get spreed;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SpreedPublicCapabilities0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SpreedPublicCapabilities0InterfaceBuilder b) {}
 }
 
 abstract class SpreedPublicCapabilities0
@@ -9320,6 +10680,16 @@ abstract class SpreedPublicCapabilities0
 
   /// Serializer for SpreedPublicCapabilities0.
   static Serializer<SpreedPublicCapabilities0> get serializer => _$spreedPublicCapabilities0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SpreedPublicCapabilities0Builder b) {
+    $SpreedPublicCapabilities0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SpreedPublicCapabilities0Builder b) {
+    $SpreedPublicCapabilities0Interface._validate(b);
+  }
 }
 
 typedef SpreedPublicCapabilities = ({
@@ -9393,6 +10763,10 @@ class _$SystemtagsCapabilities_Systemtags_EnabledSerializer
 @BuiltValue(instantiable: false)
 abstract interface class $SystemtagsCapabilities_SystemtagsInterface {
   SystemtagsCapabilities_Systemtags_Enabled get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SystemtagsCapabilities_SystemtagsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SystemtagsCapabilities_SystemtagsInterfaceBuilder b) {}
 }
 
 abstract class SystemtagsCapabilities_Systemtags
@@ -9424,11 +10798,25 @@ abstract class SystemtagsCapabilities_Systemtags
 
   /// Serializer for SystemtagsCapabilities_Systemtags.
   static Serializer<SystemtagsCapabilities_Systemtags> get serializer => _$systemtagsCapabilitiesSystemtagsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SystemtagsCapabilities_SystemtagsBuilder b) {
+    $SystemtagsCapabilities_SystemtagsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SystemtagsCapabilities_SystemtagsBuilder b) {
+    $SystemtagsCapabilities_SystemtagsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SystemtagsCapabilitiesInterface {
   SystemtagsCapabilities_Systemtags get systemtags;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SystemtagsCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SystemtagsCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class SystemtagsCapabilities
@@ -9457,6 +10845,16 @@ abstract class SystemtagsCapabilities
 
   /// Serializer for SystemtagsCapabilities.
   static Serializer<SystemtagsCapabilities> get serializer => _$systemtagsCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SystemtagsCapabilitiesBuilder b) {
+    $SystemtagsCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SystemtagsCapabilitiesBuilder b) {
+    $SystemtagsCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -9481,6 +10879,10 @@ abstract interface class $ThemingPublicCapabilities_ThemingInterface {
   bool get backgroundDefault;
   String get logoheader;
   String get favicon;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ThemingPublicCapabilities_ThemingInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ThemingPublicCapabilities_ThemingInterfaceBuilder b) {}
 }
 
 abstract class ThemingPublicCapabilities_Theming
@@ -9512,11 +10914,25 @@ abstract class ThemingPublicCapabilities_Theming
 
   /// Serializer for ThemingPublicCapabilities_Theming.
   static Serializer<ThemingPublicCapabilities_Theming> get serializer => _$themingPublicCapabilitiesThemingSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ThemingPublicCapabilities_ThemingBuilder b) {
+    $ThemingPublicCapabilities_ThemingInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ThemingPublicCapabilities_ThemingBuilder b) {
+    $ThemingPublicCapabilities_ThemingInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ThemingPublicCapabilitiesInterface {
   ThemingPublicCapabilities_Theming get theming;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ThemingPublicCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ThemingPublicCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class ThemingPublicCapabilities
@@ -9545,6 +10961,16 @@ abstract class ThemingPublicCapabilities
 
   /// Serializer for ThemingPublicCapabilities.
   static Serializer<ThemingPublicCapabilities> get serializer => _$themingPublicCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ThemingPublicCapabilitiesBuilder b) {
+    $ThemingPublicCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ThemingPublicCapabilitiesBuilder b) {
+    $ThemingPublicCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -9553,6 +10979,10 @@ abstract interface class $UserStatusCapabilities_UserStatusInterface {
   bool get restore;
   @BuiltValueField(wireName: 'supports_emoji')
   bool get supportsEmoji;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusCapabilities_UserStatusInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusCapabilities_UserStatusInterfaceBuilder b) {}
 }
 
 abstract class UserStatusCapabilities_UserStatus
@@ -9584,12 +11014,26 @@ abstract class UserStatusCapabilities_UserStatus
 
   /// Serializer for UserStatusCapabilities_UserStatus.
   static Serializer<UserStatusCapabilities_UserStatus> get serializer => _$userStatusCapabilitiesUserStatusSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusCapabilities_UserStatusBuilder b) {
+    $UserStatusCapabilities_UserStatusInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusCapabilities_UserStatusBuilder b) {
+    $UserStatusCapabilities_UserStatusInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusCapabilitiesInterface {
   @BuiltValueField(wireName: 'user_status')
   UserStatusCapabilities_UserStatus get userStatus;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class UserStatusCapabilities
@@ -9618,11 +11062,25 @@ abstract class UserStatusCapabilities
 
   /// Serializer for UserStatusCapabilities.
   static Serializer<UserStatusCapabilities> get serializer => _$userStatusCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusCapabilitiesBuilder b) {
+    $UserStatusCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusCapabilitiesBuilder b) {
+    $UserStatusCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusCapabilities_WeatherStatusInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusCapabilities_WeatherStatusInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusCapabilities_WeatherStatusInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusCapabilities_WeatherStatus
@@ -9655,12 +11113,26 @@ abstract class WeatherStatusCapabilities_WeatherStatus
   /// Serializer for WeatherStatusCapabilities_WeatherStatus.
   static Serializer<WeatherStatusCapabilities_WeatherStatus> get serializer =>
       _$weatherStatusCapabilitiesWeatherStatusSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusCapabilities_WeatherStatusBuilder b) {
+    $WeatherStatusCapabilities_WeatherStatusInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusCapabilities_WeatherStatusBuilder b) {
+    $WeatherStatusCapabilities_WeatherStatusInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusCapabilitiesInterface {
   @BuiltValueField(wireName: 'weather_status')
   WeatherStatusCapabilities_WeatherStatus get weatherStatus;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusCapabilities
@@ -9689,6 +11161,16 @@ abstract class WeatherStatusCapabilities
 
   /// Serializer for WeatherStatusCapabilities.
   static Serializer<WeatherStatusCapabilities> get serializer => _$weatherStatusCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusCapabilitiesBuilder b) {
+    $WeatherStatusCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusCapabilitiesBuilder b) {
+    $WeatherStatusCapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -9696,6 +11178,10 @@ abstract interface class $NotesCapabilities_NotesInterface {
   @BuiltValueField(wireName: 'api_version')
   BuiltList<String>? get apiVersion;
   String? get version;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NotesCapabilities_NotesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NotesCapabilities_NotesInterfaceBuilder b) {}
 }
 
 abstract class NotesCapabilities_Notes
@@ -9724,11 +11210,25 @@ abstract class NotesCapabilities_Notes
 
   /// Serializer for NotesCapabilities_Notes.
   static Serializer<NotesCapabilities_Notes> get serializer => _$notesCapabilitiesNotesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NotesCapabilities_NotesBuilder b) {
+    $NotesCapabilities_NotesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NotesCapabilities_NotesBuilder b) {
+    $NotesCapabilities_NotesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $NotesCapabilitiesInterface {
   NotesCapabilities_Notes get notes;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NotesCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NotesCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class NotesCapabilities
@@ -9756,6 +11256,16 @@ abstract class NotesCapabilities
 
   /// Serializer for NotesCapabilities.
   static Serializer<NotesCapabilities> get serializer => _$notesCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NotesCapabilitiesBuilder b) {
+    $NotesCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NotesCapabilitiesBuilder b) {
+    $NotesCapabilitiesInterface._validate(b);
+  }
 }
 
 typedef OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities = ({
@@ -9781,6 +11291,12 @@ typedef OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities = ({
 abstract interface class $OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterface {
   OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version get version;
   OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities get capabilities;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {
+    b.capabilities?.validateAnyOf();
+  }
 }
 
 abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data
@@ -9816,9 +11332,14 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data
   static Serializer<OcsGetCapabilitiesResponseApplicationJson_Ocs_Data> get serializer =>
       _$ocsGetCapabilitiesResponseApplicationJsonOcsDataSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder b) {
+    $OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder b) {
-    b.capabilities?.validateAnyOf();
+    $OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterface._validate(b);
   }
 }
 
@@ -9826,6 +11347,10 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data
 abstract interface class $OcsGetCapabilitiesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OcsGetCapabilitiesResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OcsGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OcsGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs
@@ -9859,11 +11384,25 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs
   /// Serializer for OcsGetCapabilitiesResponseApplicationJson_Ocs.
   static Serializer<OcsGetCapabilitiesResponseApplicationJson_Ocs> get serializer =>
       _$ocsGetCapabilitiesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OcsGetCapabilitiesResponseApplicationJson_OcsBuilder b) {
+    $OcsGetCapabilitiesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OcsGetCapabilitiesResponseApplicationJson_OcsBuilder b) {
+    $OcsGetCapabilitiesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OcsGetCapabilitiesResponseApplicationJsonInterface {
   OcsGetCapabilitiesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OcsGetCapabilitiesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OcsGetCapabilitiesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class OcsGetCapabilitiesResponseApplicationJson
@@ -9897,6 +11436,16 @@ abstract class OcsGetCapabilitiesResponseApplicationJson
   /// Serializer for OcsGetCapabilitiesResponseApplicationJson.
   static Serializer<OcsGetCapabilitiesResponseApplicationJson> get serializer =>
       _$ocsGetCapabilitiesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OcsGetCapabilitiesResponseApplicationJsonBuilder b) {
+    $OcsGetCapabilitiesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OcsGetCapabilitiesResponseApplicationJsonBuilder b) {
+    $OcsGetCapabilitiesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class PreviewGetPreviewByFileIdA extends EnumClass {
@@ -10288,6 +11837,10 @@ class _$PreviewGetPreviewMimeFallbackSerializer implements PrimitiveSerializer<P
 abstract interface class $ProfileApiSetVisibilityResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ProfileApiSetVisibilityResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ProfileApiSetVisibilityResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ProfileApiSetVisibilityResponseApplicationJson_Ocs
@@ -10322,11 +11875,25 @@ abstract class ProfileApiSetVisibilityResponseApplicationJson_Ocs
   /// Serializer for ProfileApiSetVisibilityResponseApplicationJson_Ocs.
   static Serializer<ProfileApiSetVisibilityResponseApplicationJson_Ocs> get serializer =>
       _$profileApiSetVisibilityResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder b) {
+    $ProfileApiSetVisibilityResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder b) {
+    $ProfileApiSetVisibilityResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ProfileApiSetVisibilityResponseApplicationJsonInterface {
   ProfileApiSetVisibilityResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ProfileApiSetVisibilityResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ProfileApiSetVisibilityResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ProfileApiSetVisibilityResponseApplicationJson
@@ -10360,6 +11927,16 @@ abstract class ProfileApiSetVisibilityResponseApplicationJson
   /// Serializer for ProfileApiSetVisibilityResponseApplicationJson.
   static Serializer<ProfileApiSetVisibilityResponseApplicationJson> get serializer =>
       _$profileApiSetVisibilityResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ProfileApiSetVisibilityResponseApplicationJsonBuilder b) {
+    $ProfileApiSetVisibilityResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ProfileApiSetVisibilityResponseApplicationJsonBuilder b) {
+    $ProfileApiSetVisibilityResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -10368,6 +11945,10 @@ abstract interface class $ReferenceInterface {
   BuiltMap<String, JsonObject> get richObject;
   OpenGraphObject get openGraphObject;
   bool get accessible;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceInterfaceBuilder b) {}
 }
 
 abstract class Reference implements $ReferenceInterface, Built<Reference, ReferenceBuilder> {
@@ -10394,11 +11975,25 @@ abstract class Reference implements $ReferenceInterface, Built<Reference, Refere
 
   /// Serializer for Reference.
   static Serializer<Reference> get serializer => _$referenceSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceBuilder b) {
+    $ReferenceInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceBuilder b) {
+    $ReferenceInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, Reference> get references;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiResolveOneResponseApplicationJson_Ocs_Data
@@ -10433,12 +12028,26 @@ abstract class ReferenceApiResolveOneResponseApplicationJson_Ocs_Data
   /// Serializer for ReferenceApiResolveOneResponseApplicationJson_Ocs_Data.
   static Serializer<ReferenceApiResolveOneResponseApplicationJson_Ocs_Data> get serializer =>
       _$referenceApiResolveOneResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder b) {
+    $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder b) {
+    $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiResolveOneResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ReferenceApiResolveOneResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiResolveOneResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiResolveOneResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiResolveOneResponseApplicationJson_Ocs
@@ -10473,11 +12082,25 @@ abstract class ReferenceApiResolveOneResponseApplicationJson_Ocs
   /// Serializer for ReferenceApiResolveOneResponseApplicationJson_Ocs.
   static Serializer<ReferenceApiResolveOneResponseApplicationJson_Ocs> get serializer =>
       _$referenceApiResolveOneResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiResolveOneResponseApplicationJson_OcsBuilder b) {
+    $ReferenceApiResolveOneResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiResolveOneResponseApplicationJson_OcsBuilder b) {
+    $ReferenceApiResolveOneResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiResolveOneResponseApplicationJsonInterface {
   ReferenceApiResolveOneResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiResolveOneResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiResolveOneResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiResolveOneResponseApplicationJson
@@ -10511,11 +12134,25 @@ abstract class ReferenceApiResolveOneResponseApplicationJson
   /// Serializer for ReferenceApiResolveOneResponseApplicationJson.
   static Serializer<ReferenceApiResolveOneResponseApplicationJson> get serializer =>
       _$referenceApiResolveOneResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiResolveOneResponseApplicationJsonBuilder b) {
+    $ReferenceApiResolveOneResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiResolveOneResponseApplicationJsonBuilder b) {
+    $ReferenceApiResolveOneResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiResolveResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, Reference> get references;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiResolveResponseApplicationJson_Ocs_Data
@@ -10550,12 +12187,26 @@ abstract class ReferenceApiResolveResponseApplicationJson_Ocs_Data
   /// Serializer for ReferenceApiResolveResponseApplicationJson_Ocs_Data.
   static Serializer<ReferenceApiResolveResponseApplicationJson_Ocs_Data> get serializer =>
       _$referenceApiResolveResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder b) {
+    $ReferenceApiResolveResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder b) {
+    $ReferenceApiResolveResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiResolveResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ReferenceApiResolveResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiResolveResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiResolveResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiResolveResponseApplicationJson_Ocs
@@ -10589,11 +12240,25 @@ abstract class ReferenceApiResolveResponseApplicationJson_Ocs
   /// Serializer for ReferenceApiResolveResponseApplicationJson_Ocs.
   static Serializer<ReferenceApiResolveResponseApplicationJson_Ocs> get serializer =>
       _$referenceApiResolveResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiResolveResponseApplicationJson_OcsBuilder b) {
+    $ReferenceApiResolveResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiResolveResponseApplicationJson_OcsBuilder b) {
+    $ReferenceApiResolveResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiResolveResponseApplicationJsonInterface {
   ReferenceApiResolveResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiResolveResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiResolveResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiResolveResponseApplicationJson
@@ -10627,6 +12292,16 @@ abstract class ReferenceApiResolveResponseApplicationJson
   /// Serializer for ReferenceApiResolveResponseApplicationJson.
   static Serializer<ReferenceApiResolveResponseApplicationJson> get serializer =>
       _$referenceApiResolveResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiResolveResponseApplicationJsonBuilder b) {
+    $ReferenceApiResolveResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiResolveResponseApplicationJsonBuilder b) {
+    $ReferenceApiResolveResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ReferenceApiExtractResolve extends EnumClass {
@@ -10695,6 +12370,10 @@ class _$ReferenceApiExtractResolveSerializer implements PrimitiveSerializer<Refe
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiExtractResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, Reference> get references;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiExtractResponseApplicationJson_Ocs_Data
@@ -10729,12 +12408,26 @@ abstract class ReferenceApiExtractResponseApplicationJson_Ocs_Data
   /// Serializer for ReferenceApiExtractResponseApplicationJson_Ocs_Data.
   static Serializer<ReferenceApiExtractResponseApplicationJson_Ocs_Data> get serializer =>
       _$referenceApiExtractResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder b) {
+    $ReferenceApiExtractResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder b) {
+    $ReferenceApiExtractResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiExtractResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ReferenceApiExtractResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiExtractResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiExtractResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiExtractResponseApplicationJson_Ocs
@@ -10768,11 +12461,25 @@ abstract class ReferenceApiExtractResponseApplicationJson_Ocs
   /// Serializer for ReferenceApiExtractResponseApplicationJson_Ocs.
   static Serializer<ReferenceApiExtractResponseApplicationJson_Ocs> get serializer =>
       _$referenceApiExtractResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiExtractResponseApplicationJson_OcsBuilder b) {
+    $ReferenceApiExtractResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiExtractResponseApplicationJson_OcsBuilder b) {
+    $ReferenceApiExtractResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiExtractResponseApplicationJsonInterface {
   ReferenceApiExtractResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiExtractResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiExtractResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiExtractResponseApplicationJson
@@ -10806,6 +12513,16 @@ abstract class ReferenceApiExtractResponseApplicationJson
   /// Serializer for ReferenceApiExtractResponseApplicationJson.
   static Serializer<ReferenceApiExtractResponseApplicationJson> get serializer =>
       _$referenceApiExtractResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiExtractResponseApplicationJsonBuilder b) {
+    $ReferenceApiExtractResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiExtractResponseApplicationJsonBuilder b) {
+    $ReferenceApiExtractResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -10817,6 +12534,10 @@ abstract interface class $ReferenceProviderInterface {
   int get order;
   @BuiltValueField(wireName: 'search_providers_ids')
   BuiltList<String>? get searchProvidersIds;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceProviderInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceProviderInterfaceBuilder b) {}
 }
 
 abstract class ReferenceProvider
@@ -10844,12 +12565,26 @@ abstract class ReferenceProvider
 
   /// Serializer for ReferenceProvider.
   static Serializer<ReferenceProvider> get serializer => _$referenceProviderSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceProviderBuilder b) {
+    $ReferenceProviderInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceProviderBuilder b) {
+    $ReferenceProviderInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ReferenceProvider> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs
@@ -10884,11 +12619,25 @@ abstract class ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs
   /// Serializer for ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs.
   static Serializer<ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs> get serializer =>
       _$referenceApiGetProvidersInfoResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder b) {
+    $ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder b) {
+    $ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiGetProvidersInfoResponseApplicationJsonInterface {
   ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiGetProvidersInfoResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiGetProvidersInfoResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiGetProvidersInfoResponseApplicationJson
@@ -10923,11 +12672,25 @@ abstract class ReferenceApiGetProvidersInfoResponseApplicationJson
   /// Serializer for ReferenceApiGetProvidersInfoResponseApplicationJson.
   static Serializer<ReferenceApiGetProvidersInfoResponseApplicationJson> get serializer =>
       _$referenceApiGetProvidersInfoResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder b) {
+    $ReferenceApiGetProvidersInfoResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder b) {
+    $ReferenceApiGetProvidersInfoResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterface {
   bool get success;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data
@@ -10962,12 +12725,26 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data
   /// Serializer for ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data.
   static Serializer<ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data> get serializer =>
       _$referenceApiTouchProviderResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder b) {
+    $ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder b) {
+    $ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiTouchProviderResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiTouchProviderResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiTouchProviderResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiTouchProviderResponseApplicationJson_Ocs
@@ -11002,11 +12779,25 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson_Ocs
   /// Serializer for ReferenceApiTouchProviderResponseApplicationJson_Ocs.
   static Serializer<ReferenceApiTouchProviderResponseApplicationJson_Ocs> get serializer =>
       _$referenceApiTouchProviderResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder b) {
+    $ReferenceApiTouchProviderResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder b) {
+    $ReferenceApiTouchProviderResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiTouchProviderResponseApplicationJsonInterface {
   ReferenceApiTouchProviderResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiTouchProviderResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiTouchProviderResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ReferenceApiTouchProviderResponseApplicationJson
@@ -11041,6 +12832,16 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson
   /// Serializer for ReferenceApiTouchProviderResponseApplicationJson.
   static Serializer<ReferenceApiTouchProviderResponseApplicationJson> get serializer =>
       _$referenceApiTouchProviderResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiTouchProviderResponseApplicationJsonBuilder b) {
+    $ReferenceApiTouchProviderResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiTouchProviderResponseApplicationJsonBuilder b) {
+    $ReferenceApiTouchProviderResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -11048,6 +12849,10 @@ abstract interface class $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_
   String get id;
   String get name;
   String get description;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types
@@ -11082,11 +12887,25 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types
   /// Serializer for TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types.
   static Serializer<TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types> get serializer =>
       _$textProcessingApiTaskTypesResponseApplicationJsonOcsDataTypesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesBuilder b) {
+    $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesBuilder b) {
+    $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types> get types;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data
@@ -11121,12 +12940,26 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data
   /// Serializer for TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data.
   static Serializer<TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data> get serializer =>
       _$textProcessingApiTaskTypesResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiTaskTypesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiTaskTypesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiTaskTypesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs
@@ -11161,11 +12994,25 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs
   /// Serializer for TextProcessingApiTaskTypesResponseApplicationJson_Ocs.
   static Serializer<TextProcessingApiTaskTypesResponseApplicationJson_Ocs> get serializer =>
       _$textProcessingApiTaskTypesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder b) {
+    $TextProcessingApiTaskTypesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder b) {
+    $TextProcessingApiTaskTypesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiTaskTypesResponseApplicationJsonInterface {
   TextProcessingApiTaskTypesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiTaskTypesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiTaskTypesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiTaskTypesResponseApplicationJson
@@ -11200,6 +13047,16 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson
   /// Serializer for TextProcessingApiTaskTypesResponseApplicationJson.
   static Serializer<TextProcessingApiTaskTypesResponseApplicationJson> get serializer =>
       _$textProcessingApiTaskTypesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiTaskTypesResponseApplicationJsonBuilder b) {
+    $TextProcessingApiTaskTypesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiTaskTypesResponseApplicationJsonBuilder b) {
+    $TextProcessingApiTaskTypesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class TextProcessingTask_Status extends EnumClass {
@@ -11294,6 +13151,10 @@ abstract interface class $TextProcessingTaskInterface {
   String? get output;
   String get identifier;
   int? get completionExpectedAt;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingTaskInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingTaskInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingTask
@@ -11322,11 +13183,25 @@ abstract class TextProcessingTask
 
   /// Serializer for TextProcessingTask.
   static Serializer<TextProcessingTask> get serializer => _$textProcessingTaskSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingTaskBuilder b) {
+    $TextProcessingTaskInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingTaskBuilder b) {
+    $TextProcessingTaskInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterface {
   TextProcessingTask get task;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiScheduleResponseApplicationJson_Ocs_Data
@@ -11361,12 +13236,26 @@ abstract class TextProcessingApiScheduleResponseApplicationJson_Ocs_Data
   /// Serializer for TextProcessingApiScheduleResponseApplicationJson_Ocs_Data.
   static Serializer<TextProcessingApiScheduleResponseApplicationJson_Ocs_Data> get serializer =>
       _$textProcessingApiScheduleResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiScheduleResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextProcessingApiScheduleResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiScheduleResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiScheduleResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiScheduleResponseApplicationJson_Ocs
@@ -11401,11 +13290,25 @@ abstract class TextProcessingApiScheduleResponseApplicationJson_Ocs
   /// Serializer for TextProcessingApiScheduleResponseApplicationJson_Ocs.
   static Serializer<TextProcessingApiScheduleResponseApplicationJson_Ocs> get serializer =>
       _$textProcessingApiScheduleResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiScheduleResponseApplicationJson_OcsBuilder b) {
+    $TextProcessingApiScheduleResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiScheduleResponseApplicationJson_OcsBuilder b) {
+    $TextProcessingApiScheduleResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiScheduleResponseApplicationJsonInterface {
   TextProcessingApiScheduleResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiScheduleResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiScheduleResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiScheduleResponseApplicationJson
@@ -11440,11 +13343,25 @@ abstract class TextProcessingApiScheduleResponseApplicationJson
   /// Serializer for TextProcessingApiScheduleResponseApplicationJson.
   static Serializer<TextProcessingApiScheduleResponseApplicationJson> get serializer =>
       _$textProcessingApiScheduleResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiScheduleResponseApplicationJsonBuilder b) {
+    $TextProcessingApiScheduleResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiScheduleResponseApplicationJsonBuilder b) {
+    $TextProcessingApiScheduleResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterface {
   TextProcessingTask get task;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data
@@ -11479,12 +13396,26 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data
   /// Serializer for TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data.
   static Serializer<TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data> get serializer =>
       _$textProcessingApiGetTaskResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiGetTaskResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiGetTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiGetTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiGetTaskResponseApplicationJson_Ocs
@@ -11519,11 +13450,25 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson_Ocs
   /// Serializer for TextProcessingApiGetTaskResponseApplicationJson_Ocs.
   static Serializer<TextProcessingApiGetTaskResponseApplicationJson_Ocs> get serializer =>
       _$textProcessingApiGetTaskResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder b) {
+    $TextProcessingApiGetTaskResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder b) {
+    $TextProcessingApiGetTaskResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiGetTaskResponseApplicationJsonInterface {
   TextProcessingApiGetTaskResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiGetTaskResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiGetTaskResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiGetTaskResponseApplicationJson
@@ -11557,11 +13502,25 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson
   /// Serializer for TextProcessingApiGetTaskResponseApplicationJson.
   static Serializer<TextProcessingApiGetTaskResponseApplicationJson> get serializer =>
       _$textProcessingApiGetTaskResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiGetTaskResponseApplicationJsonBuilder b) {
+    $TextProcessingApiGetTaskResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiGetTaskResponseApplicationJsonBuilder b) {
+    $TextProcessingApiGetTaskResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterface {
   TextProcessingTask get task;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data
@@ -11596,12 +13555,26 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data
   /// Serializer for TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data.
   static Serializer<TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data> get serializer =>
       _$textProcessingApiDeleteTaskResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs
@@ -11636,11 +13609,25 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs
   /// Serializer for TextProcessingApiDeleteTaskResponseApplicationJson_Ocs.
   static Serializer<TextProcessingApiDeleteTaskResponseApplicationJson_Ocs> get serializer =>
       _$textProcessingApiDeleteTaskResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder b) {
+    $TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder b) {
+    $TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiDeleteTaskResponseApplicationJsonInterface {
   TextProcessingApiDeleteTaskResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiDeleteTaskResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiDeleteTaskResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiDeleteTaskResponseApplicationJson
@@ -11675,11 +13662,25 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson
   /// Serializer for TextProcessingApiDeleteTaskResponseApplicationJson.
   static Serializer<TextProcessingApiDeleteTaskResponseApplicationJson> get serializer =>
       _$textProcessingApiDeleteTaskResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiDeleteTaskResponseApplicationJsonBuilder b) {
+    $TextProcessingApiDeleteTaskResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiDeleteTaskResponseApplicationJsonBuilder b) {
+    $TextProcessingApiDeleteTaskResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TextProcessingTask> get tasks;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data
@@ -11714,12 +13715,26 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data
   /// Serializer for TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data.
   static Serializer<TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data> get serializer =>
       _$textProcessingApiListTasksByAppResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs
@@ -11754,11 +13769,25 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs
   /// Serializer for TextProcessingApiListTasksByAppResponseApplicationJson_Ocs.
   static Serializer<TextProcessingApiListTasksByAppResponseApplicationJson_Ocs> get serializer =>
       _$textProcessingApiListTasksByAppResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder b) {
+    $TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder b) {
+    $TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextProcessingApiListTasksByAppResponseApplicationJsonInterface {
   TextProcessingApiListTasksByAppResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiListTasksByAppResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiListTasksByAppResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TextProcessingApiListTasksByAppResponseApplicationJson
@@ -11793,11 +13822,25 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson
   /// Serializer for TextProcessingApiListTasksByAppResponseApplicationJson.
   static Serializer<TextProcessingApiListTasksByAppResponseApplicationJson> get serializer =>
       _$textProcessingApiListTasksByAppResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiListTasksByAppResponseApplicationJsonBuilder b) {
+    $TextProcessingApiListTasksByAppResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiListTasksByAppResponseApplicationJsonBuilder b) {
+    $TextProcessingApiListTasksByAppResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterface {
   bool get isAvailable;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data
@@ -11832,12 +13875,26 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data
   /// Serializer for TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data.
   static Serializer<TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data> get serializer =>
       _$textToImageApiIsAvailableResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiIsAvailableResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiIsAvailableResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiIsAvailableResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiIsAvailableResponseApplicationJson_Ocs
@@ -11872,11 +13929,25 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson_Ocs
   /// Serializer for TextToImageApiIsAvailableResponseApplicationJson_Ocs.
   static Serializer<TextToImageApiIsAvailableResponseApplicationJson_Ocs> get serializer =>
       _$textToImageApiIsAvailableResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder b) {
+    $TextToImageApiIsAvailableResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder b) {
+    $TextToImageApiIsAvailableResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiIsAvailableResponseApplicationJsonInterface {
   TextToImageApiIsAvailableResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiIsAvailableResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiIsAvailableResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiIsAvailableResponseApplicationJson
@@ -11911,6 +13982,16 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson
   /// Serializer for TextToImageApiIsAvailableResponseApplicationJson.
   static Serializer<TextToImageApiIsAvailableResponseApplicationJson> get serializer =>
       _$textToImageApiIsAvailableResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiIsAvailableResponseApplicationJsonBuilder b) {
+    $TextToImageApiIsAvailableResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiIsAvailableResponseApplicationJsonBuilder b) {
+    $TextToImageApiIsAvailableResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class TextToImageTask_Status extends EnumClass {
@@ -12004,6 +14085,10 @@ abstract interface class $TextToImageTaskInterface {
   String? get identifier;
   int get numberOfImages;
   int? get completionExpectedAt;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageTaskInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageTaskInterfaceBuilder b) {}
 }
 
 abstract class TextToImageTask implements $TextToImageTaskInterface, Built<TextToImageTask, TextToImageTaskBuilder> {
@@ -12030,11 +14115,25 @@ abstract class TextToImageTask implements $TextToImageTaskInterface, Built<TextT
 
   /// Serializer for TextToImageTask.
   static Serializer<TextToImageTask> get serializer => _$textToImageTaskSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageTaskBuilder b) {
+    $TextToImageTaskInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageTaskBuilder b) {
+    $TextToImageTaskInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterface {
   TextToImageTask get task;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiScheduleResponseApplicationJson_Ocs_Data
@@ -12069,12 +14168,26 @@ abstract class TextToImageApiScheduleResponseApplicationJson_Ocs_Data
   /// Serializer for TextToImageApiScheduleResponseApplicationJson_Ocs_Data.
   static Serializer<TextToImageApiScheduleResponseApplicationJson_Ocs_Data> get serializer =>
       _$textToImageApiScheduleResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiScheduleResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextToImageApiScheduleResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiScheduleResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiScheduleResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiScheduleResponseApplicationJson_Ocs
@@ -12109,11 +14222,25 @@ abstract class TextToImageApiScheduleResponseApplicationJson_Ocs
   /// Serializer for TextToImageApiScheduleResponseApplicationJson_Ocs.
   static Serializer<TextToImageApiScheduleResponseApplicationJson_Ocs> get serializer =>
       _$textToImageApiScheduleResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiScheduleResponseApplicationJson_OcsBuilder b) {
+    $TextToImageApiScheduleResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiScheduleResponseApplicationJson_OcsBuilder b) {
+    $TextToImageApiScheduleResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiScheduleResponseApplicationJsonInterface {
   TextToImageApiScheduleResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiScheduleResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiScheduleResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiScheduleResponseApplicationJson
@@ -12147,11 +14274,25 @@ abstract class TextToImageApiScheduleResponseApplicationJson
   /// Serializer for TextToImageApiScheduleResponseApplicationJson.
   static Serializer<TextToImageApiScheduleResponseApplicationJson> get serializer =>
       _$textToImageApiScheduleResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiScheduleResponseApplicationJsonBuilder b) {
+    $TextToImageApiScheduleResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiScheduleResponseApplicationJsonBuilder b) {
+    $TextToImageApiScheduleResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterface {
   TextToImageTask get task;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiGetTaskResponseApplicationJson_Ocs_Data
@@ -12186,12 +14327,26 @@ abstract class TextToImageApiGetTaskResponseApplicationJson_Ocs_Data
   /// Serializer for TextToImageApiGetTaskResponseApplicationJson_Ocs_Data.
   static Serializer<TextToImageApiGetTaskResponseApplicationJson_Ocs_Data> get serializer =>
       _$textToImageApiGetTaskResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiGetTaskResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextToImageApiGetTaskResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiGetTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiGetTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiGetTaskResponseApplicationJson_Ocs
@@ -12226,11 +14381,25 @@ abstract class TextToImageApiGetTaskResponseApplicationJson_Ocs
   /// Serializer for TextToImageApiGetTaskResponseApplicationJson_Ocs.
   static Serializer<TextToImageApiGetTaskResponseApplicationJson_Ocs> get serializer =>
       _$textToImageApiGetTaskResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiGetTaskResponseApplicationJson_OcsBuilder b) {
+    $TextToImageApiGetTaskResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiGetTaskResponseApplicationJson_OcsBuilder b) {
+    $TextToImageApiGetTaskResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiGetTaskResponseApplicationJsonInterface {
   TextToImageApiGetTaskResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiGetTaskResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiGetTaskResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiGetTaskResponseApplicationJson
@@ -12264,11 +14433,25 @@ abstract class TextToImageApiGetTaskResponseApplicationJson
   /// Serializer for TextToImageApiGetTaskResponseApplicationJson.
   static Serializer<TextToImageApiGetTaskResponseApplicationJson> get serializer =>
       _$textToImageApiGetTaskResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiGetTaskResponseApplicationJsonBuilder b) {
+    $TextToImageApiGetTaskResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiGetTaskResponseApplicationJsonBuilder b) {
+    $TextToImageApiGetTaskResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterface {
   TextToImageTask get task;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data
@@ -12303,12 +14486,26 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data
   /// Serializer for TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data.
   static Serializer<TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data> get serializer =>
       _$textToImageApiDeleteTaskResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiDeleteTaskResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiDeleteTaskResponseApplicationJson_Ocs
@@ -12343,11 +14540,25 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson_Ocs
   /// Serializer for TextToImageApiDeleteTaskResponseApplicationJson_Ocs.
   static Serializer<TextToImageApiDeleteTaskResponseApplicationJson_Ocs> get serializer =>
       _$textToImageApiDeleteTaskResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder b) {
+    $TextToImageApiDeleteTaskResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder b) {
+    $TextToImageApiDeleteTaskResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiDeleteTaskResponseApplicationJsonInterface {
   TextToImageApiDeleteTaskResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiDeleteTaskResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiDeleteTaskResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiDeleteTaskResponseApplicationJson
@@ -12381,11 +14592,25 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson
   /// Serializer for TextToImageApiDeleteTaskResponseApplicationJson.
   static Serializer<TextToImageApiDeleteTaskResponseApplicationJson> get serializer =>
       _$textToImageApiDeleteTaskResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiDeleteTaskResponseApplicationJsonBuilder b) {
+    $TextToImageApiDeleteTaskResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiDeleteTaskResponseApplicationJsonBuilder b) {
+    $TextToImageApiDeleteTaskResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TextToImageTask> get tasks;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data
@@ -12420,12 +14645,26 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data
   /// Serializer for TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data.
   static Serializer<TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data> get serializer =>
       _$textToImageApiListTasksByAppResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder b) {
+    $TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiListTasksByAppResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiListTasksByAppResponseApplicationJson_Ocs
@@ -12460,11 +14699,25 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson_Ocs
   /// Serializer for TextToImageApiListTasksByAppResponseApplicationJson_Ocs.
   static Serializer<TextToImageApiListTasksByAppResponseApplicationJson_Ocs> get serializer =>
       _$textToImageApiListTasksByAppResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder b) {
+    $TextToImageApiListTasksByAppResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder b) {
+    $TextToImageApiListTasksByAppResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TextToImageApiListTasksByAppResponseApplicationJsonInterface {
   TextToImageApiListTasksByAppResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiListTasksByAppResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiListTasksByAppResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TextToImageApiListTasksByAppResponseApplicationJson
@@ -12499,6 +14752,16 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson
   /// Serializer for TextToImageApiListTasksByAppResponseApplicationJson.
   static Serializer<TextToImageApiListTasksByAppResponseApplicationJson> get serializer =>
       _$textToImageApiListTasksByAppResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiListTasksByAppResponseApplicationJsonBuilder b) {
+    $TextToImageApiListTasksByAppResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiListTasksByAppResponseApplicationJsonBuilder b) {
+    $TextToImageApiListTasksByAppResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -12507,6 +14770,10 @@ abstract interface class $TranslationApiLanguagesResponseApplicationJson_Ocs_Dat
   String get fromLabel;
   String get to;
   String get toLabel;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesInterfaceBuilder b) {}
 }
 
 abstract class TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages
@@ -12541,12 +14808,26 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages
   /// Serializer for TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages.
   static Serializer<TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages> get serializer =>
       _$translationApiLanguagesResponseApplicationJsonOcsDataLanguagesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesBuilder b) {
+    $TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesBuilder b) {
+    $TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages> get languages;
   bool get languageDetection;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TranslationApiLanguagesResponseApplicationJson_Ocs_Data
@@ -12581,12 +14862,26 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs_Data
   /// Serializer for TranslationApiLanguagesResponseApplicationJson_Ocs_Data.
   static Serializer<TranslationApiLanguagesResponseApplicationJson_Ocs_Data> get serializer =>
       _$translationApiLanguagesResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder b) {
+    $TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder b) {
+    $TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TranslationApiLanguagesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TranslationApiLanguagesResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TranslationApiLanguagesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TranslationApiLanguagesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TranslationApiLanguagesResponseApplicationJson_Ocs
@@ -12621,11 +14916,25 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs
   /// Serializer for TranslationApiLanguagesResponseApplicationJson_Ocs.
   static Serializer<TranslationApiLanguagesResponseApplicationJson_Ocs> get serializer =>
       _$translationApiLanguagesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TranslationApiLanguagesResponseApplicationJson_OcsBuilder b) {
+    $TranslationApiLanguagesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TranslationApiLanguagesResponseApplicationJson_OcsBuilder b) {
+    $TranslationApiLanguagesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TranslationApiLanguagesResponseApplicationJsonInterface {
   TranslationApiLanguagesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TranslationApiLanguagesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TranslationApiLanguagesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TranslationApiLanguagesResponseApplicationJson
@@ -12659,12 +14968,26 @@ abstract class TranslationApiLanguagesResponseApplicationJson
   /// Serializer for TranslationApiLanguagesResponseApplicationJson.
   static Serializer<TranslationApiLanguagesResponseApplicationJson> get serializer =>
       _$translationApiLanguagesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TranslationApiLanguagesResponseApplicationJsonBuilder b) {
+    $TranslationApiLanguagesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TranslationApiLanguagesResponseApplicationJsonBuilder b) {
+    $TranslationApiLanguagesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TranslationApiTranslateResponseApplicationJson_Ocs_DataInterface {
   String get text;
   String? get from;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TranslationApiTranslateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TranslationApiTranslateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TranslationApiTranslateResponseApplicationJson_Ocs_Data
@@ -12699,12 +15022,26 @@ abstract class TranslationApiTranslateResponseApplicationJson_Ocs_Data
   /// Serializer for TranslationApiTranslateResponseApplicationJson_Ocs_Data.
   static Serializer<TranslationApiTranslateResponseApplicationJson_Ocs_Data> get serializer =>
       _$translationApiTranslateResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder b) {
+    $TranslationApiTranslateResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder b) {
+    $TranslationApiTranslateResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TranslationApiTranslateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TranslationApiTranslateResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TranslationApiTranslateResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TranslationApiTranslateResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TranslationApiTranslateResponseApplicationJson_Ocs
@@ -12739,11 +15076,25 @@ abstract class TranslationApiTranslateResponseApplicationJson_Ocs
   /// Serializer for TranslationApiTranslateResponseApplicationJson_Ocs.
   static Serializer<TranslationApiTranslateResponseApplicationJson_Ocs> get serializer =>
       _$translationApiTranslateResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TranslationApiTranslateResponseApplicationJson_OcsBuilder b) {
+    $TranslationApiTranslateResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TranslationApiTranslateResponseApplicationJson_OcsBuilder b) {
+    $TranslationApiTranslateResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TranslationApiTranslateResponseApplicationJsonInterface {
   TranslationApiTranslateResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TranslationApiTranslateResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TranslationApiTranslateResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TranslationApiTranslateResponseApplicationJson
@@ -12777,6 +15128,16 @@ abstract class TranslationApiTranslateResponseApplicationJson
   /// Serializer for TranslationApiTranslateResponseApplicationJson.
   static Serializer<TranslationApiTranslateResponseApplicationJson> get serializer =>
       _$translationApiTranslateResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TranslationApiTranslateResponseApplicationJsonBuilder b) {
+    $TranslationApiTranslateResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TranslationApiTranslateResponseApplicationJsonBuilder b) {
+    $TranslationApiTranslateResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -12789,6 +15150,10 @@ abstract interface class $UnifiedSearchProviderInterface {
   BuiltList<String>? get triggers;
   BuiltMap<String, String>? get filters;
   bool? get inAppSearch;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedSearchProviderInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedSearchProviderInterfaceBuilder b) {}
 }
 
 abstract class UnifiedSearchProvider
@@ -12817,12 +15182,26 @@ abstract class UnifiedSearchProvider
 
   /// Serializer for UnifiedSearchProvider.
   static Serializer<UnifiedSearchProvider> get serializer => _$unifiedSearchProviderSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedSearchProviderBuilder b) {
+    $UnifiedSearchProviderInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UnifiedSearchProviderBuilder b) {
+    $UnifiedSearchProviderInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UnifiedSearchGetProvidersResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<UnifiedSearchProvider> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedSearchGetProvidersResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedSearchGetProvidersResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UnifiedSearchGetProvidersResponseApplicationJson_Ocs
@@ -12857,11 +15236,25 @@ abstract class UnifiedSearchGetProvidersResponseApplicationJson_Ocs
   /// Serializer for UnifiedSearchGetProvidersResponseApplicationJson_Ocs.
   static Serializer<UnifiedSearchGetProvidersResponseApplicationJson_Ocs> get serializer =>
       _$unifiedSearchGetProvidersResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder b) {
+    $UnifiedSearchGetProvidersResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder b) {
+    $UnifiedSearchGetProvidersResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UnifiedSearchGetProvidersResponseApplicationJsonInterface {
   UnifiedSearchGetProvidersResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedSearchGetProvidersResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedSearchGetProvidersResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UnifiedSearchGetProvidersResponseApplicationJson
@@ -12896,6 +15289,16 @@ abstract class UnifiedSearchGetProvidersResponseApplicationJson
   /// Serializer for UnifiedSearchGetProvidersResponseApplicationJson.
   static Serializer<UnifiedSearchGetProvidersResponseApplicationJson> get serializer =>
       _$unifiedSearchGetProvidersResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedSearchGetProvidersResponseApplicationJsonBuilder b) {
+    $UnifiedSearchGetProvidersResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UnifiedSearchGetProvidersResponseApplicationJsonBuilder b) {
+    $UnifiedSearchGetProvidersResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 typedef UnifiedSearchSearchCursor = ({int? $int, String? string});
@@ -12909,6 +15312,10 @@ abstract interface class $UnifiedSearchResultEntryInterface {
   String get icon;
   bool get rounded;
   BuiltList<String> get attributes;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedSearchResultEntryInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedSearchResultEntryInterfaceBuilder b) {}
 }
 
 abstract class UnifiedSearchResultEntry
@@ -12937,6 +15344,16 @@ abstract class UnifiedSearchResultEntry
 
   /// Serializer for UnifiedSearchResultEntry.
   static Serializer<UnifiedSearchResultEntry> get serializer => _$unifiedSearchResultEntrySerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedSearchResultEntryBuilder b) {
+    $UnifiedSearchResultEntryInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UnifiedSearchResultEntryBuilder b) {
+    $UnifiedSearchResultEntryInterface._validate(b);
+  }
 }
 
 typedef UnifiedSearchResult_Cursor = ({int? $int, String? string});
@@ -12947,6 +15364,12 @@ abstract interface class $UnifiedSearchResultInterface {
   bool get isPaginated;
   BuiltList<UnifiedSearchResultEntry> get entries;
   UnifiedSearchResult_Cursor? get cursor;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedSearchResultInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedSearchResultInterfaceBuilder b) {
+    b.cursor?.validateOneOf();
+  }
 }
 
 abstract class UnifiedSearchResult
@@ -12976,9 +15399,14 @@ abstract class UnifiedSearchResult
   /// Serializer for UnifiedSearchResult.
   static Serializer<UnifiedSearchResult> get serializer => _$unifiedSearchResultSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedSearchResultBuilder b) {
+    $UnifiedSearchResultInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UnifiedSearchResultBuilder b) {
-    b.cursor?.validateOneOf();
+    $UnifiedSearchResultInterface._validate(b);
   }
 }
 
@@ -12986,6 +15414,10 @@ abstract class UnifiedSearchResult
 abstract interface class $UnifiedSearchSearchResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UnifiedSearchResult get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedSearchSearchResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedSearchSearchResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UnifiedSearchSearchResponseApplicationJson_Ocs
@@ -13019,11 +15451,25 @@ abstract class UnifiedSearchSearchResponseApplicationJson_Ocs
   /// Serializer for UnifiedSearchSearchResponseApplicationJson_Ocs.
   static Serializer<UnifiedSearchSearchResponseApplicationJson_Ocs> get serializer =>
       _$unifiedSearchSearchResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedSearchSearchResponseApplicationJson_OcsBuilder b) {
+    $UnifiedSearchSearchResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UnifiedSearchSearchResponseApplicationJson_OcsBuilder b) {
+    $UnifiedSearchSearchResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UnifiedSearchSearchResponseApplicationJsonInterface {
   UnifiedSearchSearchResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedSearchSearchResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedSearchSearchResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UnifiedSearchSearchResponseApplicationJson
@@ -13057,12 +15503,26 @@ abstract class UnifiedSearchSearchResponseApplicationJson
   /// Serializer for UnifiedSearchSearchResponseApplicationJson.
   static Serializer<UnifiedSearchSearchResponseApplicationJson> get serializer =>
       _$unifiedSearchSearchResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedSearchSearchResponseApplicationJsonBuilder b) {
+    $UnifiedSearchSearchResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UnifiedSearchSearchResponseApplicationJsonBuilder b) {
+    $UnifiedSearchSearchResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterface {
   BuiltList<String> get regular;
   BuiltList<String> get admin;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder b) {}
 }
 
 abstract class WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew
@@ -13097,6 +15557,16 @@ abstract class WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew
   /// Serializer for WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew.
   static Serializer<WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew> get serializer =>
       _$whatsNewGetResponseApplicationJsonOcsDataWhatsNewSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder b) {
+    $WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder b) {
+    $WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -13105,6 +15575,10 @@ abstract interface class $WhatsNewGetResponseApplicationJson_Ocs_DataInterface {
   String get product;
   String get version;
   WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew? get whatsNew;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WhatsNewGetResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WhatsNewGetResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class WhatsNewGetResponseApplicationJson_Ocs_Data
@@ -13138,12 +15612,26 @@ abstract class WhatsNewGetResponseApplicationJson_Ocs_Data
   /// Serializer for WhatsNewGetResponseApplicationJson_Ocs_Data.
   static Serializer<WhatsNewGetResponseApplicationJson_Ocs_Data> get serializer =>
       _$whatsNewGetResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WhatsNewGetResponseApplicationJson_Ocs_DataBuilder b) {
+    $WhatsNewGetResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WhatsNewGetResponseApplicationJson_Ocs_DataBuilder b) {
+    $WhatsNewGetResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WhatsNewGetResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   WhatsNewGetResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WhatsNewGetResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WhatsNewGetResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class WhatsNewGetResponseApplicationJson_Ocs
@@ -13176,11 +15664,25 @@ abstract class WhatsNewGetResponseApplicationJson_Ocs
   /// Serializer for WhatsNewGetResponseApplicationJson_Ocs.
   static Serializer<WhatsNewGetResponseApplicationJson_Ocs> get serializer =>
       _$whatsNewGetResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WhatsNewGetResponseApplicationJson_OcsBuilder b) {
+    $WhatsNewGetResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WhatsNewGetResponseApplicationJson_OcsBuilder b) {
+    $WhatsNewGetResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WhatsNewGetResponseApplicationJsonInterface {
   WhatsNewGetResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WhatsNewGetResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WhatsNewGetResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class WhatsNewGetResponseApplicationJson
@@ -13213,12 +15715,26 @@ abstract class WhatsNewGetResponseApplicationJson
   /// Serializer for WhatsNewGetResponseApplicationJson.
   static Serializer<WhatsNewGetResponseApplicationJson> get serializer =>
       _$whatsNewGetResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WhatsNewGetResponseApplicationJsonBuilder b) {
+    $WhatsNewGetResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WhatsNewGetResponseApplicationJsonBuilder b) {
+    $WhatsNewGetResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WhatsNewDismissResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WhatsNewDismissResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WhatsNewDismissResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class WhatsNewDismissResponseApplicationJson_Ocs
@@ -13252,11 +15768,25 @@ abstract class WhatsNewDismissResponseApplicationJson_Ocs
   /// Serializer for WhatsNewDismissResponseApplicationJson_Ocs.
   static Serializer<WhatsNewDismissResponseApplicationJson_Ocs> get serializer =>
       _$whatsNewDismissResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WhatsNewDismissResponseApplicationJson_OcsBuilder b) {
+    $WhatsNewDismissResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WhatsNewDismissResponseApplicationJson_OcsBuilder b) {
+    $WhatsNewDismissResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WhatsNewDismissResponseApplicationJsonInterface {
   WhatsNewDismissResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WhatsNewDismissResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WhatsNewDismissResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class WhatsNewDismissResponseApplicationJson
@@ -13289,11 +15819,25 @@ abstract class WhatsNewDismissResponseApplicationJson
   /// Serializer for WhatsNewDismissResponseApplicationJson.
   static Serializer<WhatsNewDismissResponseApplicationJson> get serializer =>
       _$whatsNewDismissResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WhatsNewDismissResponseApplicationJsonBuilder b) {
+    $WhatsNewDismissResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WhatsNewDismissResponseApplicationJsonBuilder b) {
+    $WhatsNewDismissResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WipeCheckWipeResponseApplicationJsonInterface {
   bool get wipe;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WipeCheckWipeResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WipeCheckWipeResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class WipeCheckWipeResponseApplicationJson
@@ -13326,6 +15870,16 @@ abstract class WipeCheckWipeResponseApplicationJson
   /// Serializer for WipeCheckWipeResponseApplicationJson.
   static Serializer<WipeCheckWipeResponseApplicationJson> get serializer =>
       _$wipeCheckWipeResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WipeCheckWipeResponseApplicationJsonBuilder b) {
+    $WipeCheckWipeResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WipeCheckWipeResponseApplicationJsonBuilder b) {
+    $WipeCheckWipeResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 /// Serialization extension for `AutocompleteResult_Status`.

--- a/packages/nextcloud/lib/src/api/core.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.g.dart
@@ -10188,7 +10188,9 @@ class StatusBuilder implements Builder<Status, StatusBuilder>, $StatusInterfaceB
   bool? get extendedSupport => _$this._extendedSupport;
   set extendedSupport(covariant bool? extendedSupport) => _$this._extendedSupport = extendedSupport;
 
-  StatusBuilder();
+  StatusBuilder() {
+    Status._defaults(this);
+  }
 
   StatusBuilder get _$this {
     final $v = _$v;
@@ -10221,6 +10223,7 @@ class StatusBuilder implements Builder<Status, StatusBuilder>, $StatusInterfaceB
   Status build() => _build();
 
   _$Status _build() {
+    Status._validate(this);
     final _$result = _$v ??
         _$Status._(
             installed: BuiltValueNullFieldError.checkNotNull(installed, r'Status', 'installed'),
@@ -10339,7 +10342,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -10369,6 +10374,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -10444,7 +10450,9 @@ class AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder
   String? get apppassword => _$this._apppassword;
   set apppassword(covariant String? apppassword) => _$this._apppassword = apppassword;
 
-  AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder();
+  AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder() {
+    AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -10470,6 +10478,7 @@ class AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder
   AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data build() => _build();
 
   _$AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data _build() {
+    AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data._(
             apppassword: BuiltValueNullFieldError.checkNotNull(
@@ -10554,7 +10563,9 @@ class AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder
       _$this._data ??= AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder();
+  AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder() {
+    AppPasswordGetAppPasswordResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -10581,6 +10592,7 @@ class AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder
   AppPasswordGetAppPasswordResponseApplicationJson_Ocs build() => _build();
 
   _$AppPasswordGetAppPasswordResponseApplicationJson_Ocs _build() {
+    AppPasswordGetAppPasswordResponseApplicationJson_Ocs._validate(this);
     _$AppPasswordGetAppPasswordResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -10664,7 +10676,9 @@ class AppPasswordGetAppPasswordResponseApplicationJsonBuilder
       _$this._ocs ??= AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder();
   set ocs(covariant AppPasswordGetAppPasswordResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AppPasswordGetAppPasswordResponseApplicationJsonBuilder();
+  AppPasswordGetAppPasswordResponseApplicationJsonBuilder() {
+    AppPasswordGetAppPasswordResponseApplicationJson._defaults(this);
+  }
 
   AppPasswordGetAppPasswordResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -10690,6 +10704,7 @@ class AppPasswordGetAppPasswordResponseApplicationJsonBuilder
   AppPasswordGetAppPasswordResponseApplicationJson build() => _build();
 
   _$AppPasswordGetAppPasswordResponseApplicationJson _build() {
+    AppPasswordGetAppPasswordResponseApplicationJson._validate(this);
     _$AppPasswordGetAppPasswordResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AppPasswordGetAppPasswordResponseApplicationJson._(ocs: ocs.build());
@@ -10772,7 +10787,9 @@ class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder
   String? get apppassword => _$this._apppassword;
   set apppassword(covariant String? apppassword) => _$this._apppassword = apppassword;
 
-  AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder();
+  AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder() {
+    AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -10798,6 +10815,7 @@ class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder
   AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data build() => _build();
 
   _$AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data _build() {
+    AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data._(
             apppassword: BuiltValueNullFieldError.checkNotNull(
@@ -10882,7 +10900,9 @@ class AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder
       _$this._data ??= AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder();
+  AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder() {
+    AppPasswordRotateAppPasswordResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -10909,6 +10929,7 @@ class AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder
   AppPasswordRotateAppPasswordResponseApplicationJson_Ocs build() => _build();
 
   _$AppPasswordRotateAppPasswordResponseApplicationJson_Ocs _build() {
+    AppPasswordRotateAppPasswordResponseApplicationJson_Ocs._validate(this);
     _$AppPasswordRotateAppPasswordResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -10993,7 +11014,9 @@ class AppPasswordRotateAppPasswordResponseApplicationJsonBuilder
       _$this._ocs ??= AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder();
   set ocs(covariant AppPasswordRotateAppPasswordResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AppPasswordRotateAppPasswordResponseApplicationJsonBuilder();
+  AppPasswordRotateAppPasswordResponseApplicationJsonBuilder() {
+    AppPasswordRotateAppPasswordResponseApplicationJson._defaults(this);
+  }
 
   AppPasswordRotateAppPasswordResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -11019,6 +11042,7 @@ class AppPasswordRotateAppPasswordResponseApplicationJsonBuilder
   AppPasswordRotateAppPasswordResponseApplicationJson build() => _build();
 
   _$AppPasswordRotateAppPasswordResponseApplicationJson _build() {
+    AppPasswordRotateAppPasswordResponseApplicationJson._validate(this);
     _$AppPasswordRotateAppPasswordResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AppPasswordRotateAppPasswordResponseApplicationJson._(ocs: ocs.build());
@@ -11112,7 +11136,9 @@ class AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder();
+  AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder() {
+    AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -11139,6 +11165,7 @@ class AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder
   AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs build() => _build();
 
   _$AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs _build() {
+    AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs._validate(this);
     _$AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -11224,7 +11251,9 @@ class AppPasswordDeleteAppPasswordResponseApplicationJsonBuilder
       _$this._ocs ??= AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder();
   set ocs(covariant AppPasswordDeleteAppPasswordResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AppPasswordDeleteAppPasswordResponseApplicationJsonBuilder();
+  AppPasswordDeleteAppPasswordResponseApplicationJsonBuilder() {
+    AppPasswordDeleteAppPasswordResponseApplicationJson._defaults(this);
+  }
 
   AppPasswordDeleteAppPasswordResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -11250,6 +11279,7 @@ class AppPasswordDeleteAppPasswordResponseApplicationJsonBuilder
   AppPasswordDeleteAppPasswordResponseApplicationJson build() => _build();
 
   _$AppPasswordDeleteAppPasswordResponseApplicationJson _build() {
+    AppPasswordDeleteAppPasswordResponseApplicationJson._validate(this);
     _$AppPasswordDeleteAppPasswordResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AppPasswordDeleteAppPasswordResponseApplicationJson._(ocs: ocs.build());
@@ -11363,7 +11393,9 @@ class AutocompleteResult_Status0Builder
   int? get clearAt => _$this._clearAt;
   set clearAt(covariant int? clearAt) => _$this._clearAt = clearAt;
 
-  AutocompleteResult_Status0Builder();
+  AutocompleteResult_Status0Builder() {
+    AutocompleteResult_Status0._defaults(this);
+  }
 
   AutocompleteResult_Status0Builder get _$this {
     final $v = _$v;
@@ -11392,6 +11424,7 @@ class AutocompleteResult_Status0Builder
   AutocompleteResult_Status0 build() => _build();
 
   _$AutocompleteResult_Status0 _build() {
+    AutocompleteResult_Status0._validate(this);
     final _$result = _$v ??
         _$AutocompleteResult_Status0._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'AutocompleteResult_Status0', 'status'),
@@ -11548,7 +11581,9 @@ class AutocompleteResultBuilder
   set shareWithDisplayNameUnique(covariant String? shareWithDisplayNameUnique) =>
       _$this._shareWithDisplayNameUnique = shareWithDisplayNameUnique;
 
-  AutocompleteResultBuilder();
+  AutocompleteResultBuilder() {
+    AutocompleteResult._defaults(this);
+  }
 
   AutocompleteResultBuilder get _$this {
     final $v = _$v;
@@ -11668,7 +11703,9 @@ class AutoCompleteGetResponseApplicationJson_OcsBuilder
   ListBuilder<AutocompleteResult> get data => _$this._data ??= ListBuilder<AutocompleteResult>();
   set data(covariant ListBuilder<AutocompleteResult>? data) => _$this._data = data;
 
-  AutoCompleteGetResponseApplicationJson_OcsBuilder();
+  AutoCompleteGetResponseApplicationJson_OcsBuilder() {
+    AutoCompleteGetResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AutoCompleteGetResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -11695,6 +11732,7 @@ class AutoCompleteGetResponseApplicationJson_OcsBuilder
   AutoCompleteGetResponseApplicationJson_Ocs build() => _build();
 
   _$AutoCompleteGetResponseApplicationJson_Ocs _build() {
+    AutoCompleteGetResponseApplicationJson_Ocs._validate(this);
     _$AutoCompleteGetResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$AutoCompleteGetResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -11774,7 +11812,9 @@ class AutoCompleteGetResponseApplicationJsonBuilder
       _$this._ocs ??= AutoCompleteGetResponseApplicationJson_OcsBuilder();
   set ocs(covariant AutoCompleteGetResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AutoCompleteGetResponseApplicationJsonBuilder();
+  AutoCompleteGetResponseApplicationJsonBuilder() {
+    AutoCompleteGetResponseApplicationJson._defaults(this);
+  }
 
   AutoCompleteGetResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -11800,6 +11840,7 @@ class AutoCompleteGetResponseApplicationJsonBuilder
   AutoCompleteGetResponseApplicationJson build() => _build();
 
   _$AutoCompleteGetResponseApplicationJson _build() {
+    AutoCompleteGetResponseApplicationJson._validate(this);
     _$AutoCompleteGetResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AutoCompleteGetResponseApplicationJson._(ocs: ocs.build());
@@ -11874,7 +11915,9 @@ class AvatarAvatarGetAvatarDarkHeadersBuilder
   set xNcIscustomavatar(covariant HeaderBuilder<int>? xNcIscustomavatar) =>
       _$this._xNcIscustomavatar = xNcIscustomavatar;
 
-  AvatarAvatarGetAvatarDarkHeadersBuilder();
+  AvatarAvatarGetAvatarDarkHeadersBuilder() {
+    AvatarAvatarGetAvatarDarkHeaders._defaults(this);
+  }
 
   AvatarAvatarGetAvatarDarkHeadersBuilder get _$this {
     final $v = _$v;
@@ -11900,6 +11943,7 @@ class AvatarAvatarGetAvatarDarkHeadersBuilder
   AvatarAvatarGetAvatarDarkHeaders build() => _build();
 
   _$AvatarAvatarGetAvatarDarkHeaders _build() {
+    AvatarAvatarGetAvatarDarkHeaders._validate(this);
     _$AvatarAvatarGetAvatarDarkHeaders _$result;
     try {
       _$result = _$v ?? _$AvatarAvatarGetAvatarDarkHeaders._(xNcIscustomavatar: _xNcIscustomavatar?.build());
@@ -11973,7 +12017,9 @@ class AvatarAvatarGetAvatarHeadersBuilder
   set xNcIscustomavatar(covariant HeaderBuilder<int>? xNcIscustomavatar) =>
       _$this._xNcIscustomavatar = xNcIscustomavatar;
 
-  AvatarAvatarGetAvatarHeadersBuilder();
+  AvatarAvatarGetAvatarHeadersBuilder() {
+    AvatarAvatarGetAvatarHeaders._defaults(this);
+  }
 
   AvatarAvatarGetAvatarHeadersBuilder get _$this {
     final $v = _$v;
@@ -11999,6 +12045,7 @@ class AvatarAvatarGetAvatarHeadersBuilder
   AvatarAvatarGetAvatarHeaders build() => _build();
 
   _$AvatarAvatarGetAvatarHeaders _build() {
+    AvatarAvatarGetAvatarHeaders._validate(this);
     _$AvatarAvatarGetAvatarHeaders _$result;
     try {
       _$result = _$v ?? _$AvatarAvatarGetAvatarHeaders._(xNcIscustomavatar: _xNcIscustomavatar?.build());
@@ -12099,7 +12146,9 @@ class LoginFlowV2CredentialsBuilder
   String? get appPassword => _$this._appPassword;
   set appPassword(covariant String? appPassword) => _$this._appPassword = appPassword;
 
-  LoginFlowV2CredentialsBuilder();
+  LoginFlowV2CredentialsBuilder() {
+    LoginFlowV2Credentials._defaults(this);
+  }
 
   LoginFlowV2CredentialsBuilder get _$this {
     final $v = _$v;
@@ -12127,6 +12176,7 @@ class LoginFlowV2CredentialsBuilder
   LoginFlowV2Credentials build() => _build();
 
   _$LoginFlowV2Credentials _build() {
+    LoginFlowV2Credentials._validate(this);
     final _$result = _$v ??
         _$LoginFlowV2Credentials._(
             server: BuiltValueNullFieldError.checkNotNull(server, r'LoginFlowV2Credentials', 'server'),
@@ -12203,7 +12253,9 @@ class LoginFlowV2_PollBuilder
   String? get endpoint => _$this._endpoint;
   set endpoint(covariant String? endpoint) => _$this._endpoint = endpoint;
 
-  LoginFlowV2_PollBuilder();
+  LoginFlowV2_PollBuilder() {
+    LoginFlowV2_Poll._defaults(this);
+  }
 
   LoginFlowV2_PollBuilder get _$this {
     final $v = _$v;
@@ -12230,6 +12282,7 @@ class LoginFlowV2_PollBuilder
   LoginFlowV2_Poll build() => _build();
 
   _$LoginFlowV2_Poll _build() {
+    LoginFlowV2_Poll._validate(this);
     final _$result = _$v ??
         _$LoginFlowV2_Poll._(
             token: BuiltValueNullFieldError.checkNotNull(token, r'LoginFlowV2_Poll', 'token'),
@@ -12304,7 +12357,9 @@ class LoginFlowV2Builder implements Builder<LoginFlowV2, LoginFlowV2Builder>, $L
   String? get login => _$this._login;
   set login(covariant String? login) => _$this._login = login;
 
-  LoginFlowV2Builder();
+  LoginFlowV2Builder() {
+    LoginFlowV2._defaults(this);
+  }
 
   LoginFlowV2Builder get _$this {
     final $v = _$v;
@@ -12331,6 +12386,7 @@ class LoginFlowV2Builder implements Builder<LoginFlowV2, LoginFlowV2Builder>, $L
   LoginFlowV2 build() => _build();
 
   _$LoginFlowV2 _build() {
+    LoginFlowV2._validate(this);
     _$LoginFlowV2 _$result;
     try {
       _$result = _$v ??
@@ -12457,7 +12513,9 @@ class OpenGraphObjectBuilder
   String? get link => _$this._link;
   set link(covariant String? link) => _$this._link = link;
 
-  OpenGraphObjectBuilder();
+  OpenGraphObjectBuilder() {
+    OpenGraphObject._defaults(this);
+  }
 
   OpenGraphObjectBuilder get _$this {
     final $v = _$v;
@@ -12487,6 +12545,7 @@ class OpenGraphObjectBuilder
   OpenGraphObject build() => _build();
 
   _$OpenGraphObject _build() {
+    OpenGraphObject._validate(this);
     final _$result = _$v ??
         _$OpenGraphObject._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'OpenGraphObject', 'id'),
@@ -12593,7 +12652,9 @@ class ResourceBuilder implements Builder<Resource, ResourceBuilder>, $ResourceIn
   bool? get accessible => _$this._accessible;
   set accessible(covariant bool? accessible) => _$this._accessible = accessible;
 
-  ResourceBuilder();
+  ResourceBuilder() {
+    Resource._defaults(this);
+  }
 
   ResourceBuilder get _$this {
     final $v = _$v;
@@ -12622,6 +12683,7 @@ class ResourceBuilder implements Builder<Resource, ResourceBuilder>, $ResourceIn
   Resource build() => _build();
 
   _$Resource _build() {
+    Resource._validate(this);
     _$Resource _$result;
     try {
       _$result = _$v ??
@@ -12723,7 +12785,9 @@ class CollectionBuilder implements Builder<Collection, CollectionBuilder>, $Coll
   ListBuilder<Resource> get resources => _$this._resources ??= ListBuilder<Resource>();
   set resources(covariant ListBuilder<Resource>? resources) => _$this._resources = resources;
 
-  CollectionBuilder();
+  CollectionBuilder() {
+    Collection._defaults(this);
+  }
 
   CollectionBuilder get _$this {
     final $v = _$v;
@@ -12751,6 +12815,7 @@ class CollectionBuilder implements Builder<Collection, CollectionBuilder>, $Coll
   Collection build() => _build();
 
   _$Collection _build() {
+    Collection._validate(this);
     _$Collection _$result;
     try {
       _$result = _$v ??
@@ -12853,7 +12918,9 @@ class CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder
   ListBuilder<Collection> get data => _$this._data ??= ListBuilder<Collection>();
   set data(covariant ListBuilder<Collection>? data) => _$this._data = data;
 
-  CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder();
+  CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder() {
+    CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -12880,6 +12947,7 @@ class CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder
   CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs build() => _build();
 
   _$CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs _build() {
+    CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs._validate(this);
     _$CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -12968,7 +13036,9 @@ class CollaborationResourcesSearchCollectionsResponseApplicationJsonBuilder
   set ocs(covariant CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsBuilder? ocs) =>
       _$this._ocs = ocs;
 
-  CollaborationResourcesSearchCollectionsResponseApplicationJsonBuilder();
+  CollaborationResourcesSearchCollectionsResponseApplicationJsonBuilder() {
+    CollaborationResourcesSearchCollectionsResponseApplicationJson._defaults(this);
+  }
 
   CollaborationResourcesSearchCollectionsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -12994,6 +13064,7 @@ class CollaborationResourcesSearchCollectionsResponseApplicationJsonBuilder
   CollaborationResourcesSearchCollectionsResponseApplicationJson build() => _build();
 
   _$CollaborationResourcesSearchCollectionsResponseApplicationJson _build() {
+    CollaborationResourcesSearchCollectionsResponseApplicationJson._validate(this);
     _$CollaborationResourcesSearchCollectionsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CollaborationResourcesSearchCollectionsResponseApplicationJson._(ocs: ocs.build());
@@ -13092,7 +13163,9 @@ class CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder
   CollectionBuilder get data => _$this._data ??= CollectionBuilder();
   set data(covariant CollectionBuilder? data) => _$this._data = data;
 
-  CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder();
+  CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder() {
+    CollaborationResourcesListCollectionResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -13119,6 +13192,7 @@ class CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder
   CollaborationResourcesListCollectionResponseApplicationJson_Ocs build() => _build();
 
   _$CollaborationResourcesListCollectionResponseApplicationJson_Ocs _build() {
+    CollaborationResourcesListCollectionResponseApplicationJson_Ocs._validate(this);
     _$CollaborationResourcesListCollectionResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -13204,7 +13278,9 @@ class CollaborationResourcesListCollectionResponseApplicationJsonBuilder
       _$this._ocs ??= CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder();
   set ocs(covariant CollaborationResourcesListCollectionResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CollaborationResourcesListCollectionResponseApplicationJsonBuilder();
+  CollaborationResourcesListCollectionResponseApplicationJsonBuilder() {
+    CollaborationResourcesListCollectionResponseApplicationJson._defaults(this);
+  }
 
   CollaborationResourcesListCollectionResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -13230,6 +13306,7 @@ class CollaborationResourcesListCollectionResponseApplicationJsonBuilder
   CollaborationResourcesListCollectionResponseApplicationJson build() => _build();
 
   _$CollaborationResourcesListCollectionResponseApplicationJson _build() {
+    CollaborationResourcesListCollectionResponseApplicationJson._validate(this);
     _$CollaborationResourcesListCollectionResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CollaborationResourcesListCollectionResponseApplicationJson._(ocs: ocs.build());
@@ -13329,7 +13406,9 @@ class CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder
   CollectionBuilder get data => _$this._data ??= CollectionBuilder();
   set data(covariant CollectionBuilder? data) => _$this._data = data;
 
-  CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder();
+  CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder() {
+    CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -13356,6 +13435,7 @@ class CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder
   CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs build() => _build();
 
   _$CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs _build() {
+    CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs._validate(this);
     _$CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -13441,7 +13521,9 @@ class CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder
       _$this._ocs ??= CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder();
   set ocs(covariant CollaborationResourcesRenameCollectionResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder();
+  CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder() {
+    CollaborationResourcesRenameCollectionResponseApplicationJson._defaults(this);
+  }
 
   CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -13467,6 +13549,7 @@ class CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder
   CollaborationResourcesRenameCollectionResponseApplicationJson build() => _build();
 
   _$CollaborationResourcesRenameCollectionResponseApplicationJson _build() {
+    CollaborationResourcesRenameCollectionResponseApplicationJson._validate(this);
     _$CollaborationResourcesRenameCollectionResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CollaborationResourcesRenameCollectionResponseApplicationJson._(ocs: ocs.build());
@@ -13565,7 +13648,9 @@ class CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder
   CollectionBuilder get data => _$this._data ??= CollectionBuilder();
   set data(covariant CollectionBuilder? data) => _$this._data = data;
 
-  CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder();
+  CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder() {
+    CollaborationResourcesAddResourceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -13592,6 +13677,7 @@ class CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder
   CollaborationResourcesAddResourceResponseApplicationJson_Ocs build() => _build();
 
   _$CollaborationResourcesAddResourceResponseApplicationJson_Ocs _build() {
+    CollaborationResourcesAddResourceResponseApplicationJson_Ocs._validate(this);
     _$CollaborationResourcesAddResourceResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -13676,7 +13762,9 @@ class CollaborationResourcesAddResourceResponseApplicationJsonBuilder
       _$this._ocs ??= CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder();
   set ocs(covariant CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CollaborationResourcesAddResourceResponseApplicationJsonBuilder();
+  CollaborationResourcesAddResourceResponseApplicationJsonBuilder() {
+    CollaborationResourcesAddResourceResponseApplicationJson._defaults(this);
+  }
 
   CollaborationResourcesAddResourceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -13702,6 +13790,7 @@ class CollaborationResourcesAddResourceResponseApplicationJsonBuilder
   CollaborationResourcesAddResourceResponseApplicationJson build() => _build();
 
   _$CollaborationResourcesAddResourceResponseApplicationJson _build() {
+    CollaborationResourcesAddResourceResponseApplicationJson._validate(this);
     _$CollaborationResourcesAddResourceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CollaborationResourcesAddResourceResponseApplicationJson._(ocs: ocs.build());
@@ -13800,7 +13889,9 @@ class CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder
   CollectionBuilder get data => _$this._data ??= CollectionBuilder();
   set data(covariant CollectionBuilder? data) => _$this._data = data;
 
-  CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder();
+  CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder() {
+    CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -13827,6 +13918,7 @@ class CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder
   CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs build() => _build();
 
   _$CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs _build() {
+    CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs._validate(this);
     _$CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -13912,7 +14004,9 @@ class CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder
       _$this._ocs ??= CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder();
   set ocs(covariant CollaborationResourcesRemoveResourceResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder();
+  CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder() {
+    CollaborationResourcesRemoveResourceResponseApplicationJson._defaults(this);
+  }
 
   CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -13938,6 +14032,7 @@ class CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder
   CollaborationResourcesRemoveResourceResponseApplicationJson build() => _build();
 
   _$CollaborationResourcesRemoveResourceResponseApplicationJson _build() {
+    CollaborationResourcesRemoveResourceResponseApplicationJson._validate(this);
     _$CollaborationResourcesRemoveResourceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CollaborationResourcesRemoveResourceResponseApplicationJson._(ocs: ocs.build());
@@ -14039,7 +14134,9 @@ class CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsB
   ListBuilder<Collection> get data => _$this._data ??= ListBuilder<Collection>();
   set data(covariant ListBuilder<Collection>? data) => _$this._data = data;
 
-  CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsBuilder();
+  CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsBuilder() {
+    CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -14067,6 +14164,7 @@ class CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsB
   CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs build() => _build();
 
   _$CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs _build() {
+    CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs._validate(this);
     _$CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -14156,7 +14254,9 @@ class CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuild
   set ocs(covariant CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsBuilder? ocs) =>
       _$this._ocs = ocs;
 
-  CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuilder();
+  CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuilder() {
+    CollaborationResourcesGetCollectionsByResourceResponseApplicationJson._defaults(this);
+  }
 
   CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -14182,6 +14282,7 @@ class CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuild
   CollaborationResourcesGetCollectionsByResourceResponseApplicationJson build() => _build();
 
   _$CollaborationResourcesGetCollectionsByResourceResponseApplicationJson _build() {
+    CollaborationResourcesGetCollectionsByResourceResponseApplicationJson._validate(this);
     _$CollaborationResourcesGetCollectionsByResourceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CollaborationResourcesGetCollectionsByResourceResponseApplicationJson._(ocs: ocs.build());
@@ -14284,7 +14385,9 @@ class CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Oc
   CollectionBuilder get data => _$this._data ??= CollectionBuilder();
   set data(covariant CollectionBuilder? data) => _$this._data = data;
 
-  CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder();
+  CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder() {
+    CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -14312,6 +14415,7 @@ class CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Oc
   CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs build() => _build();
 
   _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs _build() {
+    CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs._validate(this);
     _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -14401,7 +14505,9 @@ class CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBui
   set ocs(covariant CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder? ocs) =>
       _$this._ocs = ocs;
 
-  CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBuilder();
+  CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBuilder() {
+    CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson._defaults(this);
+  }
 
   CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -14427,6 +14533,7 @@ class CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBui
   CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson build() => _build();
 
   _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson _build() {
+    CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson._validate(this);
     _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson._(ocs: ocs.build());
@@ -14540,7 +14647,9 @@ class ContactsActionBuilder implements Builder<ContactsAction, ContactsActionBui
   String? get appId => _$this._appId;
   set appId(covariant String? appId) => _$this._appId = appId;
 
-  ContactsActionBuilder();
+  ContactsActionBuilder() {
+    ContactsAction._defaults(this);
+  }
 
   ContactsActionBuilder get _$this {
     final $v = _$v;
@@ -14569,6 +14678,7 @@ class ContactsActionBuilder implements Builder<ContactsAction, ContactsActionBui
   ContactsAction build() => _build();
 
   _$ContactsAction _build() {
+    ContactsAction._validate(this);
     final _$result = _$v ??
         _$ContactsAction._(
             title: BuiltValueNullFieldError.checkNotNull(title, r'ContactsAction', 'title'),
@@ -14671,7 +14781,9 @@ class HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<ContactsAction> get actions => _$this._actions ??= ListBuilder<ContactsAction>();
   set actions(covariant ListBuilder<ContactsAction>? actions) => _$this._actions = actions;
 
-  HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder();
+  HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder() {
+    HoverCardGetUserResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -14699,6 +14811,7 @@ class HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder
   HoverCardGetUserResponseApplicationJson_Ocs_Data build() => _build();
 
   _$HoverCardGetUserResponseApplicationJson_Ocs_Data _build() {
+    HoverCardGetUserResponseApplicationJson_Ocs_Data._validate(this);
     _$HoverCardGetUserResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ??
@@ -14797,7 +14910,9 @@ class HoverCardGetUserResponseApplicationJson_OcsBuilder
       _$this._data ??= HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant HoverCardGetUserResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  HoverCardGetUserResponseApplicationJson_OcsBuilder();
+  HoverCardGetUserResponseApplicationJson_OcsBuilder() {
+    HoverCardGetUserResponseApplicationJson_Ocs._defaults(this);
+  }
 
   HoverCardGetUserResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -14824,6 +14939,7 @@ class HoverCardGetUserResponseApplicationJson_OcsBuilder
   HoverCardGetUserResponseApplicationJson_Ocs build() => _build();
 
   _$HoverCardGetUserResponseApplicationJson_Ocs _build() {
+    HoverCardGetUserResponseApplicationJson_Ocs._validate(this);
     _$HoverCardGetUserResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$HoverCardGetUserResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -14903,7 +15019,9 @@ class HoverCardGetUserResponseApplicationJsonBuilder
       _$this._ocs ??= HoverCardGetUserResponseApplicationJson_OcsBuilder();
   set ocs(covariant HoverCardGetUserResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  HoverCardGetUserResponseApplicationJsonBuilder();
+  HoverCardGetUserResponseApplicationJsonBuilder() {
+    HoverCardGetUserResponseApplicationJson._defaults(this);
+  }
 
   HoverCardGetUserResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -14929,6 +15047,7 @@ class HoverCardGetUserResponseApplicationJsonBuilder
   HoverCardGetUserResponseApplicationJson build() => _build();
 
   _$HoverCardGetUserResponseApplicationJson _build() {
+    HoverCardGetUserResponseApplicationJson._validate(this);
     _$HoverCardGetUserResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$HoverCardGetUserResponseApplicationJson._(ocs: ocs.build());
@@ -15117,7 +15236,9 @@ class NavigationEntryBuilder
   int? get unread => _$this._unread;
   set unread(covariant int? unread) => _$this._unread = unread;
 
-  NavigationEntryBuilder();
+  NavigationEntryBuilder() {
+    NavigationEntry._defaults(this);
+  }
 
   NavigationEntryBuilder get _$this {
     final $v = _$v;
@@ -15242,7 +15363,9 @@ class NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder
   ListBuilder<NavigationEntry> get data => _$this._data ??= ListBuilder<NavigationEntry>();
   set data(covariant ListBuilder<NavigationEntry>? data) => _$this._data = data;
 
-  NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder();
+  NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder() {
+    NavigationGetAppsNavigationResponseApplicationJson_Ocs._defaults(this);
+  }
 
   NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -15269,6 +15392,7 @@ class NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder
   NavigationGetAppsNavigationResponseApplicationJson_Ocs build() => _build();
 
   _$NavigationGetAppsNavigationResponseApplicationJson_Ocs _build() {
+    NavigationGetAppsNavigationResponseApplicationJson_Ocs._validate(this);
     _$NavigationGetAppsNavigationResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -15352,7 +15476,9 @@ class NavigationGetAppsNavigationResponseApplicationJsonBuilder
       _$this._ocs ??= NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder();
   set ocs(covariant NavigationGetAppsNavigationResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  NavigationGetAppsNavigationResponseApplicationJsonBuilder();
+  NavigationGetAppsNavigationResponseApplicationJsonBuilder() {
+    NavigationGetAppsNavigationResponseApplicationJson._defaults(this);
+  }
 
   NavigationGetAppsNavigationResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -15378,6 +15504,7 @@ class NavigationGetAppsNavigationResponseApplicationJsonBuilder
   NavigationGetAppsNavigationResponseApplicationJson build() => _build();
 
   _$NavigationGetAppsNavigationResponseApplicationJson _build() {
+    NavigationGetAppsNavigationResponseApplicationJson._validate(this);
     _$NavigationGetAppsNavigationResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$NavigationGetAppsNavigationResponseApplicationJson._(ocs: ocs.build());
@@ -15473,7 +15600,9 @@ class NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder
   ListBuilder<NavigationEntry> get data => _$this._data ??= ListBuilder<NavigationEntry>();
   set data(covariant ListBuilder<NavigationEntry>? data) => _$this._data = data;
 
-  NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder();
+  NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder() {
+    NavigationGetSettingsNavigationResponseApplicationJson_Ocs._defaults(this);
+  }
 
   NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -15500,6 +15629,7 @@ class NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder
   NavigationGetSettingsNavigationResponseApplicationJson_Ocs build() => _build();
 
   _$NavigationGetSettingsNavigationResponseApplicationJson_Ocs _build() {
+    NavigationGetSettingsNavigationResponseApplicationJson_Ocs._validate(this);
     _$NavigationGetSettingsNavigationResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -15584,7 +15714,9 @@ class NavigationGetSettingsNavigationResponseApplicationJsonBuilder
       _$this._ocs ??= NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder();
   set ocs(covariant NavigationGetSettingsNavigationResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  NavigationGetSettingsNavigationResponseApplicationJsonBuilder();
+  NavigationGetSettingsNavigationResponseApplicationJsonBuilder() {
+    NavigationGetSettingsNavigationResponseApplicationJson._defaults(this);
+  }
 
   NavigationGetSettingsNavigationResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -15610,6 +15742,7 @@ class NavigationGetSettingsNavigationResponseApplicationJsonBuilder
   NavigationGetSettingsNavigationResponseApplicationJson build() => _build();
 
   _$NavigationGetSettingsNavigationResponseApplicationJson _build() {
+    NavigationGetSettingsNavigationResponseApplicationJson._validate(this);
     _$NavigationGetSettingsNavigationResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$NavigationGetSettingsNavigationResponseApplicationJson._(ocs: ocs.build());
@@ -15692,7 +15825,9 @@ class OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder
   String? get webdav => _$this._webdav;
   set webdav(covariant String? webdav) => _$this._webdav = webdav;
 
-  OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder();
+  OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder() {
+    OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols._defaults(this);
+  }
 
   OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder get _$this {
     final $v = _$v;
@@ -15718,6 +15853,7 @@ class OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder
   OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols build() => _build();
 
   _$OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols _build() {
+    OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols._validate(this);
     final _$result = _$v ??
         _$OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols._(
             webdav: BuiltValueNullFieldError.checkNotNull(
@@ -15820,7 +15956,9 @@ class OcmDiscoveryResponseApplicationJson_ResourceTypesBuilder
   set protocols(covariant OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsBuilder? protocols) =>
       _$this._protocols = protocols;
 
-  OcmDiscoveryResponseApplicationJson_ResourceTypesBuilder();
+  OcmDiscoveryResponseApplicationJson_ResourceTypesBuilder() {
+    OcmDiscoveryResponseApplicationJson_ResourceTypes._defaults(this);
+  }
 
   OcmDiscoveryResponseApplicationJson_ResourceTypesBuilder get _$this {
     final $v = _$v;
@@ -15848,6 +15986,7 @@ class OcmDiscoveryResponseApplicationJson_ResourceTypesBuilder
   OcmDiscoveryResponseApplicationJson_ResourceTypes build() => _build();
 
   _$OcmDiscoveryResponseApplicationJson_ResourceTypes _build() {
+    OcmDiscoveryResponseApplicationJson_ResourceTypes._validate(this);
     _$OcmDiscoveryResponseApplicationJson_ResourceTypes _$result;
     try {
       _$result = _$v ??
@@ -15975,7 +16114,9 @@ class OcmDiscoveryResponseApplicationJsonBuilder
   set resourceTypes(covariant ListBuilder<OcmDiscoveryResponseApplicationJson_ResourceTypes>? resourceTypes) =>
       _$this._resourceTypes = resourceTypes;
 
-  OcmDiscoveryResponseApplicationJsonBuilder();
+  OcmDiscoveryResponseApplicationJsonBuilder() {
+    OcmDiscoveryResponseApplicationJson._defaults(this);
+  }
 
   OcmDiscoveryResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -16004,6 +16145,7 @@ class OcmDiscoveryResponseApplicationJsonBuilder
   OcmDiscoveryResponseApplicationJson build() => _build();
 
   _$OcmDiscoveryResponseApplicationJson _build() {
+    OcmDiscoveryResponseApplicationJson._validate(this);
     _$OcmDiscoveryResponseApplicationJson _$result;
     try {
       _$result = _$v ??
@@ -16086,7 +16228,9 @@ class OcmOcmDiscoveryHeadersBuilder
           covariant HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders) =>
       _$this._xNextcloudOcmProviders = xNextcloudOcmProviders;
 
-  OcmOcmDiscoveryHeadersBuilder();
+  OcmOcmDiscoveryHeadersBuilder() {
+    OcmOcmDiscoveryHeaders._defaults(this);
+  }
 
   OcmOcmDiscoveryHeadersBuilder get _$this {
     final $v = _$v;
@@ -16112,6 +16256,7 @@ class OcmOcmDiscoveryHeadersBuilder
   OcmOcmDiscoveryHeaders build() => _build();
 
   _$OcmOcmDiscoveryHeaders _build() {
+    OcmOcmDiscoveryHeaders._validate(this);
     _$OcmOcmDiscoveryHeaders _$result;
     try {
       _$result = _$v ?? _$OcmOcmDiscoveryHeaders._(xNextcloudOcmProviders: _xNextcloudOcmProviders?.build());
@@ -16271,7 +16416,9 @@ class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionBuilder
   bool? get extendedSupport => _$this._extendedSupport;
   set extendedSupport(covariant bool? extendedSupport) => _$this._extendedSupport = extendedSupport;
 
-  OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionBuilder();
+  OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionBuilder() {
+    OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version._defaults(this);
+  }
 
   OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionBuilder get _$this {
     final $v = _$v;
@@ -16302,6 +16449,7 @@ class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionBuilder
   OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version build() => _build();
 
   _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version _build() {
+    OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version._validate(this);
     final _$result = _$v ??
         _$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version._(
             major: BuiltValueNullFieldError.checkNotNull(
@@ -16376,7 +16524,9 @@ class CommentsCapabilities_FilesBuilder
   bool? get comments => _$this._comments;
   set comments(covariant bool? comments) => _$this._comments = comments;
 
-  CommentsCapabilities_FilesBuilder();
+  CommentsCapabilities_FilesBuilder() {
+    CommentsCapabilities_Files._defaults(this);
+  }
 
   CommentsCapabilities_FilesBuilder get _$this {
     final $v = _$v;
@@ -16402,6 +16552,7 @@ class CommentsCapabilities_FilesBuilder
   CommentsCapabilities_Files build() => _build();
 
   _$CommentsCapabilities_Files _build() {
+    CommentsCapabilities_Files._validate(this);
     final _$result = _$v ??
         _$CommentsCapabilities_Files._(
             comments: BuiltValueNullFieldError.checkNotNull(comments, r'CommentsCapabilities_Files', 'comments'));
@@ -16463,7 +16614,9 @@ class CommentsCapabilitiesBuilder
   CommentsCapabilities_FilesBuilder get files => _$this._files ??= CommentsCapabilities_FilesBuilder();
   set files(covariant CommentsCapabilities_FilesBuilder? files) => _$this._files = files;
 
-  CommentsCapabilitiesBuilder();
+  CommentsCapabilitiesBuilder() {
+    CommentsCapabilities._defaults(this);
+  }
 
   CommentsCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -16489,6 +16642,7 @@ class CommentsCapabilitiesBuilder
   CommentsCapabilities build() => _build();
 
   _$CommentsCapabilities _build() {
+    CommentsCapabilities._validate(this);
     _$CommentsCapabilities _$result;
     try {
       _$result = _$v ?? _$CommentsCapabilities._(files: files.build());
@@ -16573,7 +16727,9 @@ class DavCapabilities_DavBuilder
   String? get bulkupload => _$this._bulkupload;
   set bulkupload(covariant String? bulkupload) => _$this._bulkupload = bulkupload;
 
-  DavCapabilities_DavBuilder();
+  DavCapabilities_DavBuilder() {
+    DavCapabilities_Dav._defaults(this);
+  }
 
   DavCapabilities_DavBuilder get _$this {
     final $v = _$v;
@@ -16600,6 +16756,7 @@ class DavCapabilities_DavBuilder
   DavCapabilities_Dav build() => _build();
 
   _$DavCapabilities_Dav _build() {
+    DavCapabilities_Dav._validate(this);
     final _$result = _$v ??
         _$DavCapabilities_Dav._(
             chunking: BuiltValueNullFieldError.checkNotNull(chunking, r'DavCapabilities_Dav', 'chunking'),
@@ -16661,7 +16818,9 @@ class DavCapabilitiesBuilder
   DavCapabilities_DavBuilder get dav => _$this._dav ??= DavCapabilities_DavBuilder();
   set dav(covariant DavCapabilities_DavBuilder? dav) => _$this._dav = dav;
 
-  DavCapabilitiesBuilder();
+  DavCapabilitiesBuilder() {
+    DavCapabilities._defaults(this);
+  }
 
   DavCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -16687,6 +16846,7 @@ class DavCapabilitiesBuilder
   DavCapabilities build() => _build();
 
   _$DavCapabilities _build() {
+    DavCapabilities._validate(this);
     _$DavCapabilities _$result;
     try {
       _$result = _$v ?? _$DavCapabilities._(dav: dav.build());
@@ -16777,7 +16937,9 @@ class DropAccountCapabilities_DropAccount_DelayBuilder
   int? get hours => _$this._hours;
   set hours(covariant int? hours) => _$this._hours = hours;
 
-  DropAccountCapabilities_DropAccount_DelayBuilder();
+  DropAccountCapabilities_DropAccount_DelayBuilder() {
+    DropAccountCapabilities_DropAccount_Delay._defaults(this);
+  }
 
   DropAccountCapabilities_DropAccount_DelayBuilder get _$this {
     final $v = _$v;
@@ -16804,6 +16966,7 @@ class DropAccountCapabilities_DropAccount_DelayBuilder
   DropAccountCapabilities_DropAccount_Delay build() => _build();
 
   _$DropAccountCapabilities_DropAccount_Delay _build() {
+    DropAccountCapabilities_DropAccount_Delay._validate(this);
     final _$result = _$v ??
         _$DropAccountCapabilities_DropAccount_Delay._(
             enabled:
@@ -16913,7 +17076,9 @@ class DropAccountCapabilities_DropAccountBuilder
   String? get details => _$this._details;
   set details(covariant String? details) => _$this._details = details;
 
-  DropAccountCapabilities_DropAccountBuilder();
+  DropAccountCapabilities_DropAccountBuilder() {
+    DropAccountCapabilities_DropAccount._defaults(this);
+  }
 
   DropAccountCapabilities_DropAccountBuilder get _$this {
     final $v = _$v;
@@ -16942,6 +17107,7 @@ class DropAccountCapabilities_DropAccountBuilder
   DropAccountCapabilities_DropAccount build() => _build();
 
   _$DropAccountCapabilities_DropAccount _build() {
+    DropAccountCapabilities_DropAccount._validate(this);
     _$DropAccountCapabilities_DropAccount _$result;
     try {
       _$result = _$v ??
@@ -17024,7 +17190,9 @@ class DropAccountCapabilitiesBuilder
   set dropAccount(covariant DropAccountCapabilities_DropAccountBuilder? dropAccount) =>
       _$this._dropAccount = dropAccount;
 
-  DropAccountCapabilitiesBuilder();
+  DropAccountCapabilitiesBuilder() {
+    DropAccountCapabilities._defaults(this);
+  }
 
   DropAccountCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -17050,6 +17218,7 @@ class DropAccountCapabilitiesBuilder
   DropAccountCapabilities build() => _build();
 
   _$DropAccountCapabilities _build() {
+    DropAccountCapabilities._validate(this);
     _$DropAccountCapabilities _$result;
     try {
       _$result = _$v ?? _$DropAccountCapabilities._(dropAccount: dropAccount.build());
@@ -17155,7 +17324,9 @@ class FilesCapabilities_Files_DirectEditingBuilder
   bool? get supportsFileId => _$this._supportsFileId;
   set supportsFileId(covariant bool? supportsFileId) => _$this._supportsFileId = supportsFileId;
 
-  FilesCapabilities_Files_DirectEditingBuilder();
+  FilesCapabilities_Files_DirectEditingBuilder() {
+    FilesCapabilities_Files_DirectEditing._defaults(this);
+  }
 
   FilesCapabilities_Files_DirectEditingBuilder get _$this {
     final $v = _$v;
@@ -17183,6 +17354,7 @@ class FilesCapabilities_Files_DirectEditingBuilder
   FilesCapabilities_Files_DirectEditing build() => _build();
 
   _$FilesCapabilities_Files_DirectEditing _build() {
+    FilesCapabilities_Files_DirectEditing._validate(this);
     final _$result = _$v ??
         _$FilesCapabilities_Files_DirectEditing._(
             url: BuiltValueNullFieldError.checkNotNull(url, r'FilesCapabilities_Files_DirectEditing', 'url'),
@@ -17283,7 +17455,9 @@ class FilesCapabilities_FilesBuilder
   set directEditing(covariant FilesCapabilities_Files_DirectEditingBuilder? directEditing) =>
       _$this._directEditing = directEditing;
 
-  FilesCapabilities_FilesBuilder();
+  FilesCapabilities_FilesBuilder() {
+    FilesCapabilities_Files._defaults(this);
+  }
 
   FilesCapabilities_FilesBuilder get _$this {
     final $v = _$v;
@@ -17311,6 +17485,7 @@ class FilesCapabilities_FilesBuilder
   FilesCapabilities_Files build() => _build();
 
   _$FilesCapabilities_Files _build() {
+    FilesCapabilities_Files._validate(this);
     _$FilesCapabilities_Files _$result;
     try {
       _$result = _$v ??
@@ -17388,7 +17563,9 @@ class FilesCapabilitiesBuilder
   FilesCapabilities_FilesBuilder get files => _$this._files ??= FilesCapabilities_FilesBuilder();
   set files(covariant FilesCapabilities_FilesBuilder? files) => _$this._files = files;
 
-  FilesCapabilitiesBuilder();
+  FilesCapabilitiesBuilder() {
+    FilesCapabilities._defaults(this);
+  }
 
   FilesCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -17414,6 +17591,7 @@ class FilesCapabilitiesBuilder
   FilesCapabilities build() => _build();
 
   _$FilesCapabilities _build() {
+    FilesCapabilities._validate(this);
     _$FilesCapabilities _$result;
     try {
       _$result = _$v ?? _$FilesCapabilities._(files: files.build());
@@ -17513,7 +17691,9 @@ class FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder
   set askForOptionalPassword(covariant bool? askForOptionalPassword) =>
       _$this._askForOptionalPassword = askForOptionalPassword;
 
-  FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder();
+  FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder() {
+    FilesSharingCapabilities_FilesSharing_Public_Password._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder get _$this {
     final $v = _$v;
@@ -17540,6 +17720,7 @@ class FilesSharingCapabilities_FilesSharing_Public_PasswordBuilder
   FilesSharingCapabilities_FilesSharing_Public_Password build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Public_Password _build() {
+    FilesSharingCapabilities_FilesSharing_Public_Password._validate(this);
     final _$result = _$v ??
         _$FilesSharingCapabilities_FilesSharing_Public_Password._(
             enforced: BuiltValueNullFieldError.checkNotNull(
@@ -17640,7 +17821,9 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder
   bool? get enforced => _$this._enforced;
   set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
-  FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder();
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder() {
+    FilesSharingCapabilities_FilesSharing_Public_ExpireDate._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder get _$this {
     final $v = _$v;
@@ -17668,6 +17851,7 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateBuilder
   FilesSharingCapabilities_FilesSharing_Public_ExpireDate build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Public_ExpireDate _build() {
+    FilesSharingCapabilities_FilesSharing_Public_ExpireDate._validate(this);
     final _$result = _$v ??
         _$FilesSharingCapabilities_FilesSharing_Public_ExpireDate._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -17768,7 +17952,9 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder
   bool? get enforced => _$this._enforced;
   set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
-  FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder();
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder() {
+    FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder get _$this {
     final $v = _$v;
@@ -17796,6 +17982,7 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalBuilder
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal _build() {
+    FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal._validate(this);
     final _$result = _$v ??
         _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternal._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -17896,7 +18083,9 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder
   bool? get enforced => _$this._enforced;
   set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
-  FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder();
+  FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder() {
+    FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder get _$this {
     final $v = _$v;
@@ -17924,6 +18113,7 @@ class FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteBuilder
   FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote _build() {
+    FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote._validate(this);
     final _$result = _$v ??
         _$FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemote._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -18112,7 +18302,9 @@ class FilesSharingCapabilities_FilesSharing_PublicBuilder
   bool? get uploadFilesDrop => _$this._uploadFilesDrop;
   set uploadFilesDrop(covariant bool? uploadFilesDrop) => _$this._uploadFilesDrop = uploadFilesDrop;
 
-  FilesSharingCapabilities_FilesSharing_PublicBuilder();
+  FilesSharingCapabilities_FilesSharing_PublicBuilder() {
+    FilesSharingCapabilities_FilesSharing_Public._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_PublicBuilder get _$this {
     final $v = _$v;
@@ -18146,6 +18338,7 @@ class FilesSharingCapabilities_FilesSharing_PublicBuilder
   FilesSharingCapabilities_FilesSharing_Public build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Public _build() {
+    FilesSharingCapabilities_FilesSharing_Public._validate(this);
     _$FilesSharingCapabilities_FilesSharing_Public _$result;
     try {
       _$result = _$v ??
@@ -18244,7 +18437,9 @@ class FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder();
+  FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder() {
+    FilesSharingCapabilities_FilesSharing_User_ExpireDate._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder get _$this {
     final $v = _$v;
@@ -18270,6 +18465,7 @@ class FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder
   FilesSharingCapabilities_FilesSharing_User_ExpireDate build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_User_ExpireDate _build() {
+    FilesSharingCapabilities_FilesSharing_User_ExpireDate._validate(this);
     final _$result = _$v ??
         _$FilesSharingCapabilities_FilesSharing_User_ExpireDate._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -18354,7 +18550,9 @@ class FilesSharingCapabilities_FilesSharing_UserBuilder
   set expireDate(covariant FilesSharingCapabilities_FilesSharing_User_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
-  FilesSharingCapabilities_FilesSharing_UserBuilder();
+  FilesSharingCapabilities_FilesSharing_UserBuilder() {
+    FilesSharingCapabilities_FilesSharing_User._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_UserBuilder get _$this {
     final $v = _$v;
@@ -18381,6 +18579,7 @@ class FilesSharingCapabilities_FilesSharing_UserBuilder
   FilesSharingCapabilities_FilesSharing_User build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_User _build() {
+    FilesSharingCapabilities_FilesSharing_User._validate(this);
     _$FilesSharingCapabilities_FilesSharing_User _$result;
     try {
       _$result = _$v ??
@@ -18466,7 +18665,9 @@ class FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder();
+  FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder() {
+    FilesSharingCapabilities_FilesSharing_Group_ExpireDate._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder get _$this {
     final $v = _$v;
@@ -18492,6 +18693,7 @@ class FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder
   FilesSharingCapabilities_FilesSharing_Group_ExpireDate build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Group_ExpireDate _build() {
+    FilesSharingCapabilities_FilesSharing_Group_ExpireDate._validate(this);
     final _$result = _$v ??
         _$FilesSharingCapabilities_FilesSharing_Group_ExpireDate._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -18576,7 +18778,9 @@ class FilesSharingCapabilities_FilesSharing_GroupBuilder
   set expireDate(covariant FilesSharingCapabilities_FilesSharing_Group_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
-  FilesSharingCapabilities_FilesSharing_GroupBuilder();
+  FilesSharingCapabilities_FilesSharing_GroupBuilder() {
+    FilesSharingCapabilities_FilesSharing_Group._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_GroupBuilder get _$this {
     final $v = _$v;
@@ -18603,6 +18807,7 @@ class FilesSharingCapabilities_FilesSharing_GroupBuilder
   FilesSharingCapabilities_FilesSharing_Group build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Group _build() {
+    FilesSharingCapabilities_FilesSharing_Group._validate(this);
     _$FilesSharingCapabilities_FilesSharing_Group _$result;
     try {
       _$result = _$v ??
@@ -18688,7 +18893,9 @@ class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder();
+  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder() {
+    FilesSharingCapabilities_FilesSharing_Federation_ExpireDate._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder get _$this {
     final $v = _$v;
@@ -18714,6 +18921,7 @@ class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateBuilder
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDate build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDate _build() {
+    FilesSharingCapabilities_FilesSharing_Federation_ExpireDate._validate(this);
     final _$result = _$v ??
         _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDate._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -18787,7 +18995,9 @@ class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilde
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder();
+  FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder() {
+    FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder get _$this {
     final $v = _$v;
@@ -18813,6 +19023,7 @@ class FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilde
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported _build() {
+    FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported._validate(this);
     final _$result = _$v ??
         _$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -18933,7 +19144,9 @@ class FilesSharingCapabilities_FilesSharing_FederationBuilder
           covariant FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedBuilder? expireDateSupported) =>
       _$this._expireDateSupported = expireDateSupported;
 
-  FilesSharingCapabilities_FilesSharing_FederationBuilder();
+  FilesSharingCapabilities_FilesSharing_FederationBuilder() {
+    FilesSharingCapabilities_FilesSharing_Federation._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_FederationBuilder get _$this {
     final $v = _$v;
@@ -18962,6 +19175,7 @@ class FilesSharingCapabilities_FilesSharing_FederationBuilder
   FilesSharingCapabilities_FilesSharing_Federation build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Federation _build() {
+    FilesSharingCapabilities_FilesSharing_Federation._validate(this);
     _$FilesSharingCapabilities_FilesSharing_Federation _$result;
     try {
       _$result = _$v ??
@@ -19067,7 +19281,9 @@ class FilesSharingCapabilities_FilesSharing_ShareeBuilder
   bool? get alwaysShowUnique => _$this._alwaysShowUnique;
   set alwaysShowUnique(covariant bool? alwaysShowUnique) => _$this._alwaysShowUnique = alwaysShowUnique;
 
-  FilesSharingCapabilities_FilesSharing_ShareeBuilder();
+  FilesSharingCapabilities_FilesSharing_ShareeBuilder() {
+    FilesSharingCapabilities_FilesSharing_Sharee._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharing_ShareeBuilder get _$this {
     final $v = _$v;
@@ -19094,6 +19310,7 @@ class FilesSharingCapabilities_FilesSharing_ShareeBuilder
   FilesSharingCapabilities_FilesSharing_Sharee build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing_Sharee _build() {
+    FilesSharingCapabilities_FilesSharing_Sharee._validate(this);
     final _$result = _$v ??
         _$FilesSharingCapabilities_FilesSharing_Sharee._(
             queryLookupDefault: BuiltValueNullFieldError.checkNotNull(
@@ -19282,7 +19499,9 @@ class FilesSharingCapabilities_FilesSharingBuilder
       _$this._sharee ??= FilesSharingCapabilities_FilesSharing_ShareeBuilder();
   set sharee(covariant FilesSharingCapabilities_FilesSharing_ShareeBuilder? sharee) => _$this._sharee = sharee;
 
-  FilesSharingCapabilities_FilesSharingBuilder();
+  FilesSharingCapabilities_FilesSharingBuilder() {
+    FilesSharingCapabilities_FilesSharing._defaults(this);
+  }
 
   FilesSharingCapabilities_FilesSharingBuilder get _$this {
     final $v = _$v;
@@ -19316,6 +19535,7 @@ class FilesSharingCapabilities_FilesSharingBuilder
   FilesSharingCapabilities_FilesSharing build() => _build();
 
   _$FilesSharingCapabilities_FilesSharing _build() {
+    FilesSharingCapabilities_FilesSharing._validate(this);
     _$FilesSharingCapabilities_FilesSharing _$result;
     try {
       _$result = _$v ??
@@ -19413,7 +19633,9 @@ class FilesSharingCapabilitiesBuilder
   set filesSharing(covariant FilesSharingCapabilities_FilesSharingBuilder? filesSharing) =>
       _$this._filesSharing = filesSharing;
 
-  FilesSharingCapabilitiesBuilder();
+  FilesSharingCapabilitiesBuilder() {
+    FilesSharingCapabilities._defaults(this);
+  }
 
   FilesSharingCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -19439,6 +19661,7 @@ class FilesSharingCapabilitiesBuilder
   FilesSharingCapabilities build() => _build();
 
   _$FilesSharingCapabilities _build() {
+    FilesSharingCapabilities._validate(this);
     _$FilesSharingCapabilities _$result;
     try {
       _$result = _$v ?? _$FilesSharingCapabilities._(filesSharing: filesSharing.build());
@@ -19512,7 +19735,9 @@ class FilesTrashbinCapabilities_FilesBuilder
   bool? get undelete => _$this._undelete;
   set undelete(covariant bool? undelete) => _$this._undelete = undelete;
 
-  FilesTrashbinCapabilities_FilesBuilder();
+  FilesTrashbinCapabilities_FilesBuilder() {
+    FilesTrashbinCapabilities_Files._defaults(this);
+  }
 
   FilesTrashbinCapabilities_FilesBuilder get _$this {
     final $v = _$v;
@@ -19538,6 +19763,7 @@ class FilesTrashbinCapabilities_FilesBuilder
   FilesTrashbinCapabilities_Files build() => _build();
 
   _$FilesTrashbinCapabilities_Files _build() {
+    FilesTrashbinCapabilities_Files._validate(this);
     final _$result = _$v ??
         _$FilesTrashbinCapabilities_Files._(
             undelete: BuiltValueNullFieldError.checkNotNull(undelete, r'FilesTrashbinCapabilities_Files', 'undelete'));
@@ -19601,7 +19827,9 @@ class FilesTrashbinCapabilitiesBuilder
   FilesTrashbinCapabilities_FilesBuilder get files => _$this._files ??= FilesTrashbinCapabilities_FilesBuilder();
   set files(covariant FilesTrashbinCapabilities_FilesBuilder? files) => _$this._files = files;
 
-  FilesTrashbinCapabilitiesBuilder();
+  FilesTrashbinCapabilitiesBuilder() {
+    FilesTrashbinCapabilities._defaults(this);
+  }
 
   FilesTrashbinCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -19627,6 +19855,7 @@ class FilesTrashbinCapabilitiesBuilder
   FilesTrashbinCapabilities build() => _build();
 
   _$FilesTrashbinCapabilities _build() {
+    FilesTrashbinCapabilities._validate(this);
     _$FilesTrashbinCapabilities _$result;
     try {
       _$result = _$v ?? _$FilesTrashbinCapabilities._(files: files.build());
@@ -19731,7 +19960,9 @@ class FilesVersionsCapabilities_FilesBuilder
   bool? get versionDeletion => _$this._versionDeletion;
   set versionDeletion(covariant bool? versionDeletion) => _$this._versionDeletion = versionDeletion;
 
-  FilesVersionsCapabilities_FilesBuilder();
+  FilesVersionsCapabilities_FilesBuilder() {
+    FilesVersionsCapabilities_Files._defaults(this);
+  }
 
   FilesVersionsCapabilities_FilesBuilder get _$this {
     final $v = _$v;
@@ -19759,6 +19990,7 @@ class FilesVersionsCapabilities_FilesBuilder
   FilesVersionsCapabilities_Files build() => _build();
 
   _$FilesVersionsCapabilities_Files _build() {
+    FilesVersionsCapabilities_Files._validate(this);
     final _$result = _$v ??
         _$FilesVersionsCapabilities_Files._(
             versioning:
@@ -19827,7 +20059,9 @@ class FilesVersionsCapabilitiesBuilder
   FilesVersionsCapabilities_FilesBuilder get files => _$this._files ??= FilesVersionsCapabilities_FilesBuilder();
   set files(covariant FilesVersionsCapabilities_FilesBuilder? files) => _$this._files = files;
 
-  FilesVersionsCapabilitiesBuilder();
+  FilesVersionsCapabilitiesBuilder() {
+    FilesVersionsCapabilities._defaults(this);
+  }
 
   FilesVersionsCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -19853,6 +20087,7 @@ class FilesVersionsCapabilitiesBuilder
   FilesVersionsCapabilities build() => _build();
 
   _$FilesVersionsCapabilities _build() {
+    FilesVersionsCapabilities._validate(this);
     _$FilesVersionsCapabilities _$result;
     try {
       _$result = _$v ?? _$FilesVersionsCapabilities._(files: files.build());
@@ -19962,7 +20197,9 @@ class NotificationsCapabilities_NotificationsBuilder
   set adminNotifications(covariant ListBuilder<String>? adminNotifications) =>
       _$this._adminNotifications = adminNotifications;
 
-  NotificationsCapabilities_NotificationsBuilder();
+  NotificationsCapabilities_NotificationsBuilder() {
+    NotificationsCapabilities_Notifications._defaults(this);
+  }
 
   NotificationsCapabilities_NotificationsBuilder get _$this {
     final $v = _$v;
@@ -19990,6 +20227,7 @@ class NotificationsCapabilities_NotificationsBuilder
   NotificationsCapabilities_Notifications build() => _build();
 
   _$NotificationsCapabilities_Notifications _build() {
+    NotificationsCapabilities_Notifications._validate(this);
     _$NotificationsCapabilities_Notifications _$result;
     try {
       _$result = _$v ??
@@ -20071,7 +20309,9 @@ class NotificationsCapabilitiesBuilder
   set notifications(covariant NotificationsCapabilities_NotificationsBuilder? notifications) =>
       _$this._notifications = notifications;
 
-  NotificationsCapabilitiesBuilder();
+  NotificationsCapabilitiesBuilder() {
+    NotificationsCapabilities._defaults(this);
+  }
 
   NotificationsCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -20097,6 +20337,7 @@ class NotificationsCapabilitiesBuilder
   NotificationsCapabilities build() => _build();
 
   _$NotificationsCapabilities _build() {
+    NotificationsCapabilities._validate(this);
     _$NotificationsCapabilities _$result;
     try {
       _$result = _$v ?? _$NotificationsCapabilities._(notifications: notifications.build());
@@ -20226,7 +20467,9 @@ class ProvisioningApiCapabilities_ProvisioningApiBuilder
   set accountPropertyScopesPublishedEnabled(covariant bool? accountPropertyScopesPublishedEnabled) =>
       _$this._accountPropertyScopesPublishedEnabled = accountPropertyScopesPublishedEnabled;
 
-  ProvisioningApiCapabilities_ProvisioningApiBuilder();
+  ProvisioningApiCapabilities_ProvisioningApiBuilder() {
+    ProvisioningApiCapabilities_ProvisioningApi._defaults(this);
+  }
 
   ProvisioningApiCapabilities_ProvisioningApiBuilder get _$this {
     final $v = _$v;
@@ -20255,6 +20498,7 @@ class ProvisioningApiCapabilities_ProvisioningApiBuilder
   ProvisioningApiCapabilities_ProvisioningApi build() => _build();
 
   _$ProvisioningApiCapabilities_ProvisioningApi _build() {
+    ProvisioningApiCapabilities_ProvisioningApi._validate(this);
     final _$result = _$v ??
         _$ProvisioningApiCapabilities_ProvisioningApi._(
             version: BuiltValueNullFieldError.checkNotNull(
@@ -20332,7 +20576,9 @@ class ProvisioningApiCapabilitiesBuilder
   set provisioningApi(covariant ProvisioningApiCapabilities_ProvisioningApiBuilder? provisioningApi) =>
       _$this._provisioningApi = provisioningApi;
 
-  ProvisioningApiCapabilitiesBuilder();
+  ProvisioningApiCapabilitiesBuilder() {
+    ProvisioningApiCapabilities._defaults(this);
+  }
 
   ProvisioningApiCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -20358,6 +20604,7 @@ class ProvisioningApiCapabilitiesBuilder
   ProvisioningApiCapabilities build() => _build();
 
   _$ProvisioningApiCapabilities _build() {
+    ProvisioningApiCapabilities._validate(this);
     _$ProvisioningApiCapabilities _$result;
     try {
       _$result = _$v ?? _$ProvisioningApiCapabilities._(provisioningApi: provisioningApi.build());
@@ -20440,7 +20687,9 @@ class SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder();
+  SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder() {
+    SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop._defaults(this);
+  }
 
   SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder get _$this {
     final $v = _$v;
@@ -20466,6 +20715,7 @@ class SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder
   SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop build() => _build();
 
   _$SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop _build() {
+    SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop._validate(this);
     final _$result = _$v ??
         _$SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -20554,7 +20804,9 @@ class SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordBuilder
   bool? get enforced => _$this._enforced;
   set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
-  SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordBuilder();
+  SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordBuilder() {
+    SharebymailCapabilities0_FilesSharing_Sharebymail_Password._defaults(this);
+  }
 
   SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordBuilder get _$this {
     final $v = _$v;
@@ -20581,6 +20833,7 @@ class SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordBuilder
   SharebymailCapabilities0_FilesSharing_Sharebymail_Password build() => _build();
 
   _$SharebymailCapabilities0_FilesSharing_Sharebymail_Password _build() {
+    SharebymailCapabilities0_FilesSharing_Sharebymail_Password._validate(this);
     final _$result = _$v ??
         _$SharebymailCapabilities0_FilesSharing_Sharebymail_Password._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -20671,7 +20924,9 @@ class SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder
   bool? get enforced => _$this._enforced;
   set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
-  SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder();
+  SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder() {
+    SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate._defaults(this);
+  }
 
   SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder get _$this {
     final $v = _$v;
@@ -20698,6 +20953,7 @@ class SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder
   SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate build() => _build();
 
   _$SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate _build() {
+    SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate._validate(this);
     final _$result = _$v ??
         _$SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -20839,7 +21095,9 @@ class SharebymailCapabilities0_FilesSharing_SharebymailBuilder
   set expireDate(covariant SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
-  SharebymailCapabilities0_FilesSharing_SharebymailBuilder();
+  SharebymailCapabilities0_FilesSharing_SharebymailBuilder() {
+    SharebymailCapabilities0_FilesSharing_Sharebymail._defaults(this);
+  }
 
   SharebymailCapabilities0_FilesSharing_SharebymailBuilder get _$this {
     final $v = _$v;
@@ -20869,6 +21127,7 @@ class SharebymailCapabilities0_FilesSharing_SharebymailBuilder
   SharebymailCapabilities0_FilesSharing_Sharebymail build() => _build();
 
   _$SharebymailCapabilities0_FilesSharing_Sharebymail _build() {
+    SharebymailCapabilities0_FilesSharing_Sharebymail._validate(this);
     _$SharebymailCapabilities0_FilesSharing_Sharebymail _$result;
     try {
       _$result = _$v ??
@@ -20960,7 +21219,9 @@ class SharebymailCapabilities0_FilesSharingBuilder
   set sharebymail(covariant SharebymailCapabilities0_FilesSharing_SharebymailBuilder? sharebymail) =>
       _$this._sharebymail = sharebymail;
 
-  SharebymailCapabilities0_FilesSharingBuilder();
+  SharebymailCapabilities0_FilesSharingBuilder() {
+    SharebymailCapabilities0_FilesSharing._defaults(this);
+  }
 
   SharebymailCapabilities0_FilesSharingBuilder get _$this {
     final $v = _$v;
@@ -20986,6 +21247,7 @@ class SharebymailCapabilities0_FilesSharingBuilder
   SharebymailCapabilities0_FilesSharing build() => _build();
 
   _$SharebymailCapabilities0_FilesSharing _build() {
+    SharebymailCapabilities0_FilesSharing._validate(this);
     _$SharebymailCapabilities0_FilesSharing _$result;
     try {
       _$result = _$v ?? _$SharebymailCapabilities0_FilesSharing._(sharebymail: sharebymail.build());
@@ -21061,7 +21323,9 @@ class SharebymailCapabilities0Builder
   set filesSharing(covariant SharebymailCapabilities0_FilesSharingBuilder? filesSharing) =>
       _$this._filesSharing = filesSharing;
 
-  SharebymailCapabilities0Builder();
+  SharebymailCapabilities0Builder() {
+    SharebymailCapabilities0._defaults(this);
+  }
 
   SharebymailCapabilities0Builder get _$this {
     final $v = _$v;
@@ -21087,6 +21351,7 @@ class SharebymailCapabilities0Builder
   SharebymailCapabilities0 build() => _build();
 
   _$SharebymailCapabilities0 _build() {
+    SharebymailCapabilities0._validate(this);
     _$SharebymailCapabilities0 _$result;
     try {
       _$result = _$v ?? _$SharebymailCapabilities0._(filesSharing: filesSharing.build());
@@ -21180,7 +21445,9 @@ class SpreedPublicCapabilities0_Spreed_Config_AttachmentsBuilder
   String? get folder => _$this._folder;
   set folder(covariant String? folder) => _$this._folder = folder;
 
-  SpreedPublicCapabilities0_Spreed_Config_AttachmentsBuilder();
+  SpreedPublicCapabilities0_Spreed_Config_AttachmentsBuilder() {
+    SpreedPublicCapabilities0_Spreed_Config_Attachments._defaults(this);
+  }
 
   SpreedPublicCapabilities0_Spreed_Config_AttachmentsBuilder get _$this {
     final $v = _$v;
@@ -21207,6 +21474,7 @@ class SpreedPublicCapabilities0_Spreed_Config_AttachmentsBuilder
   SpreedPublicCapabilities0_Spreed_Config_Attachments build() => _build();
 
   _$SpreedPublicCapabilities0_Spreed_Config_Attachments _build() {
+    SpreedPublicCapabilities0_Spreed_Config_Attachments._validate(this);
     final _$result = _$v ??
         _$SpreedPublicCapabilities0_Spreed_Config_Attachments._(
             allowed: BuiltValueNullFieldError.checkNotNull(
@@ -21408,7 +21676,9 @@ class SpreedPublicCapabilities0_Spreed_Config_CallBuilder
   bool? get canEnableSip => _$this._canEnableSip;
   set canEnableSip(covariant bool? canEnableSip) => _$this._canEnableSip = canEnableSip;
 
-  SpreedPublicCapabilities0_Spreed_Config_CallBuilder();
+  SpreedPublicCapabilities0_Spreed_Config_CallBuilder() {
+    SpreedPublicCapabilities0_Spreed_Config_Call._defaults(this);
+  }
 
   SpreedPublicCapabilities0_Spreed_Config_CallBuilder get _$this {
     final $v = _$v;
@@ -21443,6 +21713,7 @@ class SpreedPublicCapabilities0_Spreed_Config_CallBuilder
   SpreedPublicCapabilities0_Spreed_Config_Call build() => _build();
 
   _$SpreedPublicCapabilities0_Spreed_Config_Call _build() {
+    SpreedPublicCapabilities0_Spreed_Config_Call._validate(this);
     _$SpreedPublicCapabilities0_Spreed_Config_Call _$result;
     try {
       _$result = _$v ??
@@ -21597,7 +21868,9 @@ class SpreedPublicCapabilities0_Spreed_Config_ChatBuilder
   ListBuilder<String> get translations => _$this._translations ??= ListBuilder<String>();
   set translations(covariant ListBuilder<String>? translations) => _$this._translations = translations;
 
-  SpreedPublicCapabilities0_Spreed_Config_ChatBuilder();
+  SpreedPublicCapabilities0_Spreed_Config_ChatBuilder() {
+    SpreedPublicCapabilities0_Spreed_Config_Chat._defaults(this);
+  }
 
   SpreedPublicCapabilities0_Spreed_Config_ChatBuilder get _$this {
     final $v = _$v;
@@ -21627,6 +21900,7 @@ class SpreedPublicCapabilities0_Spreed_Config_ChatBuilder
   SpreedPublicCapabilities0_Spreed_Config_Chat build() => _build();
 
   _$SpreedPublicCapabilities0_Spreed_Config_Chat _build() {
+    SpreedPublicCapabilities0_Spreed_Config_Chat._validate(this);
     _$SpreedPublicCapabilities0_Spreed_Config_Chat _$result;
     try {
       _$result = _$v ??
@@ -21717,7 +21991,9 @@ class SpreedPublicCapabilities0_Spreed_Config_ConversationsBuilder
   bool? get canCreate => _$this._canCreate;
   set canCreate(covariant bool? canCreate) => _$this._canCreate = canCreate;
 
-  SpreedPublicCapabilities0_Spreed_Config_ConversationsBuilder();
+  SpreedPublicCapabilities0_Spreed_Config_ConversationsBuilder() {
+    SpreedPublicCapabilities0_Spreed_Config_Conversations._defaults(this);
+  }
 
   SpreedPublicCapabilities0_Spreed_Config_ConversationsBuilder get _$this {
     final $v = _$v;
@@ -21743,6 +22019,7 @@ class SpreedPublicCapabilities0_Spreed_Config_ConversationsBuilder
   SpreedPublicCapabilities0_Spreed_Config_Conversations build() => _build();
 
   _$SpreedPublicCapabilities0_Spreed_Config_Conversations _build() {
+    SpreedPublicCapabilities0_Spreed_Config_Conversations._validate(this);
     final _$result = _$v ??
         _$SpreedPublicCapabilities0_Spreed_Config_Conversations._(
             canCreate: BuiltValueNullFieldError.checkNotNull(
@@ -21814,7 +22091,9 @@ class SpreedPublicCapabilities0_Spreed_Config_PreviewsBuilder
   int? get maxGifSize => _$this._maxGifSize;
   set maxGifSize(covariant int? maxGifSize) => _$this._maxGifSize = maxGifSize;
 
-  SpreedPublicCapabilities0_Spreed_Config_PreviewsBuilder();
+  SpreedPublicCapabilities0_Spreed_Config_PreviewsBuilder() {
+    SpreedPublicCapabilities0_Spreed_Config_Previews._defaults(this);
+  }
 
   SpreedPublicCapabilities0_Spreed_Config_PreviewsBuilder get _$this {
     final $v = _$v;
@@ -21840,6 +22119,7 @@ class SpreedPublicCapabilities0_Spreed_Config_PreviewsBuilder
   SpreedPublicCapabilities0_Spreed_Config_Previews build() => _build();
 
   _$SpreedPublicCapabilities0_Spreed_Config_Previews _build() {
+    SpreedPublicCapabilities0_Spreed_Config_Previews._validate(this);
     final _$result = _$v ??
         _$SpreedPublicCapabilities0_Spreed_Config_Previews._(
             maxGifSize: BuiltValueNullFieldError.checkNotNull(
@@ -21925,7 +22205,9 @@ class SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder
   String? get helloV2TokenKey => _$this._helloV2TokenKey;
   set helloV2TokenKey(covariant String? helloV2TokenKey) => _$this._helloV2TokenKey = helloV2TokenKey;
 
-  SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder();
+  SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder() {
+    SpreedPublicCapabilities0_Spreed_Config_Signaling._defaults(this);
+  }
 
   SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder get _$this {
     final $v = _$v;
@@ -21952,6 +22234,7 @@ class SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder
   SpreedPublicCapabilities0_Spreed_Config_Signaling build() => _build();
 
   _$SpreedPublicCapabilities0_Spreed_Config_Signaling _build() {
+    SpreedPublicCapabilities0_Spreed_Config_Signaling._validate(this);
     final _$result = _$v ??
         _$SpreedPublicCapabilities0_Spreed_Config_Signaling._(
             sessionPingLimit: BuiltValueNullFieldError.checkNotNull(
@@ -22105,7 +22388,9 @@ class SpreedPublicCapabilities0_Spreed_ConfigBuilder
   set signaling(covariant SpreedPublicCapabilities0_Spreed_Config_SignalingBuilder? signaling) =>
       _$this._signaling = signaling;
 
-  SpreedPublicCapabilities0_Spreed_ConfigBuilder();
+  SpreedPublicCapabilities0_Spreed_ConfigBuilder() {
+    SpreedPublicCapabilities0_Spreed_Config._defaults(this);
+  }
 
   SpreedPublicCapabilities0_Spreed_ConfigBuilder get _$this {
     final $v = _$v;
@@ -22136,6 +22421,7 @@ class SpreedPublicCapabilities0_Spreed_ConfigBuilder
   SpreedPublicCapabilities0_Spreed_Config build() => _build();
 
   _$SpreedPublicCapabilities0_Spreed_Config _build() {
+    SpreedPublicCapabilities0_Spreed_Config._validate(this);
     _$SpreedPublicCapabilities0_Spreed_Config _$result;
     try {
       _$result = _$v ??
@@ -22257,7 +22543,9 @@ class SpreedPublicCapabilities0_SpreedBuilder
   String? get version => _$this._version;
   set version(covariant String? version) => _$this._version = version;
 
-  SpreedPublicCapabilities0_SpreedBuilder();
+  SpreedPublicCapabilities0_SpreedBuilder() {
+    SpreedPublicCapabilities0_Spreed._defaults(this);
+  }
 
   SpreedPublicCapabilities0_SpreedBuilder get _$this {
     final $v = _$v;
@@ -22285,6 +22573,7 @@ class SpreedPublicCapabilities0_SpreedBuilder
   SpreedPublicCapabilities0_Spreed build() => _build();
 
   _$SpreedPublicCapabilities0_Spreed _build() {
+    SpreedPublicCapabilities0_Spreed._validate(this);
     _$SpreedPublicCapabilities0_Spreed _$result;
     try {
       _$result = _$v ??
@@ -22364,7 +22653,9 @@ class SpreedPublicCapabilities0Builder
   SpreedPublicCapabilities0_SpreedBuilder get spreed => _$this._spreed ??= SpreedPublicCapabilities0_SpreedBuilder();
   set spreed(covariant SpreedPublicCapabilities0_SpreedBuilder? spreed) => _$this._spreed = spreed;
 
-  SpreedPublicCapabilities0Builder();
+  SpreedPublicCapabilities0Builder() {
+    SpreedPublicCapabilities0._defaults(this);
+  }
 
   SpreedPublicCapabilities0Builder get _$this {
     final $v = _$v;
@@ -22390,6 +22681,7 @@ class SpreedPublicCapabilities0Builder
   SpreedPublicCapabilities0 build() => _build();
 
   _$SpreedPublicCapabilities0 _build() {
+    SpreedPublicCapabilities0._validate(this);
     _$SpreedPublicCapabilities0 _$result;
     try {
       _$result = _$v ?? _$SpreedPublicCapabilities0._(spreed: spreed.build());
@@ -22463,7 +22755,9 @@ class SystemtagsCapabilities_SystemtagsBuilder
   SystemtagsCapabilities_Systemtags_Enabled? get enabled => _$this._enabled;
   set enabled(covariant SystemtagsCapabilities_Systemtags_Enabled? enabled) => _$this._enabled = enabled;
 
-  SystemtagsCapabilities_SystemtagsBuilder();
+  SystemtagsCapabilities_SystemtagsBuilder() {
+    SystemtagsCapabilities_Systemtags._defaults(this);
+  }
 
   SystemtagsCapabilities_SystemtagsBuilder get _$this {
     final $v = _$v;
@@ -22489,6 +22783,7 @@ class SystemtagsCapabilities_SystemtagsBuilder
   SystemtagsCapabilities_Systemtags build() => _build();
 
   _$SystemtagsCapabilities_Systemtags _build() {
+    SystemtagsCapabilities_Systemtags._validate(this);
     final _$result = _$v ??
         _$SystemtagsCapabilities_Systemtags._(
             enabled: BuiltValueNullFieldError.checkNotNull(enabled, r'SystemtagsCapabilities_Systemtags', 'enabled'));
@@ -22551,7 +22846,9 @@ class SystemtagsCapabilitiesBuilder
       _$this._systemtags ??= SystemtagsCapabilities_SystemtagsBuilder();
   set systemtags(covariant SystemtagsCapabilities_SystemtagsBuilder? systemtags) => _$this._systemtags = systemtags;
 
-  SystemtagsCapabilitiesBuilder();
+  SystemtagsCapabilitiesBuilder() {
+    SystemtagsCapabilities._defaults(this);
+  }
 
   SystemtagsCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -22577,6 +22874,7 @@ class SystemtagsCapabilitiesBuilder
   SystemtagsCapabilities build() => _build();
 
   _$SystemtagsCapabilities _build() {
+    SystemtagsCapabilities._validate(this);
     _$SystemtagsCapabilities _$result;
     try {
       _$result = _$v ?? _$SystemtagsCapabilities._(systemtags: systemtags.build());
@@ -22838,7 +23136,9 @@ class ThemingPublicCapabilities_ThemingBuilder
   String? get favicon => _$this._favicon;
   set favicon(covariant String? favicon) => _$this._favicon = favicon;
 
-  ThemingPublicCapabilities_ThemingBuilder();
+  ThemingPublicCapabilities_ThemingBuilder() {
+    ThemingPublicCapabilities_Theming._defaults(this);
+  }
 
   ThemingPublicCapabilities_ThemingBuilder get _$this {
     final $v = _$v;
@@ -22877,6 +23177,7 @@ class ThemingPublicCapabilities_ThemingBuilder
   ThemingPublicCapabilities_Theming build() => _build();
 
   _$ThemingPublicCapabilities_Theming _build() {
+    ThemingPublicCapabilities_Theming._validate(this);
     final _$result = _$v ??
         _$ThemingPublicCapabilities_Theming._(
             name: BuiltValueNullFieldError.checkNotNull(name, r'ThemingPublicCapabilities_Theming', 'name'),
@@ -22962,7 +23263,9 @@ class ThemingPublicCapabilitiesBuilder
       _$this._theming ??= ThemingPublicCapabilities_ThemingBuilder();
   set theming(covariant ThemingPublicCapabilities_ThemingBuilder? theming) => _$this._theming = theming;
 
-  ThemingPublicCapabilitiesBuilder();
+  ThemingPublicCapabilitiesBuilder() {
+    ThemingPublicCapabilities._defaults(this);
+  }
 
   ThemingPublicCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -22988,6 +23291,7 @@ class ThemingPublicCapabilitiesBuilder
   ThemingPublicCapabilities build() => _build();
 
   _$ThemingPublicCapabilities _build() {
+    ThemingPublicCapabilities._validate(this);
     _$ThemingPublicCapabilities _$result;
     try {
       _$result = _$v ?? _$ThemingPublicCapabilities._(theming: theming.build());
@@ -23091,7 +23395,9 @@ class UserStatusCapabilities_UserStatusBuilder
   bool? get supportsEmoji => _$this._supportsEmoji;
   set supportsEmoji(covariant bool? supportsEmoji) => _$this._supportsEmoji = supportsEmoji;
 
-  UserStatusCapabilities_UserStatusBuilder();
+  UserStatusCapabilities_UserStatusBuilder() {
+    UserStatusCapabilities_UserStatus._defaults(this);
+  }
 
   UserStatusCapabilities_UserStatusBuilder get _$this {
     final $v = _$v;
@@ -23119,6 +23425,7 @@ class UserStatusCapabilities_UserStatusBuilder
   UserStatusCapabilities_UserStatus build() => _build();
 
   _$UserStatusCapabilities_UserStatus _build() {
+    UserStatusCapabilities_UserStatus._validate(this);
     final _$result = _$v ??
         _$UserStatusCapabilities_UserStatus._(
             enabled: BuiltValueNullFieldError.checkNotNull(enabled, r'UserStatusCapabilities_UserStatus', 'enabled'),
@@ -23184,7 +23491,9 @@ class UserStatusCapabilitiesBuilder
       _$this._userStatus ??= UserStatusCapabilities_UserStatusBuilder();
   set userStatus(covariant UserStatusCapabilities_UserStatusBuilder? userStatus) => _$this._userStatus = userStatus;
 
-  UserStatusCapabilitiesBuilder();
+  UserStatusCapabilitiesBuilder() {
+    UserStatusCapabilities._defaults(this);
+  }
 
   UserStatusCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -23210,6 +23519,7 @@ class UserStatusCapabilitiesBuilder
   UserStatusCapabilities build() => _build();
 
   _$UserStatusCapabilities _build() {
+    UserStatusCapabilities._validate(this);
     _$UserStatusCapabilities _$result;
     try {
       _$result = _$v ?? _$UserStatusCapabilities._(userStatus: userStatus.build());
@@ -23287,7 +23597,9 @@ class WeatherStatusCapabilities_WeatherStatusBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  WeatherStatusCapabilities_WeatherStatusBuilder();
+  WeatherStatusCapabilities_WeatherStatusBuilder() {
+    WeatherStatusCapabilities_WeatherStatus._defaults(this);
+  }
 
   WeatherStatusCapabilities_WeatherStatusBuilder get _$this {
     final $v = _$v;
@@ -23313,6 +23625,7 @@ class WeatherStatusCapabilities_WeatherStatusBuilder
   WeatherStatusCapabilities_WeatherStatus build() => _build();
 
   _$WeatherStatusCapabilities_WeatherStatus _build() {
+    WeatherStatusCapabilities_WeatherStatus._validate(this);
     final _$result = _$v ??
         _$WeatherStatusCapabilities_WeatherStatus._(
             enabled:
@@ -23379,7 +23692,9 @@ class WeatherStatusCapabilitiesBuilder
   set weatherStatus(covariant WeatherStatusCapabilities_WeatherStatusBuilder? weatherStatus) =>
       _$this._weatherStatus = weatherStatus;
 
-  WeatherStatusCapabilitiesBuilder();
+  WeatherStatusCapabilitiesBuilder() {
+    WeatherStatusCapabilities._defaults(this);
+  }
 
   WeatherStatusCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -23405,6 +23720,7 @@ class WeatherStatusCapabilitiesBuilder
   WeatherStatusCapabilities build() => _build();
 
   _$WeatherStatusCapabilities _build() {
+    WeatherStatusCapabilities._validate(this);
     _$WeatherStatusCapabilities _$result;
     try {
       _$result = _$v ?? _$WeatherStatusCapabilities._(weatherStatus: weatherStatus.build());
@@ -23489,7 +23805,9 @@ class NotesCapabilities_NotesBuilder
   String? get version => _$this._version;
   set version(covariant String? version) => _$this._version = version;
 
-  NotesCapabilities_NotesBuilder();
+  NotesCapabilities_NotesBuilder() {
+    NotesCapabilities_Notes._defaults(this);
+  }
 
   NotesCapabilities_NotesBuilder get _$this {
     final $v = _$v;
@@ -23516,6 +23834,7 @@ class NotesCapabilities_NotesBuilder
   NotesCapabilities_Notes build() => _build();
 
   _$NotesCapabilities_Notes _build() {
+    NotesCapabilities_Notes._validate(this);
     _$NotesCapabilities_Notes _$result;
     try {
       _$result = _$v ?? _$NotesCapabilities_Notes._(apiVersion: _apiVersion?.build(), version: version);
@@ -23586,7 +23905,9 @@ class NotesCapabilitiesBuilder
   NotesCapabilities_NotesBuilder get notes => _$this._notes ??= NotesCapabilities_NotesBuilder();
   set notes(covariant NotesCapabilities_NotesBuilder? notes) => _$this._notes = notes;
 
-  NotesCapabilitiesBuilder();
+  NotesCapabilitiesBuilder() {
+    NotesCapabilities._defaults(this);
+  }
 
   NotesCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -23612,6 +23933,7 @@ class NotesCapabilitiesBuilder
   NotesCapabilities build() => _build();
 
   _$NotesCapabilities _build() {
+    NotesCapabilities._validate(this);
     _$NotesCapabilities _$result;
     try {
       _$result = _$v ?? _$NotesCapabilities._(notes: notes.build());
@@ -23711,7 +24033,9 @@ class OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder
   set capabilities(covariant OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities? capabilities) =>
       _$this._capabilities = capabilities;
 
-  OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder();
+  OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder() {
+    OcsGetCapabilitiesResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -23835,7 +24159,9 @@ class OcsGetCapabilitiesResponseApplicationJson_OcsBuilder
       _$this._data ??= OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant OcsGetCapabilitiesResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  OcsGetCapabilitiesResponseApplicationJson_OcsBuilder();
+  OcsGetCapabilitiesResponseApplicationJson_OcsBuilder() {
+    OcsGetCapabilitiesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   OcsGetCapabilitiesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -23862,6 +24188,7 @@ class OcsGetCapabilitiesResponseApplicationJson_OcsBuilder
   OcsGetCapabilitiesResponseApplicationJson_Ocs build() => _build();
 
   _$OcsGetCapabilitiesResponseApplicationJson_Ocs _build() {
+    OcsGetCapabilitiesResponseApplicationJson_Ocs._validate(this);
     _$OcsGetCapabilitiesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$OcsGetCapabilitiesResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -23941,7 +24268,9 @@ class OcsGetCapabilitiesResponseApplicationJsonBuilder
       _$this._ocs ??= OcsGetCapabilitiesResponseApplicationJson_OcsBuilder();
   set ocs(covariant OcsGetCapabilitiesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  OcsGetCapabilitiesResponseApplicationJsonBuilder();
+  OcsGetCapabilitiesResponseApplicationJsonBuilder() {
+    OcsGetCapabilitiesResponseApplicationJson._defaults(this);
+  }
 
   OcsGetCapabilitiesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -23967,6 +24296,7 @@ class OcsGetCapabilitiesResponseApplicationJsonBuilder
   OcsGetCapabilitiesResponseApplicationJson build() => _build();
 
   _$OcsGetCapabilitiesResponseApplicationJson _build() {
+    OcsGetCapabilitiesResponseApplicationJson._validate(this);
     _$OcsGetCapabilitiesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$OcsGetCapabilitiesResponseApplicationJson._(ocs: ocs.build());
@@ -24058,7 +24388,9 @@ class ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder();
+  ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder() {
+    ProfileApiSetVisibilityResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -24085,6 +24417,7 @@ class ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder
   ProfileApiSetVisibilityResponseApplicationJson_Ocs build() => _build();
 
   _$ProfileApiSetVisibilityResponseApplicationJson_Ocs _build() {
+    ProfileApiSetVisibilityResponseApplicationJson_Ocs._validate(this);
     _$ProfileApiSetVisibilityResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -24167,7 +24500,9 @@ class ProfileApiSetVisibilityResponseApplicationJsonBuilder
       _$this._ocs ??= ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder();
   set ocs(covariant ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ProfileApiSetVisibilityResponseApplicationJsonBuilder();
+  ProfileApiSetVisibilityResponseApplicationJsonBuilder() {
+    ProfileApiSetVisibilityResponseApplicationJson._defaults(this);
+  }
 
   ProfileApiSetVisibilityResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -24193,6 +24528,7 @@ class ProfileApiSetVisibilityResponseApplicationJsonBuilder
   ProfileApiSetVisibilityResponseApplicationJson build() => _build();
 
   _$ProfileApiSetVisibilityResponseApplicationJson _build() {
+    ProfileApiSetVisibilityResponseApplicationJson._validate(this);
     _$ProfileApiSetVisibilityResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ProfileApiSetVisibilityResponseApplicationJson._(ocs: ocs.build());
@@ -24306,7 +24642,9 @@ class ReferenceBuilder implements Builder<Reference, ReferenceBuilder>, $Referen
   bool? get accessible => _$this._accessible;
   set accessible(covariant bool? accessible) => _$this._accessible = accessible;
 
-  ReferenceBuilder();
+  ReferenceBuilder() {
+    Reference._defaults(this);
+  }
 
   ReferenceBuilder get _$this {
     final $v = _$v;
@@ -24335,6 +24673,7 @@ class ReferenceBuilder implements Builder<Reference, ReferenceBuilder>, $Referen
   Reference build() => _build();
 
   _$Reference _build() {
+    Reference._validate(this);
     _$Reference _$result;
     try {
       _$result = _$v ??
@@ -24423,7 +24762,9 @@ class ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder
   MapBuilder<String, Reference> get references => _$this._references ??= MapBuilder<String, Reference>();
   set references(covariant MapBuilder<String, Reference>? references) => _$this._references = references;
 
-  ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder();
+  ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder() {
+    ReferenceApiResolveOneResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -24449,6 +24790,7 @@ class ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder
   ReferenceApiResolveOneResponseApplicationJson_Ocs_Data build() => _build();
 
   _$ReferenceApiResolveOneResponseApplicationJson_Ocs_Data _build() {
+    ReferenceApiResolveOneResponseApplicationJson_Ocs_Data._validate(this);
     _$ReferenceApiResolveOneResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$ReferenceApiResolveOneResponseApplicationJson_Ocs_Data._(references: references.build());
@@ -24542,7 +24884,9 @@ class ReferenceApiResolveOneResponseApplicationJson_OcsBuilder
       _$this._data ??= ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  ReferenceApiResolveOneResponseApplicationJson_OcsBuilder();
+  ReferenceApiResolveOneResponseApplicationJson_OcsBuilder() {
+    ReferenceApiResolveOneResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ReferenceApiResolveOneResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -24569,6 +24913,7 @@ class ReferenceApiResolveOneResponseApplicationJson_OcsBuilder
   ReferenceApiResolveOneResponseApplicationJson_Ocs build() => _build();
 
   _$ReferenceApiResolveOneResponseApplicationJson_Ocs _build() {
+    ReferenceApiResolveOneResponseApplicationJson_Ocs._validate(this);
     _$ReferenceApiResolveOneResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ReferenceApiResolveOneResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -24649,7 +24994,9 @@ class ReferenceApiResolveOneResponseApplicationJsonBuilder
       _$this._ocs ??= ReferenceApiResolveOneResponseApplicationJson_OcsBuilder();
   set ocs(covariant ReferenceApiResolveOneResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ReferenceApiResolveOneResponseApplicationJsonBuilder();
+  ReferenceApiResolveOneResponseApplicationJsonBuilder() {
+    ReferenceApiResolveOneResponseApplicationJson._defaults(this);
+  }
 
   ReferenceApiResolveOneResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -24675,6 +25022,7 @@ class ReferenceApiResolveOneResponseApplicationJsonBuilder
   ReferenceApiResolveOneResponseApplicationJson build() => _build();
 
   _$ReferenceApiResolveOneResponseApplicationJson _build() {
+    ReferenceApiResolveOneResponseApplicationJson._validate(this);
     _$ReferenceApiResolveOneResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ReferenceApiResolveOneResponseApplicationJson._(ocs: ocs.build());
@@ -24756,7 +25104,9 @@ class ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder
   MapBuilder<String, Reference> get references => _$this._references ??= MapBuilder<String, Reference>();
   set references(covariant MapBuilder<String, Reference>? references) => _$this._references = references;
 
-  ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder();
+  ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder() {
+    ReferenceApiResolveResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -24782,6 +25132,7 @@ class ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder
   ReferenceApiResolveResponseApplicationJson_Ocs_Data build() => _build();
 
   _$ReferenceApiResolveResponseApplicationJson_Ocs_Data _build() {
+    ReferenceApiResolveResponseApplicationJson_Ocs_Data._validate(this);
     _$ReferenceApiResolveResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$ReferenceApiResolveResponseApplicationJson_Ocs_Data._(references: references.build());
@@ -24874,7 +25225,9 @@ class ReferenceApiResolveResponseApplicationJson_OcsBuilder
       _$this._data ??= ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  ReferenceApiResolveResponseApplicationJson_OcsBuilder();
+  ReferenceApiResolveResponseApplicationJson_OcsBuilder() {
+    ReferenceApiResolveResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ReferenceApiResolveResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -24901,6 +25254,7 @@ class ReferenceApiResolveResponseApplicationJson_OcsBuilder
   ReferenceApiResolveResponseApplicationJson_Ocs build() => _build();
 
   _$ReferenceApiResolveResponseApplicationJson_Ocs _build() {
+    ReferenceApiResolveResponseApplicationJson_Ocs._validate(this);
     _$ReferenceApiResolveResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ReferenceApiResolveResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -24981,7 +25335,9 @@ class ReferenceApiResolveResponseApplicationJsonBuilder
       _$this._ocs ??= ReferenceApiResolveResponseApplicationJson_OcsBuilder();
   set ocs(covariant ReferenceApiResolveResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ReferenceApiResolveResponseApplicationJsonBuilder();
+  ReferenceApiResolveResponseApplicationJsonBuilder() {
+    ReferenceApiResolveResponseApplicationJson._defaults(this);
+  }
 
   ReferenceApiResolveResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -25007,6 +25363,7 @@ class ReferenceApiResolveResponseApplicationJsonBuilder
   ReferenceApiResolveResponseApplicationJson build() => _build();
 
   _$ReferenceApiResolveResponseApplicationJson _build() {
+    ReferenceApiResolveResponseApplicationJson._validate(this);
     _$ReferenceApiResolveResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ReferenceApiResolveResponseApplicationJson._(ocs: ocs.build());
@@ -25088,7 +25445,9 @@ class ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder
   MapBuilder<String, Reference> get references => _$this._references ??= MapBuilder<String, Reference>();
   set references(covariant MapBuilder<String, Reference>? references) => _$this._references = references;
 
-  ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder();
+  ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder() {
+    ReferenceApiExtractResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -25114,6 +25473,7 @@ class ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder
   ReferenceApiExtractResponseApplicationJson_Ocs_Data build() => _build();
 
   _$ReferenceApiExtractResponseApplicationJson_Ocs_Data _build() {
+    ReferenceApiExtractResponseApplicationJson_Ocs_Data._validate(this);
     _$ReferenceApiExtractResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$ReferenceApiExtractResponseApplicationJson_Ocs_Data._(references: references.build());
@@ -25206,7 +25566,9 @@ class ReferenceApiExtractResponseApplicationJson_OcsBuilder
       _$this._data ??= ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  ReferenceApiExtractResponseApplicationJson_OcsBuilder();
+  ReferenceApiExtractResponseApplicationJson_OcsBuilder() {
+    ReferenceApiExtractResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ReferenceApiExtractResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -25233,6 +25595,7 @@ class ReferenceApiExtractResponseApplicationJson_OcsBuilder
   ReferenceApiExtractResponseApplicationJson_Ocs build() => _build();
 
   _$ReferenceApiExtractResponseApplicationJson_Ocs _build() {
+    ReferenceApiExtractResponseApplicationJson_Ocs._validate(this);
     _$ReferenceApiExtractResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ReferenceApiExtractResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -25313,7 +25676,9 @@ class ReferenceApiExtractResponseApplicationJsonBuilder
       _$this._ocs ??= ReferenceApiExtractResponseApplicationJson_OcsBuilder();
   set ocs(covariant ReferenceApiExtractResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ReferenceApiExtractResponseApplicationJsonBuilder();
+  ReferenceApiExtractResponseApplicationJsonBuilder() {
+    ReferenceApiExtractResponseApplicationJson._defaults(this);
+  }
 
   ReferenceApiExtractResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -25339,6 +25704,7 @@ class ReferenceApiExtractResponseApplicationJsonBuilder
   ReferenceApiExtractResponseApplicationJson build() => _build();
 
   _$ReferenceApiExtractResponseApplicationJson _build() {
+    ReferenceApiExtractResponseApplicationJson._validate(this);
     _$ReferenceApiExtractResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ReferenceApiExtractResponseApplicationJson._(ocs: ocs.build());
@@ -25466,7 +25832,9 @@ class ReferenceProviderBuilder
   set searchProvidersIds(covariant ListBuilder<String>? searchProvidersIds) =>
       _$this._searchProvidersIds = searchProvidersIds;
 
-  ReferenceProviderBuilder();
+  ReferenceProviderBuilder() {
+    ReferenceProvider._defaults(this);
+  }
 
   ReferenceProviderBuilder get _$this {
     final $v = _$v;
@@ -25496,6 +25864,7 @@ class ReferenceProviderBuilder
   ReferenceProvider build() => _build();
 
   _$ReferenceProvider _build() {
+    ReferenceProvider._validate(this);
     _$ReferenceProvider _$result;
     try {
       _$result = _$v ??
@@ -25594,7 +25963,9 @@ class ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder
   ListBuilder<ReferenceProvider> get data => _$this._data ??= ListBuilder<ReferenceProvider>();
   set data(covariant ListBuilder<ReferenceProvider>? data) => _$this._data = data;
 
-  ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder();
+  ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder() {
+    ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -25621,6 +25992,7 @@ class ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder
   ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs build() => _build();
 
   _$ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs _build() {
+    ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs._validate(this);
     _$ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -25705,7 +26077,9 @@ class ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder
       _$this._ocs ??= ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder();
   set ocs(covariant ReferenceApiGetProvidersInfoResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder();
+  ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder() {
+    ReferenceApiGetProvidersInfoResponseApplicationJson._defaults(this);
+  }
 
   ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -25731,6 +26105,7 @@ class ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder
   ReferenceApiGetProvidersInfoResponseApplicationJson build() => _build();
 
   _$ReferenceApiGetProvidersInfoResponseApplicationJson _build() {
+    ReferenceApiGetProvidersInfoResponseApplicationJson._validate(this);
     _$ReferenceApiGetProvidersInfoResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ReferenceApiGetProvidersInfoResponseApplicationJson._(ocs: ocs.build());
@@ -25813,7 +26188,9 @@ class ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder
   bool? get success => _$this._success;
   set success(covariant bool? success) => _$this._success = success;
 
-  ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder();
+  ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder() {
+    ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -25839,6 +26216,7 @@ class ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder
   ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data build() => _build();
 
   _$ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data _build() {
+    ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data._(
             success: BuiltValueNullFieldError.checkNotNull(
@@ -25923,7 +26301,9 @@ class ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder
       _$this._data ??= ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder();
+  ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder() {
+    ReferenceApiTouchProviderResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -25950,6 +26330,7 @@ class ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder
   ReferenceApiTouchProviderResponseApplicationJson_Ocs build() => _build();
 
   _$ReferenceApiTouchProviderResponseApplicationJson_Ocs _build() {
+    ReferenceApiTouchProviderResponseApplicationJson_Ocs._validate(this);
     _$ReferenceApiTouchProviderResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -26033,7 +26414,9 @@ class ReferenceApiTouchProviderResponseApplicationJsonBuilder
       _$this._ocs ??= ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder();
   set ocs(covariant ReferenceApiTouchProviderResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ReferenceApiTouchProviderResponseApplicationJsonBuilder();
+  ReferenceApiTouchProviderResponseApplicationJsonBuilder() {
+    ReferenceApiTouchProviderResponseApplicationJson._defaults(this);
+  }
 
   ReferenceApiTouchProviderResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -26059,6 +26442,7 @@ class ReferenceApiTouchProviderResponseApplicationJsonBuilder
   ReferenceApiTouchProviderResponseApplicationJson build() => _build();
 
   _$ReferenceApiTouchProviderResponseApplicationJson _build() {
+    ReferenceApiTouchProviderResponseApplicationJson._validate(this);
     _$ReferenceApiTouchProviderResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ReferenceApiTouchProviderResponseApplicationJson._(ocs: ocs.build());
@@ -26172,7 +26556,9 @@ class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesBuilder
   String? get description => _$this._description;
   set description(covariant String? description) => _$this._description = description;
 
-  TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesBuilder();
+  TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesBuilder() {
+    TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types._defaults(this);
+  }
 
   TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesBuilder get _$this {
     final $v = _$v;
@@ -26200,6 +26586,7 @@ class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesBuilder
   TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types build() => _build();
 
   _$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types _build() {
+    TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types._validate(this);
     final _$result = _$v ??
         _$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types._(
             id: BuiltValueNullFieldError.checkNotNull(
@@ -26278,7 +26665,9 @@ class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder
   set types(covariant ListBuilder<TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types>? types) =>
       _$this._types = types;
 
-  TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder();
+  TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder() {
+    TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -26304,6 +26693,7 @@ class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder
   TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data _build() {
+    TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data._validate(this);
     _$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data._(types: types.build());
@@ -26398,7 +26788,9 @@ class TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder
       _$this._data ??= TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder();
+  TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder() {
+    TextProcessingApiTaskTypesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -26425,6 +26817,7 @@ class TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder
   TextProcessingApiTaskTypesResponseApplicationJson_Ocs build() => _build();
 
   _$TextProcessingApiTaskTypesResponseApplicationJson_Ocs _build() {
+    TextProcessingApiTaskTypesResponseApplicationJson_Ocs._validate(this);
     _$TextProcessingApiTaskTypesResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -26508,7 +26901,9 @@ class TextProcessingApiTaskTypesResponseApplicationJsonBuilder
       _$this._ocs ??= TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder();
   set ocs(covariant TextProcessingApiTaskTypesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TextProcessingApiTaskTypesResponseApplicationJsonBuilder();
+  TextProcessingApiTaskTypesResponseApplicationJsonBuilder() {
+    TextProcessingApiTaskTypesResponseApplicationJson._defaults(this);
+  }
 
   TextProcessingApiTaskTypesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -26534,6 +26929,7 @@ class TextProcessingApiTaskTypesResponseApplicationJsonBuilder
   TextProcessingApiTaskTypesResponseApplicationJson build() => _build();
 
   _$TextProcessingApiTaskTypesResponseApplicationJson _build() {
+    TextProcessingApiTaskTypesResponseApplicationJson._validate(this);
     _$TextProcessingApiTaskTypesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiTaskTypesResponseApplicationJson._(ocs: ocs.build());
@@ -26719,7 +27115,9 @@ class TextProcessingTaskBuilder
   int? get completionExpectedAt => _$this._completionExpectedAt;
   set completionExpectedAt(covariant int? completionExpectedAt) => _$this._completionExpectedAt = completionExpectedAt;
 
-  TextProcessingTaskBuilder();
+  TextProcessingTaskBuilder() {
+    TextProcessingTask._defaults(this);
+  }
 
   TextProcessingTaskBuilder get _$this {
     final $v = _$v;
@@ -26753,6 +27151,7 @@ class TextProcessingTaskBuilder
   TextProcessingTask build() => _build();
 
   _$TextProcessingTask _build() {
+    TextProcessingTask._validate(this);
     final _$result = _$v ??
         _$TextProcessingTask._(
             id: id,
@@ -26831,7 +27230,9 @@ class TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder
   TextProcessingTaskBuilder get task => _$this._task ??= TextProcessingTaskBuilder();
   set task(covariant TextProcessingTaskBuilder? task) => _$this._task = task;
 
-  TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder();
+  TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder() {
+    TextProcessingApiScheduleResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -26857,6 +27258,7 @@ class TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder
   TextProcessingApiScheduleResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TextProcessingApiScheduleResponseApplicationJson_Ocs_Data _build() {
+    TextProcessingApiScheduleResponseApplicationJson_Ocs_Data._validate(this);
     _$TextProcessingApiScheduleResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiScheduleResponseApplicationJson_Ocs_Data._(task: task.build());
@@ -26951,7 +27353,9 @@ class TextProcessingApiScheduleResponseApplicationJson_OcsBuilder
       _$this._data ??= TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TextProcessingApiScheduleResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TextProcessingApiScheduleResponseApplicationJson_OcsBuilder();
+  TextProcessingApiScheduleResponseApplicationJson_OcsBuilder() {
+    TextProcessingApiScheduleResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TextProcessingApiScheduleResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -26978,6 +27382,7 @@ class TextProcessingApiScheduleResponseApplicationJson_OcsBuilder
   TextProcessingApiScheduleResponseApplicationJson_Ocs build() => _build();
 
   _$TextProcessingApiScheduleResponseApplicationJson_Ocs _build() {
+    TextProcessingApiScheduleResponseApplicationJson_Ocs._validate(this);
     _$TextProcessingApiScheduleResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -27061,7 +27466,9 @@ class TextProcessingApiScheduleResponseApplicationJsonBuilder
       _$this._ocs ??= TextProcessingApiScheduleResponseApplicationJson_OcsBuilder();
   set ocs(covariant TextProcessingApiScheduleResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TextProcessingApiScheduleResponseApplicationJsonBuilder();
+  TextProcessingApiScheduleResponseApplicationJsonBuilder() {
+    TextProcessingApiScheduleResponseApplicationJson._defaults(this);
+  }
 
   TextProcessingApiScheduleResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -27087,6 +27494,7 @@ class TextProcessingApiScheduleResponseApplicationJsonBuilder
   TextProcessingApiScheduleResponseApplicationJson build() => _build();
 
   _$TextProcessingApiScheduleResponseApplicationJson _build() {
+    TextProcessingApiScheduleResponseApplicationJson._validate(this);
     _$TextProcessingApiScheduleResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiScheduleResponseApplicationJson._(ocs: ocs.build());
@@ -27167,7 +27575,9 @@ class TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder
   TextProcessingTaskBuilder get task => _$this._task ??= TextProcessingTaskBuilder();
   set task(covariant TextProcessingTaskBuilder? task) => _$this._task = task;
 
-  TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder();
+  TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder() {
+    TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -27193,6 +27603,7 @@ class TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder
   TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data _build() {
+    TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data._validate(this);
     _$TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data._(task: task.build());
@@ -27287,7 +27698,9 @@ class TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder
       _$this._data ??= TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder();
+  TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder() {
+    TextProcessingApiGetTaskResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -27314,6 +27727,7 @@ class TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder
   TextProcessingApiGetTaskResponseApplicationJson_Ocs build() => _build();
 
   _$TextProcessingApiGetTaskResponseApplicationJson_Ocs _build() {
+    TextProcessingApiGetTaskResponseApplicationJson_Ocs._validate(this);
     _$TextProcessingApiGetTaskResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiGetTaskResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -27396,7 +27810,9 @@ class TextProcessingApiGetTaskResponseApplicationJsonBuilder
       _$this._ocs ??= TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder();
   set ocs(covariant TextProcessingApiGetTaskResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TextProcessingApiGetTaskResponseApplicationJsonBuilder();
+  TextProcessingApiGetTaskResponseApplicationJsonBuilder() {
+    TextProcessingApiGetTaskResponseApplicationJson._defaults(this);
+  }
 
   TextProcessingApiGetTaskResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -27422,6 +27838,7 @@ class TextProcessingApiGetTaskResponseApplicationJsonBuilder
   TextProcessingApiGetTaskResponseApplicationJson build() => _build();
 
   _$TextProcessingApiGetTaskResponseApplicationJson _build() {
+    TextProcessingApiGetTaskResponseApplicationJson._validate(this);
     _$TextProcessingApiGetTaskResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiGetTaskResponseApplicationJson._(ocs: ocs.build());
@@ -27503,7 +27920,9 @@ class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder
   TextProcessingTaskBuilder get task => _$this._task ??= TextProcessingTaskBuilder();
   set task(covariant TextProcessingTaskBuilder? task) => _$this._task = task;
 
-  TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder();
+  TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder() {
+    TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -27529,6 +27948,7 @@ class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder
   TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data _build() {
+    TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data._validate(this);
     _$TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data._(task: task.build());
@@ -27623,7 +28043,9 @@ class TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder
       _$this._data ??= TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder();
+  TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder() {
+    TextProcessingApiDeleteTaskResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -27650,6 +28072,7 @@ class TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder
   TextProcessingApiDeleteTaskResponseApplicationJson_Ocs build() => _build();
 
   _$TextProcessingApiDeleteTaskResponseApplicationJson_Ocs _build() {
+    TextProcessingApiDeleteTaskResponseApplicationJson_Ocs._validate(this);
     _$TextProcessingApiDeleteTaskResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -27733,7 +28156,9 @@ class TextProcessingApiDeleteTaskResponseApplicationJsonBuilder
       _$this._ocs ??= TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder();
   set ocs(covariant TextProcessingApiDeleteTaskResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TextProcessingApiDeleteTaskResponseApplicationJsonBuilder();
+  TextProcessingApiDeleteTaskResponseApplicationJsonBuilder() {
+    TextProcessingApiDeleteTaskResponseApplicationJson._defaults(this);
+  }
 
   TextProcessingApiDeleteTaskResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -27759,6 +28184,7 @@ class TextProcessingApiDeleteTaskResponseApplicationJsonBuilder
   TextProcessingApiDeleteTaskResponseApplicationJson build() => _build();
 
   _$TextProcessingApiDeleteTaskResponseApplicationJson _build() {
+    TextProcessingApiDeleteTaskResponseApplicationJson._validate(this);
     _$TextProcessingApiDeleteTaskResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiDeleteTaskResponseApplicationJson._(ocs: ocs.build());
@@ -27841,7 +28267,9 @@ class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<TextProcessingTask> get tasks => _$this._tasks ??= ListBuilder<TextProcessingTask>();
   set tasks(covariant ListBuilder<TextProcessingTask>? tasks) => _$this._tasks = tasks;
 
-  TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder();
+  TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder() {
+    TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -27867,6 +28295,7 @@ class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder
   TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data _build() {
+    TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data._validate(this);
     _$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data._(tasks: tasks.build());
@@ -27964,7 +28393,9 @@ class TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder
   set data(covariant TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
-  TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder();
+  TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder() {
+    TextProcessingApiListTasksByAppResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -27991,6 +28422,7 @@ class TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder
   TextProcessingApiListTasksByAppResponseApplicationJson_Ocs build() => _build();
 
   _$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs _build() {
+    TextProcessingApiListTasksByAppResponseApplicationJson_Ocs._validate(this);
     _$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -28075,7 +28507,9 @@ class TextProcessingApiListTasksByAppResponseApplicationJsonBuilder
       _$this._ocs ??= TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder();
   set ocs(covariant TextProcessingApiListTasksByAppResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TextProcessingApiListTasksByAppResponseApplicationJsonBuilder();
+  TextProcessingApiListTasksByAppResponseApplicationJsonBuilder() {
+    TextProcessingApiListTasksByAppResponseApplicationJson._defaults(this);
+  }
 
   TextProcessingApiListTasksByAppResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -28101,6 +28535,7 @@ class TextProcessingApiListTasksByAppResponseApplicationJsonBuilder
   TextProcessingApiListTasksByAppResponseApplicationJson build() => _build();
 
   _$TextProcessingApiListTasksByAppResponseApplicationJson _build() {
+    TextProcessingApiListTasksByAppResponseApplicationJson._validate(this);
     _$TextProcessingApiListTasksByAppResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TextProcessingApiListTasksByAppResponseApplicationJson._(ocs: ocs.build());
@@ -28183,7 +28618,9 @@ class TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder
   bool? get isAvailable => _$this._isAvailable;
   set isAvailable(covariant bool? isAvailable) => _$this._isAvailable = isAvailable;
 
-  TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder();
+  TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder() {
+    TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -28209,6 +28646,7 @@ class TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder
   TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data _build() {
+    TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data._(
             isAvailable: BuiltValueNullFieldError.checkNotNull(
@@ -28293,7 +28731,9 @@ class TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder
       _$this._data ??= TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder();
+  TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder() {
+    TextToImageApiIsAvailableResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -28320,6 +28760,7 @@ class TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder
   TextToImageApiIsAvailableResponseApplicationJson_Ocs build() => _build();
 
   _$TextToImageApiIsAvailableResponseApplicationJson_Ocs _build() {
+    TextToImageApiIsAvailableResponseApplicationJson_Ocs._validate(this);
     _$TextToImageApiIsAvailableResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -28403,7 +28844,9 @@ class TextToImageApiIsAvailableResponseApplicationJsonBuilder
       _$this._ocs ??= TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder();
   set ocs(covariant TextToImageApiIsAvailableResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TextToImageApiIsAvailableResponseApplicationJsonBuilder();
+  TextToImageApiIsAvailableResponseApplicationJsonBuilder() {
+    TextToImageApiIsAvailableResponseApplicationJson._defaults(this);
+  }
 
   TextToImageApiIsAvailableResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -28429,6 +28872,7 @@ class TextToImageApiIsAvailableResponseApplicationJsonBuilder
   TextToImageApiIsAvailableResponseApplicationJson build() => _build();
 
   _$TextToImageApiIsAvailableResponseApplicationJson _build() {
+    TextToImageApiIsAvailableResponseApplicationJson._validate(this);
     _$TextToImageApiIsAvailableResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TextToImageApiIsAvailableResponseApplicationJson._(ocs: ocs.build());
@@ -28599,7 +29043,9 @@ class TextToImageTaskBuilder
   int? get completionExpectedAt => _$this._completionExpectedAt;
   set completionExpectedAt(covariant int? completionExpectedAt) => _$this._completionExpectedAt = completionExpectedAt;
 
-  TextToImageTaskBuilder();
+  TextToImageTaskBuilder() {
+    TextToImageTask._defaults(this);
+  }
 
   TextToImageTaskBuilder get _$this {
     final $v = _$v;
@@ -28632,6 +29078,7 @@ class TextToImageTaskBuilder
   TextToImageTask build() => _build();
 
   _$TextToImageTask _build() {
+    TextToImageTask._validate(this);
     final _$result = _$v ??
         _$TextToImageTask._(
             id: id,
@@ -28708,7 +29155,9 @@ class TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder
   TextToImageTaskBuilder get task => _$this._task ??= TextToImageTaskBuilder();
   set task(covariant TextToImageTaskBuilder? task) => _$this._task = task;
 
-  TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder();
+  TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder() {
+    TextToImageApiScheduleResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -28734,6 +29183,7 @@ class TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder
   TextToImageApiScheduleResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TextToImageApiScheduleResponseApplicationJson_Ocs_Data _build() {
+    TextToImageApiScheduleResponseApplicationJson_Ocs_Data._validate(this);
     _$TextToImageApiScheduleResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$TextToImageApiScheduleResponseApplicationJson_Ocs_Data._(task: task.build());
@@ -28827,7 +29277,9 @@ class TextToImageApiScheduleResponseApplicationJson_OcsBuilder
       _$this._data ??= TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TextToImageApiScheduleResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TextToImageApiScheduleResponseApplicationJson_OcsBuilder();
+  TextToImageApiScheduleResponseApplicationJson_OcsBuilder() {
+    TextToImageApiScheduleResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TextToImageApiScheduleResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -28854,6 +29306,7 @@ class TextToImageApiScheduleResponseApplicationJson_OcsBuilder
   TextToImageApiScheduleResponseApplicationJson_Ocs build() => _build();
 
   _$TextToImageApiScheduleResponseApplicationJson_Ocs _build() {
+    TextToImageApiScheduleResponseApplicationJson_Ocs._validate(this);
     _$TextToImageApiScheduleResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$TextToImageApiScheduleResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -28934,7 +29387,9 @@ class TextToImageApiScheduleResponseApplicationJsonBuilder
       _$this._ocs ??= TextToImageApiScheduleResponseApplicationJson_OcsBuilder();
   set ocs(covariant TextToImageApiScheduleResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TextToImageApiScheduleResponseApplicationJsonBuilder();
+  TextToImageApiScheduleResponseApplicationJsonBuilder() {
+    TextToImageApiScheduleResponseApplicationJson._defaults(this);
+  }
 
   TextToImageApiScheduleResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -28960,6 +29415,7 @@ class TextToImageApiScheduleResponseApplicationJsonBuilder
   TextToImageApiScheduleResponseApplicationJson build() => _build();
 
   _$TextToImageApiScheduleResponseApplicationJson _build() {
+    TextToImageApiScheduleResponseApplicationJson._validate(this);
     _$TextToImageApiScheduleResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TextToImageApiScheduleResponseApplicationJson._(ocs: ocs.build());
@@ -29039,7 +29495,9 @@ class TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder
   TextToImageTaskBuilder get task => _$this._task ??= TextToImageTaskBuilder();
   set task(covariant TextToImageTaskBuilder? task) => _$this._task = task;
 
-  TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder();
+  TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder() {
+    TextToImageApiGetTaskResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -29065,6 +29523,7 @@ class TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder
   TextToImageApiGetTaskResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TextToImageApiGetTaskResponseApplicationJson_Ocs_Data _build() {
+    TextToImageApiGetTaskResponseApplicationJson_Ocs_Data._validate(this);
     _$TextToImageApiGetTaskResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$TextToImageApiGetTaskResponseApplicationJson_Ocs_Data._(task: task.build());
@@ -29158,7 +29617,9 @@ class TextToImageApiGetTaskResponseApplicationJson_OcsBuilder
       _$this._data ??= TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TextToImageApiGetTaskResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TextToImageApiGetTaskResponseApplicationJson_OcsBuilder();
+  TextToImageApiGetTaskResponseApplicationJson_OcsBuilder() {
+    TextToImageApiGetTaskResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TextToImageApiGetTaskResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -29185,6 +29646,7 @@ class TextToImageApiGetTaskResponseApplicationJson_OcsBuilder
   TextToImageApiGetTaskResponseApplicationJson_Ocs build() => _build();
 
   _$TextToImageApiGetTaskResponseApplicationJson_Ocs _build() {
+    TextToImageApiGetTaskResponseApplicationJson_Ocs._validate(this);
     _$TextToImageApiGetTaskResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$TextToImageApiGetTaskResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -29265,7 +29727,9 @@ class TextToImageApiGetTaskResponseApplicationJsonBuilder
       _$this._ocs ??= TextToImageApiGetTaskResponseApplicationJson_OcsBuilder();
   set ocs(covariant TextToImageApiGetTaskResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TextToImageApiGetTaskResponseApplicationJsonBuilder();
+  TextToImageApiGetTaskResponseApplicationJsonBuilder() {
+    TextToImageApiGetTaskResponseApplicationJson._defaults(this);
+  }
 
   TextToImageApiGetTaskResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -29291,6 +29755,7 @@ class TextToImageApiGetTaskResponseApplicationJsonBuilder
   TextToImageApiGetTaskResponseApplicationJson build() => _build();
 
   _$TextToImageApiGetTaskResponseApplicationJson _build() {
+    TextToImageApiGetTaskResponseApplicationJson._validate(this);
     _$TextToImageApiGetTaskResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TextToImageApiGetTaskResponseApplicationJson._(ocs: ocs.build());
@@ -29370,7 +29835,9 @@ class TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder
   TextToImageTaskBuilder get task => _$this._task ??= TextToImageTaskBuilder();
   set task(covariant TextToImageTaskBuilder? task) => _$this._task = task;
 
-  TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder();
+  TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder() {
+    TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -29396,6 +29863,7 @@ class TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder
   TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data _build() {
+    TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data._validate(this);
     _$TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data._(task: task.build());
@@ -29490,7 +29958,9 @@ class TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder
       _$this._data ??= TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder();
+  TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder() {
+    TextToImageApiDeleteTaskResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -29517,6 +29987,7 @@ class TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder
   TextToImageApiDeleteTaskResponseApplicationJson_Ocs build() => _build();
 
   _$TextToImageApiDeleteTaskResponseApplicationJson_Ocs _build() {
+    TextToImageApiDeleteTaskResponseApplicationJson_Ocs._validate(this);
     _$TextToImageApiDeleteTaskResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$TextToImageApiDeleteTaskResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -29599,7 +30070,9 @@ class TextToImageApiDeleteTaskResponseApplicationJsonBuilder
       _$this._ocs ??= TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder();
   set ocs(covariant TextToImageApiDeleteTaskResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TextToImageApiDeleteTaskResponseApplicationJsonBuilder();
+  TextToImageApiDeleteTaskResponseApplicationJsonBuilder() {
+    TextToImageApiDeleteTaskResponseApplicationJson._defaults(this);
+  }
 
   TextToImageApiDeleteTaskResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -29625,6 +30098,7 @@ class TextToImageApiDeleteTaskResponseApplicationJsonBuilder
   TextToImageApiDeleteTaskResponseApplicationJson build() => _build();
 
   _$TextToImageApiDeleteTaskResponseApplicationJson _build() {
+    TextToImageApiDeleteTaskResponseApplicationJson._validate(this);
     _$TextToImageApiDeleteTaskResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TextToImageApiDeleteTaskResponseApplicationJson._(ocs: ocs.build());
@@ -29707,7 +30181,9 @@ class TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<TextToImageTask> get tasks => _$this._tasks ??= ListBuilder<TextToImageTask>();
   set tasks(covariant ListBuilder<TextToImageTask>? tasks) => _$this._tasks = tasks;
 
-  TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder();
+  TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder() {
+    TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -29733,6 +30209,7 @@ class TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder
   TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data _build() {
+    TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data._validate(this);
     _$TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data._(tasks: tasks.build());
@@ -29827,7 +30304,9 @@ class TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder
       _$this._data ??= TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder();
+  TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder() {
+    TextToImageApiListTasksByAppResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -29854,6 +30333,7 @@ class TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder
   TextToImageApiListTasksByAppResponseApplicationJson_Ocs build() => _build();
 
   _$TextToImageApiListTasksByAppResponseApplicationJson_Ocs _build() {
+    TextToImageApiListTasksByAppResponseApplicationJson_Ocs._validate(this);
     _$TextToImageApiListTasksByAppResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -29938,7 +30418,9 @@ class TextToImageApiListTasksByAppResponseApplicationJsonBuilder
       _$this._ocs ??= TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder();
   set ocs(covariant TextToImageApiListTasksByAppResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TextToImageApiListTasksByAppResponseApplicationJsonBuilder();
+  TextToImageApiListTasksByAppResponseApplicationJsonBuilder() {
+    TextToImageApiListTasksByAppResponseApplicationJson._defaults(this);
+  }
 
   TextToImageApiListTasksByAppResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -29964,6 +30446,7 @@ class TextToImageApiListTasksByAppResponseApplicationJsonBuilder
   TextToImageApiListTasksByAppResponseApplicationJson build() => _build();
 
   _$TextToImageApiListTasksByAppResponseApplicationJson _build() {
+    TextToImageApiListTasksByAppResponseApplicationJson._validate(this);
     _$TextToImageApiListTasksByAppResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TextToImageApiListTasksByAppResponseApplicationJson._(ocs: ocs.build());
@@ -30092,7 +30575,9 @@ class TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesBuilder
   String? get toLabel => _$this._toLabel;
   set toLabel(covariant String? toLabel) => _$this._toLabel = toLabel;
 
-  TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesBuilder();
+  TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesBuilder() {
+    TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages._defaults(this);
+  }
 
   TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesBuilder get _$this {
     final $v = _$v;
@@ -30121,6 +30606,7 @@ class TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesBuilder
   TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages build() => _build();
 
   _$TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages _build() {
+    TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages._validate(this);
     final _$result = _$v ??
         _$TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages._(
             from: BuiltValueNullFieldError.checkNotNull(
@@ -30218,7 +30704,9 @@ class TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder
   bool? get languageDetection => _$this._languageDetection;
   set languageDetection(covariant bool? languageDetection) => _$this._languageDetection = languageDetection;
 
-  TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder();
+  TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder() {
+    TranslationApiLanguagesResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -30245,6 +30733,7 @@ class TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder
   TranslationApiLanguagesResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TranslationApiLanguagesResponseApplicationJson_Ocs_Data _build() {
+    TranslationApiLanguagesResponseApplicationJson_Ocs_Data._validate(this);
     _$TranslationApiLanguagesResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ??
@@ -30342,7 +30831,9 @@ class TranslationApiLanguagesResponseApplicationJson_OcsBuilder
       _$this._data ??= TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TranslationApiLanguagesResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TranslationApiLanguagesResponseApplicationJson_OcsBuilder();
+  TranslationApiLanguagesResponseApplicationJson_OcsBuilder() {
+    TranslationApiLanguagesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TranslationApiLanguagesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -30369,6 +30860,7 @@ class TranslationApiLanguagesResponseApplicationJson_OcsBuilder
   TranslationApiLanguagesResponseApplicationJson_Ocs build() => _build();
 
   _$TranslationApiLanguagesResponseApplicationJson_Ocs _build() {
+    TranslationApiLanguagesResponseApplicationJson_Ocs._validate(this);
     _$TranslationApiLanguagesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$TranslationApiLanguagesResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -30449,7 +30941,9 @@ class TranslationApiLanguagesResponseApplicationJsonBuilder
       _$this._ocs ??= TranslationApiLanguagesResponseApplicationJson_OcsBuilder();
   set ocs(covariant TranslationApiLanguagesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TranslationApiLanguagesResponseApplicationJsonBuilder();
+  TranslationApiLanguagesResponseApplicationJsonBuilder() {
+    TranslationApiLanguagesResponseApplicationJson._defaults(this);
+  }
 
   TranslationApiLanguagesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -30475,6 +30969,7 @@ class TranslationApiLanguagesResponseApplicationJsonBuilder
   TranslationApiLanguagesResponseApplicationJson build() => _build();
 
   _$TranslationApiLanguagesResponseApplicationJson _build() {
+    TranslationApiLanguagesResponseApplicationJson._validate(this);
     _$TranslationApiLanguagesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TranslationApiLanguagesResponseApplicationJson._(ocs: ocs.build());
@@ -30567,7 +31062,9 @@ class TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder
   String? get from => _$this._from;
   set from(covariant String? from) => _$this._from = from;
 
-  TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder();
+  TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder() {
+    TranslationApiTranslateResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -30594,6 +31091,7 @@ class TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder
   TranslationApiTranslateResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TranslationApiTranslateResponseApplicationJson_Ocs_Data _build() {
+    TranslationApiTranslateResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$TranslationApiTranslateResponseApplicationJson_Ocs_Data._(
             text: BuiltValueNullFieldError.checkNotNull(
@@ -30678,7 +31176,9 @@ class TranslationApiTranslateResponseApplicationJson_OcsBuilder
       _$this._data ??= TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TranslationApiTranslateResponseApplicationJson_OcsBuilder();
+  TranslationApiTranslateResponseApplicationJson_OcsBuilder() {
+    TranslationApiTranslateResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TranslationApiTranslateResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -30705,6 +31205,7 @@ class TranslationApiTranslateResponseApplicationJson_OcsBuilder
   TranslationApiTranslateResponseApplicationJson_Ocs build() => _build();
 
   _$TranslationApiTranslateResponseApplicationJson_Ocs _build() {
+    TranslationApiTranslateResponseApplicationJson_Ocs._validate(this);
     _$TranslationApiTranslateResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$TranslationApiTranslateResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -30785,7 +31286,9 @@ class TranslationApiTranslateResponseApplicationJsonBuilder
       _$this._ocs ??= TranslationApiTranslateResponseApplicationJson_OcsBuilder();
   set ocs(covariant TranslationApiTranslateResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TranslationApiTranslateResponseApplicationJsonBuilder();
+  TranslationApiTranslateResponseApplicationJsonBuilder() {
+    TranslationApiTranslateResponseApplicationJson._defaults(this);
+  }
 
   TranslationApiTranslateResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -30811,6 +31314,7 @@ class TranslationApiTranslateResponseApplicationJsonBuilder
   TranslationApiTranslateResponseApplicationJson build() => _build();
 
   _$TranslationApiTranslateResponseApplicationJson _build() {
+    TranslationApiTranslateResponseApplicationJson._validate(this);
     _$TranslationApiTranslateResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TranslationApiTranslateResponseApplicationJson._(ocs: ocs.build());
@@ -30981,7 +31485,9 @@ class UnifiedSearchProviderBuilder
   bool? get inAppSearch => _$this._inAppSearch;
   set inAppSearch(covariant bool? inAppSearch) => _$this._inAppSearch = inAppSearch;
 
-  UnifiedSearchProviderBuilder();
+  UnifiedSearchProviderBuilder() {
+    UnifiedSearchProvider._defaults(this);
+  }
 
   UnifiedSearchProviderBuilder get _$this {
     final $v = _$v;
@@ -31014,6 +31520,7 @@ class UnifiedSearchProviderBuilder
   UnifiedSearchProvider build() => _build();
 
   _$UnifiedSearchProvider _build() {
+    UnifiedSearchProvider._validate(this);
     _$UnifiedSearchProvider _$result;
     try {
       _$result = _$v ??
@@ -31117,7 +31624,9 @@ class UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder
   ListBuilder<UnifiedSearchProvider> get data => _$this._data ??= ListBuilder<UnifiedSearchProvider>();
   set data(covariant ListBuilder<UnifiedSearchProvider>? data) => _$this._data = data;
 
-  UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder();
+  UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder() {
+    UnifiedSearchGetProvidersResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -31144,6 +31653,7 @@ class UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder
   UnifiedSearchGetProvidersResponseApplicationJson_Ocs build() => _build();
 
   _$UnifiedSearchGetProvidersResponseApplicationJson_Ocs _build() {
+    UnifiedSearchGetProvidersResponseApplicationJson_Ocs._validate(this);
     _$UnifiedSearchGetProvidersResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -31227,7 +31737,9 @@ class UnifiedSearchGetProvidersResponseApplicationJsonBuilder
       _$this._ocs ??= UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder();
   set ocs(covariant UnifiedSearchGetProvidersResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UnifiedSearchGetProvidersResponseApplicationJsonBuilder();
+  UnifiedSearchGetProvidersResponseApplicationJsonBuilder() {
+    UnifiedSearchGetProvidersResponseApplicationJson._defaults(this);
+  }
 
   UnifiedSearchGetProvidersResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -31253,6 +31765,7 @@ class UnifiedSearchGetProvidersResponseApplicationJsonBuilder
   UnifiedSearchGetProvidersResponseApplicationJson build() => _build();
 
   _$UnifiedSearchGetProvidersResponseApplicationJson _build() {
+    UnifiedSearchGetProvidersResponseApplicationJson._validate(this);
     _$UnifiedSearchGetProvidersResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UnifiedSearchGetProvidersResponseApplicationJson._(ocs: ocs.build());
@@ -31416,7 +31929,9 @@ class UnifiedSearchResultEntryBuilder
   ListBuilder<String> get attributes => _$this._attributes ??= ListBuilder<String>();
   set attributes(covariant ListBuilder<String>? attributes) => _$this._attributes = attributes;
 
-  UnifiedSearchResultEntryBuilder();
+  UnifiedSearchResultEntryBuilder() {
+    UnifiedSearchResultEntry._defaults(this);
+  }
 
   UnifiedSearchResultEntryBuilder get _$this {
     final $v = _$v;
@@ -31448,6 +31963,7 @@ class UnifiedSearchResultEntryBuilder
   UnifiedSearchResultEntry build() => _build();
 
   _$UnifiedSearchResultEntry _build() {
+    UnifiedSearchResultEntry._validate(this);
     _$UnifiedSearchResultEntry _$result;
     try {
       _$result = _$v ??
@@ -31572,7 +32088,9 @@ class UnifiedSearchResultBuilder
   UnifiedSearchResult_Cursor? get cursor => _$this._cursor;
   set cursor(covariant UnifiedSearchResult_Cursor? cursor) => _$this._cursor = cursor;
 
-  UnifiedSearchResultBuilder();
+  UnifiedSearchResultBuilder() {
+    UnifiedSearchResult._defaults(this);
+  }
 
   UnifiedSearchResultBuilder get _$this {
     final $v = _$v;
@@ -31697,7 +32215,9 @@ class UnifiedSearchSearchResponseApplicationJson_OcsBuilder
   UnifiedSearchResultBuilder get data => _$this._data ??= UnifiedSearchResultBuilder();
   set data(covariant UnifiedSearchResultBuilder? data) => _$this._data = data;
 
-  UnifiedSearchSearchResponseApplicationJson_OcsBuilder();
+  UnifiedSearchSearchResponseApplicationJson_OcsBuilder() {
+    UnifiedSearchSearchResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UnifiedSearchSearchResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -31724,6 +32244,7 @@ class UnifiedSearchSearchResponseApplicationJson_OcsBuilder
   UnifiedSearchSearchResponseApplicationJson_Ocs build() => _build();
 
   _$UnifiedSearchSearchResponseApplicationJson_Ocs _build() {
+    UnifiedSearchSearchResponseApplicationJson_Ocs._validate(this);
     _$UnifiedSearchSearchResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$UnifiedSearchSearchResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -31804,7 +32325,9 @@ class UnifiedSearchSearchResponseApplicationJsonBuilder
       _$this._ocs ??= UnifiedSearchSearchResponseApplicationJson_OcsBuilder();
   set ocs(covariant UnifiedSearchSearchResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UnifiedSearchSearchResponseApplicationJsonBuilder();
+  UnifiedSearchSearchResponseApplicationJsonBuilder() {
+    UnifiedSearchSearchResponseApplicationJson._defaults(this);
+  }
 
   UnifiedSearchSearchResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -31830,6 +32353,7 @@ class UnifiedSearchSearchResponseApplicationJsonBuilder
   UnifiedSearchSearchResponseApplicationJson build() => _build();
 
   _$UnifiedSearchSearchResponseApplicationJson _build() {
+    UnifiedSearchSearchResponseApplicationJson._validate(this);
     _$UnifiedSearchSearchResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UnifiedSearchSearchResponseApplicationJson._(ocs: ocs.build());
@@ -31924,7 +32448,9 @@ class WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder
   ListBuilder<String> get admin => _$this._admin ??= ListBuilder<String>();
   set admin(covariant ListBuilder<String>? admin) => _$this._admin = admin;
 
-  WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder();
+  WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder() {
+    WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew._defaults(this);
+  }
 
   WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder get _$this {
     final $v = _$v;
@@ -31951,6 +32477,7 @@ class WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder
   WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew build() => _build();
 
   _$WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew _build() {
+    WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew._validate(this);
     _$WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew _$result;
     try {
       _$result = _$v ??
@@ -32076,7 +32603,9 @@ class WhatsNewGetResponseApplicationJson_Ocs_DataBuilder
   set whatsNew(covariant WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewBuilder? whatsNew) =>
       _$this._whatsNew = whatsNew;
 
-  WhatsNewGetResponseApplicationJson_Ocs_DataBuilder();
+  WhatsNewGetResponseApplicationJson_Ocs_DataBuilder() {
+    WhatsNewGetResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   WhatsNewGetResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -32105,6 +32634,7 @@ class WhatsNewGetResponseApplicationJson_Ocs_DataBuilder
   WhatsNewGetResponseApplicationJson_Ocs_Data build() => _build();
 
   _$WhatsNewGetResponseApplicationJson_Ocs_Data _build() {
+    WhatsNewGetResponseApplicationJson_Ocs_Data._validate(this);
     _$WhatsNewGetResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ??
@@ -32204,7 +32734,9 @@ class WhatsNewGetResponseApplicationJson_OcsBuilder
       _$this._data ??= WhatsNewGetResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant WhatsNewGetResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  WhatsNewGetResponseApplicationJson_OcsBuilder();
+  WhatsNewGetResponseApplicationJson_OcsBuilder() {
+    WhatsNewGetResponseApplicationJson_Ocs._defaults(this);
+  }
 
   WhatsNewGetResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -32231,6 +32763,7 @@ class WhatsNewGetResponseApplicationJson_OcsBuilder
   WhatsNewGetResponseApplicationJson_Ocs build() => _build();
 
   _$WhatsNewGetResponseApplicationJson_Ocs _build() {
+    WhatsNewGetResponseApplicationJson_Ocs._validate(this);
     _$WhatsNewGetResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$WhatsNewGetResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -32307,7 +32840,9 @@ class WhatsNewGetResponseApplicationJsonBuilder
       _$this._ocs ??= WhatsNewGetResponseApplicationJson_OcsBuilder();
   set ocs(covariant WhatsNewGetResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  WhatsNewGetResponseApplicationJsonBuilder();
+  WhatsNewGetResponseApplicationJsonBuilder() {
+    WhatsNewGetResponseApplicationJson._defaults(this);
+  }
 
   WhatsNewGetResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -32333,6 +32868,7 @@ class WhatsNewGetResponseApplicationJsonBuilder
   WhatsNewGetResponseApplicationJson build() => _build();
 
   _$WhatsNewGetResponseApplicationJson _build() {
+    WhatsNewGetResponseApplicationJson._validate(this);
     _$WhatsNewGetResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$WhatsNewGetResponseApplicationJson._(ocs: ocs.build());
@@ -32423,7 +32959,9 @@ class WhatsNewDismissResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  WhatsNewDismissResponseApplicationJson_OcsBuilder();
+  WhatsNewDismissResponseApplicationJson_OcsBuilder() {
+    WhatsNewDismissResponseApplicationJson_Ocs._defaults(this);
+  }
 
   WhatsNewDismissResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -32450,6 +32988,7 @@ class WhatsNewDismissResponseApplicationJson_OcsBuilder
   WhatsNewDismissResponseApplicationJson_Ocs build() => _build();
 
   _$WhatsNewDismissResponseApplicationJson_Ocs _build() {
+    WhatsNewDismissResponseApplicationJson_Ocs._validate(this);
     _$WhatsNewDismissResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -32530,7 +33069,9 @@ class WhatsNewDismissResponseApplicationJsonBuilder
       _$this._ocs ??= WhatsNewDismissResponseApplicationJson_OcsBuilder();
   set ocs(covariant WhatsNewDismissResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  WhatsNewDismissResponseApplicationJsonBuilder();
+  WhatsNewDismissResponseApplicationJsonBuilder() {
+    WhatsNewDismissResponseApplicationJson._defaults(this);
+  }
 
   WhatsNewDismissResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -32556,6 +33097,7 @@ class WhatsNewDismissResponseApplicationJsonBuilder
   WhatsNewDismissResponseApplicationJson build() => _build();
 
   _$WhatsNewDismissResponseApplicationJson _build() {
+    WhatsNewDismissResponseApplicationJson._validate(this);
     _$WhatsNewDismissResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$WhatsNewDismissResponseApplicationJson._(ocs: ocs.build());
@@ -32631,7 +33173,9 @@ class WipeCheckWipeResponseApplicationJsonBuilder
   bool? get wipe => _$this._wipe;
   set wipe(covariant bool? wipe) => _$this._wipe = wipe;
 
-  WipeCheckWipeResponseApplicationJsonBuilder();
+  WipeCheckWipeResponseApplicationJsonBuilder() {
+    WipeCheckWipeResponseApplicationJson._defaults(this);
+  }
 
   WipeCheckWipeResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -32657,6 +33201,7 @@ class WipeCheckWipeResponseApplicationJsonBuilder
   WipeCheckWipeResponseApplicationJson build() => _build();
 
   _$WipeCheckWipeResponseApplicationJson _build() {
+    WipeCheckWipeResponseApplicationJson._validate(this);
     final _$result = _$v ??
         _$WipeCheckWipeResponseApplicationJson._(
             wipe: BuiltValueNullFieldError.checkNotNull(wipe, r'WipeCheckWipeResponseApplicationJson', 'wipe'));

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.dart
@@ -385,6 +385,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -411,6 +415,16 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -418,6 +432,10 @@ abstract interface class $Widget_ButtonsInterface {
   String get type;
   String get text;
   String get link;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Widget_ButtonsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Widget_ButtonsInterfaceBuilder b) {}
 }
 
 abstract class Widget_Buttons implements $Widget_ButtonsInterface, Built<Widget_Buttons, Widget_ButtonsBuilder> {
@@ -444,6 +462,16 @@ abstract class Widget_Buttons implements $Widget_ButtonsInterface, Built<Widget_
 
   /// Serializer for Widget_Buttons.
   static Serializer<Widget_Buttons> get serializer => _$widgetButtonsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Widget_ButtonsBuilder b) {
+    $Widget_ButtonsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Widget_ButtonsBuilder b) {
+    $Widget_ButtonsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -464,6 +492,10 @@ abstract interface class $WidgetInterface {
   @BuiltValueField(wireName: 'reload_interval')
   int? get reloadInterval;
   BuiltList<Widget_Buttons>? get buttons;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WidgetInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WidgetInterfaceBuilder b) {}
 }
 
 abstract class Widget implements $WidgetInterface, Built<Widget, WidgetBuilder> {
@@ -490,12 +522,26 @@ abstract class Widget implements $WidgetInterface, Built<Widget, WidgetBuilder> 
 
   /// Serializer for Widget.
   static Serializer<Widget> get serializer => _$widgetSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WidgetBuilder b) {
+    $WidgetInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WidgetBuilder b) {
+    $WidgetInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DashboardApiGetWidgetsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, Widget> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DashboardApiGetWidgetsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DashboardApiGetWidgetsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class DashboardApiGetWidgetsResponseApplicationJson_Ocs
@@ -530,11 +576,25 @@ abstract class DashboardApiGetWidgetsResponseApplicationJson_Ocs
   /// Serializer for DashboardApiGetWidgetsResponseApplicationJson_Ocs.
   static Serializer<DashboardApiGetWidgetsResponseApplicationJson_Ocs> get serializer =>
       _$dashboardApiGetWidgetsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder b) {
+    $DashboardApiGetWidgetsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder b) {
+    $DashboardApiGetWidgetsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DashboardApiGetWidgetsResponseApplicationJsonInterface {
   DashboardApiGetWidgetsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DashboardApiGetWidgetsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DashboardApiGetWidgetsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DashboardApiGetWidgetsResponseApplicationJson
@@ -568,6 +628,16 @@ abstract class DashboardApiGetWidgetsResponseApplicationJson
   /// Serializer for DashboardApiGetWidgetsResponseApplicationJson.
   static Serializer<DashboardApiGetWidgetsResponseApplicationJson> get serializer =>
       _$dashboardApiGetWidgetsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DashboardApiGetWidgetsResponseApplicationJsonBuilder b) {
+    $DashboardApiGetWidgetsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DashboardApiGetWidgetsResponseApplicationJsonBuilder b) {
+    $DashboardApiGetWidgetsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -578,6 +648,10 @@ abstract interface class $WidgetItemInterface {
   String get iconUrl;
   String? get overlayIconUrl;
   String get sinceId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WidgetItemInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WidgetItemInterfaceBuilder b) {}
 }
 
 abstract class WidgetItem implements $WidgetItemInterface, Built<WidgetItem, WidgetItemBuilder> {
@@ -604,12 +678,26 @@ abstract class WidgetItem implements $WidgetItemInterface, Built<WidgetItem, Wid
 
   /// Serializer for WidgetItem.
   static Serializer<WidgetItem> get serializer => _$widgetItemSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WidgetItemBuilder b) {
+    $WidgetItemInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WidgetItemBuilder b) {
+    $WidgetItemInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<WidgetItem>> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class DashboardApiGetWidgetItemsResponseApplicationJson_Ocs
@@ -644,11 +732,25 @@ abstract class DashboardApiGetWidgetItemsResponseApplicationJson_Ocs
   /// Serializer for DashboardApiGetWidgetItemsResponseApplicationJson_Ocs.
   static Serializer<DashboardApiGetWidgetItemsResponseApplicationJson_Ocs> get serializer =>
       _$dashboardApiGetWidgetItemsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder b) {
+    $DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder b) {
+    $DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DashboardApiGetWidgetItemsResponseApplicationJsonInterface {
   DashboardApiGetWidgetItemsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DashboardApiGetWidgetItemsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DashboardApiGetWidgetItemsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DashboardApiGetWidgetItemsResponseApplicationJson
@@ -683,6 +785,16 @@ abstract class DashboardApiGetWidgetItemsResponseApplicationJson
   /// Serializer for DashboardApiGetWidgetItemsResponseApplicationJson.
   static Serializer<DashboardApiGetWidgetItemsResponseApplicationJson> get serializer =>
       _$dashboardApiGetWidgetItemsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DashboardApiGetWidgetItemsResponseApplicationJsonBuilder b) {
+    $DashboardApiGetWidgetItemsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DashboardApiGetWidgetItemsResponseApplicationJsonBuilder b) {
+    $DashboardApiGetWidgetItemsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -690,6 +802,10 @@ abstract interface class $WidgetItemsInterface {
   BuiltList<WidgetItem> get items;
   String get emptyContentMessage;
   String get halfEmptyContentMessage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WidgetItemsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WidgetItemsInterfaceBuilder b) {}
 }
 
 abstract class WidgetItems implements $WidgetItemsInterface, Built<WidgetItems, WidgetItemsBuilder> {
@@ -716,12 +832,26 @@ abstract class WidgetItems implements $WidgetItemsInterface, Built<WidgetItems, 
 
   /// Serializer for WidgetItems.
   static Serializer<WidgetItems> get serializer => _$widgetItemsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WidgetItemsBuilder b) {
+    $WidgetItemsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WidgetItemsBuilder b) {
+    $WidgetItemsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, WidgetItems> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs
@@ -756,11 +886,25 @@ abstract class DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs
   /// Serializer for DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs.
   static Serializer<DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs> get serializer =>
       _$dashboardApiGetWidgetItemsV2ResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder b) {
+    $DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder b) {
+    $DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterface {
   DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DashboardApiGetWidgetItemsV2ResponseApplicationJson
@@ -795,6 +939,16 @@ abstract class DashboardApiGetWidgetItemsV2ResponseApplicationJson
   /// Serializer for DashboardApiGetWidgetItemsV2ResponseApplicationJson.
   static Serializer<DashboardApiGetWidgetItemsV2ResponseApplicationJson> get serializer =>
       _$dashboardApiGetWidgetItemsV2ResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder b) {
+    $DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder b) {
+    $DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.g.dart
@@ -756,7 +756,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -786,6 +788,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -875,7 +878,9 @@ class Widget_ButtonsBuilder implements Builder<Widget_Buttons, Widget_ButtonsBui
   String? get link => _$this._link;
   set link(covariant String? link) => _$this._link = link;
 
-  Widget_ButtonsBuilder();
+  Widget_ButtonsBuilder() {
+    Widget_Buttons._defaults(this);
+  }
 
   Widget_ButtonsBuilder get _$this {
     final $v = _$v;
@@ -903,6 +908,7 @@ class Widget_ButtonsBuilder implements Builder<Widget_Buttons, Widget_ButtonsBui
   Widget_Buttons build() => _build();
 
   _$Widget_Buttons _build() {
+    Widget_Buttons._validate(this);
     final _$result = _$v ??
         _$Widget_Buttons._(
             type: BuiltValueNullFieldError.checkNotNull(type, r'Widget_Buttons', 'type'),
@@ -1090,7 +1096,9 @@ class WidgetBuilder implements Builder<Widget, WidgetBuilder>, $WidgetInterfaceB
   ListBuilder<Widget_Buttons> get buttons => _$this._buttons ??= ListBuilder<Widget_Buttons>();
   set buttons(covariant ListBuilder<Widget_Buttons>? buttons) => _$this._buttons = buttons;
 
-  WidgetBuilder();
+  WidgetBuilder() {
+    Widget._defaults(this);
+  }
 
   WidgetBuilder get _$this {
     final $v = _$v;
@@ -1125,6 +1133,7 @@ class WidgetBuilder implements Builder<Widget, WidgetBuilder>, $WidgetInterfaceB
   Widget build() => _build();
 
   _$Widget _build() {
+    Widget._validate(this);
     _$Widget _$result;
     try {
       _$result = _$v ??
@@ -1230,7 +1239,9 @@ class DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder
   MapBuilder<String, Widget> get data => _$this._data ??= MapBuilder<String, Widget>();
   set data(covariant MapBuilder<String, Widget>? data) => _$this._data = data;
 
-  DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder();
+  DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder() {
+    DashboardApiGetWidgetsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1257,6 +1268,7 @@ class DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder
   DashboardApiGetWidgetsResponseApplicationJson_Ocs build() => _build();
 
   _$DashboardApiGetWidgetsResponseApplicationJson_Ocs _build() {
+    DashboardApiGetWidgetsResponseApplicationJson_Ocs._validate(this);
     _$DashboardApiGetWidgetsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$DashboardApiGetWidgetsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -1337,7 +1349,9 @@ class DashboardApiGetWidgetsResponseApplicationJsonBuilder
       _$this._ocs ??= DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder();
   set ocs(covariant DashboardApiGetWidgetsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  DashboardApiGetWidgetsResponseApplicationJsonBuilder();
+  DashboardApiGetWidgetsResponseApplicationJsonBuilder() {
+    DashboardApiGetWidgetsResponseApplicationJson._defaults(this);
+  }
 
   DashboardApiGetWidgetsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1363,6 +1377,7 @@ class DashboardApiGetWidgetsResponseApplicationJsonBuilder
   DashboardApiGetWidgetsResponseApplicationJson build() => _build();
 
   _$DashboardApiGetWidgetsResponseApplicationJson _build() {
+    DashboardApiGetWidgetsResponseApplicationJson._validate(this);
     _$DashboardApiGetWidgetsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$DashboardApiGetWidgetsResponseApplicationJson._(ocs: ocs.build());
@@ -1505,7 +1520,9 @@ class WidgetItemBuilder implements Builder<WidgetItem, WidgetItemBuilder>, $Widg
   String? get sinceId => _$this._sinceId;
   set sinceId(covariant String? sinceId) => _$this._sinceId = sinceId;
 
-  WidgetItemBuilder();
+  WidgetItemBuilder() {
+    WidgetItem._defaults(this);
+  }
 
   WidgetItemBuilder get _$this {
     final $v = _$v;
@@ -1536,6 +1553,7 @@ class WidgetItemBuilder implements Builder<WidgetItem, WidgetItemBuilder>, $Widg
   WidgetItem build() => _build();
 
   _$WidgetItem _build() {
+    WidgetItem._validate(this);
     final _$result = _$v ??
         _$WidgetItem._(
             subtitle: BuiltValueNullFieldError.checkNotNull(subtitle, r'WidgetItem', 'subtitle'),
@@ -1623,7 +1641,9 @@ class DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder
   MapBuilder<String, BuiltList<WidgetItem>> get data => _$this._data ??= MapBuilder<String, BuiltList<WidgetItem>>();
   set data(covariant MapBuilder<String, BuiltList<WidgetItem>>? data) => _$this._data = data;
 
-  DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder();
+  DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder() {
+    DashboardApiGetWidgetItemsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1650,6 +1670,7 @@ class DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder
   DashboardApiGetWidgetItemsResponseApplicationJson_Ocs build() => _build();
 
   _$DashboardApiGetWidgetItemsResponseApplicationJson_Ocs _build() {
+    DashboardApiGetWidgetItemsResponseApplicationJson_Ocs._validate(this);
     _$DashboardApiGetWidgetItemsResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -1733,7 +1754,9 @@ class DashboardApiGetWidgetItemsResponseApplicationJsonBuilder
       _$this._ocs ??= DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder();
   set ocs(covariant DashboardApiGetWidgetItemsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  DashboardApiGetWidgetItemsResponseApplicationJsonBuilder();
+  DashboardApiGetWidgetItemsResponseApplicationJsonBuilder() {
+    DashboardApiGetWidgetItemsResponseApplicationJson._defaults(this);
+  }
 
   DashboardApiGetWidgetItemsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1759,6 +1782,7 @@ class DashboardApiGetWidgetItemsResponseApplicationJsonBuilder
   DashboardApiGetWidgetItemsResponseApplicationJson build() => _build();
 
   _$DashboardApiGetWidgetItemsResponseApplicationJson _build() {
+    DashboardApiGetWidgetItemsResponseApplicationJson._validate(this);
     _$DashboardApiGetWidgetItemsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$DashboardApiGetWidgetItemsResponseApplicationJson._(ocs: ocs.build());
@@ -1860,7 +1884,9 @@ class WidgetItemsBuilder implements Builder<WidgetItems, WidgetItemsBuilder>, $W
   set halfEmptyContentMessage(covariant String? halfEmptyContentMessage) =>
       _$this._halfEmptyContentMessage = halfEmptyContentMessage;
 
-  WidgetItemsBuilder();
+  WidgetItemsBuilder() {
+    WidgetItems._defaults(this);
+  }
 
   WidgetItemsBuilder get _$this {
     final $v = _$v;
@@ -1888,6 +1914,7 @@ class WidgetItemsBuilder implements Builder<WidgetItems, WidgetItemsBuilder>, $W
   WidgetItems build() => _build();
 
   _$WidgetItems _build() {
+    WidgetItems._validate(this);
     _$WidgetItems _$result;
     try {
       _$result = _$v ??
@@ -1986,7 +2013,9 @@ class DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder
   MapBuilder<String, WidgetItems> get data => _$this._data ??= MapBuilder<String, WidgetItems>();
   set data(covariant MapBuilder<String, WidgetItems>? data) => _$this._data = data;
 
-  DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder();
+  DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder() {
+    DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs._defaults(this);
+  }
 
   DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2013,6 +2042,7 @@ class DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder
   DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs build() => _build();
 
   _$DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs _build() {
+    DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs._validate(this);
     _$DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -2097,7 +2127,9 @@ class DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder
       _$this._ocs ??= DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder();
   set ocs(covariant DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder();
+  DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder() {
+    DashboardApiGetWidgetItemsV2ResponseApplicationJson._defaults(this);
+  }
 
   DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -2123,6 +2155,7 @@ class DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder
   DashboardApiGetWidgetItemsV2ResponseApplicationJson build() => _build();
 
   _$DashboardApiGetWidgetItemsV2ResponseApplicationJson _build() {
+    DashboardApiGetWidgetItemsV2ResponseApplicationJson._validate(this);
     _$DashboardApiGetWidgetItemsV2ResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$DashboardApiGetWidgetItemsV2ResponseApplicationJson._(ocs: ocs.build());

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -598,6 +598,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -624,11 +628,25 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectGetUrlResponseApplicationJson_Ocs_DataInterface {
   String get url;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectGetUrlResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectGetUrlResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class DirectGetUrlResponseApplicationJson_Ocs_Data
@@ -662,12 +680,26 @@ abstract class DirectGetUrlResponseApplicationJson_Ocs_Data
   /// Serializer for DirectGetUrlResponseApplicationJson_Ocs_Data.
   static Serializer<DirectGetUrlResponseApplicationJson_Ocs_Data> get serializer =>
       _$directGetUrlResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectGetUrlResponseApplicationJson_Ocs_DataBuilder b) {
+    $DirectGetUrlResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectGetUrlResponseApplicationJson_Ocs_DataBuilder b) {
+    $DirectGetUrlResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectGetUrlResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   DirectGetUrlResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectGetUrlResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectGetUrlResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class DirectGetUrlResponseApplicationJson_Ocs
@@ -700,11 +732,25 @@ abstract class DirectGetUrlResponseApplicationJson_Ocs
   /// Serializer for DirectGetUrlResponseApplicationJson_Ocs.
   static Serializer<DirectGetUrlResponseApplicationJson_Ocs> get serializer =>
       _$directGetUrlResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectGetUrlResponseApplicationJson_OcsBuilder b) {
+    $DirectGetUrlResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectGetUrlResponseApplicationJson_OcsBuilder b) {
+    $DirectGetUrlResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectGetUrlResponseApplicationJsonInterface {
   DirectGetUrlResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectGetUrlResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectGetUrlResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DirectGetUrlResponseApplicationJson
@@ -737,12 +783,26 @@ abstract class DirectGetUrlResponseApplicationJson
   /// Serializer for DirectGetUrlResponseApplicationJson.
   static Serializer<DirectGetUrlResponseApplicationJson> get serializer =>
       _$directGetUrlResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectGetUrlResponseApplicationJsonBuilder b) {
+    $DirectGetUrlResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectGetUrlResponseApplicationJsonBuilder b) {
+    $DirectGetUrlResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OutOfOfficeDataCommonInterface {
   String get userId;
   String get message;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeDataCommonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeDataCommonInterfaceBuilder b) {}
 }
 
 abstract class OutOfOfficeDataCommon
@@ -771,6 +831,16 @@ abstract class OutOfOfficeDataCommon
 
   /// Serializer for OutOfOfficeDataCommon.
   static Serializer<OutOfOfficeDataCommon> get serializer => _$outOfOfficeDataCommonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeDataCommonBuilder b) {
+    $OutOfOfficeDataCommonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeDataCommonBuilder b) {
+    $OutOfOfficeDataCommonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -779,6 +849,10 @@ abstract interface class $CurrentOutOfOfficeDataInterface implements $OutOfOffic
   int get startDate;
   int get endDate;
   String get shortMessage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CurrentOutOfOfficeDataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CurrentOutOfOfficeDataInterfaceBuilder b) {}
 }
 
 abstract class CurrentOutOfOfficeData
@@ -807,12 +881,26 @@ abstract class CurrentOutOfOfficeData
 
   /// Serializer for CurrentOutOfOfficeData.
   static Serializer<CurrentOutOfOfficeData> get serializer => _$currentOutOfOfficeDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CurrentOutOfOfficeDataBuilder b) {
+    $CurrentOutOfOfficeDataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CurrentOutOfOfficeDataBuilder b) {
+    $CurrentOutOfOfficeDataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   CurrentOutOfOfficeData get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs
@@ -847,11 +935,25 @@ abstract class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs
   /// Serializer for OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs.
   static Serializer<OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs> get serializer =>
       _$outOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsBuilder b) {
+    $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsBuilder b) {
+    $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterface {
   OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson
@@ -886,6 +988,16 @@ abstract class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson
   /// Serializer for OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson.
   static Serializer<OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson> get serializer =>
       _$outOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonBuilder b) {
+    $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonBuilder b) {
+    $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -894,6 +1006,10 @@ abstract interface class $OutOfOfficeDataInterface implements $OutOfOfficeDataCo
   String get firstDay;
   String get lastDay;
   String get status;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeDataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeDataInterfaceBuilder b) {}
 }
 
 abstract class OutOfOfficeData implements $OutOfOfficeDataInterface, Built<OutOfOfficeData, OutOfOfficeDataBuilder> {
@@ -920,12 +1036,26 @@ abstract class OutOfOfficeData implements $OutOfOfficeDataInterface, Built<OutOf
 
   /// Serializer for OutOfOfficeData.
   static Serializer<OutOfOfficeData> get serializer => _$outOfOfficeDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeDataBuilder b) {
+    $OutOfOfficeDataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeDataBuilder b) {
+    $OutOfOfficeDataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OutOfOfficeData get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs
@@ -960,11 +1090,25 @@ abstract class OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs
   /// Serializer for OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs.
   static Serializer<OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs> get serializer =>
       _$outOfOfficeGetOutOfOfficeResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsBuilder b) {
+    $OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsBuilder b) {
+    $OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterface {
   OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class OutOfOfficeGetOutOfOfficeResponseApplicationJson
@@ -999,12 +1143,26 @@ abstract class OutOfOfficeGetOutOfOfficeResponseApplicationJson
   /// Serializer for OutOfOfficeGetOutOfOfficeResponseApplicationJson.
   static Serializer<OutOfOfficeGetOutOfOfficeResponseApplicationJson> get serializer =>
       _$outOfOfficeGetOutOfOfficeResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeGetOutOfOfficeResponseApplicationJsonBuilder b) {
+    $OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeGetOutOfOfficeResponseApplicationJsonBuilder b) {
+    $OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OutOfOfficeData get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs
@@ -1039,11 +1197,25 @@ abstract class OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs
   /// Serializer for OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs.
   static Serializer<OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs> get serializer =>
       _$outOfOfficeSetOutOfOfficeResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsBuilder b) {
+    $OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsBuilder b) {
+    $OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterface {
   OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class OutOfOfficeSetOutOfOfficeResponseApplicationJson
@@ -1078,12 +1250,26 @@ abstract class OutOfOfficeSetOutOfOfficeResponseApplicationJson
   /// Serializer for OutOfOfficeSetOutOfOfficeResponseApplicationJson.
   static Serializer<OutOfOfficeSetOutOfOfficeResponseApplicationJson> get serializer =>
       _$outOfOfficeSetOutOfOfficeResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeSetOutOfOfficeResponseApplicationJsonBuilder b) {
+    $OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeSetOutOfOfficeResponseApplicationJsonBuilder b) {
+    $OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject? get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs
@@ -1118,11 +1304,25 @@ abstract class OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs
   /// Serializer for OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs.
   static Serializer<OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs> get serializer =>
       _$outOfOfficeClearOutOfOfficeResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsBuilder b) {
+    $OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsBuilder b) {
+    $OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterface {
   OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class OutOfOfficeClearOutOfOfficeResponseApplicationJson
@@ -1157,12 +1357,26 @@ abstract class OutOfOfficeClearOutOfOfficeResponseApplicationJson
   /// Serializer for OutOfOfficeClearOutOfOfficeResponseApplicationJson.
   static Serializer<OutOfOfficeClearOutOfOfficeResponseApplicationJson> get serializer =>
       _$outOfOfficeClearOutOfOfficeResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeClearOutOfOfficeResponseApplicationJsonBuilder b) {
+    $OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeClearOutOfOfficeResponseApplicationJsonBuilder b) {
+    $OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities_DavInterface {
   String get chunking;
   String? get bulkupload;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_DavInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_DavInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_Dav
@@ -1190,11 +1404,25 @@ abstract class Capabilities_Dav
 
   /// Serializer for Capabilities_Dav.
   static Serializer<Capabilities_Dav> get serializer => _$capabilitiesDavSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_DavBuilder b) {
+    $Capabilities_DavInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_DavBuilder b) {
+    $Capabilities_DavInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   Capabilities_Dav get dav;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -1221,6 +1449,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -850,9 +850,14 @@ abstract interface class $CurrentOutOfOfficeDataInterface implements $OutOfOffic
   int get endDate;
   String get shortMessage;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($CurrentOutOfOfficeDataInterfaceBuilder b) {}
+  static void _defaults($CurrentOutOfOfficeDataInterfaceBuilder b) {
+    $OutOfOfficeDataCommonInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($CurrentOutOfOfficeDataInterfaceBuilder b) {}
+  static void _validate($CurrentOutOfOfficeDataInterfaceBuilder b) {
+    $OutOfOfficeDataCommonInterface._validate(b);
+  }
 }
 
 abstract class CurrentOutOfOfficeData
@@ -1007,9 +1012,14 @@ abstract interface class $OutOfOfficeDataInterface implements $OutOfOfficeDataCo
   String get lastDay;
   String get status;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($OutOfOfficeDataInterfaceBuilder b) {}
+  static void _defaults($OutOfOfficeDataInterfaceBuilder b) {
+    $OutOfOfficeDataCommonInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($OutOfOfficeDataInterfaceBuilder b) {}
+  static void _validate($OutOfOfficeDataInterfaceBuilder b) {
+    $OutOfOfficeDataCommonInterface._validate(b);
+  }
 }
 
 abstract class OutOfOfficeData implements $OutOfOfficeDataInterface, Built<OutOfOfficeData, OutOfOfficeDataBuilder> {

--- a/packages/nextcloud/lib/src/api/dav.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.g.dart
@@ -985,7 +985,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -1015,6 +1017,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -1085,7 +1088,9 @@ class DirectGetUrlResponseApplicationJson_Ocs_DataBuilder
   String? get url => _$this._url;
   set url(covariant String? url) => _$this._url = url;
 
-  DirectGetUrlResponseApplicationJson_Ocs_DataBuilder();
+  DirectGetUrlResponseApplicationJson_Ocs_DataBuilder() {
+    DirectGetUrlResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   DirectGetUrlResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -1111,6 +1116,7 @@ class DirectGetUrlResponseApplicationJson_Ocs_DataBuilder
   DirectGetUrlResponseApplicationJson_Ocs_Data build() => _build();
 
   _$DirectGetUrlResponseApplicationJson_Ocs_Data _build() {
+    DirectGetUrlResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$DirectGetUrlResponseApplicationJson_Ocs_Data._(
             url: BuiltValueNullFieldError.checkNotNull(url, r'DirectGetUrlResponseApplicationJson_Ocs_Data', 'url'));
@@ -1192,7 +1198,9 @@ class DirectGetUrlResponseApplicationJson_OcsBuilder
       _$this._data ??= DirectGetUrlResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant DirectGetUrlResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  DirectGetUrlResponseApplicationJson_OcsBuilder();
+  DirectGetUrlResponseApplicationJson_OcsBuilder() {
+    DirectGetUrlResponseApplicationJson_Ocs._defaults(this);
+  }
 
   DirectGetUrlResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1219,6 +1227,7 @@ class DirectGetUrlResponseApplicationJson_OcsBuilder
   DirectGetUrlResponseApplicationJson_Ocs build() => _build();
 
   _$DirectGetUrlResponseApplicationJson_Ocs _build() {
+    DirectGetUrlResponseApplicationJson_Ocs._validate(this);
     _$DirectGetUrlResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$DirectGetUrlResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -1295,7 +1304,9 @@ class DirectGetUrlResponseApplicationJsonBuilder
       _$this._ocs ??= DirectGetUrlResponseApplicationJson_OcsBuilder();
   set ocs(covariant DirectGetUrlResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  DirectGetUrlResponseApplicationJsonBuilder();
+  DirectGetUrlResponseApplicationJsonBuilder() {
+    DirectGetUrlResponseApplicationJson._defaults(this);
+  }
 
   DirectGetUrlResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1321,6 +1332,7 @@ class DirectGetUrlResponseApplicationJsonBuilder
   DirectGetUrlResponseApplicationJson build() => _build();
 
   _$DirectGetUrlResponseApplicationJson _build() {
+    DirectGetUrlResponseApplicationJson._validate(this);
     _$DirectGetUrlResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$DirectGetUrlResponseApplicationJson._(ocs: ocs.build());
@@ -1406,7 +1418,9 @@ class OutOfOfficeDataCommonBuilder
   String? get message => _$this._message;
   set message(covariant String? message) => _$this._message = message;
 
-  OutOfOfficeDataCommonBuilder();
+  OutOfOfficeDataCommonBuilder() {
+    OutOfOfficeDataCommon._defaults(this);
+  }
 
   OutOfOfficeDataCommonBuilder get _$this {
     final $v = _$v;
@@ -1433,6 +1447,7 @@ class OutOfOfficeDataCommonBuilder
   OutOfOfficeDataCommon build() => _build();
 
   _$OutOfOfficeDataCommon _build() {
+    OutOfOfficeDataCommon._validate(this);
     final _$result = _$v ??
         _$OutOfOfficeDataCommon._(
             userId: BuiltValueNullFieldError.checkNotNull(userId, r'OutOfOfficeDataCommon', 'userId'),
@@ -1570,7 +1585,9 @@ class CurrentOutOfOfficeDataBuilder
   String? get message => _$this._message;
   set message(covariant String? message) => _$this._message = message;
 
-  CurrentOutOfOfficeDataBuilder();
+  CurrentOutOfOfficeDataBuilder() {
+    CurrentOutOfOfficeData._defaults(this);
+  }
 
   CurrentOutOfOfficeDataBuilder get _$this {
     final $v = _$v;
@@ -1601,6 +1618,7 @@ class CurrentOutOfOfficeDataBuilder
   CurrentOutOfOfficeData build() => _build();
 
   _$CurrentOutOfOfficeData _build() {
+    CurrentOutOfOfficeData._validate(this);
     final _$result = _$v ??
         _$CurrentOutOfOfficeData._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'CurrentOutOfOfficeData', 'id'),
@@ -1694,7 +1712,9 @@ class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsBuilder
   CurrentOutOfOfficeDataBuilder get data => _$this._data ??= CurrentOutOfOfficeDataBuilder();
   set data(covariant CurrentOutOfOfficeDataBuilder? data) => _$this._data = data;
 
-  OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsBuilder();
+  OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsBuilder() {
+    OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs._defaults(this);
+  }
 
   OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1721,6 +1741,7 @@ class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsBuilder
   OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs build() => _build();
 
   _$OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs _build() {
+    OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs._validate(this);
     _$OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -1806,7 +1827,9 @@ class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonBuilder
       _$this._ocs ??= OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsBuilder();
   set ocs(covariant OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonBuilder();
+  OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonBuilder() {
+    OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson._defaults(this);
+  }
 
   OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1832,6 +1855,7 @@ class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonBuilder
   OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson build() => _build();
 
   _$OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson _build() {
+    OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson._validate(this);
     _$OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson._(ocs: ocs.build());
@@ -1978,7 +2002,9 @@ class OutOfOfficeDataBuilder
   String? get message => _$this._message;
   set message(covariant String? message) => _$this._message = message;
 
-  OutOfOfficeDataBuilder();
+  OutOfOfficeDataBuilder() {
+    OutOfOfficeData._defaults(this);
+  }
 
   OutOfOfficeDataBuilder get _$this {
     final $v = _$v;
@@ -2009,6 +2035,7 @@ class OutOfOfficeDataBuilder
   OutOfOfficeData build() => _build();
 
   _$OutOfOfficeData _build() {
+    OutOfOfficeData._validate(this);
     final _$result = _$v ??
         _$OutOfOfficeData._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'OutOfOfficeData', 'id'),
@@ -2096,7 +2123,9 @@ class OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsBuilder
   OutOfOfficeDataBuilder get data => _$this._data ??= OutOfOfficeDataBuilder();
   set data(covariant OutOfOfficeDataBuilder? data) => _$this._data = data;
 
-  OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsBuilder();
+  OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsBuilder() {
+    OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs._defaults(this);
+  }
 
   OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2123,6 +2152,7 @@ class OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsBuilder
   OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs build() => _build();
 
   _$OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs _build() {
+    OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs._validate(this);
     _$OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -2206,7 +2236,9 @@ class OutOfOfficeGetOutOfOfficeResponseApplicationJsonBuilder
       _$this._ocs ??= OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsBuilder();
   set ocs(covariant OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  OutOfOfficeGetOutOfOfficeResponseApplicationJsonBuilder();
+  OutOfOfficeGetOutOfOfficeResponseApplicationJsonBuilder() {
+    OutOfOfficeGetOutOfOfficeResponseApplicationJson._defaults(this);
+  }
 
   OutOfOfficeGetOutOfOfficeResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -2232,6 +2264,7 @@ class OutOfOfficeGetOutOfOfficeResponseApplicationJsonBuilder
   OutOfOfficeGetOutOfOfficeResponseApplicationJson build() => _build();
 
   _$OutOfOfficeGetOutOfOfficeResponseApplicationJson _build() {
+    OutOfOfficeGetOutOfOfficeResponseApplicationJson._validate(this);
     _$OutOfOfficeGetOutOfOfficeResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$OutOfOfficeGetOutOfOfficeResponseApplicationJson._(ocs: ocs.build());
@@ -2325,7 +2358,9 @@ class OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsBuilder
   OutOfOfficeDataBuilder get data => _$this._data ??= OutOfOfficeDataBuilder();
   set data(covariant OutOfOfficeDataBuilder? data) => _$this._data = data;
 
-  OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsBuilder();
+  OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsBuilder() {
+    OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs._defaults(this);
+  }
 
   OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2352,6 +2387,7 @@ class OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsBuilder
   OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs build() => _build();
 
   _$OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs _build() {
+    OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs._validate(this);
     _$OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -2435,7 +2471,9 @@ class OutOfOfficeSetOutOfOfficeResponseApplicationJsonBuilder
       _$this._ocs ??= OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsBuilder();
   set ocs(covariant OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  OutOfOfficeSetOutOfOfficeResponseApplicationJsonBuilder();
+  OutOfOfficeSetOutOfOfficeResponseApplicationJsonBuilder() {
+    OutOfOfficeSetOutOfOfficeResponseApplicationJson._defaults(this);
+  }
 
   OutOfOfficeSetOutOfOfficeResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -2461,6 +2499,7 @@ class OutOfOfficeSetOutOfOfficeResponseApplicationJsonBuilder
   OutOfOfficeSetOutOfOfficeResponseApplicationJson build() => _build();
 
   _$OutOfOfficeSetOutOfOfficeResponseApplicationJson _build() {
+    OutOfOfficeSetOutOfOfficeResponseApplicationJson._validate(this);
     _$OutOfOfficeSetOutOfOfficeResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$OutOfOfficeSetOutOfOfficeResponseApplicationJson._(ocs: ocs.build());
@@ -2553,7 +2592,9 @@ class OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsBuilder();
+  OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsBuilder() {
+    OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs._defaults(this);
+  }
 
   OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2580,6 +2621,7 @@ class OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsBuilder
   OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs build() => _build();
 
   _$OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs _build() {
+    OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs._validate(this);
     _$OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs._(meta: meta.build(), data: data);
@@ -2660,7 +2702,9 @@ class OutOfOfficeClearOutOfOfficeResponseApplicationJsonBuilder
       _$this._ocs ??= OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsBuilder();
   set ocs(covariant OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  OutOfOfficeClearOutOfOfficeResponseApplicationJsonBuilder();
+  OutOfOfficeClearOutOfOfficeResponseApplicationJsonBuilder() {
+    OutOfOfficeClearOutOfOfficeResponseApplicationJson._defaults(this);
+  }
 
   OutOfOfficeClearOutOfOfficeResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -2686,6 +2730,7 @@ class OutOfOfficeClearOutOfOfficeResponseApplicationJsonBuilder
   OutOfOfficeClearOutOfOfficeResponseApplicationJson build() => _build();
 
   _$OutOfOfficeClearOutOfOfficeResponseApplicationJson _build() {
+    OutOfOfficeClearOutOfOfficeResponseApplicationJson._validate(this);
     _$OutOfOfficeClearOutOfOfficeResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$OutOfOfficeClearOutOfOfficeResponseApplicationJson._(ocs: ocs.build());
@@ -2770,7 +2815,9 @@ class Capabilities_DavBuilder
   String? get bulkupload => _$this._bulkupload;
   set bulkupload(covariant String? bulkupload) => _$this._bulkupload = bulkupload;
 
-  Capabilities_DavBuilder();
+  Capabilities_DavBuilder() {
+    Capabilities_Dav._defaults(this);
+  }
 
   Capabilities_DavBuilder get _$this {
     final $v = _$v;
@@ -2797,6 +2844,7 @@ class Capabilities_DavBuilder
   Capabilities_Dav build() => _build();
 
   _$Capabilities_Dav _build() {
+    Capabilities_Dav._validate(this);
     final _$result = _$v ??
         _$Capabilities_Dav._(
             chunking: BuiltValueNullFieldError.checkNotNull(chunking, r'Capabilities_Dav', 'chunking'),
@@ -2857,7 +2905,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities_DavBuilder get dav => _$this._dav ??= Capabilities_DavBuilder();
   set dav(covariant Capabilities_DavBuilder? dav) => _$this._dav = dav;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -2883,6 +2933,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(dav: dav.build());

--- a/packages/nextcloud/lib/src/api/drop_account.openapi.dart
+++ b/packages/nextcloud/lib/src/api/drop_account.openapi.dart
@@ -27,6 +27,10 @@ part 'drop_account.openapi.g.dart';
 abstract interface class $Capabilities_DropAccount_DelayInterface {
   bool get enabled;
   int get hours;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_DropAccount_DelayInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_DropAccount_DelayInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_DropAccount_Delay
@@ -58,6 +62,16 @@ abstract class Capabilities_DropAccount_Delay
 
   /// Serializer for Capabilities_DropAccount_Delay.
   static Serializer<Capabilities_DropAccount_Delay> get serializer => _$capabilitiesDropAccountDelaySerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_DropAccount_DelayBuilder b) {
+    $Capabilities_DropAccount_DelayInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_DropAccount_DelayBuilder b) {
+    $Capabilities_DropAccount_DelayInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -67,6 +81,10 @@ abstract interface class $Capabilities_DropAccountInterface {
   String get apiVersion;
   Capabilities_DropAccount_Delay get delay;
   String? get details;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_DropAccountInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_DropAccountInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_DropAccount
@@ -95,12 +113,26 @@ abstract class Capabilities_DropAccount
 
   /// Serializer for Capabilities_DropAccount.
   static Serializer<Capabilities_DropAccount> get serializer => _$capabilitiesDropAccountSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_DropAccountBuilder b) {
+    $Capabilities_DropAccountInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_DropAccountBuilder b) {
+    $Capabilities_DropAccountInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   @BuiltValueField(wireName: 'drop-account')
   Capabilities_DropAccount get dropAccount;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -127,6 +159,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/drop_account.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/drop_account.openapi.g.dart
@@ -220,7 +220,9 @@ class Capabilities_DropAccount_DelayBuilder
   int? get hours => _$this._hours;
   set hours(covariant int? hours) => _$this._hours = hours;
 
-  Capabilities_DropAccount_DelayBuilder();
+  Capabilities_DropAccount_DelayBuilder() {
+    Capabilities_DropAccount_Delay._defaults(this);
+  }
 
   Capabilities_DropAccount_DelayBuilder get _$this {
     final $v = _$v;
@@ -247,6 +249,7 @@ class Capabilities_DropAccount_DelayBuilder
   Capabilities_DropAccount_Delay build() => _build();
 
   _$Capabilities_DropAccount_Delay _build() {
+    Capabilities_DropAccount_Delay._validate(this);
     final _$result = _$v ??
         _$Capabilities_DropAccount_Delay._(
             enabled: BuiltValueNullFieldError.checkNotNull(enabled, r'Capabilities_DropAccount_Delay', 'enabled'),
@@ -353,7 +356,9 @@ class Capabilities_DropAccountBuilder
   String? get details => _$this._details;
   set details(covariant String? details) => _$this._details = details;
 
-  Capabilities_DropAccountBuilder();
+  Capabilities_DropAccountBuilder() {
+    Capabilities_DropAccount._defaults(this);
+  }
 
   Capabilities_DropAccountBuilder get _$this {
     final $v = _$v;
@@ -382,6 +387,7 @@ class Capabilities_DropAccountBuilder
   Capabilities_DropAccount build() => _build();
 
   _$Capabilities_DropAccount _build() {
+    Capabilities_DropAccount._validate(this);
     _$Capabilities_DropAccount _$result;
     try {
       _$result = _$v ??
@@ -456,7 +462,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities_DropAccountBuilder get dropAccount => _$this._dropAccount ??= Capabilities_DropAccountBuilder();
   set dropAccount(covariant Capabilities_DropAccountBuilder? dropAccount) => _$this._dropAccount = dropAccount;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -482,6 +490,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(dropAccount: dropAccount.build());

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -1427,6 +1427,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -1453,6 +1457,16 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1462,6 +1476,10 @@ abstract interface class $DirectEditingInfoResponseApplicationJson_Ocs_Data_Edit
   BuiltList<String> get mimetypes;
   BuiltList<String> get optionalMimetypes;
   bool get secure;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors
@@ -1496,6 +1514,16 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors
   /// Serializer for DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors.
   static Serializer<DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors> get serializer =>
       _$directEditingInfoResponseApplicationJsonOcsDataEditorsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsBuilder b) {
+    $DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsBuilder b) {
+    $DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1507,6 +1535,10 @@ abstract interface class $DirectEditingInfoResponseApplicationJson_Ocs_Data_Crea
   String get $extension;
   bool get templates;
   BuiltList<String> get mimetypes;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators
@@ -1541,12 +1573,26 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators
   /// Serializer for DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators.
   static Serializer<DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators> get serializer =>
       _$directEditingInfoResponseApplicationJsonOcsDataCreatorsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsBuilder b) {
+    $DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsBuilder b) {
+    $DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingInfoResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors> get editors;
   BuiltMap<String, DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators> get creators;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingInfoResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingInfoResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data
@@ -1581,12 +1627,26 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data
   /// Serializer for DirectEditingInfoResponseApplicationJson_Ocs_Data.
   static Serializer<DirectEditingInfoResponseApplicationJson_Ocs_Data> get serializer =>
       _$directEditingInfoResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder b) {
+    $DirectEditingInfoResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder b) {
+    $DirectEditingInfoResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingInfoResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   DirectEditingInfoResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingInfoResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingInfoResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingInfoResponseApplicationJson_Ocs
@@ -1620,11 +1680,25 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs
   /// Serializer for DirectEditingInfoResponseApplicationJson_Ocs.
   static Serializer<DirectEditingInfoResponseApplicationJson_Ocs> get serializer =>
       _$directEditingInfoResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingInfoResponseApplicationJson_OcsBuilder b) {
+    $DirectEditingInfoResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingInfoResponseApplicationJson_OcsBuilder b) {
+    $DirectEditingInfoResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingInfoResponseApplicationJsonInterface {
   DirectEditingInfoResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingInfoResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingInfoResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingInfoResponseApplicationJson
@@ -1658,6 +1732,16 @@ abstract class DirectEditingInfoResponseApplicationJson
   /// Serializer for DirectEditingInfoResponseApplicationJson.
   static Serializer<DirectEditingInfoResponseApplicationJson> get serializer =>
       _$directEditingInfoResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingInfoResponseApplicationJsonBuilder b) {
+    $DirectEditingInfoResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingInfoResponseApplicationJsonBuilder b) {
+    $DirectEditingInfoResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1668,6 +1752,10 @@ abstract interface class $DirectEditingTemplatesResponseApplicationJson_Ocs_Data
   @BuiltValueField(wireName: 'extension')
   String get $extension;
   String get mimetype;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates
@@ -1702,11 +1790,25 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates
   /// Serializer for DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates.
   static Serializer<DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates> get serializer =>
       _$directEditingTemplatesResponseApplicationJsonOcsDataTemplatesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesBuilder b) {
+    $DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesBuilder b) {
+    $DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates> get templates;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingTemplatesResponseApplicationJson_Ocs_Data
@@ -1741,12 +1843,26 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs_Data
   /// Serializer for DirectEditingTemplatesResponseApplicationJson_Ocs_Data.
   static Serializer<DirectEditingTemplatesResponseApplicationJson_Ocs_Data> get serializer =>
       _$directEditingTemplatesResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder b) {
+    $DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder b) {
+    $DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingTemplatesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   DirectEditingTemplatesResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingTemplatesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingTemplatesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingTemplatesResponseApplicationJson_Ocs
@@ -1781,11 +1897,25 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs
   /// Serializer for DirectEditingTemplatesResponseApplicationJson_Ocs.
   static Serializer<DirectEditingTemplatesResponseApplicationJson_Ocs> get serializer =>
       _$directEditingTemplatesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingTemplatesResponseApplicationJson_OcsBuilder b) {
+    $DirectEditingTemplatesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingTemplatesResponseApplicationJson_OcsBuilder b) {
+    $DirectEditingTemplatesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingTemplatesResponseApplicationJsonInterface {
   DirectEditingTemplatesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingTemplatesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingTemplatesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingTemplatesResponseApplicationJson
@@ -1819,11 +1949,25 @@ abstract class DirectEditingTemplatesResponseApplicationJson
   /// Serializer for DirectEditingTemplatesResponseApplicationJson.
   static Serializer<DirectEditingTemplatesResponseApplicationJson> get serializer =>
       _$directEditingTemplatesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingTemplatesResponseApplicationJsonBuilder b) {
+    $DirectEditingTemplatesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingTemplatesResponseApplicationJsonBuilder b) {
+    $DirectEditingTemplatesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingOpenResponseApplicationJson_Ocs_DataInterface {
   String get url;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingOpenResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingOpenResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingOpenResponseApplicationJson_Ocs_Data
@@ -1858,12 +2002,26 @@ abstract class DirectEditingOpenResponseApplicationJson_Ocs_Data
   /// Serializer for DirectEditingOpenResponseApplicationJson_Ocs_Data.
   static Serializer<DirectEditingOpenResponseApplicationJson_Ocs_Data> get serializer =>
       _$directEditingOpenResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder b) {
+    $DirectEditingOpenResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder b) {
+    $DirectEditingOpenResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingOpenResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   DirectEditingOpenResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingOpenResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingOpenResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingOpenResponseApplicationJson_Ocs
@@ -1897,11 +2055,25 @@ abstract class DirectEditingOpenResponseApplicationJson_Ocs
   /// Serializer for DirectEditingOpenResponseApplicationJson_Ocs.
   static Serializer<DirectEditingOpenResponseApplicationJson_Ocs> get serializer =>
       _$directEditingOpenResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingOpenResponseApplicationJson_OcsBuilder b) {
+    $DirectEditingOpenResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingOpenResponseApplicationJson_OcsBuilder b) {
+    $DirectEditingOpenResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingOpenResponseApplicationJsonInterface {
   DirectEditingOpenResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingOpenResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingOpenResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingOpenResponseApplicationJson
@@ -1935,11 +2107,25 @@ abstract class DirectEditingOpenResponseApplicationJson
   /// Serializer for DirectEditingOpenResponseApplicationJson.
   static Serializer<DirectEditingOpenResponseApplicationJson> get serializer =>
       _$directEditingOpenResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingOpenResponseApplicationJsonBuilder b) {
+    $DirectEditingOpenResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingOpenResponseApplicationJsonBuilder b) {
+    $DirectEditingOpenResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingCreateResponseApplicationJson_Ocs_DataInterface {
   String get url;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingCreateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingCreateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingCreateResponseApplicationJson_Ocs_Data
@@ -1974,12 +2160,26 @@ abstract class DirectEditingCreateResponseApplicationJson_Ocs_Data
   /// Serializer for DirectEditingCreateResponseApplicationJson_Ocs_Data.
   static Serializer<DirectEditingCreateResponseApplicationJson_Ocs_Data> get serializer =>
       _$directEditingCreateResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder b) {
+    $DirectEditingCreateResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder b) {
+    $DirectEditingCreateResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingCreateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   DirectEditingCreateResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingCreateResponseApplicationJson_Ocs
@@ -2013,11 +2213,25 @@ abstract class DirectEditingCreateResponseApplicationJson_Ocs
   /// Serializer for DirectEditingCreateResponseApplicationJson_Ocs.
   static Serializer<DirectEditingCreateResponseApplicationJson_Ocs> get serializer =>
       _$directEditingCreateResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingCreateResponseApplicationJson_OcsBuilder b) {
+    $DirectEditingCreateResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingCreateResponseApplicationJson_OcsBuilder b) {
+    $DirectEditingCreateResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DirectEditingCreateResponseApplicationJsonInterface {
   DirectEditingCreateResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingCreateResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingCreateResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DirectEditingCreateResponseApplicationJson
@@ -2051,6 +2265,16 @@ abstract class DirectEditingCreateResponseApplicationJson
   /// Serializer for DirectEditingCreateResponseApplicationJson.
   static Serializer<DirectEditingCreateResponseApplicationJson> get serializer =>
       _$directEditingCreateResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingCreateResponseApplicationJsonBuilder b) {
+    $DirectEditingCreateResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingCreateResponseApplicationJsonBuilder b) {
+    $DirectEditingCreateResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -2059,6 +2283,10 @@ abstract interface class $OpenLocalEditorCreateResponseApplicationJson_Ocs_DataI
   String get pathHash;
   int get expirationTime;
   String get token;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class OpenLocalEditorCreateResponseApplicationJson_Ocs_Data
@@ -2093,12 +2321,26 @@ abstract class OpenLocalEditorCreateResponseApplicationJson_Ocs_Data
   /// Serializer for OpenLocalEditorCreateResponseApplicationJson_Ocs_Data.
   static Serializer<OpenLocalEditorCreateResponseApplicationJson_Ocs_Data> get serializer =>
       _$openLocalEditorCreateResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder b) {
+    $OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder b) {
+    $OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OpenLocalEditorCreateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OpenLocalEditorCreateResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OpenLocalEditorCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OpenLocalEditorCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class OpenLocalEditorCreateResponseApplicationJson_Ocs
@@ -2133,11 +2375,25 @@ abstract class OpenLocalEditorCreateResponseApplicationJson_Ocs
   /// Serializer for OpenLocalEditorCreateResponseApplicationJson_Ocs.
   static Serializer<OpenLocalEditorCreateResponseApplicationJson_Ocs> get serializer =>
       _$openLocalEditorCreateResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OpenLocalEditorCreateResponseApplicationJson_OcsBuilder b) {
+    $OpenLocalEditorCreateResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenLocalEditorCreateResponseApplicationJson_OcsBuilder b) {
+    $OpenLocalEditorCreateResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OpenLocalEditorCreateResponseApplicationJsonInterface {
   OpenLocalEditorCreateResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OpenLocalEditorCreateResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OpenLocalEditorCreateResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class OpenLocalEditorCreateResponseApplicationJson
@@ -2171,6 +2427,16 @@ abstract class OpenLocalEditorCreateResponseApplicationJson
   /// Serializer for OpenLocalEditorCreateResponseApplicationJson.
   static Serializer<OpenLocalEditorCreateResponseApplicationJson> get serializer =>
       _$openLocalEditorCreateResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OpenLocalEditorCreateResponseApplicationJsonBuilder b) {
+    $OpenLocalEditorCreateResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenLocalEditorCreateResponseApplicationJsonBuilder b) {
+    $OpenLocalEditorCreateResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -2179,6 +2445,10 @@ abstract interface class $OpenLocalEditorValidateResponseApplicationJson_Ocs_Dat
   String get pathHash;
   int get expirationTime;
   String get token;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class OpenLocalEditorValidateResponseApplicationJson_Ocs_Data
@@ -2213,12 +2483,26 @@ abstract class OpenLocalEditorValidateResponseApplicationJson_Ocs_Data
   /// Serializer for OpenLocalEditorValidateResponseApplicationJson_Ocs_Data.
   static Serializer<OpenLocalEditorValidateResponseApplicationJson_Ocs_Data> get serializer =>
       _$openLocalEditorValidateResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder b) {
+    $OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder b) {
+    $OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OpenLocalEditorValidateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OpenLocalEditorValidateResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OpenLocalEditorValidateResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OpenLocalEditorValidateResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class OpenLocalEditorValidateResponseApplicationJson_Ocs
@@ -2253,11 +2537,25 @@ abstract class OpenLocalEditorValidateResponseApplicationJson_Ocs
   /// Serializer for OpenLocalEditorValidateResponseApplicationJson_Ocs.
   static Serializer<OpenLocalEditorValidateResponseApplicationJson_Ocs> get serializer =>
       _$openLocalEditorValidateResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OpenLocalEditorValidateResponseApplicationJson_OcsBuilder b) {
+    $OpenLocalEditorValidateResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenLocalEditorValidateResponseApplicationJson_OcsBuilder b) {
+    $OpenLocalEditorValidateResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $OpenLocalEditorValidateResponseApplicationJsonInterface {
   OpenLocalEditorValidateResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OpenLocalEditorValidateResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OpenLocalEditorValidateResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class OpenLocalEditorValidateResponseApplicationJson
@@ -2291,6 +2589,16 @@ abstract class OpenLocalEditorValidateResponseApplicationJson
   /// Serializer for OpenLocalEditorValidateResponseApplicationJson.
   static Serializer<OpenLocalEditorValidateResponseApplicationJson> get serializer =>
       _$openLocalEditorValidateResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OpenLocalEditorValidateResponseApplicationJsonBuilder b) {
+    $OpenLocalEditorValidateResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenLocalEditorValidateResponseApplicationJsonBuilder b) {
+    $OpenLocalEditorValidateResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -2303,6 +2611,10 @@ abstract interface class $TemplateFileCreatorInterface {
   BuiltList<String> get mimetypes;
   double? get ratio;
   String get actionLabel;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplateFileCreatorInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplateFileCreatorInterfaceBuilder b) {}
 }
 
 abstract class TemplateFileCreator
@@ -2331,12 +2643,26 @@ abstract class TemplateFileCreator
 
   /// Serializer for TemplateFileCreator.
   static Serializer<TemplateFileCreator> get serializer => _$templateFileCreatorSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplateFileCreatorBuilder b) {
+    $TemplateFileCreatorInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplateFileCreatorBuilder b) {
+    $TemplateFileCreatorInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TemplateListResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<TemplateFileCreator> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplateListResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplateListResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TemplateListResponseApplicationJson_Ocs
@@ -2369,11 +2695,25 @@ abstract class TemplateListResponseApplicationJson_Ocs
   /// Serializer for TemplateListResponseApplicationJson_Ocs.
   static Serializer<TemplateListResponseApplicationJson_Ocs> get serializer =>
       _$templateListResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplateListResponseApplicationJson_OcsBuilder b) {
+    $TemplateListResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplateListResponseApplicationJson_OcsBuilder b) {
+    $TemplateListResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TemplateListResponseApplicationJsonInterface {
   TemplateListResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplateListResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplateListResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TemplateListResponseApplicationJson
@@ -2406,6 +2746,16 @@ abstract class TemplateListResponseApplicationJson
   /// Serializer for TemplateListResponseApplicationJson.
   static Serializer<TemplateListResponseApplicationJson> get serializer =>
       _$templateListResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplateListResponseApplicationJsonBuilder b) {
+    $TemplateListResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplateListResponseApplicationJsonBuilder b) {
+    $TemplateListResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -2419,6 +2769,10 @@ abstract interface class $TemplateFileInterface {
   int get size;
   String get type;
   bool get hasPreview;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplateFileInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplateFileInterfaceBuilder b) {}
 }
 
 abstract class TemplateFile implements $TemplateFileInterface, Built<TemplateFile, TemplateFileBuilder> {
@@ -2445,12 +2799,26 @@ abstract class TemplateFile implements $TemplateFileInterface, Built<TemplateFil
 
   /// Serializer for TemplateFile.
   static Serializer<TemplateFile> get serializer => _$templateFileSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplateFileBuilder b) {
+    $TemplateFileInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplateFileBuilder b) {
+    $TemplateFileInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TemplateCreateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TemplateFile get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplateCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplateCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TemplateCreateResponseApplicationJson_Ocs
@@ -2484,11 +2852,25 @@ abstract class TemplateCreateResponseApplicationJson_Ocs
   /// Serializer for TemplateCreateResponseApplicationJson_Ocs.
   static Serializer<TemplateCreateResponseApplicationJson_Ocs> get serializer =>
       _$templateCreateResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplateCreateResponseApplicationJson_OcsBuilder b) {
+    $TemplateCreateResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplateCreateResponseApplicationJson_OcsBuilder b) {
+    $TemplateCreateResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TemplateCreateResponseApplicationJsonInterface {
   TemplateCreateResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplateCreateResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplateCreateResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TemplateCreateResponseApplicationJson
@@ -2521,6 +2903,16 @@ abstract class TemplateCreateResponseApplicationJson
   /// Serializer for TemplateCreateResponseApplicationJson.
   static Serializer<TemplateCreateResponseApplicationJson> get serializer =>
       _$templateCreateResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplateCreateResponseApplicationJsonBuilder b) {
+    $TemplateCreateResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplateCreateResponseApplicationJsonBuilder b) {
+    $TemplateCreateResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class TemplatePathCopySystemTemplates extends EnumClass {
@@ -2592,6 +2984,10 @@ abstract interface class $TemplatePathResponseApplicationJson_Ocs_DataInterface 
   @BuiltValueField(wireName: 'template_path')
   String get templatePath;
   BuiltList<TemplateFileCreator> get templates;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplatePathResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplatePathResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class TemplatePathResponseApplicationJson_Ocs_Data
@@ -2625,12 +3021,26 @@ abstract class TemplatePathResponseApplicationJson_Ocs_Data
   /// Serializer for TemplatePathResponseApplicationJson_Ocs_Data.
   static Serializer<TemplatePathResponseApplicationJson_Ocs_Data> get serializer =>
       _$templatePathResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplatePathResponseApplicationJson_Ocs_DataBuilder b) {
+    $TemplatePathResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplatePathResponseApplicationJson_Ocs_DataBuilder b) {
+    $TemplatePathResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TemplatePathResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TemplatePathResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplatePathResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplatePathResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TemplatePathResponseApplicationJson_Ocs
@@ -2663,11 +3073,25 @@ abstract class TemplatePathResponseApplicationJson_Ocs
   /// Serializer for TemplatePathResponseApplicationJson_Ocs.
   static Serializer<TemplatePathResponseApplicationJson_Ocs> get serializer =>
       _$templatePathResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplatePathResponseApplicationJson_OcsBuilder b) {
+    $TemplatePathResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplatePathResponseApplicationJson_OcsBuilder b) {
+    $TemplatePathResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TemplatePathResponseApplicationJsonInterface {
   TemplatePathResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplatePathResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplatePathResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TemplatePathResponseApplicationJson
@@ -2700,12 +3124,26 @@ abstract class TemplatePathResponseApplicationJson
   /// Serializer for TemplatePathResponseApplicationJson.
   static Serializer<TemplatePathResponseApplicationJson> get serializer =>
       _$templatePathResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplatePathResponseApplicationJsonBuilder b) {
+    $TemplatePathResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplatePathResponseApplicationJsonBuilder b) {
+    $TemplatePathResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TransferOwnershipTransferResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TransferOwnershipTransferResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TransferOwnershipTransferResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TransferOwnershipTransferResponseApplicationJson_Ocs
@@ -2740,11 +3178,25 @@ abstract class TransferOwnershipTransferResponseApplicationJson_Ocs
   /// Serializer for TransferOwnershipTransferResponseApplicationJson_Ocs.
   static Serializer<TransferOwnershipTransferResponseApplicationJson_Ocs> get serializer =>
       _$transferOwnershipTransferResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TransferOwnershipTransferResponseApplicationJson_OcsBuilder b) {
+    $TransferOwnershipTransferResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TransferOwnershipTransferResponseApplicationJson_OcsBuilder b) {
+    $TransferOwnershipTransferResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TransferOwnershipTransferResponseApplicationJsonInterface {
   TransferOwnershipTransferResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TransferOwnershipTransferResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TransferOwnershipTransferResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TransferOwnershipTransferResponseApplicationJson
@@ -2779,12 +3231,26 @@ abstract class TransferOwnershipTransferResponseApplicationJson
   /// Serializer for TransferOwnershipTransferResponseApplicationJson.
   static Serializer<TransferOwnershipTransferResponseApplicationJson> get serializer =>
       _$transferOwnershipTransferResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TransferOwnershipTransferResponseApplicationJsonBuilder b) {
+    $TransferOwnershipTransferResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TransferOwnershipTransferResponseApplicationJsonBuilder b) {
+    $TransferOwnershipTransferResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TransferOwnershipAcceptResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TransferOwnershipAcceptResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TransferOwnershipAcceptResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TransferOwnershipAcceptResponseApplicationJson_Ocs
@@ -2819,11 +3285,25 @@ abstract class TransferOwnershipAcceptResponseApplicationJson_Ocs
   /// Serializer for TransferOwnershipAcceptResponseApplicationJson_Ocs.
   static Serializer<TransferOwnershipAcceptResponseApplicationJson_Ocs> get serializer =>
       _$transferOwnershipAcceptResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TransferOwnershipAcceptResponseApplicationJson_OcsBuilder b) {
+    $TransferOwnershipAcceptResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TransferOwnershipAcceptResponseApplicationJson_OcsBuilder b) {
+    $TransferOwnershipAcceptResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TransferOwnershipAcceptResponseApplicationJsonInterface {
   TransferOwnershipAcceptResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TransferOwnershipAcceptResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TransferOwnershipAcceptResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TransferOwnershipAcceptResponseApplicationJson
@@ -2857,12 +3337,26 @@ abstract class TransferOwnershipAcceptResponseApplicationJson
   /// Serializer for TransferOwnershipAcceptResponseApplicationJson.
   static Serializer<TransferOwnershipAcceptResponseApplicationJson> get serializer =>
       _$transferOwnershipAcceptResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TransferOwnershipAcceptResponseApplicationJsonBuilder b) {
+    $TransferOwnershipAcceptResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TransferOwnershipAcceptResponseApplicationJsonBuilder b) {
+    $TransferOwnershipAcceptResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TransferOwnershipRejectResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TransferOwnershipRejectResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TransferOwnershipRejectResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TransferOwnershipRejectResponseApplicationJson_Ocs
@@ -2897,11 +3391,25 @@ abstract class TransferOwnershipRejectResponseApplicationJson_Ocs
   /// Serializer for TransferOwnershipRejectResponseApplicationJson_Ocs.
   static Serializer<TransferOwnershipRejectResponseApplicationJson_Ocs> get serializer =>
       _$transferOwnershipRejectResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TransferOwnershipRejectResponseApplicationJson_OcsBuilder b) {
+    $TransferOwnershipRejectResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TransferOwnershipRejectResponseApplicationJson_OcsBuilder b) {
+    $TransferOwnershipRejectResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TransferOwnershipRejectResponseApplicationJsonInterface {
   TransferOwnershipRejectResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TransferOwnershipRejectResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TransferOwnershipRejectResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TransferOwnershipRejectResponseApplicationJson
@@ -2935,6 +3443,16 @@ abstract class TransferOwnershipRejectResponseApplicationJson
   /// Serializer for TransferOwnershipRejectResponseApplicationJson.
   static Serializer<TransferOwnershipRejectResponseApplicationJson> get serializer =>
       _$transferOwnershipRejectResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TransferOwnershipRejectResponseApplicationJsonBuilder b) {
+    $TransferOwnershipRejectResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TransferOwnershipRejectResponseApplicationJsonBuilder b) {
+    $TransferOwnershipRejectResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -2942,6 +3460,10 @@ abstract interface class $Capabilities_Files_DirectEditingInterface {
   String get url;
   String get etag;
   bool get supportsFileId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_Files_DirectEditingInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_Files_DirectEditingInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_Files_DirectEditing
@@ -2973,6 +3495,16 @@ abstract class Capabilities_Files_DirectEditing
 
   /// Serializer for Capabilities_Files_DirectEditing.
   static Serializer<Capabilities_Files_DirectEditing> get serializer => _$capabilitiesFilesDirectEditingSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_Files_DirectEditingBuilder b) {
+    $Capabilities_Files_DirectEditingInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_Files_DirectEditingBuilder b) {
+    $Capabilities_Files_DirectEditingInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -2981,6 +3513,10 @@ abstract interface class $Capabilities_FilesInterface {
   @BuiltValueField(wireName: 'blacklisted_files')
   BuiltList<JsonObject> get blacklistedFiles;
   Capabilities_Files_DirectEditing get directEditing;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_Files
@@ -3009,11 +3545,25 @@ abstract class Capabilities_Files
 
   /// Serializer for Capabilities_Files.
   static Serializer<Capabilities_Files> get serializer => _$capabilitiesFilesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesBuilder b) {
+    $Capabilities_FilesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesBuilder b) {
+    $Capabilities_FilesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   Capabilities_Files get files;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -3040,6 +3590,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/files.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.g.dart
@@ -2257,7 +2257,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -2287,6 +2289,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -2424,7 +2427,9 @@ class DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsBuilder
   bool? get secure => _$this._secure;
   set secure(covariant bool? secure) => _$this._secure = secure;
 
-  DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsBuilder();
+  DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsBuilder() {
+    DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors._defaults(this);
+  }
 
   DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsBuilder get _$this {
     final $v = _$v;
@@ -2454,6 +2459,7 @@ class DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsBuilder
   DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors build() => _build();
 
   _$DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors _build() {
+    DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors._validate(this);
     _$DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors _$result;
     try {
       _$result = _$v ??
@@ -2623,7 +2629,9 @@ class DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsBuilder
   ListBuilder<String> get mimetypes => _$this._mimetypes ??= ListBuilder<String>();
   set mimetypes(covariant ListBuilder<String>? mimetypes) => _$this._mimetypes = mimetypes;
 
-  DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsBuilder();
+  DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsBuilder() {
+    DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators._defaults(this);
+  }
 
   DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsBuilder get _$this {
     final $v = _$v;
@@ -2654,6 +2662,7 @@ class DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsBuilder
   DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators build() => _build();
 
   _$DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators _build() {
+    DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators._validate(this);
     _$DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators _$result;
     try {
       _$result = _$v ??
@@ -2764,7 +2773,9 @@ class DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder
   set creators(covariant MapBuilder<String, DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators>? creators) =>
       _$this._creators = creators;
 
-  DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder();
+  DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder() {
+    DirectEditingInfoResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -2791,6 +2802,7 @@ class DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder
   DirectEditingInfoResponseApplicationJson_Ocs_Data build() => _build();
 
   _$DirectEditingInfoResponseApplicationJson_Ocs_Data _build() {
+    DirectEditingInfoResponseApplicationJson_Ocs_Data._validate(this);
     _$DirectEditingInfoResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ??
@@ -2886,7 +2898,9 @@ class DirectEditingInfoResponseApplicationJson_OcsBuilder
       _$this._data ??= DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant DirectEditingInfoResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  DirectEditingInfoResponseApplicationJson_OcsBuilder();
+  DirectEditingInfoResponseApplicationJson_OcsBuilder() {
+    DirectEditingInfoResponseApplicationJson_Ocs._defaults(this);
+  }
 
   DirectEditingInfoResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2913,6 +2927,7 @@ class DirectEditingInfoResponseApplicationJson_OcsBuilder
   DirectEditingInfoResponseApplicationJson_Ocs build() => _build();
 
   _$DirectEditingInfoResponseApplicationJson_Ocs _build() {
+    DirectEditingInfoResponseApplicationJson_Ocs._validate(this);
     _$DirectEditingInfoResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$DirectEditingInfoResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -2992,7 +3007,9 @@ class DirectEditingInfoResponseApplicationJsonBuilder
       _$this._ocs ??= DirectEditingInfoResponseApplicationJson_OcsBuilder();
   set ocs(covariant DirectEditingInfoResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  DirectEditingInfoResponseApplicationJsonBuilder();
+  DirectEditingInfoResponseApplicationJsonBuilder() {
+    DirectEditingInfoResponseApplicationJson._defaults(this);
+  }
 
   DirectEditingInfoResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3018,6 +3035,7 @@ class DirectEditingInfoResponseApplicationJsonBuilder
   DirectEditingInfoResponseApplicationJson build() => _build();
 
   _$DirectEditingInfoResponseApplicationJson _build() {
+    DirectEditingInfoResponseApplicationJson._validate(this);
     _$DirectEditingInfoResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$DirectEditingInfoResponseApplicationJson._(ocs: ocs.build());
@@ -3156,7 +3174,9 @@ class DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesBuilder
   String? get mimetype => _$this._mimetype;
   set mimetype(covariant String? mimetype) => _$this._mimetype = mimetype;
 
-  DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesBuilder();
+  DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesBuilder() {
+    DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates._defaults(this);
+  }
 
   DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesBuilder get _$this {
     final $v = _$v;
@@ -3186,6 +3206,7 @@ class DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesBuilder
   DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates build() => _build();
 
   _$DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates _build() {
+    DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates._validate(this);
     final _$result = _$v ??
         _$DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates._(
             id: BuiltValueNullFieldError.checkNotNull(
@@ -3268,7 +3289,9 @@ class DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder
           covariant MapBuilder<String, DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates>? templates) =>
       _$this._templates = templates;
 
-  DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder();
+  DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder() {
+    DirectEditingTemplatesResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -3294,6 +3317,7 @@ class DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder
   DirectEditingTemplatesResponseApplicationJson_Ocs_Data build() => _build();
 
   _$DirectEditingTemplatesResponseApplicationJson_Ocs_Data _build() {
+    DirectEditingTemplatesResponseApplicationJson_Ocs_Data._validate(this);
     _$DirectEditingTemplatesResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$DirectEditingTemplatesResponseApplicationJson_Ocs_Data._(templates: templates.build());
@@ -3387,7 +3411,9 @@ class DirectEditingTemplatesResponseApplicationJson_OcsBuilder
       _$this._data ??= DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant DirectEditingTemplatesResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  DirectEditingTemplatesResponseApplicationJson_OcsBuilder();
+  DirectEditingTemplatesResponseApplicationJson_OcsBuilder() {
+    DirectEditingTemplatesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   DirectEditingTemplatesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3414,6 +3440,7 @@ class DirectEditingTemplatesResponseApplicationJson_OcsBuilder
   DirectEditingTemplatesResponseApplicationJson_Ocs build() => _build();
 
   _$DirectEditingTemplatesResponseApplicationJson_Ocs _build() {
+    DirectEditingTemplatesResponseApplicationJson_Ocs._validate(this);
     _$DirectEditingTemplatesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$DirectEditingTemplatesResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -3494,7 +3521,9 @@ class DirectEditingTemplatesResponseApplicationJsonBuilder
       _$this._ocs ??= DirectEditingTemplatesResponseApplicationJson_OcsBuilder();
   set ocs(covariant DirectEditingTemplatesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  DirectEditingTemplatesResponseApplicationJsonBuilder();
+  DirectEditingTemplatesResponseApplicationJsonBuilder() {
+    DirectEditingTemplatesResponseApplicationJson._defaults(this);
+  }
 
   DirectEditingTemplatesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3520,6 +3549,7 @@ class DirectEditingTemplatesResponseApplicationJsonBuilder
   DirectEditingTemplatesResponseApplicationJson build() => _build();
 
   _$DirectEditingTemplatesResponseApplicationJson _build() {
+    DirectEditingTemplatesResponseApplicationJson._validate(this);
     _$DirectEditingTemplatesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$DirectEditingTemplatesResponseApplicationJson._(ocs: ocs.build());
@@ -3598,7 +3628,9 @@ class DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder
   String? get url => _$this._url;
   set url(covariant String? url) => _$this._url = url;
 
-  DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder();
+  DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder() {
+    DirectEditingOpenResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -3624,6 +3656,7 @@ class DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder
   DirectEditingOpenResponseApplicationJson_Ocs_Data build() => _build();
 
   _$DirectEditingOpenResponseApplicationJson_Ocs_Data _build() {
+    DirectEditingOpenResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$DirectEditingOpenResponseApplicationJson_Ocs_Data._(
             url: BuiltValueNullFieldError.checkNotNull(
@@ -3706,7 +3739,9 @@ class DirectEditingOpenResponseApplicationJson_OcsBuilder
       _$this._data ??= DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  DirectEditingOpenResponseApplicationJson_OcsBuilder();
+  DirectEditingOpenResponseApplicationJson_OcsBuilder() {
+    DirectEditingOpenResponseApplicationJson_Ocs._defaults(this);
+  }
 
   DirectEditingOpenResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3733,6 +3768,7 @@ class DirectEditingOpenResponseApplicationJson_OcsBuilder
   DirectEditingOpenResponseApplicationJson_Ocs build() => _build();
 
   _$DirectEditingOpenResponseApplicationJson_Ocs _build() {
+    DirectEditingOpenResponseApplicationJson_Ocs._validate(this);
     _$DirectEditingOpenResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$DirectEditingOpenResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -3812,7 +3848,9 @@ class DirectEditingOpenResponseApplicationJsonBuilder
       _$this._ocs ??= DirectEditingOpenResponseApplicationJson_OcsBuilder();
   set ocs(covariant DirectEditingOpenResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  DirectEditingOpenResponseApplicationJsonBuilder();
+  DirectEditingOpenResponseApplicationJsonBuilder() {
+    DirectEditingOpenResponseApplicationJson._defaults(this);
+  }
 
   DirectEditingOpenResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3838,6 +3876,7 @@ class DirectEditingOpenResponseApplicationJsonBuilder
   DirectEditingOpenResponseApplicationJson build() => _build();
 
   _$DirectEditingOpenResponseApplicationJson _build() {
+    DirectEditingOpenResponseApplicationJson._validate(this);
     _$DirectEditingOpenResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$DirectEditingOpenResponseApplicationJson._(ocs: ocs.build());
@@ -3917,7 +3956,9 @@ class DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder
   String? get url => _$this._url;
   set url(covariant String? url) => _$this._url = url;
 
-  DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder();
+  DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder() {
+    DirectEditingCreateResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -3943,6 +3984,7 @@ class DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder
   DirectEditingCreateResponseApplicationJson_Ocs_Data build() => _build();
 
   _$DirectEditingCreateResponseApplicationJson_Ocs_Data _build() {
+    DirectEditingCreateResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$DirectEditingCreateResponseApplicationJson_Ocs_Data._(
             url: BuiltValueNullFieldError.checkNotNull(
@@ -4025,7 +4067,9 @@ class DirectEditingCreateResponseApplicationJson_OcsBuilder
       _$this._data ??= DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant DirectEditingCreateResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  DirectEditingCreateResponseApplicationJson_OcsBuilder();
+  DirectEditingCreateResponseApplicationJson_OcsBuilder() {
+    DirectEditingCreateResponseApplicationJson_Ocs._defaults(this);
+  }
 
   DirectEditingCreateResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -4052,6 +4096,7 @@ class DirectEditingCreateResponseApplicationJson_OcsBuilder
   DirectEditingCreateResponseApplicationJson_Ocs build() => _build();
 
   _$DirectEditingCreateResponseApplicationJson_Ocs _build() {
+    DirectEditingCreateResponseApplicationJson_Ocs._validate(this);
     _$DirectEditingCreateResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$DirectEditingCreateResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -4132,7 +4177,9 @@ class DirectEditingCreateResponseApplicationJsonBuilder
       _$this._ocs ??= DirectEditingCreateResponseApplicationJson_OcsBuilder();
   set ocs(covariant DirectEditingCreateResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  DirectEditingCreateResponseApplicationJsonBuilder();
+  DirectEditingCreateResponseApplicationJsonBuilder() {
+    DirectEditingCreateResponseApplicationJson._defaults(this);
+  }
 
   DirectEditingCreateResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -4158,6 +4205,7 @@ class DirectEditingCreateResponseApplicationJsonBuilder
   DirectEditingCreateResponseApplicationJson build() => _build();
 
   _$DirectEditingCreateResponseApplicationJson _build() {
+    DirectEditingCreateResponseApplicationJson._validate(this);
     _$DirectEditingCreateResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$DirectEditingCreateResponseApplicationJson._(ocs: ocs.build());
@@ -4281,7 +4329,9 @@ class OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder
   String? get token => _$this._token;
   set token(covariant String? token) => _$this._token = token;
 
-  OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder();
+  OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder() {
+    OpenLocalEditorCreateResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -4310,6 +4360,7 @@ class OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder
   OpenLocalEditorCreateResponseApplicationJson_Ocs_Data build() => _build();
 
   _$OpenLocalEditorCreateResponseApplicationJson_Ocs_Data _build() {
+    OpenLocalEditorCreateResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$OpenLocalEditorCreateResponseApplicationJson_Ocs_Data._(
             userId: userId,
@@ -4398,7 +4449,9 @@ class OpenLocalEditorCreateResponseApplicationJson_OcsBuilder
       _$this._data ??= OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  OpenLocalEditorCreateResponseApplicationJson_OcsBuilder();
+  OpenLocalEditorCreateResponseApplicationJson_OcsBuilder() {
+    OpenLocalEditorCreateResponseApplicationJson_Ocs._defaults(this);
+  }
 
   OpenLocalEditorCreateResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -4425,6 +4478,7 @@ class OpenLocalEditorCreateResponseApplicationJson_OcsBuilder
   OpenLocalEditorCreateResponseApplicationJson_Ocs build() => _build();
 
   _$OpenLocalEditorCreateResponseApplicationJson_Ocs _build() {
+    OpenLocalEditorCreateResponseApplicationJson_Ocs._validate(this);
     _$OpenLocalEditorCreateResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$OpenLocalEditorCreateResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -4505,7 +4559,9 @@ class OpenLocalEditorCreateResponseApplicationJsonBuilder
       _$this._ocs ??= OpenLocalEditorCreateResponseApplicationJson_OcsBuilder();
   set ocs(covariant OpenLocalEditorCreateResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  OpenLocalEditorCreateResponseApplicationJsonBuilder();
+  OpenLocalEditorCreateResponseApplicationJsonBuilder() {
+    OpenLocalEditorCreateResponseApplicationJson._defaults(this);
+  }
 
   OpenLocalEditorCreateResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -4531,6 +4587,7 @@ class OpenLocalEditorCreateResponseApplicationJsonBuilder
   OpenLocalEditorCreateResponseApplicationJson build() => _build();
 
   _$OpenLocalEditorCreateResponseApplicationJson _build() {
+    OpenLocalEditorCreateResponseApplicationJson._validate(this);
     _$OpenLocalEditorCreateResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$OpenLocalEditorCreateResponseApplicationJson._(ocs: ocs.build());
@@ -4655,7 +4712,9 @@ class OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder
   String? get token => _$this._token;
   set token(covariant String? token) => _$this._token = token;
 
-  OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder();
+  OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder() {
+    OpenLocalEditorValidateResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -4684,6 +4743,7 @@ class OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder
   OpenLocalEditorValidateResponseApplicationJson_Ocs_Data build() => _build();
 
   _$OpenLocalEditorValidateResponseApplicationJson_Ocs_Data _build() {
+    OpenLocalEditorValidateResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$OpenLocalEditorValidateResponseApplicationJson_Ocs_Data._(
             userId: BuiltValueNullFieldError.checkNotNull(
@@ -4773,7 +4833,9 @@ class OpenLocalEditorValidateResponseApplicationJson_OcsBuilder
       _$this._data ??= OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant OpenLocalEditorValidateResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  OpenLocalEditorValidateResponseApplicationJson_OcsBuilder();
+  OpenLocalEditorValidateResponseApplicationJson_OcsBuilder() {
+    OpenLocalEditorValidateResponseApplicationJson_Ocs._defaults(this);
+  }
 
   OpenLocalEditorValidateResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -4800,6 +4862,7 @@ class OpenLocalEditorValidateResponseApplicationJson_OcsBuilder
   OpenLocalEditorValidateResponseApplicationJson_Ocs build() => _build();
 
   _$OpenLocalEditorValidateResponseApplicationJson_Ocs _build() {
+    OpenLocalEditorValidateResponseApplicationJson_Ocs._validate(this);
     _$OpenLocalEditorValidateResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$OpenLocalEditorValidateResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -4880,7 +4943,9 @@ class OpenLocalEditorValidateResponseApplicationJsonBuilder
       _$this._ocs ??= OpenLocalEditorValidateResponseApplicationJson_OcsBuilder();
   set ocs(covariant OpenLocalEditorValidateResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  OpenLocalEditorValidateResponseApplicationJsonBuilder();
+  OpenLocalEditorValidateResponseApplicationJsonBuilder() {
+    OpenLocalEditorValidateResponseApplicationJson._defaults(this);
+  }
 
   OpenLocalEditorValidateResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -4906,6 +4971,7 @@ class OpenLocalEditorValidateResponseApplicationJsonBuilder
   OpenLocalEditorValidateResponseApplicationJson build() => _build();
 
   _$OpenLocalEditorValidateResponseApplicationJson _build() {
+    OpenLocalEditorValidateResponseApplicationJson._validate(this);
     _$OpenLocalEditorValidateResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$OpenLocalEditorValidateResponseApplicationJson._(ocs: ocs.build());
@@ -5065,7 +5131,9 @@ class TemplateFileCreatorBuilder
   String? get actionLabel => _$this._actionLabel;
   set actionLabel(covariant String? actionLabel) => _$this._actionLabel = actionLabel;
 
-  TemplateFileCreatorBuilder();
+  TemplateFileCreatorBuilder() {
+    TemplateFileCreator._defaults(this);
+  }
 
   TemplateFileCreatorBuilder get _$this {
     final $v = _$v;
@@ -5097,6 +5165,7 @@ class TemplateFileCreatorBuilder
   TemplateFileCreator build() => _build();
 
   _$TemplateFileCreator _build() {
+    TemplateFileCreator._validate(this);
     _$TemplateFileCreator _$result;
     try {
       _$result = _$v ??
@@ -5195,7 +5264,9 @@ class TemplateListResponseApplicationJson_OcsBuilder
   ListBuilder<TemplateFileCreator> get data => _$this._data ??= ListBuilder<TemplateFileCreator>();
   set data(covariant ListBuilder<TemplateFileCreator>? data) => _$this._data = data;
 
-  TemplateListResponseApplicationJson_OcsBuilder();
+  TemplateListResponseApplicationJson_OcsBuilder() {
+    TemplateListResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TemplateListResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -5222,6 +5293,7 @@ class TemplateListResponseApplicationJson_OcsBuilder
   TemplateListResponseApplicationJson_Ocs build() => _build();
 
   _$TemplateListResponseApplicationJson_Ocs _build() {
+    TemplateListResponseApplicationJson_Ocs._validate(this);
     _$TemplateListResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$TemplateListResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -5298,7 +5370,9 @@ class TemplateListResponseApplicationJsonBuilder
       _$this._ocs ??= TemplateListResponseApplicationJson_OcsBuilder();
   set ocs(covariant TemplateListResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TemplateListResponseApplicationJsonBuilder();
+  TemplateListResponseApplicationJsonBuilder() {
+    TemplateListResponseApplicationJson._defaults(this);
+  }
 
   TemplateListResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -5324,6 +5398,7 @@ class TemplateListResponseApplicationJsonBuilder
   TemplateListResponseApplicationJson build() => _build();
 
   _$TemplateListResponseApplicationJson _build() {
+    TemplateListResponseApplicationJson._validate(this);
     _$TemplateListResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TemplateListResponseApplicationJson._(ocs: ocs.build());
@@ -5509,7 +5584,9 @@ class TemplateFileBuilder implements Builder<TemplateFile, TemplateFileBuilder>,
   bool? get hasPreview => _$this._hasPreview;
   set hasPreview(covariant bool? hasPreview) => _$this._hasPreview = hasPreview;
 
-  TemplateFileBuilder();
+  TemplateFileBuilder() {
+    TemplateFile._defaults(this);
+  }
 
   TemplateFileBuilder get _$this {
     final $v = _$v;
@@ -5543,6 +5620,7 @@ class TemplateFileBuilder implements Builder<TemplateFile, TemplateFileBuilder>,
   TemplateFile build() => _build();
 
   _$TemplateFile _build() {
+    TemplateFile._validate(this);
     final _$result = _$v ??
         _$TemplateFile._(
             basename: BuiltValueNullFieldError.checkNotNull(basename, r'TemplateFile', 'basename'),
@@ -5631,7 +5709,9 @@ class TemplateCreateResponseApplicationJson_OcsBuilder
   TemplateFileBuilder get data => _$this._data ??= TemplateFileBuilder();
   set data(covariant TemplateFileBuilder? data) => _$this._data = data;
 
-  TemplateCreateResponseApplicationJson_OcsBuilder();
+  TemplateCreateResponseApplicationJson_OcsBuilder() {
+    TemplateCreateResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TemplateCreateResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -5658,6 +5738,7 @@ class TemplateCreateResponseApplicationJson_OcsBuilder
   TemplateCreateResponseApplicationJson_Ocs build() => _build();
 
   _$TemplateCreateResponseApplicationJson_Ocs _build() {
+    TemplateCreateResponseApplicationJson_Ocs._validate(this);
     _$TemplateCreateResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$TemplateCreateResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -5736,7 +5817,9 @@ class TemplateCreateResponseApplicationJsonBuilder
       _$this._ocs ??= TemplateCreateResponseApplicationJson_OcsBuilder();
   set ocs(covariant TemplateCreateResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TemplateCreateResponseApplicationJsonBuilder();
+  TemplateCreateResponseApplicationJsonBuilder() {
+    TemplateCreateResponseApplicationJson._defaults(this);
+  }
 
   TemplateCreateResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -5762,6 +5845,7 @@ class TemplateCreateResponseApplicationJsonBuilder
   TemplateCreateResponseApplicationJson build() => _build();
 
   _$TemplateCreateResponseApplicationJson _build() {
+    TemplateCreateResponseApplicationJson._validate(this);
     _$TemplateCreateResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TemplateCreateResponseApplicationJson._(ocs: ocs.build());
@@ -5855,7 +5939,9 @@ class TemplatePathResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<TemplateFileCreator> get templates => _$this._templates ??= ListBuilder<TemplateFileCreator>();
   set templates(covariant ListBuilder<TemplateFileCreator>? templates) => _$this._templates = templates;
 
-  TemplatePathResponseApplicationJson_Ocs_DataBuilder();
+  TemplatePathResponseApplicationJson_Ocs_DataBuilder() {
+    TemplatePathResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   TemplatePathResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -5882,6 +5968,7 @@ class TemplatePathResponseApplicationJson_Ocs_DataBuilder
   TemplatePathResponseApplicationJson_Ocs_Data build() => _build();
 
   _$TemplatePathResponseApplicationJson_Ocs_Data _build() {
+    TemplatePathResponseApplicationJson_Ocs_Data._validate(this);
     _$TemplatePathResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ??
@@ -5977,7 +6064,9 @@ class TemplatePathResponseApplicationJson_OcsBuilder
       _$this._data ??= TemplatePathResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant TemplatePathResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  TemplatePathResponseApplicationJson_OcsBuilder();
+  TemplatePathResponseApplicationJson_OcsBuilder() {
+    TemplatePathResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TemplatePathResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6004,6 +6093,7 @@ class TemplatePathResponseApplicationJson_OcsBuilder
   TemplatePathResponseApplicationJson_Ocs build() => _build();
 
   _$TemplatePathResponseApplicationJson_Ocs _build() {
+    TemplatePathResponseApplicationJson_Ocs._validate(this);
     _$TemplatePathResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$TemplatePathResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -6080,7 +6170,9 @@ class TemplatePathResponseApplicationJsonBuilder
       _$this._ocs ??= TemplatePathResponseApplicationJson_OcsBuilder();
   set ocs(covariant TemplatePathResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TemplatePathResponseApplicationJsonBuilder();
+  TemplatePathResponseApplicationJsonBuilder() {
+    TemplatePathResponseApplicationJson._defaults(this);
+  }
 
   TemplatePathResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6106,6 +6198,7 @@ class TemplatePathResponseApplicationJsonBuilder
   TemplatePathResponseApplicationJson build() => _build();
 
   _$TemplatePathResponseApplicationJson _build() {
+    TemplatePathResponseApplicationJson._validate(this);
     _$TemplatePathResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TemplatePathResponseApplicationJson._(ocs: ocs.build());
@@ -6198,7 +6291,9 @@ class TransferOwnershipTransferResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  TransferOwnershipTransferResponseApplicationJson_OcsBuilder();
+  TransferOwnershipTransferResponseApplicationJson_OcsBuilder() {
+    TransferOwnershipTransferResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TransferOwnershipTransferResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6225,6 +6320,7 @@ class TransferOwnershipTransferResponseApplicationJson_OcsBuilder
   TransferOwnershipTransferResponseApplicationJson_Ocs build() => _build();
 
   _$TransferOwnershipTransferResponseApplicationJson_Ocs _build() {
+    TransferOwnershipTransferResponseApplicationJson_Ocs._validate(this);
     _$TransferOwnershipTransferResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -6309,7 +6405,9 @@ class TransferOwnershipTransferResponseApplicationJsonBuilder
       _$this._ocs ??= TransferOwnershipTransferResponseApplicationJson_OcsBuilder();
   set ocs(covariant TransferOwnershipTransferResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TransferOwnershipTransferResponseApplicationJsonBuilder();
+  TransferOwnershipTransferResponseApplicationJsonBuilder() {
+    TransferOwnershipTransferResponseApplicationJson._defaults(this);
+  }
 
   TransferOwnershipTransferResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6335,6 +6433,7 @@ class TransferOwnershipTransferResponseApplicationJsonBuilder
   TransferOwnershipTransferResponseApplicationJson build() => _build();
 
   _$TransferOwnershipTransferResponseApplicationJson _build() {
+    TransferOwnershipTransferResponseApplicationJson._validate(this);
     _$TransferOwnershipTransferResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TransferOwnershipTransferResponseApplicationJson._(ocs: ocs.build());
@@ -6427,7 +6526,9 @@ class TransferOwnershipAcceptResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  TransferOwnershipAcceptResponseApplicationJson_OcsBuilder();
+  TransferOwnershipAcceptResponseApplicationJson_OcsBuilder() {
+    TransferOwnershipAcceptResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TransferOwnershipAcceptResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6454,6 +6555,7 @@ class TransferOwnershipAcceptResponseApplicationJson_OcsBuilder
   TransferOwnershipAcceptResponseApplicationJson_Ocs build() => _build();
 
   _$TransferOwnershipAcceptResponseApplicationJson_Ocs _build() {
+    TransferOwnershipAcceptResponseApplicationJson_Ocs._validate(this);
     _$TransferOwnershipAcceptResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -6536,7 +6638,9 @@ class TransferOwnershipAcceptResponseApplicationJsonBuilder
       _$this._ocs ??= TransferOwnershipAcceptResponseApplicationJson_OcsBuilder();
   set ocs(covariant TransferOwnershipAcceptResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TransferOwnershipAcceptResponseApplicationJsonBuilder();
+  TransferOwnershipAcceptResponseApplicationJsonBuilder() {
+    TransferOwnershipAcceptResponseApplicationJson._defaults(this);
+  }
 
   TransferOwnershipAcceptResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6562,6 +6666,7 @@ class TransferOwnershipAcceptResponseApplicationJsonBuilder
   TransferOwnershipAcceptResponseApplicationJson build() => _build();
 
   _$TransferOwnershipAcceptResponseApplicationJson _build() {
+    TransferOwnershipAcceptResponseApplicationJson._validate(this);
     _$TransferOwnershipAcceptResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TransferOwnershipAcceptResponseApplicationJson._(ocs: ocs.build());
@@ -6654,7 +6759,9 @@ class TransferOwnershipRejectResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  TransferOwnershipRejectResponseApplicationJson_OcsBuilder();
+  TransferOwnershipRejectResponseApplicationJson_OcsBuilder() {
+    TransferOwnershipRejectResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TransferOwnershipRejectResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6681,6 +6788,7 @@ class TransferOwnershipRejectResponseApplicationJson_OcsBuilder
   TransferOwnershipRejectResponseApplicationJson_Ocs build() => _build();
 
   _$TransferOwnershipRejectResponseApplicationJson_Ocs _build() {
+    TransferOwnershipRejectResponseApplicationJson_Ocs._validate(this);
     _$TransferOwnershipRejectResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -6763,7 +6871,9 @@ class TransferOwnershipRejectResponseApplicationJsonBuilder
       _$this._ocs ??= TransferOwnershipRejectResponseApplicationJson_OcsBuilder();
   set ocs(covariant TransferOwnershipRejectResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TransferOwnershipRejectResponseApplicationJsonBuilder();
+  TransferOwnershipRejectResponseApplicationJsonBuilder() {
+    TransferOwnershipRejectResponseApplicationJson._defaults(this);
+  }
 
   TransferOwnershipRejectResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6789,6 +6899,7 @@ class TransferOwnershipRejectResponseApplicationJsonBuilder
   TransferOwnershipRejectResponseApplicationJson build() => _build();
 
   _$TransferOwnershipRejectResponseApplicationJson _build() {
+    TransferOwnershipRejectResponseApplicationJson._validate(this);
     _$TransferOwnershipRejectResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TransferOwnershipRejectResponseApplicationJson._(ocs: ocs.build());
@@ -6893,7 +7004,9 @@ class Capabilities_Files_DirectEditingBuilder
   bool? get supportsFileId => _$this._supportsFileId;
   set supportsFileId(covariant bool? supportsFileId) => _$this._supportsFileId = supportsFileId;
 
-  Capabilities_Files_DirectEditingBuilder();
+  Capabilities_Files_DirectEditingBuilder() {
+    Capabilities_Files_DirectEditing._defaults(this);
+  }
 
   Capabilities_Files_DirectEditingBuilder get _$this {
     final $v = _$v;
@@ -6921,6 +7034,7 @@ class Capabilities_Files_DirectEditingBuilder
   Capabilities_Files_DirectEditing build() => _build();
 
   _$Capabilities_Files_DirectEditing _build() {
+    Capabilities_Files_DirectEditing._validate(this);
     final _$result = _$v ??
         _$Capabilities_Files_DirectEditing._(
             url: BuiltValueNullFieldError.checkNotNull(url, r'Capabilities_Files_DirectEditing', 'url'),
@@ -7018,7 +7132,9 @@ class Capabilities_FilesBuilder
   set directEditing(covariant Capabilities_Files_DirectEditingBuilder? directEditing) =>
       _$this._directEditing = directEditing;
 
-  Capabilities_FilesBuilder();
+  Capabilities_FilesBuilder() {
+    Capabilities_Files._defaults(this);
+  }
 
   Capabilities_FilesBuilder get _$this {
     final $v = _$v;
@@ -7046,6 +7162,7 @@ class Capabilities_FilesBuilder
   Capabilities_Files build() => _build();
 
   _$Capabilities_Files _build() {
+    Capabilities_Files._validate(this);
     _$Capabilities_Files _$result;
     try {
       _$result = _$v ??
@@ -7122,7 +7239,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities_FilesBuilder get files => _$this._files ??= Capabilities_FilesBuilder();
   set files(covariant Capabilities_FilesBuilder? files) => _$this._files = files;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -7148,6 +7267,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(files: files.build());

--- a/packages/nextcloud/lib/src/api/files_external.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.dart
@@ -144,6 +144,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -170,6 +174,16 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 class Mount_Type extends EnumClass {
@@ -365,6 +379,10 @@ abstract interface class $StorageConfigInterface {
   String? get statusMessage;
   StorageConfig_Type get type;
   bool get userProvided;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($StorageConfigInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($StorageConfigInterfaceBuilder b) {}
 }
 
 abstract class StorageConfig implements $StorageConfigInterface, Built<StorageConfig, StorageConfigBuilder> {
@@ -391,6 +409,16 @@ abstract class StorageConfig implements $StorageConfigInterface, Built<StorageCo
 
   /// Serializer for StorageConfig.
   static Serializer<StorageConfig> get serializer => _$storageConfigSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(StorageConfigBuilder b) {
+    $StorageConfigInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(StorageConfigBuilder b) {
+    $StorageConfigInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -405,6 +433,10 @@ abstract interface class $MountInterface {
   @BuiltValueField(wireName: 'class')
   String get $class;
   StorageConfig get config;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MountInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MountInterfaceBuilder b) {}
 }
 
 abstract class Mount implements $MountInterface, Built<Mount, MountBuilder> {
@@ -431,12 +463,26 @@ abstract class Mount implements $MountInterface, Built<Mount, MountBuilder> {
 
   /// Serializer for Mount.
   static Serializer<Mount> get serializer => _$mountSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MountBuilder b) {
+    $MountInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MountBuilder b) {
+    $MountInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiGetUserMountsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Mount> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGetUserMountsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGetUserMountsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ApiGetUserMountsResponseApplicationJson_Ocs
@@ -470,11 +516,25 @@ abstract class ApiGetUserMountsResponseApplicationJson_Ocs
   /// Serializer for ApiGetUserMountsResponseApplicationJson_Ocs.
   static Serializer<ApiGetUserMountsResponseApplicationJson_Ocs> get serializer =>
       _$apiGetUserMountsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGetUserMountsResponseApplicationJson_OcsBuilder b) {
+    $ApiGetUserMountsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGetUserMountsResponseApplicationJson_OcsBuilder b) {
+    $ApiGetUserMountsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiGetUserMountsResponseApplicationJsonInterface {
   ApiGetUserMountsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGetUserMountsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGetUserMountsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ApiGetUserMountsResponseApplicationJson
@@ -507,6 +567,16 @@ abstract class ApiGetUserMountsResponseApplicationJson
   /// Serializer for ApiGetUserMountsResponseApplicationJson.
   static Serializer<ApiGetUserMountsResponseApplicationJson> get serializer =>
       _$apiGetUserMountsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGetUserMountsResponseApplicationJsonBuilder b) {
+    $ApiGetUserMountsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGetUserMountsResponseApplicationJsonBuilder b) {
+    $ApiGetUserMountsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/files_external.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.g.dart
@@ -543,7 +543,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -573,6 +575,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -803,7 +806,9 @@ class StorageConfigBuilder implements Builder<StorageConfig, StorageConfigBuilde
   bool? get userProvided => _$this._userProvided;
   set userProvided(covariant bool? userProvided) => _$this._userProvided = userProvided;
 
-  StorageConfigBuilder();
+  StorageConfigBuilder() {
+    StorageConfig._defaults(this);
+  }
 
   StorageConfigBuilder get _$this {
     final $v = _$v;
@@ -841,6 +846,7 @@ class StorageConfigBuilder implements Builder<StorageConfig, StorageConfigBuilde
   StorageConfig build() => _build();
 
   _$StorageConfig _build() {
+    StorageConfig._validate(this);
     _$StorageConfig _$result;
     try {
       _$result = _$v ??
@@ -1048,7 +1054,9 @@ class MountBuilder implements Builder<Mount, MountBuilder>, $MountInterfaceBuild
   StorageConfigBuilder get config => _$this._config ??= StorageConfigBuilder();
   set config(covariant StorageConfigBuilder? config) => _$this._config = config;
 
-  MountBuilder();
+  MountBuilder() {
+    Mount._defaults(this);
+  }
 
   MountBuilder get _$this {
     final $v = _$v;
@@ -1082,6 +1090,7 @@ class MountBuilder implements Builder<Mount, MountBuilder>, $MountInterfaceBuild
   Mount build() => _build();
 
   _$Mount _build() {
+    Mount._validate(this);
     _$Mount _$result;
     try {
       _$result = _$v ??
@@ -1182,7 +1191,9 @@ class ApiGetUserMountsResponseApplicationJson_OcsBuilder
   ListBuilder<Mount> get data => _$this._data ??= ListBuilder<Mount>();
   set data(covariant ListBuilder<Mount>? data) => _$this._data = data;
 
-  ApiGetUserMountsResponseApplicationJson_OcsBuilder();
+  ApiGetUserMountsResponseApplicationJson_OcsBuilder() {
+    ApiGetUserMountsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ApiGetUserMountsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1209,6 +1220,7 @@ class ApiGetUserMountsResponseApplicationJson_OcsBuilder
   ApiGetUserMountsResponseApplicationJson_Ocs build() => _build();
 
   _$ApiGetUserMountsResponseApplicationJson_Ocs _build() {
+    ApiGetUserMountsResponseApplicationJson_Ocs._validate(this);
     _$ApiGetUserMountsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ApiGetUserMountsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -1288,7 +1300,9 @@ class ApiGetUserMountsResponseApplicationJsonBuilder
       _$this._ocs ??= ApiGetUserMountsResponseApplicationJson_OcsBuilder();
   set ocs(covariant ApiGetUserMountsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ApiGetUserMountsResponseApplicationJsonBuilder();
+  ApiGetUserMountsResponseApplicationJsonBuilder() {
+    ApiGetUserMountsResponseApplicationJson._defaults(this);
+  }
 
   ApiGetUserMountsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1314,6 +1328,7 @@ class ApiGetUserMountsResponseApplicationJsonBuilder
   ApiGetUserMountsResponseApplicationJson build() => _build();
 
   _$ApiGetUserMountsResponseApplicationJson _build() {
+    ApiGetUserMountsResponseApplicationJson._validate(this);
     _$ApiGetUserMountsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ApiGetUserMountsResponseApplicationJson._(ocs: ocs.build());

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
@@ -400,6 +400,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -426,11 +430,25 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiGetResponseApplicationJson_Ocs_DataInterface {
   String? get dueDate;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGetResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGetResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class ApiGetResponseApplicationJson_Ocs_Data
@@ -463,12 +481,26 @@ abstract class ApiGetResponseApplicationJson_Ocs_Data
   /// Serializer for ApiGetResponseApplicationJson_Ocs_Data.
   static Serializer<ApiGetResponseApplicationJson_Ocs_Data> get serializer =>
       _$apiGetResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGetResponseApplicationJson_Ocs_DataBuilder b) {
+    $ApiGetResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGetResponseApplicationJson_Ocs_DataBuilder b) {
+    $ApiGetResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiGetResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ApiGetResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGetResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGetResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ApiGetResponseApplicationJson_Ocs
@@ -500,11 +532,25 @@ abstract class ApiGetResponseApplicationJson_Ocs
 
   /// Serializer for ApiGetResponseApplicationJson_Ocs.
   static Serializer<ApiGetResponseApplicationJson_Ocs> get serializer => _$apiGetResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGetResponseApplicationJson_OcsBuilder b) {
+    $ApiGetResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGetResponseApplicationJson_OcsBuilder b) {
+    $ApiGetResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiGetResponseApplicationJsonInterface {
   ApiGetResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGetResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGetResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ApiGetResponseApplicationJson
@@ -536,12 +582,26 @@ abstract class ApiGetResponseApplicationJson
 
   /// Serializer for ApiGetResponseApplicationJson.
   static Serializer<ApiGetResponseApplicationJson> get serializer => _$apiGetResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGetResponseApplicationJsonBuilder b) {
+    $ApiGetResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGetResponseApplicationJsonBuilder b) {
+    $ApiGetResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiSetResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiSetResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiSetResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ApiSetResponseApplicationJson_Ocs
@@ -573,11 +633,25 @@ abstract class ApiSetResponseApplicationJson_Ocs
 
   /// Serializer for ApiSetResponseApplicationJson_Ocs.
   static Serializer<ApiSetResponseApplicationJson_Ocs> get serializer => _$apiSetResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiSetResponseApplicationJson_OcsBuilder b) {
+    $ApiSetResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiSetResponseApplicationJson_OcsBuilder b) {
+    $ApiSetResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiSetResponseApplicationJsonInterface {
   ApiSetResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiSetResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiSetResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ApiSetResponseApplicationJson
@@ -609,12 +683,26 @@ abstract class ApiSetResponseApplicationJson
 
   /// Serializer for ApiSetResponseApplicationJson.
   static Serializer<ApiSetResponseApplicationJson> get serializer => _$apiSetResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiSetResponseApplicationJsonBuilder b) {
+    $ApiSetResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiSetResponseApplicationJsonBuilder b) {
+    $ApiSetResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiRemoveResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiRemoveResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiRemoveResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ApiRemoveResponseApplicationJson_Ocs
@@ -647,11 +735,25 @@ abstract class ApiRemoveResponseApplicationJson_Ocs
   /// Serializer for ApiRemoveResponseApplicationJson_Ocs.
   static Serializer<ApiRemoveResponseApplicationJson_Ocs> get serializer =>
       _$apiRemoveResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiRemoveResponseApplicationJson_OcsBuilder b) {
+    $ApiRemoveResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiRemoveResponseApplicationJson_OcsBuilder b) {
+    $ApiRemoveResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiRemoveResponseApplicationJsonInterface {
   ApiRemoveResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiRemoveResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiRemoveResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ApiRemoveResponseApplicationJson
@@ -683,6 +785,16 @@ abstract class ApiRemoveResponseApplicationJson
 
   /// Serializer for ApiRemoveResponseApplicationJson.
   static Serializer<ApiRemoveResponseApplicationJson> get serializer => _$apiRemoveResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiRemoveResponseApplicationJsonBuilder b) {
+    $ApiRemoveResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiRemoveResponseApplicationJsonBuilder b) {
+    $ApiRemoveResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.g.dart
@@ -487,7 +487,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -517,6 +519,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -585,7 +588,9 @@ class ApiGetResponseApplicationJson_Ocs_DataBuilder
   String? get dueDate => _$this._dueDate;
   set dueDate(covariant String? dueDate) => _$this._dueDate = dueDate;
 
-  ApiGetResponseApplicationJson_Ocs_DataBuilder();
+  ApiGetResponseApplicationJson_Ocs_DataBuilder() {
+    ApiGetResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   ApiGetResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -611,6 +616,7 @@ class ApiGetResponseApplicationJson_Ocs_DataBuilder
   ApiGetResponseApplicationJson_Ocs_Data build() => _build();
 
   _$ApiGetResponseApplicationJson_Ocs_Data _build() {
+    ApiGetResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ?? _$ApiGetResponseApplicationJson_Ocs_Data._(dueDate: dueDate);
     replace(_$result);
     return _$result;
@@ -687,7 +693,9 @@ class ApiGetResponseApplicationJson_OcsBuilder
       _$this._data ??= ApiGetResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant ApiGetResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  ApiGetResponseApplicationJson_OcsBuilder();
+  ApiGetResponseApplicationJson_OcsBuilder() {
+    ApiGetResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ApiGetResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -714,6 +722,7 @@ class ApiGetResponseApplicationJson_OcsBuilder
   ApiGetResponseApplicationJson_Ocs build() => _build();
 
   _$ApiGetResponseApplicationJson_Ocs _build() {
+    ApiGetResponseApplicationJson_Ocs._validate(this);
     _$ApiGetResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ApiGetResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -789,7 +798,9 @@ class ApiGetResponseApplicationJsonBuilder
   ApiGetResponseApplicationJson_OcsBuilder get ocs => _$this._ocs ??= ApiGetResponseApplicationJson_OcsBuilder();
   set ocs(covariant ApiGetResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ApiGetResponseApplicationJsonBuilder();
+  ApiGetResponseApplicationJsonBuilder() {
+    ApiGetResponseApplicationJson._defaults(this);
+  }
 
   ApiGetResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -815,6 +826,7 @@ class ApiGetResponseApplicationJsonBuilder
   ApiGetResponseApplicationJson build() => _build();
 
   _$ApiGetResponseApplicationJson _build() {
+    ApiGetResponseApplicationJson._validate(this);
     _$ApiGetResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ApiGetResponseApplicationJson._(ocs: ocs.build());
@@ -902,7 +914,9 @@ class ApiSetResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ApiSetResponseApplicationJson_OcsBuilder();
+  ApiSetResponseApplicationJson_OcsBuilder() {
+    ApiSetResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ApiSetResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -929,6 +943,7 @@ class ApiSetResponseApplicationJson_OcsBuilder
   ApiSetResponseApplicationJson_Ocs build() => _build();
 
   _$ApiSetResponseApplicationJson_Ocs _build() {
+    ApiSetResponseApplicationJson_Ocs._validate(this);
     _$ApiSetResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -1005,7 +1020,9 @@ class ApiSetResponseApplicationJsonBuilder
   ApiSetResponseApplicationJson_OcsBuilder get ocs => _$this._ocs ??= ApiSetResponseApplicationJson_OcsBuilder();
   set ocs(covariant ApiSetResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ApiSetResponseApplicationJsonBuilder();
+  ApiSetResponseApplicationJsonBuilder() {
+    ApiSetResponseApplicationJson._defaults(this);
+  }
 
   ApiSetResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1031,6 +1048,7 @@ class ApiSetResponseApplicationJsonBuilder
   ApiSetResponseApplicationJson build() => _build();
 
   _$ApiSetResponseApplicationJson _build() {
+    ApiSetResponseApplicationJson._validate(this);
     _$ApiSetResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ApiSetResponseApplicationJson._(ocs: ocs.build());
@@ -1120,7 +1138,9 @@ class ApiRemoveResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ApiRemoveResponseApplicationJson_OcsBuilder();
+  ApiRemoveResponseApplicationJson_OcsBuilder() {
+    ApiRemoveResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ApiRemoveResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1147,6 +1167,7 @@ class ApiRemoveResponseApplicationJson_OcsBuilder
   ApiRemoveResponseApplicationJson_Ocs build() => _build();
 
   _$ApiRemoveResponseApplicationJson_Ocs _build() {
+    ApiRemoveResponseApplicationJson_Ocs._validate(this);
     _$ApiRemoveResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -1223,7 +1244,9 @@ class ApiRemoveResponseApplicationJsonBuilder
   ApiRemoveResponseApplicationJson_OcsBuilder get ocs => _$this._ocs ??= ApiRemoveResponseApplicationJson_OcsBuilder();
   set ocs(covariant ApiRemoveResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ApiRemoveResponseApplicationJsonBuilder();
+  ApiRemoveResponseApplicationJsonBuilder() {
+    ApiRemoveResponseApplicationJson._defaults(this);
+  }
 
   ApiRemoveResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1249,6 +1272,7 @@ class ApiRemoveResponseApplicationJsonBuilder
   ApiRemoveResponseApplicationJson build() => _build();
 
   _$ApiRemoveResponseApplicationJson _build() {
+    ApiRemoveResponseApplicationJson._validate(this);
     _$ApiRemoveResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ApiRemoveResponseApplicationJson._(ocs: ocs.build());

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -4915,9 +4915,14 @@ abstract class ShareeValue implements $ShareeValueInterface, Built<ShareeValue, 
 abstract interface class $ShareeCircle_ValueInterface implements $ShareeValueInterface {
   String get circle;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ShareeCircle_ValueInterfaceBuilder b) {}
+  static void _defaults($ShareeCircle_ValueInterfaceBuilder b) {
+    $ShareeValueInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ShareeCircle_ValueInterfaceBuilder b) {}
+  static void _validate($ShareeCircle_ValueInterfaceBuilder b) {
+    $ShareeValueInterface._validate(b);
+  }
 }
 
 abstract class ShareeCircle_Value
@@ -4963,9 +4968,14 @@ abstract interface class $ShareeCircleInterface implements $ShareeInterface {
   String get shareWithDescription;
   ShareeCircle_Value get value;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ShareeCircleInterfaceBuilder b) {}
+  static void _defaults($ShareeCircleInterfaceBuilder b) {
+    $ShareeInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ShareeCircleInterfaceBuilder b) {}
+  static void _validate($ShareeCircleInterfaceBuilder b) {
+    $ShareeInterface._validate(b);
+  }
 }
 
 abstract class ShareeCircle implements $ShareeCircleInterface, Built<ShareeCircle, ShareeCircleBuilder> {
@@ -5012,9 +5022,14 @@ abstract interface class $ShareeEmailInterface implements $ShareeInterface {
   String get shareWithDisplayNameUnique;
   ShareeValue get value;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ShareeEmailInterfaceBuilder b) {}
+  static void _defaults($ShareeEmailInterfaceBuilder b) {
+    $ShareeInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ShareeEmailInterfaceBuilder b) {}
+  static void _validate($ShareeEmailInterfaceBuilder b) {
+    $ShareeInterface._validate(b);
+  }
 }
 
 abstract class ShareeEmail implements $ShareeEmailInterface, Built<ShareeEmail, ShareeEmailBuilder> {
@@ -5057,9 +5072,14 @@ abstract class ShareeEmail implements $ShareeEmailInterface, Built<ShareeEmail, 
 abstract interface class $ShareeRemoteGroup_ValueInterface implements $ShareeValueInterface {
   String get server;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ShareeRemoteGroup_ValueInterfaceBuilder b) {}
+  static void _defaults($ShareeRemoteGroup_ValueInterfaceBuilder b) {
+    $ShareeValueInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ShareeRemoteGroup_ValueInterfaceBuilder b) {}
+  static void _validate($ShareeRemoteGroup_ValueInterfaceBuilder b) {
+    $ShareeValueInterface._validate(b);
+  }
 }
 
 abstract class ShareeRemoteGroup_Value
@@ -5106,9 +5126,14 @@ abstract interface class $ShareeRemoteGroupInterface implements $ShareeInterface
   String get name;
   ShareeRemoteGroup_Value get value;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ShareeRemoteGroupInterfaceBuilder b) {}
+  static void _defaults($ShareeRemoteGroupInterfaceBuilder b) {
+    $ShareeInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ShareeRemoteGroupInterfaceBuilder b) {}
+  static void _validate($ShareeRemoteGroupInterfaceBuilder b) {
+    $ShareeInterface._validate(b);
+  }
 }
 
 abstract class ShareeRemoteGroup
@@ -5152,9 +5177,14 @@ abstract class ShareeRemoteGroup
 abstract interface class $ShareeRemote_ValueInterface implements $ShareeValueInterface {
   String get server;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ShareeRemote_ValueInterfaceBuilder b) {}
+  static void _defaults($ShareeRemote_ValueInterfaceBuilder b) {
+    $ShareeValueInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ShareeRemote_ValueInterfaceBuilder b) {}
+  static void _validate($ShareeRemote_ValueInterfaceBuilder b) {
+    $ShareeValueInterface._validate(b);
+  }
 }
 
 abstract class ShareeRemote_Value
@@ -5202,9 +5232,14 @@ abstract interface class $ShareeRemoteInterface implements $ShareeInterface {
   String get type;
   ShareeRemote_Value get value;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ShareeRemoteInterfaceBuilder b) {}
+  static void _defaults($ShareeRemoteInterfaceBuilder b) {
+    $ShareeInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ShareeRemoteInterfaceBuilder b) {}
+  static void _validate($ShareeRemoteInterfaceBuilder b) {
+    $ShareeInterface._validate(b);
+  }
 }
 
 abstract class ShareeRemote implements $ShareeRemoteInterface, Built<ShareeRemote, ShareeRemoteBuilder> {
@@ -5300,9 +5335,14 @@ abstract interface class $ShareeUserInterface implements $ShareeInterface {
   ShareeUser_Status get status;
   ShareeValue get value;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ShareeUserInterfaceBuilder b) {}
+  static void _defaults($ShareeUserInterfaceBuilder b) {
+    $ShareeInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ShareeUserInterfaceBuilder b) {}
+  static void _validate($ShareeUserInterfaceBuilder b) {
+    $ShareeInterface._validate(b);
+  }
 }
 
 abstract class ShareeUser implements $ShareeUserInterface, Built<ShareeUser, ShareeUserBuilder> {
@@ -5503,9 +5543,14 @@ abstract class ShareeLookup_Extra
 abstract interface class $ShareeLookup_ValueInterface implements $ShareeValueInterface {
   bool get globalScale;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ShareeLookup_ValueInterfaceBuilder b) {}
+  static void _defaults($ShareeLookup_ValueInterfaceBuilder b) {
+    $ShareeValueInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ShareeLookup_ValueInterfaceBuilder b) {}
+  static void _validate($ShareeLookup_ValueInterfaceBuilder b) {
+    $ShareeValueInterface._validate(b);
+  }
 }
 
 abstract class ShareeLookup_Value
@@ -5551,9 +5596,14 @@ abstract interface class $ShareeLookupInterface implements $ShareeInterface {
   ShareeLookup_Extra get extra;
   ShareeLookup_Value get value;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ShareeLookupInterfaceBuilder b) {}
+  static void _defaults($ShareeLookupInterfaceBuilder b) {
+    $ShareeInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ShareeLookupInterfaceBuilder b) {}
+  static void _validate($ShareeLookupInterfaceBuilder b) {
+    $ShareeInterface._validate(b);
+  }
 }
 
 abstract class ShareeLookup implements $ShareeLookupInterface, Built<ShareeLookup, ShareeLookupBuilder> {

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -2365,6 +2365,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -2391,6 +2395,16 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -2428,6 +2442,10 @@ abstract interface class $DeletedShareInterface {
   String? get shareWithDisplayname;
   @BuiltValueField(wireName: 'share_with_link')
   String? get shareWithLink;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DeletedShareInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DeletedShareInterfaceBuilder b) {}
 }
 
 abstract class DeletedShare implements $DeletedShareInterface, Built<DeletedShare, DeletedShareBuilder> {
@@ -2454,12 +2472,26 @@ abstract class DeletedShare implements $DeletedShareInterface, Built<DeletedShar
 
   /// Serializer for DeletedShare.
   static Serializer<DeletedShare> get serializer => _$deletedShareSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DeletedShareBuilder b) {
+    $DeletedShareInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DeletedShareBuilder b) {
+    $DeletedShareInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DeletedShareapiIndexResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<DeletedShare> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DeletedShareapiIndexResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DeletedShareapiIndexResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class DeletedShareapiIndexResponseApplicationJson_Ocs
@@ -2493,11 +2525,25 @@ abstract class DeletedShareapiIndexResponseApplicationJson_Ocs
   /// Serializer for DeletedShareapiIndexResponseApplicationJson_Ocs.
   static Serializer<DeletedShareapiIndexResponseApplicationJson_Ocs> get serializer =>
       _$deletedShareapiIndexResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DeletedShareapiIndexResponseApplicationJson_OcsBuilder b) {
+    $DeletedShareapiIndexResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DeletedShareapiIndexResponseApplicationJson_OcsBuilder b) {
+    $DeletedShareapiIndexResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DeletedShareapiIndexResponseApplicationJsonInterface {
   DeletedShareapiIndexResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DeletedShareapiIndexResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DeletedShareapiIndexResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DeletedShareapiIndexResponseApplicationJson
@@ -2531,12 +2577,26 @@ abstract class DeletedShareapiIndexResponseApplicationJson
   /// Serializer for DeletedShareapiIndexResponseApplicationJson.
   static Serializer<DeletedShareapiIndexResponseApplicationJson> get serializer =>
       _$deletedShareapiIndexResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DeletedShareapiIndexResponseApplicationJsonBuilder b) {
+    $DeletedShareapiIndexResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DeletedShareapiIndexResponseApplicationJsonBuilder b) {
+    $DeletedShareapiIndexResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DeletedShareapiUndeleteResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DeletedShareapiUndeleteResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DeletedShareapiUndeleteResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class DeletedShareapiUndeleteResponseApplicationJson_Ocs
@@ -2571,11 +2631,25 @@ abstract class DeletedShareapiUndeleteResponseApplicationJson_Ocs
   /// Serializer for DeletedShareapiUndeleteResponseApplicationJson_Ocs.
   static Serializer<DeletedShareapiUndeleteResponseApplicationJson_Ocs> get serializer =>
       _$deletedShareapiUndeleteResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder b) {
+    $DeletedShareapiUndeleteResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder b) {
+    $DeletedShareapiUndeleteResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DeletedShareapiUndeleteResponseApplicationJsonInterface {
   DeletedShareapiUndeleteResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DeletedShareapiUndeleteResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DeletedShareapiUndeleteResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DeletedShareapiUndeleteResponseApplicationJson
@@ -2609,6 +2683,16 @@ abstract class DeletedShareapiUndeleteResponseApplicationJson
   /// Serializer for DeletedShareapiUndeleteResponseApplicationJson.
   static Serializer<DeletedShareapiUndeleteResponseApplicationJson> get serializer =>
       _$deletedShareapiUndeleteResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DeletedShareapiUndeleteResponseApplicationJsonBuilder b) {
+    $DeletedShareapiUndeleteResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DeletedShareapiUndeleteResponseApplicationJsonBuilder b) {
+    $DeletedShareapiUndeleteResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class PublicPreviewGetPreviewA extends EnumClass {
@@ -2696,6 +2780,10 @@ abstract interface class $RemoteShareInterface {
   int get shareType;
   String? get type;
   String get user;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteShareInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteShareInterfaceBuilder b) {}
 }
 
 abstract class RemoteShare implements $RemoteShareInterface, Built<RemoteShare, RemoteShareBuilder> {
@@ -2722,12 +2810,26 @@ abstract class RemoteShare implements $RemoteShareInterface, Built<RemoteShare, 
 
   /// Serializer for RemoteShare.
   static Serializer<RemoteShare> get serializer => _$remoteShareSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteShareBuilder b) {
+    $RemoteShareInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteShareBuilder b) {
+    $RemoteShareInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteGetSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<RemoteShare> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteGetSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteGetSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RemoteGetSharesResponseApplicationJson_Ocs
@@ -2761,11 +2863,25 @@ abstract class RemoteGetSharesResponseApplicationJson_Ocs
   /// Serializer for RemoteGetSharesResponseApplicationJson_Ocs.
   static Serializer<RemoteGetSharesResponseApplicationJson_Ocs> get serializer =>
       _$remoteGetSharesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteGetSharesResponseApplicationJson_OcsBuilder b) {
+    $RemoteGetSharesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteGetSharesResponseApplicationJson_OcsBuilder b) {
+    $RemoteGetSharesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteGetSharesResponseApplicationJsonInterface {
   RemoteGetSharesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteGetSharesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteGetSharesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RemoteGetSharesResponseApplicationJson
@@ -2798,12 +2914,26 @@ abstract class RemoteGetSharesResponseApplicationJson
   /// Serializer for RemoteGetSharesResponseApplicationJson.
   static Serializer<RemoteGetSharesResponseApplicationJson> get serializer =>
       _$remoteGetSharesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteGetSharesResponseApplicationJsonBuilder b) {
+    $RemoteGetSharesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteGetSharesResponseApplicationJsonBuilder b) {
+    $RemoteGetSharesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteGetOpenSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<RemoteShare> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteGetOpenSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteGetOpenSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RemoteGetOpenSharesResponseApplicationJson_Ocs
@@ -2837,11 +2967,25 @@ abstract class RemoteGetOpenSharesResponseApplicationJson_Ocs
   /// Serializer for RemoteGetOpenSharesResponseApplicationJson_Ocs.
   static Serializer<RemoteGetOpenSharesResponseApplicationJson_Ocs> get serializer =>
       _$remoteGetOpenSharesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteGetOpenSharesResponseApplicationJson_OcsBuilder b) {
+    $RemoteGetOpenSharesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteGetOpenSharesResponseApplicationJson_OcsBuilder b) {
+    $RemoteGetOpenSharesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteGetOpenSharesResponseApplicationJsonInterface {
   RemoteGetOpenSharesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteGetOpenSharesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteGetOpenSharesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RemoteGetOpenSharesResponseApplicationJson
@@ -2875,12 +3019,26 @@ abstract class RemoteGetOpenSharesResponseApplicationJson
   /// Serializer for RemoteGetOpenSharesResponseApplicationJson.
   static Serializer<RemoteGetOpenSharesResponseApplicationJson> get serializer =>
       _$remoteGetOpenSharesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteGetOpenSharesResponseApplicationJsonBuilder b) {
+    $RemoteGetOpenSharesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteGetOpenSharesResponseApplicationJsonBuilder b) {
+    $RemoteGetOpenSharesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteAcceptShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteAcceptShareResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteAcceptShareResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RemoteAcceptShareResponseApplicationJson_Ocs
@@ -2914,11 +3072,25 @@ abstract class RemoteAcceptShareResponseApplicationJson_Ocs
   /// Serializer for RemoteAcceptShareResponseApplicationJson_Ocs.
   static Serializer<RemoteAcceptShareResponseApplicationJson_Ocs> get serializer =>
       _$remoteAcceptShareResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteAcceptShareResponseApplicationJson_OcsBuilder b) {
+    $RemoteAcceptShareResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteAcceptShareResponseApplicationJson_OcsBuilder b) {
+    $RemoteAcceptShareResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteAcceptShareResponseApplicationJsonInterface {
   RemoteAcceptShareResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteAcceptShareResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteAcceptShareResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RemoteAcceptShareResponseApplicationJson
@@ -2952,12 +3124,26 @@ abstract class RemoteAcceptShareResponseApplicationJson
   /// Serializer for RemoteAcceptShareResponseApplicationJson.
   static Serializer<RemoteAcceptShareResponseApplicationJson> get serializer =>
       _$remoteAcceptShareResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteAcceptShareResponseApplicationJsonBuilder b) {
+    $RemoteAcceptShareResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteAcceptShareResponseApplicationJsonBuilder b) {
+    $RemoteAcceptShareResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteDeclineShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteDeclineShareResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteDeclineShareResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RemoteDeclineShareResponseApplicationJson_Ocs
@@ -2991,11 +3177,25 @@ abstract class RemoteDeclineShareResponseApplicationJson_Ocs
   /// Serializer for RemoteDeclineShareResponseApplicationJson_Ocs.
   static Serializer<RemoteDeclineShareResponseApplicationJson_Ocs> get serializer =>
       _$remoteDeclineShareResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteDeclineShareResponseApplicationJson_OcsBuilder b) {
+    $RemoteDeclineShareResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteDeclineShareResponseApplicationJson_OcsBuilder b) {
+    $RemoteDeclineShareResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteDeclineShareResponseApplicationJsonInterface {
   RemoteDeclineShareResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteDeclineShareResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteDeclineShareResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RemoteDeclineShareResponseApplicationJson
@@ -3029,12 +3229,26 @@ abstract class RemoteDeclineShareResponseApplicationJson
   /// Serializer for RemoteDeclineShareResponseApplicationJson.
   static Serializer<RemoteDeclineShareResponseApplicationJson> get serializer =>
       _$remoteDeclineShareResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteDeclineShareResponseApplicationJsonBuilder b) {
+    $RemoteDeclineShareResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteDeclineShareResponseApplicationJsonBuilder b) {
+    $RemoteDeclineShareResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteGetShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   RemoteShare get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteGetShareResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteGetShareResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RemoteGetShareResponseApplicationJson_Ocs
@@ -3068,11 +3282,25 @@ abstract class RemoteGetShareResponseApplicationJson_Ocs
   /// Serializer for RemoteGetShareResponseApplicationJson_Ocs.
   static Serializer<RemoteGetShareResponseApplicationJson_Ocs> get serializer =>
       _$remoteGetShareResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteGetShareResponseApplicationJson_OcsBuilder b) {
+    $RemoteGetShareResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteGetShareResponseApplicationJson_OcsBuilder b) {
+    $RemoteGetShareResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteGetShareResponseApplicationJsonInterface {
   RemoteGetShareResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteGetShareResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteGetShareResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RemoteGetShareResponseApplicationJson
@@ -3105,12 +3333,26 @@ abstract class RemoteGetShareResponseApplicationJson
   /// Serializer for RemoteGetShareResponseApplicationJson.
   static Serializer<RemoteGetShareResponseApplicationJson> get serializer =>
       _$remoteGetShareResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteGetShareResponseApplicationJsonBuilder b) {
+    $RemoteGetShareResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteGetShareResponseApplicationJsonBuilder b) {
+    $RemoteGetShareResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteUnshareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteUnshareResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteUnshareResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RemoteUnshareResponseApplicationJson_Ocs
@@ -3144,11 +3386,25 @@ abstract class RemoteUnshareResponseApplicationJson_Ocs
   /// Serializer for RemoteUnshareResponseApplicationJson_Ocs.
   static Serializer<RemoteUnshareResponseApplicationJson_Ocs> get serializer =>
       _$remoteUnshareResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteUnshareResponseApplicationJson_OcsBuilder b) {
+    $RemoteUnshareResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteUnshareResponseApplicationJson_OcsBuilder b) {
+    $RemoteUnshareResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RemoteUnshareResponseApplicationJsonInterface {
   RemoteUnshareResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RemoteUnshareResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RemoteUnshareResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RemoteUnshareResponseApplicationJson
@@ -3181,6 +3437,16 @@ abstract class RemoteUnshareResponseApplicationJson
   /// Serializer for RemoteUnshareResponseApplicationJson.
   static Serializer<RemoteUnshareResponseApplicationJson> get serializer =>
       _$remoteUnshareResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RemoteUnshareResponseApplicationJsonBuilder b) {
+    $RemoteUnshareResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RemoteUnshareResponseApplicationJsonBuilder b) {
+    $RemoteUnshareResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -3195,6 +3461,10 @@ abstract interface class $ShareInfoInterface {
   String get type;
   String get etag;
   BuiltList<BuiltMap<String, JsonObject>>? get children;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareInfoInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareInfoInterfaceBuilder b) {}
 }
 
 abstract class ShareInfo implements $ShareInfoInterface, Built<ShareInfo, ShareInfoBuilder> {
@@ -3221,6 +3491,16 @@ abstract class ShareInfo implements $ShareInfoInterface, Built<ShareInfo, ShareI
 
   /// Serializer for ShareInfo.
   static Serializer<ShareInfo> get serializer => _$shareInfoSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareInfoBuilder b) {
+    $ShareInfoInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareInfoBuilder b) {
+    $ShareInfoInterface._validate(b);
+  }
 }
 
 class Share_HideDownload extends EnumClass {
@@ -3416,6 +3696,10 @@ abstract interface class $Share_StatusInterface {
   String? get icon;
   String? get message;
   String? get status;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Share_StatusInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Share_StatusInterfaceBuilder b) {}
 }
 
 abstract class Share_Status implements $Share_StatusInterface, Built<Share_Status, Share_StatusBuilder> {
@@ -3442,6 +3726,16 @@ abstract class Share_Status implements $Share_StatusInterface, Built<Share_Statu
 
   /// Serializer for Share_Status.
   static Serializer<Share_Status> get serializer => _$shareStatusSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Share_StatusBuilder b) {
+    $Share_StatusInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Share_StatusBuilder b) {
+    $Share_StatusInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -3513,6 +3807,10 @@ abstract interface class $ShareInterface {
   @BuiltValueField(wireName: 'uid_owner')
   String get uidOwner;
   String? get url;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareInterfaceBuilder b) {}
 }
 
 abstract class Share implements $ShareInterface, Built<Share, ShareBuilder> {
@@ -3539,12 +3837,26 @@ abstract class Share implements $ShareInterface, Built<Share, ShareBuilder> {
 
   /// Serializer for Share.
   static Serializer<Share> get serializer => _$shareSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareBuilder b) {
+    $ShareInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareBuilder b) {
+    $ShareInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiGetSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Share> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiGetSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiGetSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ShareapiGetSharesResponseApplicationJson_Ocs
@@ -3578,11 +3890,25 @@ abstract class ShareapiGetSharesResponseApplicationJson_Ocs
   /// Serializer for ShareapiGetSharesResponseApplicationJson_Ocs.
   static Serializer<ShareapiGetSharesResponseApplicationJson_Ocs> get serializer =>
       _$shareapiGetSharesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiGetSharesResponseApplicationJson_OcsBuilder b) {
+    $ShareapiGetSharesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiGetSharesResponseApplicationJson_OcsBuilder b) {
+    $ShareapiGetSharesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiGetSharesResponseApplicationJsonInterface {
   ShareapiGetSharesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiGetSharesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiGetSharesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ShareapiGetSharesResponseApplicationJson
@@ -3616,12 +3942,26 @@ abstract class ShareapiGetSharesResponseApplicationJson
   /// Serializer for ShareapiGetSharesResponseApplicationJson.
   static Serializer<ShareapiGetSharesResponseApplicationJson> get serializer =>
       _$shareapiGetSharesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiGetSharesResponseApplicationJsonBuilder b) {
+    $ShareapiGetSharesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiGetSharesResponseApplicationJsonBuilder b) {
+    $ShareapiGetSharesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiCreateShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Share get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiCreateShareResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiCreateShareResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ShareapiCreateShareResponseApplicationJson_Ocs
@@ -3655,11 +3995,25 @@ abstract class ShareapiCreateShareResponseApplicationJson_Ocs
   /// Serializer for ShareapiCreateShareResponseApplicationJson_Ocs.
   static Serializer<ShareapiCreateShareResponseApplicationJson_Ocs> get serializer =>
       _$shareapiCreateShareResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiCreateShareResponseApplicationJson_OcsBuilder b) {
+    $ShareapiCreateShareResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiCreateShareResponseApplicationJson_OcsBuilder b) {
+    $ShareapiCreateShareResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiCreateShareResponseApplicationJsonInterface {
   ShareapiCreateShareResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiCreateShareResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiCreateShareResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ShareapiCreateShareResponseApplicationJson
@@ -3693,12 +4047,26 @@ abstract class ShareapiCreateShareResponseApplicationJson
   /// Serializer for ShareapiCreateShareResponseApplicationJson.
   static Serializer<ShareapiCreateShareResponseApplicationJson> get serializer =>
       _$shareapiCreateShareResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiCreateShareResponseApplicationJsonBuilder b) {
+    $ShareapiCreateShareResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiCreateShareResponseApplicationJsonBuilder b) {
+    $ShareapiCreateShareResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiGetInheritedSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Share> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiGetInheritedSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiGetInheritedSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ShareapiGetInheritedSharesResponseApplicationJson_Ocs
@@ -3733,11 +4101,25 @@ abstract class ShareapiGetInheritedSharesResponseApplicationJson_Ocs
   /// Serializer for ShareapiGetInheritedSharesResponseApplicationJson_Ocs.
   static Serializer<ShareapiGetInheritedSharesResponseApplicationJson_Ocs> get serializer =>
       _$shareapiGetInheritedSharesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder b) {
+    $ShareapiGetInheritedSharesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder b) {
+    $ShareapiGetInheritedSharesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiGetInheritedSharesResponseApplicationJsonInterface {
   ShareapiGetInheritedSharesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiGetInheritedSharesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiGetInheritedSharesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ShareapiGetInheritedSharesResponseApplicationJson
@@ -3772,12 +4154,26 @@ abstract class ShareapiGetInheritedSharesResponseApplicationJson
   /// Serializer for ShareapiGetInheritedSharesResponseApplicationJson.
   static Serializer<ShareapiGetInheritedSharesResponseApplicationJson> get serializer =>
       _$shareapiGetInheritedSharesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiGetInheritedSharesResponseApplicationJsonBuilder b) {
+    $ShareapiGetInheritedSharesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiGetInheritedSharesResponseApplicationJsonBuilder b) {
+    $ShareapiGetInheritedSharesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiPendingSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Share> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiPendingSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiPendingSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ShareapiPendingSharesResponseApplicationJson_Ocs
@@ -3812,11 +4208,25 @@ abstract class ShareapiPendingSharesResponseApplicationJson_Ocs
   /// Serializer for ShareapiPendingSharesResponseApplicationJson_Ocs.
   static Serializer<ShareapiPendingSharesResponseApplicationJson_Ocs> get serializer =>
       _$shareapiPendingSharesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiPendingSharesResponseApplicationJson_OcsBuilder b) {
+    $ShareapiPendingSharesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiPendingSharesResponseApplicationJson_OcsBuilder b) {
+    $ShareapiPendingSharesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiPendingSharesResponseApplicationJsonInterface {
   ShareapiPendingSharesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiPendingSharesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiPendingSharesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ShareapiPendingSharesResponseApplicationJson
@@ -3850,6 +4260,16 @@ abstract class ShareapiPendingSharesResponseApplicationJson
   /// Serializer for ShareapiPendingSharesResponseApplicationJson.
   static Serializer<ShareapiPendingSharesResponseApplicationJson> get serializer =>
       _$shareapiPendingSharesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiPendingSharesResponseApplicationJsonBuilder b) {
+    $ShareapiPendingSharesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiPendingSharesResponseApplicationJsonBuilder b) {
+    $ShareapiPendingSharesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ShareapiGetShareIncludeTags extends EnumClass {
@@ -3919,6 +4339,10 @@ class _$ShareapiGetShareIncludeTagsSerializer implements PrimitiveSerializer<Sha
 abstract interface class $ShareapiGetShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Share get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiGetShareResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiGetShareResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ShareapiGetShareResponseApplicationJson_Ocs
@@ -3952,11 +4376,25 @@ abstract class ShareapiGetShareResponseApplicationJson_Ocs
   /// Serializer for ShareapiGetShareResponseApplicationJson_Ocs.
   static Serializer<ShareapiGetShareResponseApplicationJson_Ocs> get serializer =>
       _$shareapiGetShareResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiGetShareResponseApplicationJson_OcsBuilder b) {
+    $ShareapiGetShareResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiGetShareResponseApplicationJson_OcsBuilder b) {
+    $ShareapiGetShareResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiGetShareResponseApplicationJsonInterface {
   ShareapiGetShareResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiGetShareResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiGetShareResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ShareapiGetShareResponseApplicationJson
@@ -3989,12 +4427,26 @@ abstract class ShareapiGetShareResponseApplicationJson
   /// Serializer for ShareapiGetShareResponseApplicationJson.
   static Serializer<ShareapiGetShareResponseApplicationJson> get serializer =>
       _$shareapiGetShareResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiGetShareResponseApplicationJsonBuilder b) {
+    $ShareapiGetShareResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiGetShareResponseApplicationJsonBuilder b) {
+    $ShareapiGetShareResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiUpdateShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Share get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiUpdateShareResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiUpdateShareResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ShareapiUpdateShareResponseApplicationJson_Ocs
@@ -4028,11 +4480,25 @@ abstract class ShareapiUpdateShareResponseApplicationJson_Ocs
   /// Serializer for ShareapiUpdateShareResponseApplicationJson_Ocs.
   static Serializer<ShareapiUpdateShareResponseApplicationJson_Ocs> get serializer =>
       _$shareapiUpdateShareResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiUpdateShareResponseApplicationJson_OcsBuilder b) {
+    $ShareapiUpdateShareResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiUpdateShareResponseApplicationJson_OcsBuilder b) {
+    $ShareapiUpdateShareResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiUpdateShareResponseApplicationJsonInterface {
   ShareapiUpdateShareResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiUpdateShareResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiUpdateShareResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ShareapiUpdateShareResponseApplicationJson
@@ -4066,12 +4532,26 @@ abstract class ShareapiUpdateShareResponseApplicationJson
   /// Serializer for ShareapiUpdateShareResponseApplicationJson.
   static Serializer<ShareapiUpdateShareResponseApplicationJson> get serializer =>
       _$shareapiUpdateShareResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiUpdateShareResponseApplicationJsonBuilder b) {
+    $ShareapiUpdateShareResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiUpdateShareResponseApplicationJsonBuilder b) {
+    $ShareapiUpdateShareResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiDeleteShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiDeleteShareResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiDeleteShareResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ShareapiDeleteShareResponseApplicationJson_Ocs
@@ -4105,11 +4585,25 @@ abstract class ShareapiDeleteShareResponseApplicationJson_Ocs
   /// Serializer for ShareapiDeleteShareResponseApplicationJson_Ocs.
   static Serializer<ShareapiDeleteShareResponseApplicationJson_Ocs> get serializer =>
       _$shareapiDeleteShareResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiDeleteShareResponseApplicationJson_OcsBuilder b) {
+    $ShareapiDeleteShareResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiDeleteShareResponseApplicationJson_OcsBuilder b) {
+    $ShareapiDeleteShareResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiDeleteShareResponseApplicationJsonInterface {
   ShareapiDeleteShareResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiDeleteShareResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiDeleteShareResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ShareapiDeleteShareResponseApplicationJson
@@ -4143,12 +4637,26 @@ abstract class ShareapiDeleteShareResponseApplicationJson
   /// Serializer for ShareapiDeleteShareResponseApplicationJson.
   static Serializer<ShareapiDeleteShareResponseApplicationJson> get serializer =>
       _$shareapiDeleteShareResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiDeleteShareResponseApplicationJsonBuilder b) {
+    $ShareapiDeleteShareResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiDeleteShareResponseApplicationJsonBuilder b) {
+    $ShareapiDeleteShareResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiAcceptShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiAcceptShareResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiAcceptShareResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ShareapiAcceptShareResponseApplicationJson_Ocs
@@ -4182,11 +4690,25 @@ abstract class ShareapiAcceptShareResponseApplicationJson_Ocs
   /// Serializer for ShareapiAcceptShareResponseApplicationJson_Ocs.
   static Serializer<ShareapiAcceptShareResponseApplicationJson_Ocs> get serializer =>
       _$shareapiAcceptShareResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiAcceptShareResponseApplicationJson_OcsBuilder b) {
+    $ShareapiAcceptShareResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiAcceptShareResponseApplicationJson_OcsBuilder b) {
+    $ShareapiAcceptShareResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareapiAcceptShareResponseApplicationJsonInterface {
   ShareapiAcceptShareResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiAcceptShareResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiAcceptShareResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ShareapiAcceptShareResponseApplicationJson
@@ -4220,6 +4742,16 @@ abstract class ShareapiAcceptShareResponseApplicationJson
   /// Serializer for ShareapiAcceptShareResponseApplicationJson.
   static Serializer<ShareapiAcceptShareResponseApplicationJson> get serializer =>
       _$shareapiAcceptShareResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiAcceptShareResponseApplicationJsonBuilder b) {
+    $ShareapiAcceptShareResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiAcceptShareResponseApplicationJsonBuilder b) {
+    $ShareapiAcceptShareResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 typedef ShareesapiSearchShareType = ({BuiltList<int>? builtListInt, int? $int});
@@ -4291,6 +4823,10 @@ class _$ShareesapiSearchLookupSerializer implements PrimitiveSerializer<Shareesa
 abstract interface class $ShareeInterface {
   int? get count;
   String get label;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeInterfaceBuilder b) {}
 }
 
 abstract class Sharee implements $ShareeInterface, Built<Sharee, ShareeBuilder> {
@@ -4317,12 +4853,26 @@ abstract class Sharee implements $ShareeInterface, Built<Sharee, ShareeBuilder> 
 
   /// Serializer for Sharee.
   static Serializer<Sharee> get serializer => _$shareeSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeBuilder b) {
+    $ShareeInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeBuilder b) {
+    $ShareeInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareeValueInterface {
   int get shareType;
   String get shareWith;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeValueInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeValueInterfaceBuilder b) {}
 }
 
 abstract class ShareeValue implements $ShareeValueInterface, Built<ShareeValue, ShareeValueBuilder> {
@@ -4349,11 +4899,25 @@ abstract class ShareeValue implements $ShareeValueInterface, Built<ShareeValue, 
 
   /// Serializer for ShareeValue.
   static Serializer<ShareeValue> get serializer => _$shareeValueSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeValueBuilder b) {
+    $ShareeValueInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeValueBuilder b) {
+    $ShareeValueInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareeCircle_ValueInterface implements $ShareeValueInterface {
   String get circle;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeCircle_ValueInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeCircle_ValueInterfaceBuilder b) {}
 }
 
 abstract class ShareeCircle_Value
@@ -4382,12 +4946,26 @@ abstract class ShareeCircle_Value
 
   /// Serializer for ShareeCircle_Value.
   static Serializer<ShareeCircle_Value> get serializer => _$shareeCircleValueSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeCircle_ValueBuilder b) {
+    $ShareeCircle_ValueInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeCircle_ValueBuilder b) {
+    $ShareeCircle_ValueInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareeCircleInterface implements $ShareeInterface {
   String get shareWithDescription;
   ShareeCircle_Value get value;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeCircleInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeCircleInterfaceBuilder b) {}
 }
 
 abstract class ShareeCircle implements $ShareeCircleInterface, Built<ShareeCircle, ShareeCircleBuilder> {
@@ -4414,6 +4992,16 @@ abstract class ShareeCircle implements $ShareeCircleInterface, Built<ShareeCircl
 
   /// Serializer for ShareeCircle.
   static Serializer<ShareeCircle> get serializer => _$shareeCircleSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeCircleBuilder b) {
+    $ShareeCircleInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeCircleBuilder b) {
+    $ShareeCircleInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -4423,6 +5011,10 @@ abstract interface class $ShareeEmailInterface implements $ShareeInterface {
   String get type;
   String get shareWithDisplayNameUnique;
   ShareeValue get value;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeEmailInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeEmailInterfaceBuilder b) {}
 }
 
 abstract class ShareeEmail implements $ShareeEmailInterface, Built<ShareeEmail, ShareeEmailBuilder> {
@@ -4449,11 +5041,25 @@ abstract class ShareeEmail implements $ShareeEmailInterface, Built<ShareeEmail, 
 
   /// Serializer for ShareeEmail.
   static Serializer<ShareeEmail> get serializer => _$shareeEmailSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeEmailBuilder b) {
+    $ShareeEmailInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeEmailBuilder b) {
+    $ShareeEmailInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareeRemoteGroup_ValueInterface implements $ShareeValueInterface {
   String get server;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeRemoteGroup_ValueInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeRemoteGroup_ValueInterfaceBuilder b) {}
 }
 
 abstract class ShareeRemoteGroup_Value
@@ -4482,6 +5088,16 @@ abstract class ShareeRemoteGroup_Value
 
   /// Serializer for ShareeRemoteGroup_Value.
   static Serializer<ShareeRemoteGroup_Value> get serializer => _$shareeRemoteGroupValueSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeRemoteGroup_ValueBuilder b) {
+    $ShareeRemoteGroup_ValueInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeRemoteGroup_ValueBuilder b) {
+    $ShareeRemoteGroup_ValueInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -4489,6 +5105,10 @@ abstract interface class $ShareeRemoteGroupInterface implements $ShareeInterface
   String get guid;
   String get name;
   ShareeRemoteGroup_Value get value;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeRemoteGroupInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeRemoteGroupInterfaceBuilder b) {}
 }
 
 abstract class ShareeRemoteGroup
@@ -4516,11 +5136,25 @@ abstract class ShareeRemoteGroup
 
   /// Serializer for ShareeRemoteGroup.
   static Serializer<ShareeRemoteGroup> get serializer => _$shareeRemoteGroupSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeRemoteGroupBuilder b) {
+    $ShareeRemoteGroupInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeRemoteGroupBuilder b) {
+    $ShareeRemoteGroupInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareeRemote_ValueInterface implements $ShareeValueInterface {
   String get server;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeRemote_ValueInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeRemote_ValueInterfaceBuilder b) {}
 }
 
 abstract class ShareeRemote_Value
@@ -4549,6 +5183,16 @@ abstract class ShareeRemote_Value
 
   /// Serializer for ShareeRemote_Value.
   static Serializer<ShareeRemote_Value> get serializer => _$shareeRemoteValueSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeRemote_ValueBuilder b) {
+    $ShareeRemote_ValueInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeRemote_ValueBuilder b) {
+    $ShareeRemote_ValueInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -4557,6 +5201,10 @@ abstract interface class $ShareeRemoteInterface implements $ShareeInterface {
   String get name;
   String get type;
   ShareeRemote_Value get value;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeRemoteInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeRemoteInterfaceBuilder b) {}
 }
 
 abstract class ShareeRemote implements $ShareeRemoteInterface, Built<ShareeRemote, ShareeRemoteBuilder> {
@@ -4583,6 +5231,16 @@ abstract class ShareeRemote implements $ShareeRemoteInterface, Built<ShareeRemot
 
   /// Serializer for ShareeRemote.
   static Serializer<ShareeRemote> get serializer => _$shareeRemoteSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeRemoteBuilder b) {
+    $ShareeRemoteInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeRemoteBuilder b) {
+    $ShareeRemoteInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -4591,6 +5249,10 @@ abstract interface class $ShareeUser_StatusInterface {
   String get message;
   String get icon;
   int? get clearAt;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeUser_StatusInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeUser_StatusInterfaceBuilder b) {}
 }
 
 abstract class ShareeUser_Status
@@ -4618,6 +5280,16 @@ abstract class ShareeUser_Status
 
   /// Serializer for ShareeUser_Status.
   static Serializer<ShareeUser_Status> get serializer => _$shareeUserStatusSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeUser_StatusBuilder b) {
+    $ShareeUser_StatusInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeUser_StatusBuilder b) {
+    $ShareeUser_StatusInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -4627,6 +5299,10 @@ abstract interface class $ShareeUserInterface implements $ShareeInterface {
   String get shareWithDisplayNameUnique;
   ShareeUser_Status get status;
   ShareeValue get value;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeUserInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeUserInterfaceBuilder b) {}
 }
 
 abstract class ShareeUser implements $ShareeUserInterface, Built<ShareeUser, ShareeUserBuilder> {
@@ -4653,6 +5329,16 @@ abstract class ShareeUser implements $ShareeUserInterface, Built<ShareeUser, Sha
 
   /// Serializer for ShareeUser.
   static Serializer<ShareeUser> get serializer => _$shareeUserSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeUserBuilder b) {
+    $ShareeUserInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeUserBuilder b) {
+    $ShareeUserInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -4665,6 +5351,10 @@ abstract interface class $ShareesSearchResult_ExactInterface {
   BuiltList<ShareeRemote> get remotes;
   BuiltList<Sharee> get rooms;
   BuiltList<ShareeUser> get users;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesSearchResult_ExactInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesSearchResult_ExactInterfaceBuilder b) {}
 }
 
 abstract class ShareesSearchResult_Exact
@@ -4693,12 +5383,26 @@ abstract class ShareesSearchResult_Exact
 
   /// Serializer for ShareesSearchResult_Exact.
   static Serializer<ShareesSearchResult_Exact> get serializer => _$shareesSearchResultExactSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesSearchResult_ExactBuilder b) {
+    $ShareesSearchResult_ExactInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesSearchResult_ExactBuilder b) {
+    $ShareesSearchResult_ExactInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $LookupInterface {
   String get value;
   int get verified;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($LookupInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($LookupInterfaceBuilder b) {}
 }
 
 abstract class Lookup implements $LookupInterface, Built<Lookup, LookupBuilder> {
@@ -4725,6 +5429,16 @@ abstract class Lookup implements $LookupInterface, Built<Lookup, LookupBuilder> 
 
   /// Serializer for Lookup.
   static Serializer<Lookup> get serializer => _$lookupSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(LookupBuilder b) {
+    $LookupInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(LookupBuilder b) {
+    $LookupInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -4741,6 +5455,10 @@ abstract interface class $ShareeLookup_ExtraInterface {
   @BuiltValueField(wireName: 'website_signature')
   Lookup? get websiteSignature;
   Lookup? get userid;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeLookup_ExtraInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeLookup_ExtraInterfaceBuilder b) {}
 }
 
 abstract class ShareeLookup_Extra
@@ -4769,11 +5487,25 @@ abstract class ShareeLookup_Extra
 
   /// Serializer for ShareeLookup_Extra.
   static Serializer<ShareeLookup_Extra> get serializer => _$shareeLookupExtraSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeLookup_ExtraBuilder b) {
+    $ShareeLookup_ExtraInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeLookup_ExtraBuilder b) {
+    $ShareeLookup_ExtraInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareeLookup_ValueInterface implements $ShareeValueInterface {
   bool get globalScale;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeLookup_ValueInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeLookup_ValueInterfaceBuilder b) {}
 }
 
 abstract class ShareeLookup_Value
@@ -4802,12 +5534,26 @@ abstract class ShareeLookup_Value
 
   /// Serializer for ShareeLookup_Value.
   static Serializer<ShareeLookup_Value> get serializer => _$shareeLookupValueSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeLookup_ValueBuilder b) {
+    $ShareeLookup_ValueInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeLookup_ValueBuilder b) {
+    $ShareeLookup_ValueInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareeLookupInterface implements $ShareeInterface {
   ShareeLookup_Extra get extra;
   ShareeLookup_Value get value;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareeLookupInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareeLookupInterfaceBuilder b) {}
 }
 
 abstract class ShareeLookup implements $ShareeLookupInterface, Built<ShareeLookup, ShareeLookupBuilder> {
@@ -4834,6 +5580,16 @@ abstract class ShareeLookup implements $ShareeLookupInterface, Built<ShareeLooku
 
   /// Serializer for ShareeLookup.
   static Serializer<ShareeLookup> get serializer => _$shareeLookupSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareeLookupBuilder b) {
+    $ShareeLookupInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareeLookupBuilder b) {
+    $ShareeLookupInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -4849,6 +5605,10 @@ abstract interface class $ShareesSearchResultInterface {
   BuiltList<Sharee> get rooms;
   BuiltList<ShareeUser> get users;
   bool get lookupEnabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesSearchResultInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesSearchResultInterfaceBuilder b) {}
 }
 
 abstract class ShareesSearchResult
@@ -4877,12 +5637,26 @@ abstract class ShareesSearchResult
 
   /// Serializer for ShareesSearchResult.
   static Serializer<ShareesSearchResult> get serializer => _$shareesSearchResultSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesSearchResultBuilder b) {
+    $ShareesSearchResultInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesSearchResultBuilder b) {
+    $ShareesSearchResultInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareesapiSearchResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ShareesSearchResult get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesapiSearchResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesapiSearchResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ShareesapiSearchResponseApplicationJson_Ocs
@@ -4916,11 +5690,25 @@ abstract class ShareesapiSearchResponseApplicationJson_Ocs
   /// Serializer for ShareesapiSearchResponseApplicationJson_Ocs.
   static Serializer<ShareesapiSearchResponseApplicationJson_Ocs> get serializer =>
       _$shareesapiSearchResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesapiSearchResponseApplicationJson_OcsBuilder b) {
+    $ShareesapiSearchResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesapiSearchResponseApplicationJson_OcsBuilder b) {
+    $ShareesapiSearchResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareesapiSearchResponseApplicationJsonInterface {
   ShareesapiSearchResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesapiSearchResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesapiSearchResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ShareesapiSearchResponseApplicationJson
@@ -4953,11 +5741,25 @@ abstract class ShareesapiSearchResponseApplicationJson
   /// Serializer for ShareesapiSearchResponseApplicationJson.
   static Serializer<ShareesapiSearchResponseApplicationJson> get serializer =>
       _$shareesapiSearchResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesapiSearchResponseApplicationJsonBuilder b) {
+    $ShareesapiSearchResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesapiSearchResponseApplicationJsonBuilder b) {
+    $ShareesapiSearchResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareesapiShareesapiSearchHeadersInterface {
   String? get link;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesapiShareesapiSearchHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesapiShareesapiSearchHeadersInterfaceBuilder b) {}
 }
 
 abstract class ShareesapiShareesapiSearchHeaders
@@ -4989,6 +5791,16 @@ abstract class ShareesapiShareesapiSearchHeaders
 
   /// Serializer for ShareesapiShareesapiSearchHeaders.
   static Serializer<ShareesapiShareesapiSearchHeaders> get serializer => _$shareesapiShareesapiSearchHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesapiShareesapiSearchHeadersBuilder b) {
+    $ShareesapiShareesapiSearchHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesapiShareesapiSearchHeadersBuilder b) {
+    $ShareesapiShareesapiSearchHeadersInterface._validate(b);
+  }
 }
 
 typedef ShareesapiFindRecommendedShareType = ({BuiltList<int>? builtListInt, int? $int});
@@ -5001,6 +5813,10 @@ abstract interface class $ShareesRecommendedResult_ExactInterface {
   BuiltList<ShareeRemoteGroup> get remoteGroups;
   BuiltList<ShareeRemote> get remotes;
   BuiltList<ShareeUser> get users;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesRecommendedResult_ExactInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesRecommendedResult_ExactInterfaceBuilder b) {}
 }
 
 abstract class ShareesRecommendedResult_Exact
@@ -5032,6 +5848,16 @@ abstract class ShareesRecommendedResult_Exact
 
   /// Serializer for ShareesRecommendedResult_Exact.
   static Serializer<ShareesRecommendedResult_Exact> get serializer => _$shareesRecommendedResultExactSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesRecommendedResult_ExactBuilder b) {
+    $ShareesRecommendedResult_ExactInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesRecommendedResult_ExactBuilder b) {
+    $ShareesRecommendedResult_ExactInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5043,6 +5869,10 @@ abstract interface class $ShareesRecommendedResultInterface {
   BuiltList<ShareeRemoteGroup> get remoteGroups;
   BuiltList<ShareeRemote> get remotes;
   BuiltList<ShareeUser> get users;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesRecommendedResultInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesRecommendedResultInterfaceBuilder b) {}
 }
 
 abstract class ShareesRecommendedResult
@@ -5071,12 +5901,26 @@ abstract class ShareesRecommendedResult
 
   /// Serializer for ShareesRecommendedResult.
   static Serializer<ShareesRecommendedResult> get serializer => _$shareesRecommendedResultSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesRecommendedResultBuilder b) {
+    $ShareesRecommendedResultInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesRecommendedResultBuilder b) {
+    $ShareesRecommendedResultInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareesapiFindRecommendedResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ShareesRecommendedResult get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesapiFindRecommendedResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesapiFindRecommendedResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ShareesapiFindRecommendedResponseApplicationJson_Ocs
@@ -5111,11 +5955,25 @@ abstract class ShareesapiFindRecommendedResponseApplicationJson_Ocs
   /// Serializer for ShareesapiFindRecommendedResponseApplicationJson_Ocs.
   static Serializer<ShareesapiFindRecommendedResponseApplicationJson_Ocs> get serializer =>
       _$shareesapiFindRecommendedResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder b) {
+    $ShareesapiFindRecommendedResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder b) {
+    $ShareesapiFindRecommendedResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ShareesapiFindRecommendedResponseApplicationJsonInterface {
   ShareesapiFindRecommendedResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesapiFindRecommendedResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesapiFindRecommendedResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ShareesapiFindRecommendedResponseApplicationJson
@@ -5150,12 +6008,26 @@ abstract class ShareesapiFindRecommendedResponseApplicationJson
   /// Serializer for ShareesapiFindRecommendedResponseApplicationJson.
   static Serializer<ShareesapiFindRecommendedResponseApplicationJson> get serializer =>
       _$shareesapiFindRecommendedResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesapiFindRecommendedResponseApplicationJsonBuilder b) {
+    $ShareesapiFindRecommendedResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesapiFindRecommendedResponseApplicationJsonBuilder b) {
+    $ShareesapiFindRecommendedResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities_FilesSharing_Public_PasswordInterface {
   bool get enforced;
   bool get askForOptionalPassword;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_Public_PasswordInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_Public_PasswordInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Public_Password
@@ -5189,6 +6061,16 @@ abstract class Capabilities_FilesSharing_Public_Password
   /// Serializer for Capabilities_FilesSharing_Public_Password.
   static Serializer<Capabilities_FilesSharing_Public_Password> get serializer =>
       _$capabilitiesFilesSharingPublicPasswordSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_Public_PasswordBuilder b) {
+    $Capabilities_FilesSharing_Public_PasswordInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_Public_PasswordBuilder b) {
+    $Capabilities_FilesSharing_Public_PasswordInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5196,6 +6078,10 @@ abstract interface class $Capabilities_FilesSharing_Public_ExpireDateInterface {
   bool get enabled;
   int? get days;
   bool? get enforced;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_Public_ExpireDateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_Public_ExpireDateInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Public_ExpireDate
@@ -5229,6 +6115,16 @@ abstract class Capabilities_FilesSharing_Public_ExpireDate
   /// Serializer for Capabilities_FilesSharing_Public_ExpireDate.
   static Serializer<Capabilities_FilesSharing_Public_ExpireDate> get serializer =>
       _$capabilitiesFilesSharingPublicExpireDateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_Public_ExpireDateBuilder b) {
+    $Capabilities_FilesSharing_Public_ExpireDateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_Public_ExpireDateBuilder b) {
+    $Capabilities_FilesSharing_Public_ExpireDateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5236,6 +6132,10 @@ abstract interface class $Capabilities_FilesSharing_Public_ExpireDateInternalInt
   bool get enabled;
   int? get days;
   bool? get enforced;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Public_ExpireDateInternal
@@ -5270,6 +6170,16 @@ abstract class Capabilities_FilesSharing_Public_ExpireDateInternal
   /// Serializer for Capabilities_FilesSharing_Public_ExpireDateInternal.
   static Serializer<Capabilities_FilesSharing_Public_ExpireDateInternal> get serializer =>
       _$capabilitiesFilesSharingPublicExpireDateInternalSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_Public_ExpireDateInternalBuilder b) {
+    $Capabilities_FilesSharing_Public_ExpireDateInternalInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_Public_ExpireDateInternalBuilder b) {
+    $Capabilities_FilesSharing_Public_ExpireDateInternalInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5277,6 +6187,10 @@ abstract interface class $Capabilities_FilesSharing_Public_ExpireDateRemoteInter
   bool get enabled;
   int? get days;
   bool? get enforced;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Public_ExpireDateRemote
@@ -5311,6 +6225,16 @@ abstract class Capabilities_FilesSharing_Public_ExpireDateRemote
   /// Serializer for Capabilities_FilesSharing_Public_ExpireDateRemote.
   static Serializer<Capabilities_FilesSharing_Public_ExpireDateRemote> get serializer =>
       _$capabilitiesFilesSharingPublicExpireDateRemoteSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_Public_ExpireDateRemoteBuilder b) {
+    $Capabilities_FilesSharing_Public_ExpireDateRemoteInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_Public_ExpireDateRemoteBuilder b) {
+    $Capabilities_FilesSharing_Public_ExpireDateRemoteInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5330,6 +6254,10 @@ abstract interface class $Capabilities_FilesSharing_PublicInterface {
   bool? get upload;
   @BuiltValueField(wireName: 'upload_files_drop')
   bool? get uploadFilesDrop;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_PublicInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_PublicInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Public
@@ -5361,11 +6289,25 @@ abstract class Capabilities_FilesSharing_Public
 
   /// Serializer for Capabilities_FilesSharing_Public.
   static Serializer<Capabilities_FilesSharing_Public> get serializer => _$capabilitiesFilesSharingPublicSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_PublicBuilder b) {
+    $Capabilities_FilesSharing_PublicInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_PublicBuilder b) {
+    $Capabilities_FilesSharing_PublicInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities_FilesSharing_User_ExpireDateInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_User_ExpireDateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_User_ExpireDateInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_User_ExpireDate
@@ -5399,6 +6341,16 @@ abstract class Capabilities_FilesSharing_User_ExpireDate
   /// Serializer for Capabilities_FilesSharing_User_ExpireDate.
   static Serializer<Capabilities_FilesSharing_User_ExpireDate> get serializer =>
       _$capabilitiesFilesSharingUserExpireDateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_User_ExpireDateBuilder b) {
+    $Capabilities_FilesSharing_User_ExpireDateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_User_ExpireDateBuilder b) {
+    $Capabilities_FilesSharing_User_ExpireDateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5407,6 +6359,10 @@ abstract interface class $Capabilities_FilesSharing_UserInterface {
   bool get sendMail;
   @BuiltValueField(wireName: 'expire_date')
   Capabilities_FilesSharing_User_ExpireDate? get expireDate;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_UserInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_UserInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_User
@@ -5438,11 +6394,25 @@ abstract class Capabilities_FilesSharing_User
 
   /// Serializer for Capabilities_FilesSharing_User.
   static Serializer<Capabilities_FilesSharing_User> get serializer => _$capabilitiesFilesSharingUserSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_UserBuilder b) {
+    $Capabilities_FilesSharing_UserInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_UserBuilder b) {
+    $Capabilities_FilesSharing_UserInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities_FilesSharing_Group_ExpireDateInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_Group_ExpireDateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_Group_ExpireDateInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Group_ExpireDate
@@ -5476,6 +6446,16 @@ abstract class Capabilities_FilesSharing_Group_ExpireDate
   /// Serializer for Capabilities_FilesSharing_Group_ExpireDate.
   static Serializer<Capabilities_FilesSharing_Group_ExpireDate> get serializer =>
       _$capabilitiesFilesSharingGroupExpireDateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_Group_ExpireDateBuilder b) {
+    $Capabilities_FilesSharing_Group_ExpireDateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_Group_ExpireDateBuilder b) {
+    $Capabilities_FilesSharing_Group_ExpireDateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5483,6 +6463,10 @@ abstract interface class $Capabilities_FilesSharing_GroupInterface {
   bool get enabled;
   @BuiltValueField(wireName: 'expire_date')
   Capabilities_FilesSharing_Group_ExpireDate? get expireDate;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_GroupInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_GroupInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Group
@@ -5514,11 +6498,25 @@ abstract class Capabilities_FilesSharing_Group
 
   /// Serializer for Capabilities_FilesSharing_Group.
   static Serializer<Capabilities_FilesSharing_Group> get serializer => _$capabilitiesFilesSharingGroupSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_GroupBuilder b) {
+    $Capabilities_FilesSharing_GroupInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_GroupBuilder b) {
+    $Capabilities_FilesSharing_GroupInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities_FilesSharing_Federation_ExpireDateInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Federation_ExpireDate
@@ -5552,11 +6550,25 @@ abstract class Capabilities_FilesSharing_Federation_ExpireDate
   /// Serializer for Capabilities_FilesSharing_Federation_ExpireDate.
   static Serializer<Capabilities_FilesSharing_Federation_ExpireDate> get serializer =>
       _$capabilitiesFilesSharingFederationExpireDateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_Federation_ExpireDateBuilder b) {
+    $Capabilities_FilesSharing_Federation_ExpireDateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_Federation_ExpireDateBuilder b) {
+    $Capabilities_FilesSharing_Federation_ExpireDateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities_FilesSharing_Federation_ExpireDateSupportedInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Federation_ExpireDateSupported
@@ -5591,6 +6603,16 @@ abstract class Capabilities_FilesSharing_Federation_ExpireDateSupported
   /// Serializer for Capabilities_FilesSharing_Federation_ExpireDateSupported.
   static Serializer<Capabilities_FilesSharing_Federation_ExpireDateSupported> get serializer =>
       _$capabilitiesFilesSharingFederationExpireDateSupportedSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder b) {
+    $Capabilities_FilesSharing_Federation_ExpireDateSupportedInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder b) {
+    $Capabilities_FilesSharing_Federation_ExpireDateSupportedInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5601,6 +6623,10 @@ abstract interface class $Capabilities_FilesSharing_FederationInterface {
   Capabilities_FilesSharing_Federation_ExpireDate get expireDate;
   @BuiltValueField(wireName: 'expire_date_supported')
   Capabilities_FilesSharing_Federation_ExpireDateSupported get expireDateSupported;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_FederationInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_FederationInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Federation
@@ -5633,6 +6659,16 @@ abstract class Capabilities_FilesSharing_Federation
   /// Serializer for Capabilities_FilesSharing_Federation.
   static Serializer<Capabilities_FilesSharing_Federation> get serializer =>
       _$capabilitiesFilesSharingFederationSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_FederationBuilder b) {
+    $Capabilities_FilesSharing_FederationInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_FederationBuilder b) {
+    $Capabilities_FilesSharing_FederationInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5641,6 +6677,10 @@ abstract interface class $Capabilities_FilesSharing_ShareeInterface {
   bool get queryLookupDefault;
   @BuiltValueField(wireName: 'always_show_unique')
   bool get alwaysShowUnique;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharing_ShareeInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharing_ShareeInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing_Sharee
@@ -5672,6 +6712,16 @@ abstract class Capabilities_FilesSharing_Sharee
 
   /// Serializer for Capabilities_FilesSharing_Sharee.
   static Serializer<Capabilities_FilesSharing_Sharee> get serializer => _$capabilitiesFilesSharingShareeSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharing_ShareeBuilder b) {
+    $Capabilities_FilesSharing_ShareeInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharing_ShareeBuilder b) {
+    $Capabilities_FilesSharing_ShareeInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -5688,6 +6738,10 @@ abstract interface class $Capabilities_FilesSharingInterface {
   int? get defaultPermissions;
   Capabilities_FilesSharing_Federation get federation;
   Capabilities_FilesSharing_Sharee get sharee;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesSharingInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesSharingInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_FilesSharing
@@ -5716,12 +6770,26 @@ abstract class Capabilities_FilesSharing
 
   /// Serializer for Capabilities_FilesSharing.
   static Serializer<Capabilities_FilesSharing> get serializer => _$capabilitiesFilesSharingSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesSharingBuilder b) {
+    $Capabilities_FilesSharingInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesSharingBuilder b) {
+    $Capabilities_FilesSharingInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   @BuiltValueField(wireName: 'files_sharing')
   Capabilities_FilesSharing get filesSharing;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -5748,6 +6816,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 /// Serialization extension for `ShareesapiSearchShareType`.

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
@@ -4931,7 +4931,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -4961,6 +4963,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -5293,7 +5296,9 @@ class DeletedShareBuilder implements Builder<DeletedShare, DeletedShareBuilder>,
   String? get shareWithLink => _$this._shareWithLink;
   set shareWithLink(covariant String? shareWithLink) => _$this._shareWithLink = shareWithLink;
 
-  DeletedShareBuilder();
+  DeletedShareBuilder() {
+    DeletedShare._defaults(this);
+  }
 
   DeletedShareBuilder get _$this {
     final $v = _$v;
@@ -5338,6 +5343,7 @@ class DeletedShareBuilder implements Builder<DeletedShare, DeletedShareBuilder>,
   DeletedShare build() => _build();
 
   _$DeletedShare _build() {
+    DeletedShare._validate(this);
     final _$result = _$v ??
         _$DeletedShare._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'DeletedShare', 'id'),
@@ -5440,7 +5446,9 @@ class DeletedShareapiIndexResponseApplicationJson_OcsBuilder
   ListBuilder<DeletedShare> get data => _$this._data ??= ListBuilder<DeletedShare>();
   set data(covariant ListBuilder<DeletedShare>? data) => _$this._data = data;
 
-  DeletedShareapiIndexResponseApplicationJson_OcsBuilder();
+  DeletedShareapiIndexResponseApplicationJson_OcsBuilder() {
+    DeletedShareapiIndexResponseApplicationJson_Ocs._defaults(this);
+  }
 
   DeletedShareapiIndexResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -5467,6 +5475,7 @@ class DeletedShareapiIndexResponseApplicationJson_OcsBuilder
   DeletedShareapiIndexResponseApplicationJson_Ocs build() => _build();
 
   _$DeletedShareapiIndexResponseApplicationJson_Ocs _build() {
+    DeletedShareapiIndexResponseApplicationJson_Ocs._validate(this);
     _$DeletedShareapiIndexResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$DeletedShareapiIndexResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -5547,7 +5556,9 @@ class DeletedShareapiIndexResponseApplicationJsonBuilder
       _$this._ocs ??= DeletedShareapiIndexResponseApplicationJson_OcsBuilder();
   set ocs(covariant DeletedShareapiIndexResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  DeletedShareapiIndexResponseApplicationJsonBuilder();
+  DeletedShareapiIndexResponseApplicationJsonBuilder() {
+    DeletedShareapiIndexResponseApplicationJson._defaults(this);
+  }
 
   DeletedShareapiIndexResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -5573,6 +5584,7 @@ class DeletedShareapiIndexResponseApplicationJsonBuilder
   DeletedShareapiIndexResponseApplicationJson build() => _build();
 
   _$DeletedShareapiIndexResponseApplicationJson _build() {
+    DeletedShareapiIndexResponseApplicationJson._validate(this);
     _$DeletedShareapiIndexResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$DeletedShareapiIndexResponseApplicationJson._(ocs: ocs.build());
@@ -5664,7 +5676,9 @@ class DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder();
+  DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder() {
+    DeletedShareapiUndeleteResponseApplicationJson_Ocs._defaults(this);
+  }
 
   DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -5691,6 +5705,7 @@ class DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder
   DeletedShareapiUndeleteResponseApplicationJson_Ocs build() => _build();
 
   _$DeletedShareapiUndeleteResponseApplicationJson_Ocs _build() {
+    DeletedShareapiUndeleteResponseApplicationJson_Ocs._validate(this);
     _$DeletedShareapiUndeleteResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -5773,7 +5788,9 @@ class DeletedShareapiUndeleteResponseApplicationJsonBuilder
       _$this._ocs ??= DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder();
   set ocs(covariant DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  DeletedShareapiUndeleteResponseApplicationJsonBuilder();
+  DeletedShareapiUndeleteResponseApplicationJsonBuilder() {
+    DeletedShareapiUndeleteResponseApplicationJson._defaults(this);
+  }
 
   DeletedShareapiUndeleteResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -5799,6 +5816,7 @@ class DeletedShareapiUndeleteResponseApplicationJsonBuilder
   DeletedShareapiUndeleteResponseApplicationJson build() => _build();
 
   _$DeletedShareapiUndeleteResponseApplicationJson _build() {
+    DeletedShareapiUndeleteResponseApplicationJson._validate(this);
     _$DeletedShareapiUndeleteResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$DeletedShareapiUndeleteResponseApplicationJson._(ocs: ocs.build());
@@ -6078,7 +6096,9 @@ class RemoteShareBuilder implements Builder<RemoteShare, RemoteShareBuilder>, $R
   String? get user => _$this._user;
   set user(covariant String? user) => _$this._user = user;
 
-  RemoteShareBuilder();
+  RemoteShareBuilder() {
+    RemoteShare._defaults(this);
+  }
 
   RemoteShareBuilder get _$this {
     final $v = _$v;
@@ -6119,6 +6139,7 @@ class RemoteShareBuilder implements Builder<RemoteShare, RemoteShareBuilder>, $R
   RemoteShare build() => _build();
 
   _$RemoteShare _build() {
+    RemoteShare._validate(this);
     final _$result = _$v ??
         _$RemoteShare._(
             accepted: BuiltValueNullFieldError.checkNotNull(accepted, r'RemoteShare', 'accepted'),
@@ -6214,7 +6235,9 @@ class RemoteGetSharesResponseApplicationJson_OcsBuilder
   ListBuilder<RemoteShare> get data => _$this._data ??= ListBuilder<RemoteShare>();
   set data(covariant ListBuilder<RemoteShare>? data) => _$this._data = data;
 
-  RemoteGetSharesResponseApplicationJson_OcsBuilder();
+  RemoteGetSharesResponseApplicationJson_OcsBuilder() {
+    RemoteGetSharesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RemoteGetSharesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6241,6 +6264,7 @@ class RemoteGetSharesResponseApplicationJson_OcsBuilder
   RemoteGetSharesResponseApplicationJson_Ocs build() => _build();
 
   _$RemoteGetSharesResponseApplicationJson_Ocs _build() {
+    RemoteGetSharesResponseApplicationJson_Ocs._validate(this);
     _$RemoteGetSharesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RemoteGetSharesResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -6320,7 +6344,9 @@ class RemoteGetSharesResponseApplicationJsonBuilder
       _$this._ocs ??= RemoteGetSharesResponseApplicationJson_OcsBuilder();
   set ocs(covariant RemoteGetSharesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RemoteGetSharesResponseApplicationJsonBuilder();
+  RemoteGetSharesResponseApplicationJsonBuilder() {
+    RemoteGetSharesResponseApplicationJson._defaults(this);
+  }
 
   RemoteGetSharesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6346,6 +6372,7 @@ class RemoteGetSharesResponseApplicationJsonBuilder
   RemoteGetSharesResponseApplicationJson build() => _build();
 
   _$RemoteGetSharesResponseApplicationJson _build() {
+    RemoteGetSharesResponseApplicationJson._validate(this);
     _$RemoteGetSharesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RemoteGetSharesResponseApplicationJson._(ocs: ocs.build());
@@ -6436,7 +6463,9 @@ class RemoteGetOpenSharesResponseApplicationJson_OcsBuilder
   ListBuilder<RemoteShare> get data => _$this._data ??= ListBuilder<RemoteShare>();
   set data(covariant ListBuilder<RemoteShare>? data) => _$this._data = data;
 
-  RemoteGetOpenSharesResponseApplicationJson_OcsBuilder();
+  RemoteGetOpenSharesResponseApplicationJson_OcsBuilder() {
+    RemoteGetOpenSharesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RemoteGetOpenSharesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6463,6 +6492,7 @@ class RemoteGetOpenSharesResponseApplicationJson_OcsBuilder
   RemoteGetOpenSharesResponseApplicationJson_Ocs build() => _build();
 
   _$RemoteGetOpenSharesResponseApplicationJson_Ocs _build() {
+    RemoteGetOpenSharesResponseApplicationJson_Ocs._validate(this);
     _$RemoteGetOpenSharesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RemoteGetOpenSharesResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -6543,7 +6573,9 @@ class RemoteGetOpenSharesResponseApplicationJsonBuilder
       _$this._ocs ??= RemoteGetOpenSharesResponseApplicationJson_OcsBuilder();
   set ocs(covariant RemoteGetOpenSharesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RemoteGetOpenSharesResponseApplicationJsonBuilder();
+  RemoteGetOpenSharesResponseApplicationJsonBuilder() {
+    RemoteGetOpenSharesResponseApplicationJson._defaults(this);
+  }
 
   RemoteGetOpenSharesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6569,6 +6601,7 @@ class RemoteGetOpenSharesResponseApplicationJsonBuilder
   RemoteGetOpenSharesResponseApplicationJson build() => _build();
 
   _$RemoteGetOpenSharesResponseApplicationJson _build() {
+    RemoteGetOpenSharesResponseApplicationJson._validate(this);
     _$RemoteGetOpenSharesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RemoteGetOpenSharesResponseApplicationJson._(ocs: ocs.build());
@@ -6659,7 +6692,9 @@ class RemoteAcceptShareResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RemoteAcceptShareResponseApplicationJson_OcsBuilder();
+  RemoteAcceptShareResponseApplicationJson_OcsBuilder() {
+    RemoteAcceptShareResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RemoteAcceptShareResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6686,6 +6721,7 @@ class RemoteAcceptShareResponseApplicationJson_OcsBuilder
   RemoteAcceptShareResponseApplicationJson_Ocs build() => _build();
 
   _$RemoteAcceptShareResponseApplicationJson_Ocs _build() {
+    RemoteAcceptShareResponseApplicationJson_Ocs._validate(this);
     _$RemoteAcceptShareResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -6767,7 +6803,9 @@ class RemoteAcceptShareResponseApplicationJsonBuilder
       _$this._ocs ??= RemoteAcceptShareResponseApplicationJson_OcsBuilder();
   set ocs(covariant RemoteAcceptShareResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RemoteAcceptShareResponseApplicationJsonBuilder();
+  RemoteAcceptShareResponseApplicationJsonBuilder() {
+    RemoteAcceptShareResponseApplicationJson._defaults(this);
+  }
 
   RemoteAcceptShareResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6793,6 +6831,7 @@ class RemoteAcceptShareResponseApplicationJsonBuilder
   RemoteAcceptShareResponseApplicationJson build() => _build();
 
   _$RemoteAcceptShareResponseApplicationJson _build() {
+    RemoteAcceptShareResponseApplicationJson._validate(this);
     _$RemoteAcceptShareResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RemoteAcceptShareResponseApplicationJson._(ocs: ocs.build());
@@ -6883,7 +6922,9 @@ class RemoteDeclineShareResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RemoteDeclineShareResponseApplicationJson_OcsBuilder();
+  RemoteDeclineShareResponseApplicationJson_OcsBuilder() {
+    RemoteDeclineShareResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RemoteDeclineShareResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6910,6 +6951,7 @@ class RemoteDeclineShareResponseApplicationJson_OcsBuilder
   RemoteDeclineShareResponseApplicationJson_Ocs build() => _build();
 
   _$RemoteDeclineShareResponseApplicationJson_Ocs _build() {
+    RemoteDeclineShareResponseApplicationJson_Ocs._validate(this);
     _$RemoteDeclineShareResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -6991,7 +7033,9 @@ class RemoteDeclineShareResponseApplicationJsonBuilder
       _$this._ocs ??= RemoteDeclineShareResponseApplicationJson_OcsBuilder();
   set ocs(covariant RemoteDeclineShareResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RemoteDeclineShareResponseApplicationJsonBuilder();
+  RemoteDeclineShareResponseApplicationJsonBuilder() {
+    RemoteDeclineShareResponseApplicationJson._defaults(this);
+  }
 
   RemoteDeclineShareResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -7017,6 +7061,7 @@ class RemoteDeclineShareResponseApplicationJsonBuilder
   RemoteDeclineShareResponseApplicationJson build() => _build();
 
   _$RemoteDeclineShareResponseApplicationJson _build() {
+    RemoteDeclineShareResponseApplicationJson._validate(this);
     _$RemoteDeclineShareResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RemoteDeclineShareResponseApplicationJson._(ocs: ocs.build());
@@ -7107,7 +7152,9 @@ class RemoteGetShareResponseApplicationJson_OcsBuilder
   RemoteShareBuilder get data => _$this._data ??= RemoteShareBuilder();
   set data(covariant RemoteShareBuilder? data) => _$this._data = data;
 
-  RemoteGetShareResponseApplicationJson_OcsBuilder();
+  RemoteGetShareResponseApplicationJson_OcsBuilder() {
+    RemoteGetShareResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RemoteGetShareResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -7134,6 +7181,7 @@ class RemoteGetShareResponseApplicationJson_OcsBuilder
   RemoteGetShareResponseApplicationJson_Ocs build() => _build();
 
   _$RemoteGetShareResponseApplicationJson_Ocs _build() {
+    RemoteGetShareResponseApplicationJson_Ocs._validate(this);
     _$RemoteGetShareResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RemoteGetShareResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -7212,7 +7260,9 @@ class RemoteGetShareResponseApplicationJsonBuilder
       _$this._ocs ??= RemoteGetShareResponseApplicationJson_OcsBuilder();
   set ocs(covariant RemoteGetShareResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RemoteGetShareResponseApplicationJsonBuilder();
+  RemoteGetShareResponseApplicationJsonBuilder() {
+    RemoteGetShareResponseApplicationJson._defaults(this);
+  }
 
   RemoteGetShareResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -7238,6 +7288,7 @@ class RemoteGetShareResponseApplicationJsonBuilder
   RemoteGetShareResponseApplicationJson build() => _build();
 
   _$RemoteGetShareResponseApplicationJson _build() {
+    RemoteGetShareResponseApplicationJson._validate(this);
     _$RemoteGetShareResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RemoteGetShareResponseApplicationJson._(ocs: ocs.build());
@@ -7328,7 +7379,9 @@ class RemoteUnshareResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RemoteUnshareResponseApplicationJson_OcsBuilder();
+  RemoteUnshareResponseApplicationJson_OcsBuilder() {
+    RemoteUnshareResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RemoteUnshareResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -7355,6 +7408,7 @@ class RemoteUnshareResponseApplicationJson_OcsBuilder
   RemoteUnshareResponseApplicationJson_Ocs build() => _build();
 
   _$RemoteUnshareResponseApplicationJson_Ocs _build() {
+    RemoteUnshareResponseApplicationJson_Ocs._validate(this);
     _$RemoteUnshareResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -7434,7 +7488,9 @@ class RemoteUnshareResponseApplicationJsonBuilder
       _$this._ocs ??= RemoteUnshareResponseApplicationJson_OcsBuilder();
   set ocs(covariant RemoteUnshareResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RemoteUnshareResponseApplicationJsonBuilder();
+  RemoteUnshareResponseApplicationJsonBuilder() {
+    RemoteUnshareResponseApplicationJson._defaults(this);
+  }
 
   RemoteUnshareResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -7460,6 +7516,7 @@ class RemoteUnshareResponseApplicationJsonBuilder
   RemoteUnshareResponseApplicationJson build() => _build();
 
   _$RemoteUnshareResponseApplicationJson _build() {
+    RemoteUnshareResponseApplicationJson._validate(this);
     _$RemoteUnshareResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RemoteUnshareResponseApplicationJson._(ocs: ocs.build());
@@ -7659,7 +7716,9 @@ class ShareInfoBuilder implements Builder<ShareInfo, ShareInfoBuilder>, $ShareIn
       _$this._children ??= ListBuilder<BuiltMap<String, JsonObject>>();
   set children(covariant ListBuilder<BuiltMap<String, JsonObject>>? children) => _$this._children = children;
 
-  ShareInfoBuilder();
+  ShareInfoBuilder() {
+    ShareInfo._defaults(this);
+  }
 
   ShareInfoBuilder get _$this {
     final $v = _$v;
@@ -7694,6 +7753,7 @@ class ShareInfoBuilder implements Builder<ShareInfo, ShareInfoBuilder>, $ShareIn
   ShareInfo build() => _build();
 
   _$ShareInfo _build() {
+    ShareInfo._validate(this);
     _$ShareInfo _$result;
     try {
       _$result = _$v ??
@@ -7811,7 +7871,9 @@ class Share_StatusBuilder implements Builder<Share_Status, Share_StatusBuilder>,
   String? get status => _$this._status;
   set status(covariant String? status) => _$this._status = status;
 
-  Share_StatusBuilder();
+  Share_StatusBuilder() {
+    Share_Status._defaults(this);
+  }
 
   Share_StatusBuilder get _$this {
     final $v = _$v;
@@ -7840,6 +7902,7 @@ class Share_StatusBuilder implements Builder<Share_Status, Share_StatusBuilder>,
   Share_Status build() => _build();
 
   _$Share_Status _build() {
+    Share_Status._validate(this);
     final _$result = _$v ?? _$Share_Status._(clearAt: clearAt, icon: icon, message: message, status: status);
     replace(_$result);
     return _$result;
@@ -8449,7 +8512,9 @@ class ShareBuilder implements Builder<Share, ShareBuilder>, $ShareInterfaceBuild
   String? get url => _$this._url;
   set url(covariant String? url) => _$this._url = url;
 
-  ShareBuilder();
+  ShareBuilder() {
+    Share._defaults(this);
+  }
 
   ShareBuilder get _$this {
     final $v = _$v;
@@ -8515,6 +8580,7 @@ class ShareBuilder implements Builder<Share, ShareBuilder>, $ShareInterfaceBuild
   Share build() => _build();
 
   _$Share _build() {
+    Share._validate(this);
     _$Share _$result;
     try {
       _$result = _$v ??
@@ -8648,7 +8714,9 @@ class ShareapiGetSharesResponseApplicationJson_OcsBuilder
   ListBuilder<Share> get data => _$this._data ??= ListBuilder<Share>();
   set data(covariant ListBuilder<Share>? data) => _$this._data = data;
 
-  ShareapiGetSharesResponseApplicationJson_OcsBuilder();
+  ShareapiGetSharesResponseApplicationJson_OcsBuilder() {
+    ShareapiGetSharesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ShareapiGetSharesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -8675,6 +8743,7 @@ class ShareapiGetSharesResponseApplicationJson_OcsBuilder
   ShareapiGetSharesResponseApplicationJson_Ocs build() => _build();
 
   _$ShareapiGetSharesResponseApplicationJson_Ocs _build() {
+    ShareapiGetSharesResponseApplicationJson_Ocs._validate(this);
     _$ShareapiGetSharesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ShareapiGetSharesResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -8754,7 +8823,9 @@ class ShareapiGetSharesResponseApplicationJsonBuilder
       _$this._ocs ??= ShareapiGetSharesResponseApplicationJson_OcsBuilder();
   set ocs(covariant ShareapiGetSharesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ShareapiGetSharesResponseApplicationJsonBuilder();
+  ShareapiGetSharesResponseApplicationJsonBuilder() {
+    ShareapiGetSharesResponseApplicationJson._defaults(this);
+  }
 
   ShareapiGetSharesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -8780,6 +8851,7 @@ class ShareapiGetSharesResponseApplicationJsonBuilder
   ShareapiGetSharesResponseApplicationJson build() => _build();
 
   _$ShareapiGetSharesResponseApplicationJson _build() {
+    ShareapiGetSharesResponseApplicationJson._validate(this);
     _$ShareapiGetSharesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ShareapiGetSharesResponseApplicationJson._(ocs: ocs.build());
@@ -8870,7 +8942,9 @@ class ShareapiCreateShareResponseApplicationJson_OcsBuilder
   ShareBuilder get data => _$this._data ??= ShareBuilder();
   set data(covariant ShareBuilder? data) => _$this._data = data;
 
-  ShareapiCreateShareResponseApplicationJson_OcsBuilder();
+  ShareapiCreateShareResponseApplicationJson_OcsBuilder() {
+    ShareapiCreateShareResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ShareapiCreateShareResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -8897,6 +8971,7 @@ class ShareapiCreateShareResponseApplicationJson_OcsBuilder
   ShareapiCreateShareResponseApplicationJson_Ocs build() => _build();
 
   _$ShareapiCreateShareResponseApplicationJson_Ocs _build() {
+    ShareapiCreateShareResponseApplicationJson_Ocs._validate(this);
     _$ShareapiCreateShareResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ShareapiCreateShareResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -8977,7 +9052,9 @@ class ShareapiCreateShareResponseApplicationJsonBuilder
       _$this._ocs ??= ShareapiCreateShareResponseApplicationJson_OcsBuilder();
   set ocs(covariant ShareapiCreateShareResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ShareapiCreateShareResponseApplicationJsonBuilder();
+  ShareapiCreateShareResponseApplicationJsonBuilder() {
+    ShareapiCreateShareResponseApplicationJson._defaults(this);
+  }
 
   ShareapiCreateShareResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -9003,6 +9080,7 @@ class ShareapiCreateShareResponseApplicationJsonBuilder
   ShareapiCreateShareResponseApplicationJson build() => _build();
 
   _$ShareapiCreateShareResponseApplicationJson _build() {
+    ShareapiCreateShareResponseApplicationJson._validate(this);
     _$ShareapiCreateShareResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ShareapiCreateShareResponseApplicationJson._(ocs: ocs.build());
@@ -9095,7 +9173,9 @@ class ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder
   ListBuilder<Share> get data => _$this._data ??= ListBuilder<Share>();
   set data(covariant ListBuilder<Share>? data) => _$this._data = data;
 
-  ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder();
+  ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder() {
+    ShareapiGetInheritedSharesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -9122,6 +9202,7 @@ class ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder
   ShareapiGetInheritedSharesResponseApplicationJson_Ocs build() => _build();
 
   _$ShareapiGetInheritedSharesResponseApplicationJson_Ocs _build() {
+    ShareapiGetInheritedSharesResponseApplicationJson_Ocs._validate(this);
     _$ShareapiGetInheritedSharesResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -9205,7 +9286,9 @@ class ShareapiGetInheritedSharesResponseApplicationJsonBuilder
       _$this._ocs ??= ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder();
   set ocs(covariant ShareapiGetInheritedSharesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ShareapiGetInheritedSharesResponseApplicationJsonBuilder();
+  ShareapiGetInheritedSharesResponseApplicationJsonBuilder() {
+    ShareapiGetInheritedSharesResponseApplicationJson._defaults(this);
+  }
 
   ShareapiGetInheritedSharesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -9231,6 +9314,7 @@ class ShareapiGetInheritedSharesResponseApplicationJsonBuilder
   ShareapiGetInheritedSharesResponseApplicationJson build() => _build();
 
   _$ShareapiGetInheritedSharesResponseApplicationJson _build() {
+    ShareapiGetInheritedSharesResponseApplicationJson._validate(this);
     _$ShareapiGetInheritedSharesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ShareapiGetInheritedSharesResponseApplicationJson._(ocs: ocs.build());
@@ -9323,7 +9407,9 @@ class ShareapiPendingSharesResponseApplicationJson_OcsBuilder
   ListBuilder<Share> get data => _$this._data ??= ListBuilder<Share>();
   set data(covariant ListBuilder<Share>? data) => _$this._data = data;
 
-  ShareapiPendingSharesResponseApplicationJson_OcsBuilder();
+  ShareapiPendingSharesResponseApplicationJson_OcsBuilder() {
+    ShareapiPendingSharesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ShareapiPendingSharesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -9350,6 +9436,7 @@ class ShareapiPendingSharesResponseApplicationJson_OcsBuilder
   ShareapiPendingSharesResponseApplicationJson_Ocs build() => _build();
 
   _$ShareapiPendingSharesResponseApplicationJson_Ocs _build() {
+    ShareapiPendingSharesResponseApplicationJson_Ocs._validate(this);
     _$ShareapiPendingSharesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ShareapiPendingSharesResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -9430,7 +9517,9 @@ class ShareapiPendingSharesResponseApplicationJsonBuilder
       _$this._ocs ??= ShareapiPendingSharesResponseApplicationJson_OcsBuilder();
   set ocs(covariant ShareapiPendingSharesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ShareapiPendingSharesResponseApplicationJsonBuilder();
+  ShareapiPendingSharesResponseApplicationJsonBuilder() {
+    ShareapiPendingSharesResponseApplicationJson._defaults(this);
+  }
 
   ShareapiPendingSharesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -9456,6 +9545,7 @@ class ShareapiPendingSharesResponseApplicationJsonBuilder
   ShareapiPendingSharesResponseApplicationJson build() => _build();
 
   _$ShareapiPendingSharesResponseApplicationJson _build() {
+    ShareapiPendingSharesResponseApplicationJson._validate(this);
     _$ShareapiPendingSharesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ShareapiPendingSharesResponseApplicationJson._(ocs: ocs.build());
@@ -9546,7 +9636,9 @@ class ShareapiGetShareResponseApplicationJson_OcsBuilder
   ShareBuilder get data => _$this._data ??= ShareBuilder();
   set data(covariant ShareBuilder? data) => _$this._data = data;
 
-  ShareapiGetShareResponseApplicationJson_OcsBuilder();
+  ShareapiGetShareResponseApplicationJson_OcsBuilder() {
+    ShareapiGetShareResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ShareapiGetShareResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -9573,6 +9665,7 @@ class ShareapiGetShareResponseApplicationJson_OcsBuilder
   ShareapiGetShareResponseApplicationJson_Ocs build() => _build();
 
   _$ShareapiGetShareResponseApplicationJson_Ocs _build() {
+    ShareapiGetShareResponseApplicationJson_Ocs._validate(this);
     _$ShareapiGetShareResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ShareapiGetShareResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -9652,7 +9745,9 @@ class ShareapiGetShareResponseApplicationJsonBuilder
       _$this._ocs ??= ShareapiGetShareResponseApplicationJson_OcsBuilder();
   set ocs(covariant ShareapiGetShareResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ShareapiGetShareResponseApplicationJsonBuilder();
+  ShareapiGetShareResponseApplicationJsonBuilder() {
+    ShareapiGetShareResponseApplicationJson._defaults(this);
+  }
 
   ShareapiGetShareResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -9678,6 +9773,7 @@ class ShareapiGetShareResponseApplicationJsonBuilder
   ShareapiGetShareResponseApplicationJson build() => _build();
 
   _$ShareapiGetShareResponseApplicationJson _build() {
+    ShareapiGetShareResponseApplicationJson._validate(this);
     _$ShareapiGetShareResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ShareapiGetShareResponseApplicationJson._(ocs: ocs.build());
@@ -9768,7 +9864,9 @@ class ShareapiUpdateShareResponseApplicationJson_OcsBuilder
   ShareBuilder get data => _$this._data ??= ShareBuilder();
   set data(covariant ShareBuilder? data) => _$this._data = data;
 
-  ShareapiUpdateShareResponseApplicationJson_OcsBuilder();
+  ShareapiUpdateShareResponseApplicationJson_OcsBuilder() {
+    ShareapiUpdateShareResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ShareapiUpdateShareResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -9795,6 +9893,7 @@ class ShareapiUpdateShareResponseApplicationJson_OcsBuilder
   ShareapiUpdateShareResponseApplicationJson_Ocs build() => _build();
 
   _$ShareapiUpdateShareResponseApplicationJson_Ocs _build() {
+    ShareapiUpdateShareResponseApplicationJson_Ocs._validate(this);
     _$ShareapiUpdateShareResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ShareapiUpdateShareResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -9875,7 +9974,9 @@ class ShareapiUpdateShareResponseApplicationJsonBuilder
       _$this._ocs ??= ShareapiUpdateShareResponseApplicationJson_OcsBuilder();
   set ocs(covariant ShareapiUpdateShareResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ShareapiUpdateShareResponseApplicationJsonBuilder();
+  ShareapiUpdateShareResponseApplicationJsonBuilder() {
+    ShareapiUpdateShareResponseApplicationJson._defaults(this);
+  }
 
   ShareapiUpdateShareResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -9901,6 +10002,7 @@ class ShareapiUpdateShareResponseApplicationJsonBuilder
   ShareapiUpdateShareResponseApplicationJson build() => _build();
 
   _$ShareapiUpdateShareResponseApplicationJson _build() {
+    ShareapiUpdateShareResponseApplicationJson._validate(this);
     _$ShareapiUpdateShareResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ShareapiUpdateShareResponseApplicationJson._(ocs: ocs.build());
@@ -9991,7 +10093,9 @@ class ShareapiDeleteShareResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ShareapiDeleteShareResponseApplicationJson_OcsBuilder();
+  ShareapiDeleteShareResponseApplicationJson_OcsBuilder() {
+    ShareapiDeleteShareResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ShareapiDeleteShareResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -10018,6 +10122,7 @@ class ShareapiDeleteShareResponseApplicationJson_OcsBuilder
   ShareapiDeleteShareResponseApplicationJson_Ocs build() => _build();
 
   _$ShareapiDeleteShareResponseApplicationJson_Ocs _build() {
+    ShareapiDeleteShareResponseApplicationJson_Ocs._validate(this);
     _$ShareapiDeleteShareResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -10100,7 +10205,9 @@ class ShareapiDeleteShareResponseApplicationJsonBuilder
       _$this._ocs ??= ShareapiDeleteShareResponseApplicationJson_OcsBuilder();
   set ocs(covariant ShareapiDeleteShareResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ShareapiDeleteShareResponseApplicationJsonBuilder();
+  ShareapiDeleteShareResponseApplicationJsonBuilder() {
+    ShareapiDeleteShareResponseApplicationJson._defaults(this);
+  }
 
   ShareapiDeleteShareResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -10126,6 +10233,7 @@ class ShareapiDeleteShareResponseApplicationJsonBuilder
   ShareapiDeleteShareResponseApplicationJson build() => _build();
 
   _$ShareapiDeleteShareResponseApplicationJson _build() {
+    ShareapiDeleteShareResponseApplicationJson._validate(this);
     _$ShareapiDeleteShareResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ShareapiDeleteShareResponseApplicationJson._(ocs: ocs.build());
@@ -10216,7 +10324,9 @@ class ShareapiAcceptShareResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ShareapiAcceptShareResponseApplicationJson_OcsBuilder();
+  ShareapiAcceptShareResponseApplicationJson_OcsBuilder() {
+    ShareapiAcceptShareResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ShareapiAcceptShareResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -10243,6 +10353,7 @@ class ShareapiAcceptShareResponseApplicationJson_OcsBuilder
   ShareapiAcceptShareResponseApplicationJson_Ocs build() => _build();
 
   _$ShareapiAcceptShareResponseApplicationJson_Ocs _build() {
+    ShareapiAcceptShareResponseApplicationJson_Ocs._validate(this);
     _$ShareapiAcceptShareResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -10325,7 +10436,9 @@ class ShareapiAcceptShareResponseApplicationJsonBuilder
       _$this._ocs ??= ShareapiAcceptShareResponseApplicationJson_OcsBuilder();
   set ocs(covariant ShareapiAcceptShareResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ShareapiAcceptShareResponseApplicationJsonBuilder();
+  ShareapiAcceptShareResponseApplicationJsonBuilder() {
+    ShareapiAcceptShareResponseApplicationJson._defaults(this);
+  }
 
   ShareapiAcceptShareResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -10351,6 +10464,7 @@ class ShareapiAcceptShareResponseApplicationJsonBuilder
   ShareapiAcceptShareResponseApplicationJson build() => _build();
 
   _$ShareapiAcceptShareResponseApplicationJson _build() {
+    ShareapiAcceptShareResponseApplicationJson._validate(this);
     _$ShareapiAcceptShareResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ShareapiAcceptShareResponseApplicationJson._(ocs: ocs.build());
@@ -10432,7 +10546,9 @@ class ShareeBuilder implements Builder<Sharee, ShareeBuilder>, $ShareeInterfaceB
   String? get label => _$this._label;
   set label(covariant String? label) => _$this._label = label;
 
-  ShareeBuilder();
+  ShareeBuilder() {
+    Sharee._defaults(this);
+  }
 
   ShareeBuilder get _$this {
     final $v = _$v;
@@ -10459,6 +10575,7 @@ class ShareeBuilder implements Builder<Sharee, ShareeBuilder>, $ShareeInterfaceB
   Sharee build() => _build();
 
   _$Sharee _build() {
+    Sharee._validate(this);
     final _$result =
         _$v ?? _$Sharee._(count: count, label: BuiltValueNullFieldError.checkNotNull(label, r'Sharee', 'label'));
     replace(_$result);
@@ -10531,7 +10648,9 @@ class ShareeValueBuilder implements Builder<ShareeValue, ShareeValueBuilder>, $S
   String? get shareWith => _$this._shareWith;
   set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
-  ShareeValueBuilder();
+  ShareeValueBuilder() {
+    ShareeValue._defaults(this);
+  }
 
   ShareeValueBuilder get _$this {
     final $v = _$v;
@@ -10558,6 +10677,7 @@ class ShareeValueBuilder implements Builder<ShareeValue, ShareeValueBuilder>, $S
   ShareeValue build() => _build();
 
   _$ShareeValue _build() {
+    ShareeValue._validate(this);
     final _$result = _$v ??
         _$ShareeValue._(
             shareType: BuiltValueNullFieldError.checkNotNull(shareType, r'ShareeValue', 'shareType'),
@@ -10649,7 +10769,9 @@ class ShareeCircle_ValueBuilder
   String? get shareWith => _$this._shareWith;
   set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
-  ShareeCircle_ValueBuilder();
+  ShareeCircle_ValueBuilder() {
+    ShareeCircle_Value._defaults(this);
+  }
 
   ShareeCircle_ValueBuilder get _$this {
     final $v = _$v;
@@ -10677,6 +10799,7 @@ class ShareeCircle_ValueBuilder
   ShareeCircle_Value build() => _build();
 
   _$ShareeCircle_Value _build() {
+    ShareeCircle_Value._validate(this);
     final _$result = _$v ??
         _$ShareeCircle_Value._(
             circle: BuiltValueNullFieldError.checkNotNull(circle, r'ShareeCircle_Value', 'circle'),
@@ -10781,7 +10904,9 @@ class ShareeCircleBuilder implements Builder<ShareeCircle, ShareeCircleBuilder>,
   String? get label => _$this._label;
   set label(covariant String? label) => _$this._label = label;
 
-  ShareeCircleBuilder();
+  ShareeCircleBuilder() {
+    ShareeCircle._defaults(this);
+  }
 
   ShareeCircleBuilder get _$this {
     final $v = _$v;
@@ -10810,6 +10935,7 @@ class ShareeCircleBuilder implements Builder<ShareeCircle, ShareeCircleBuilder>,
   ShareeCircle build() => _build();
 
   _$ShareeCircle _build() {
+    ShareeCircle._validate(this);
     _$ShareeCircle _$result;
     try {
       _$result = _$v ??
@@ -10974,7 +11100,9 @@ class ShareeEmailBuilder implements Builder<ShareeEmail, ShareeEmailBuilder>, $S
   String? get label => _$this._label;
   set label(covariant String? label) => _$this._label = label;
 
-  ShareeEmailBuilder();
+  ShareeEmailBuilder() {
+    ShareeEmail._defaults(this);
+  }
 
   ShareeEmailBuilder get _$this {
     final $v = _$v;
@@ -11006,6 +11134,7 @@ class ShareeEmailBuilder implements Builder<ShareeEmail, ShareeEmailBuilder>, $S
   ShareeEmail build() => _build();
 
   _$ShareeEmail _build() {
+    ShareeEmail._validate(this);
     _$ShareeEmail _$result;
     try {
       _$result = _$v ??
@@ -11117,7 +11246,9 @@ class ShareeRemoteGroup_ValueBuilder
   String? get shareWith => _$this._shareWith;
   set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
-  ShareeRemoteGroup_ValueBuilder();
+  ShareeRemoteGroup_ValueBuilder() {
+    ShareeRemoteGroup_Value._defaults(this);
+  }
 
   ShareeRemoteGroup_ValueBuilder get _$this {
     final $v = _$v;
@@ -11145,6 +11276,7 @@ class ShareeRemoteGroup_ValueBuilder
   ShareeRemoteGroup_Value build() => _build();
 
   _$ShareeRemoteGroup_Value _build() {
+    ShareeRemoteGroup_Value._validate(this);
     final _$result = _$v ??
         _$ShareeRemoteGroup_Value._(
             server: BuiltValueNullFieldError.checkNotNull(server, r'ShareeRemoteGroup_Value', 'server'),
@@ -11262,7 +11394,9 @@ class ShareeRemoteGroupBuilder
   String? get label => _$this._label;
   set label(covariant String? label) => _$this._label = label;
 
-  ShareeRemoteGroupBuilder();
+  ShareeRemoteGroupBuilder() {
+    ShareeRemoteGroup._defaults(this);
+  }
 
   ShareeRemoteGroupBuilder get _$this {
     final $v = _$v;
@@ -11292,6 +11426,7 @@ class ShareeRemoteGroupBuilder
   ShareeRemoteGroup build() => _build();
 
   _$ShareeRemoteGroup _build() {
+    ShareeRemoteGroup._validate(this);
     _$ShareeRemoteGroup _$result;
     try {
       _$result = _$v ??
@@ -11398,7 +11533,9 @@ class ShareeRemote_ValueBuilder
   String? get shareWith => _$this._shareWith;
   set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
-  ShareeRemote_ValueBuilder();
+  ShareeRemote_ValueBuilder() {
+    ShareeRemote_Value._defaults(this);
+  }
 
   ShareeRemote_ValueBuilder get _$this {
     final $v = _$v;
@@ -11426,6 +11563,7 @@ class ShareeRemote_ValueBuilder
   ShareeRemote_Value build() => _build();
 
   _$ShareeRemote_Value _build() {
+    ShareeRemote_Value._validate(this);
     final _$result = _$v ??
         _$ShareeRemote_Value._(
             server: BuiltValueNullFieldError.checkNotNull(server, r'ShareeRemote_Value', 'server'),
@@ -11561,7 +11699,9 @@ class ShareeRemoteBuilder implements Builder<ShareeRemote, ShareeRemoteBuilder>,
   String? get label => _$this._label;
   set label(covariant String? label) => _$this._label = label;
 
-  ShareeRemoteBuilder();
+  ShareeRemoteBuilder() {
+    ShareeRemote._defaults(this);
+  }
 
   ShareeRemoteBuilder get _$this {
     final $v = _$v;
@@ -11592,6 +11732,7 @@ class ShareeRemoteBuilder implements Builder<ShareeRemote, ShareeRemoteBuilder>,
   ShareeRemote build() => _build();
 
   _$ShareeRemote _build() {
+    ShareeRemote._validate(this);
     _$ShareeRemote _$result;
     try {
       _$result = _$v ??
@@ -11710,7 +11851,9 @@ class ShareeUser_StatusBuilder
   int? get clearAt => _$this._clearAt;
   set clearAt(covariant int? clearAt) => _$this._clearAt = clearAt;
 
-  ShareeUser_StatusBuilder();
+  ShareeUser_StatusBuilder() {
+    ShareeUser_Status._defaults(this);
+  }
 
   ShareeUser_StatusBuilder get _$this {
     final $v = _$v;
@@ -11739,6 +11882,7 @@ class ShareeUser_StatusBuilder
   ShareeUser_Status build() => _build();
 
   _$ShareeUser_Status _build() {
+    ShareeUser_Status._validate(this);
     final _$result = _$v ??
         _$ShareeUser_Status._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'ShareeUser_Status', 'status'),
@@ -11889,7 +12033,9 @@ class ShareeUserBuilder implements Builder<ShareeUser, ShareeUserBuilder>, $Shar
   String? get label => _$this._label;
   set label(covariant String? label) => _$this._label = label;
 
-  ShareeUserBuilder();
+  ShareeUserBuilder() {
+    ShareeUser._defaults(this);
+  }
 
   ShareeUserBuilder get _$this {
     final $v = _$v;
@@ -11921,6 +12067,7 @@ class ShareeUserBuilder implements Builder<ShareeUser, ShareeUserBuilder>, $Shar
   ShareeUser build() => _build();
 
   _$ShareeUser _build() {
+    ShareeUser._validate(this);
     _$ShareeUser _$result;
     try {
       _$result = _$v ??
@@ -12094,7 +12241,9 @@ class ShareesSearchResult_ExactBuilder
   ListBuilder<ShareeUser> get users => _$this._users ??= ListBuilder<ShareeUser>();
   set users(covariant ListBuilder<ShareeUser>? users) => _$this._users = users;
 
-  ShareesSearchResult_ExactBuilder();
+  ShareesSearchResult_ExactBuilder() {
+    ShareesSearchResult_Exact._defaults(this);
+  }
 
   ShareesSearchResult_ExactBuilder get _$this {
     final $v = _$v;
@@ -12126,6 +12275,7 @@ class ShareesSearchResult_ExactBuilder
   ShareesSearchResult_Exact build() => _build();
 
   _$ShareesSearchResult_Exact _build() {
+    ShareesSearchResult_Exact._validate(this);
     _$ShareesSearchResult_Exact _$result;
     try {
       _$result = _$v ??
@@ -12228,7 +12378,9 @@ class LookupBuilder implements Builder<Lookup, LookupBuilder>, $LookupInterfaceB
   int? get verified => _$this._verified;
   set verified(covariant int? verified) => _$this._verified = verified;
 
-  LookupBuilder();
+  LookupBuilder() {
+    Lookup._defaults(this);
+  }
 
   LookupBuilder get _$this {
     final $v = _$v;
@@ -12255,6 +12407,7 @@ class LookupBuilder implements Builder<Lookup, LookupBuilder>, $LookupInterfaceB
   Lookup build() => _build();
 
   _$Lookup _build() {
+    Lookup._validate(this);
     final _$result = _$v ??
         _$Lookup._(
             value: BuiltValueNullFieldError.checkNotNull(value, r'Lookup', 'value'),
@@ -12439,7 +12592,9 @@ class ShareeLookup_ExtraBuilder
   LookupBuilder get userid => _$this._userid ??= LookupBuilder();
   set userid(covariant LookupBuilder? userid) => _$this._userid = userid;
 
-  ShareeLookup_ExtraBuilder();
+  ShareeLookup_ExtraBuilder() {
+    ShareeLookup_Extra._defaults(this);
+  }
 
   ShareeLookup_ExtraBuilder get _$this {
     final $v = _$v;
@@ -12474,6 +12629,7 @@ class ShareeLookup_ExtraBuilder
   ShareeLookup_Extra build() => _build();
 
   _$ShareeLookup_Extra _build() {
+    ShareeLookup_Extra._validate(this);
     _$ShareeLookup_Extra _$result;
     try {
       _$result = _$v ??
@@ -12601,7 +12757,9 @@ class ShareeLookup_ValueBuilder
   String? get shareWith => _$this._shareWith;
   set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
 
-  ShareeLookup_ValueBuilder();
+  ShareeLookup_ValueBuilder() {
+    ShareeLookup_Value._defaults(this);
+  }
 
   ShareeLookup_ValueBuilder get _$this {
     final $v = _$v;
@@ -12629,6 +12787,7 @@ class ShareeLookup_ValueBuilder
   ShareeLookup_Value build() => _build();
 
   _$ShareeLookup_Value _build() {
+    ShareeLookup_Value._validate(this);
     final _$result = _$v ??
         _$ShareeLookup_Value._(
             globalScale: BuiltValueNullFieldError.checkNotNull(globalScale, r'ShareeLookup_Value', 'globalScale'),
@@ -12731,7 +12890,9 @@ class ShareeLookupBuilder implements Builder<ShareeLookup, ShareeLookupBuilder>,
   String? get label => _$this._label;
   set label(covariant String? label) => _$this._label = label;
 
-  ShareeLookupBuilder();
+  ShareeLookupBuilder() {
+    ShareeLookup._defaults(this);
+  }
 
   ShareeLookupBuilder get _$this {
     final $v = _$v;
@@ -12760,6 +12921,7 @@ class ShareeLookupBuilder implements Builder<ShareeLookup, ShareeLookupBuilder>,
   ShareeLookup build() => _build();
 
   _$ShareeLookup _build() {
+    ShareeLookup._validate(this);
     _$ShareeLookup _$result;
     try {
       _$result = _$v ??
@@ -12969,7 +13131,9 @@ class ShareesSearchResultBuilder
   bool? get lookupEnabled => _$this._lookupEnabled;
   set lookupEnabled(covariant bool? lookupEnabled) => _$this._lookupEnabled = lookupEnabled;
 
-  ShareesSearchResultBuilder();
+  ShareesSearchResultBuilder() {
+    ShareesSearchResult._defaults(this);
+  }
 
   ShareesSearchResultBuilder get _$this {
     final $v = _$v;
@@ -13004,6 +13168,7 @@ class ShareesSearchResultBuilder
   ShareesSearchResult build() => _build();
 
   _$ShareesSearchResult _build() {
+    ShareesSearchResult._validate(this);
     _$ShareesSearchResult _$result;
     try {
       _$result = _$v ??
@@ -13122,7 +13287,9 @@ class ShareesapiSearchResponseApplicationJson_OcsBuilder
   ShareesSearchResultBuilder get data => _$this._data ??= ShareesSearchResultBuilder();
   set data(covariant ShareesSearchResultBuilder? data) => _$this._data = data;
 
-  ShareesapiSearchResponseApplicationJson_OcsBuilder();
+  ShareesapiSearchResponseApplicationJson_OcsBuilder() {
+    ShareesapiSearchResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ShareesapiSearchResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -13149,6 +13316,7 @@ class ShareesapiSearchResponseApplicationJson_OcsBuilder
   ShareesapiSearchResponseApplicationJson_Ocs build() => _build();
 
   _$ShareesapiSearchResponseApplicationJson_Ocs _build() {
+    ShareesapiSearchResponseApplicationJson_Ocs._validate(this);
     _$ShareesapiSearchResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ShareesapiSearchResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -13228,7 +13396,9 @@ class ShareesapiSearchResponseApplicationJsonBuilder
       _$this._ocs ??= ShareesapiSearchResponseApplicationJson_OcsBuilder();
   set ocs(covariant ShareesapiSearchResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ShareesapiSearchResponseApplicationJsonBuilder();
+  ShareesapiSearchResponseApplicationJsonBuilder() {
+    ShareesapiSearchResponseApplicationJson._defaults(this);
+  }
 
   ShareesapiSearchResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -13254,6 +13424,7 @@ class ShareesapiSearchResponseApplicationJsonBuilder
   ShareesapiSearchResponseApplicationJson build() => _build();
 
   _$ShareesapiSearchResponseApplicationJson _build() {
+    ShareesapiSearchResponseApplicationJson._validate(this);
     _$ShareesapiSearchResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ShareesapiSearchResponseApplicationJson._(ocs: ocs.build());
@@ -13325,7 +13496,9 @@ class ShareesapiShareesapiSearchHeadersBuilder
   String? get link => _$this._link;
   set link(covariant String? link) => _$this._link = link;
 
-  ShareesapiShareesapiSearchHeadersBuilder();
+  ShareesapiShareesapiSearchHeadersBuilder() {
+    ShareesapiShareesapiSearchHeaders._defaults(this);
+  }
 
   ShareesapiShareesapiSearchHeadersBuilder get _$this {
     final $v = _$v;
@@ -13351,6 +13524,7 @@ class ShareesapiShareesapiSearchHeadersBuilder
   ShareesapiShareesapiSearchHeaders build() => _build();
 
   _$ShareesapiShareesapiSearchHeaders _build() {
+    ShareesapiShareesapiSearchHeaders._validate(this);
     final _$result = _$v ?? _$ShareesapiShareesapiSearchHeaders._(link: link);
     replace(_$result);
     return _$result;
@@ -13473,7 +13647,9 @@ class ShareesRecommendedResult_ExactBuilder
   ListBuilder<ShareeUser> get users => _$this._users ??= ListBuilder<ShareeUser>();
   set users(covariant ListBuilder<ShareeUser>? users) => _$this._users = users;
 
-  ShareesRecommendedResult_ExactBuilder();
+  ShareesRecommendedResult_ExactBuilder() {
+    ShareesRecommendedResult_Exact._defaults(this);
+  }
 
   ShareesRecommendedResult_ExactBuilder get _$this {
     final $v = _$v;
@@ -13503,6 +13679,7 @@ class ShareesRecommendedResult_ExactBuilder
   ShareesRecommendedResult_Exact build() => _build();
 
   _$ShareesRecommendedResult_Exact _build() {
+    ShareesRecommendedResult_Exact._validate(this);
     _$ShareesRecommendedResult_Exact _$result;
     try {
       _$result = _$v ??
@@ -13665,7 +13842,9 @@ class ShareesRecommendedResultBuilder
   ListBuilder<ShareeUser> get users => _$this._users ??= ListBuilder<ShareeUser>();
   set users(covariant ListBuilder<ShareeUser>? users) => _$this._users = users;
 
-  ShareesRecommendedResultBuilder();
+  ShareesRecommendedResultBuilder() {
+    ShareesRecommendedResult._defaults(this);
+  }
 
   ShareesRecommendedResultBuilder get _$this {
     final $v = _$v;
@@ -13696,6 +13875,7 @@ class ShareesRecommendedResultBuilder
   ShareesRecommendedResult build() => _build();
 
   _$ShareesRecommendedResult _build() {
+    ShareesRecommendedResult._validate(this);
     _$ShareesRecommendedResult _$result;
     try {
       _$result = _$v ??
@@ -13805,7 +13985,9 @@ class ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder
   ShareesRecommendedResultBuilder get data => _$this._data ??= ShareesRecommendedResultBuilder();
   set data(covariant ShareesRecommendedResultBuilder? data) => _$this._data = data;
 
-  ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder();
+  ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder() {
+    ShareesapiFindRecommendedResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -13832,6 +14014,7 @@ class ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder
   ShareesapiFindRecommendedResponseApplicationJson_Ocs build() => _build();
 
   _$ShareesapiFindRecommendedResponseApplicationJson_Ocs _build() {
+    ShareesapiFindRecommendedResponseApplicationJson_Ocs._validate(this);
     _$ShareesapiFindRecommendedResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -13915,7 +14098,9 @@ class ShareesapiFindRecommendedResponseApplicationJsonBuilder
       _$this._ocs ??= ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder();
   set ocs(covariant ShareesapiFindRecommendedResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ShareesapiFindRecommendedResponseApplicationJsonBuilder();
+  ShareesapiFindRecommendedResponseApplicationJsonBuilder() {
+    ShareesapiFindRecommendedResponseApplicationJson._defaults(this);
+  }
 
   ShareesapiFindRecommendedResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -13941,6 +14126,7 @@ class ShareesapiFindRecommendedResponseApplicationJsonBuilder
   ShareesapiFindRecommendedResponseApplicationJson build() => _build();
 
   _$ShareesapiFindRecommendedResponseApplicationJson _build() {
+    ShareesapiFindRecommendedResponseApplicationJson._validate(this);
     _$ShareesapiFindRecommendedResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ShareesapiFindRecommendedResponseApplicationJson._(ocs: ocs.build());
@@ -14037,7 +14223,9 @@ class Capabilities_FilesSharing_Public_PasswordBuilder
   set askForOptionalPassword(covariant bool? askForOptionalPassword) =>
       _$this._askForOptionalPassword = askForOptionalPassword;
 
-  Capabilities_FilesSharing_Public_PasswordBuilder();
+  Capabilities_FilesSharing_Public_PasswordBuilder() {
+    Capabilities_FilesSharing_Public_Password._defaults(this);
+  }
 
   Capabilities_FilesSharing_Public_PasswordBuilder get _$this {
     final $v = _$v;
@@ -14064,6 +14252,7 @@ class Capabilities_FilesSharing_Public_PasswordBuilder
   Capabilities_FilesSharing_Public_Password build() => _build();
 
   _$Capabilities_FilesSharing_Public_Password _build() {
+    Capabilities_FilesSharing_Public_Password._validate(this);
     final _$result = _$v ??
         _$Capabilities_FilesSharing_Public_Password._(
             enforced: BuiltValueNullFieldError.checkNotNull(
@@ -14160,7 +14349,9 @@ class Capabilities_FilesSharing_Public_ExpireDateBuilder
   bool? get enforced => _$this._enforced;
   set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
-  Capabilities_FilesSharing_Public_ExpireDateBuilder();
+  Capabilities_FilesSharing_Public_ExpireDateBuilder() {
+    Capabilities_FilesSharing_Public_ExpireDate._defaults(this);
+  }
 
   Capabilities_FilesSharing_Public_ExpireDateBuilder get _$this {
     final $v = _$v;
@@ -14188,6 +14379,7 @@ class Capabilities_FilesSharing_Public_ExpireDateBuilder
   Capabilities_FilesSharing_Public_ExpireDate build() => _build();
 
   _$Capabilities_FilesSharing_Public_ExpireDate _build() {
+    Capabilities_FilesSharing_Public_ExpireDate._validate(this);
     final _$result = _$v ??
         _$Capabilities_FilesSharing_Public_ExpireDate._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -14287,7 +14479,9 @@ class Capabilities_FilesSharing_Public_ExpireDateInternalBuilder
   bool? get enforced => _$this._enforced;
   set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
-  Capabilities_FilesSharing_Public_ExpireDateInternalBuilder();
+  Capabilities_FilesSharing_Public_ExpireDateInternalBuilder() {
+    Capabilities_FilesSharing_Public_ExpireDateInternal._defaults(this);
+  }
 
   Capabilities_FilesSharing_Public_ExpireDateInternalBuilder get _$this {
     final $v = _$v;
@@ -14315,6 +14509,7 @@ class Capabilities_FilesSharing_Public_ExpireDateInternalBuilder
   Capabilities_FilesSharing_Public_ExpireDateInternal build() => _build();
 
   _$Capabilities_FilesSharing_Public_ExpireDateInternal _build() {
+    Capabilities_FilesSharing_Public_ExpireDateInternal._validate(this);
     final _$result = _$v ??
         _$Capabilities_FilesSharing_Public_ExpireDateInternal._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -14412,7 +14607,9 @@ class Capabilities_FilesSharing_Public_ExpireDateRemoteBuilder
   bool? get enforced => _$this._enforced;
   set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
-  Capabilities_FilesSharing_Public_ExpireDateRemoteBuilder();
+  Capabilities_FilesSharing_Public_ExpireDateRemoteBuilder() {
+    Capabilities_FilesSharing_Public_ExpireDateRemote._defaults(this);
+  }
 
   Capabilities_FilesSharing_Public_ExpireDateRemoteBuilder get _$this {
     final $v = _$v;
@@ -14440,6 +14637,7 @@ class Capabilities_FilesSharing_Public_ExpireDateRemoteBuilder
   Capabilities_FilesSharing_Public_ExpireDateRemote build() => _build();
 
   _$Capabilities_FilesSharing_Public_ExpireDateRemote _build() {
+    Capabilities_FilesSharing_Public_ExpireDateRemote._validate(this);
     final _$result = _$v ??
         _$Capabilities_FilesSharing_Public_ExpireDateRemote._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -14622,7 +14820,9 @@ class Capabilities_FilesSharing_PublicBuilder
   bool? get uploadFilesDrop => _$this._uploadFilesDrop;
   set uploadFilesDrop(covariant bool? uploadFilesDrop) => _$this._uploadFilesDrop = uploadFilesDrop;
 
-  Capabilities_FilesSharing_PublicBuilder();
+  Capabilities_FilesSharing_PublicBuilder() {
+    Capabilities_FilesSharing_Public._defaults(this);
+  }
 
   Capabilities_FilesSharing_PublicBuilder get _$this {
     final $v = _$v;
@@ -14656,6 +14856,7 @@ class Capabilities_FilesSharing_PublicBuilder
   Capabilities_FilesSharing_Public build() => _build();
 
   _$Capabilities_FilesSharing_Public _build() {
+    Capabilities_FilesSharing_Public._validate(this);
     _$Capabilities_FilesSharing_Public _$result;
     try {
       _$result = _$v ??
@@ -14750,7 +14951,9 @@ class Capabilities_FilesSharing_User_ExpireDateBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  Capabilities_FilesSharing_User_ExpireDateBuilder();
+  Capabilities_FilesSharing_User_ExpireDateBuilder() {
+    Capabilities_FilesSharing_User_ExpireDate._defaults(this);
+  }
 
   Capabilities_FilesSharing_User_ExpireDateBuilder get _$this {
     final $v = _$v;
@@ -14776,6 +14979,7 @@ class Capabilities_FilesSharing_User_ExpireDateBuilder
   Capabilities_FilesSharing_User_ExpireDate build() => _build();
 
   _$Capabilities_FilesSharing_User_ExpireDate _build() {
+    Capabilities_FilesSharing_User_ExpireDate._validate(this);
     final _$result = _$v ??
         _$Capabilities_FilesSharing_User_ExpireDate._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -14855,7 +15059,9 @@ class Capabilities_FilesSharing_UserBuilder
   set expireDate(covariant Capabilities_FilesSharing_User_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
-  Capabilities_FilesSharing_UserBuilder();
+  Capabilities_FilesSharing_UserBuilder() {
+    Capabilities_FilesSharing_User._defaults(this);
+  }
 
   Capabilities_FilesSharing_UserBuilder get _$this {
     final $v = _$v;
@@ -14882,6 +15088,7 @@ class Capabilities_FilesSharing_UserBuilder
   Capabilities_FilesSharing_User build() => _build();
 
   _$Capabilities_FilesSharing_User _build() {
+    Capabilities_FilesSharing_User._validate(this);
     _$Capabilities_FilesSharing_User _$result;
     try {
       _$result = _$v ??
@@ -14962,7 +15169,9 @@ class Capabilities_FilesSharing_Group_ExpireDateBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  Capabilities_FilesSharing_Group_ExpireDateBuilder();
+  Capabilities_FilesSharing_Group_ExpireDateBuilder() {
+    Capabilities_FilesSharing_Group_ExpireDate._defaults(this);
+  }
 
   Capabilities_FilesSharing_Group_ExpireDateBuilder get _$this {
     final $v = _$v;
@@ -14988,6 +15197,7 @@ class Capabilities_FilesSharing_Group_ExpireDateBuilder
   Capabilities_FilesSharing_Group_ExpireDate build() => _build();
 
   _$Capabilities_FilesSharing_Group_ExpireDate _build() {
+    Capabilities_FilesSharing_Group_ExpireDate._validate(this);
     final _$result = _$v ??
         _$Capabilities_FilesSharing_Group_ExpireDate._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -15067,7 +15277,9 @@ class Capabilities_FilesSharing_GroupBuilder
   set expireDate(covariant Capabilities_FilesSharing_Group_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
-  Capabilities_FilesSharing_GroupBuilder();
+  Capabilities_FilesSharing_GroupBuilder() {
+    Capabilities_FilesSharing_Group._defaults(this);
+  }
 
   Capabilities_FilesSharing_GroupBuilder get _$this {
     final $v = _$v;
@@ -15094,6 +15306,7 @@ class Capabilities_FilesSharing_GroupBuilder
   Capabilities_FilesSharing_Group build() => _build();
 
   _$Capabilities_FilesSharing_Group _build() {
+    Capabilities_FilesSharing_Group._validate(this);
     _$Capabilities_FilesSharing_Group _$result;
     try {
       _$result = _$v ??
@@ -15175,7 +15388,9 @@ class Capabilities_FilesSharing_Federation_ExpireDateBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  Capabilities_FilesSharing_Federation_ExpireDateBuilder();
+  Capabilities_FilesSharing_Federation_ExpireDateBuilder() {
+    Capabilities_FilesSharing_Federation_ExpireDate._defaults(this);
+  }
 
   Capabilities_FilesSharing_Federation_ExpireDateBuilder get _$this {
     final $v = _$v;
@@ -15201,6 +15416,7 @@ class Capabilities_FilesSharing_Federation_ExpireDateBuilder
   Capabilities_FilesSharing_Federation_ExpireDate build() => _build();
 
   _$Capabilities_FilesSharing_Federation_ExpireDate _build() {
+    Capabilities_FilesSharing_Federation_ExpireDate._validate(this);
     final _$result = _$v ??
         _$Capabilities_FilesSharing_Federation_ExpireDate._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -15273,7 +15489,9 @@ class Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder();
+  Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder() {
+    Capabilities_FilesSharing_Federation_ExpireDateSupported._defaults(this);
+  }
 
   Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder get _$this {
     final $v = _$v;
@@ -15299,6 +15517,7 @@ class Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder
   Capabilities_FilesSharing_Federation_ExpireDateSupported build() => _build();
 
   _$Capabilities_FilesSharing_Federation_ExpireDateSupported _build() {
+    Capabilities_FilesSharing_Federation_ExpireDateSupported._validate(this);
     final _$result = _$v ??
         _$Capabilities_FilesSharing_Federation_ExpireDateSupported._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -15415,7 +15634,9 @@ class Capabilities_FilesSharing_FederationBuilder
           covariant Capabilities_FilesSharing_Federation_ExpireDateSupportedBuilder? expireDateSupported) =>
       _$this._expireDateSupported = expireDateSupported;
 
-  Capabilities_FilesSharing_FederationBuilder();
+  Capabilities_FilesSharing_FederationBuilder() {
+    Capabilities_FilesSharing_Federation._defaults(this);
+  }
 
   Capabilities_FilesSharing_FederationBuilder get _$this {
     final $v = _$v;
@@ -15444,6 +15665,7 @@ class Capabilities_FilesSharing_FederationBuilder
   Capabilities_FilesSharing_Federation build() => _build();
 
   _$Capabilities_FilesSharing_Federation _build() {
+    Capabilities_FilesSharing_Federation._validate(this);
     _$Capabilities_FilesSharing_Federation _$result;
     try {
       _$result = _$v ??
@@ -15543,7 +15765,9 @@ class Capabilities_FilesSharing_ShareeBuilder
   bool? get alwaysShowUnique => _$this._alwaysShowUnique;
   set alwaysShowUnique(covariant bool? alwaysShowUnique) => _$this._alwaysShowUnique = alwaysShowUnique;
 
-  Capabilities_FilesSharing_ShareeBuilder();
+  Capabilities_FilesSharing_ShareeBuilder() {
+    Capabilities_FilesSharing_Sharee._defaults(this);
+  }
 
   Capabilities_FilesSharing_ShareeBuilder get _$this {
     final $v = _$v;
@@ -15570,6 +15794,7 @@ class Capabilities_FilesSharing_ShareeBuilder
   Capabilities_FilesSharing_Sharee build() => _build();
 
   _$Capabilities_FilesSharing_Sharee _build() {
+    Capabilities_FilesSharing_Sharee._validate(this);
     final _$result = _$v ??
         _$Capabilities_FilesSharing_Sharee._(
             queryLookupDefault: BuiltValueNullFieldError.checkNotNull(
@@ -15751,7 +15976,9 @@ class Capabilities_FilesSharingBuilder
   Capabilities_FilesSharing_ShareeBuilder get sharee => _$this._sharee ??= Capabilities_FilesSharing_ShareeBuilder();
   set sharee(covariant Capabilities_FilesSharing_ShareeBuilder? sharee) => _$this._sharee = sharee;
 
-  Capabilities_FilesSharingBuilder();
+  Capabilities_FilesSharingBuilder() {
+    Capabilities_FilesSharing._defaults(this);
+  }
 
   Capabilities_FilesSharingBuilder get _$this {
     final $v = _$v;
@@ -15785,6 +16012,7 @@ class Capabilities_FilesSharingBuilder
   Capabilities_FilesSharing build() => _build();
 
   _$Capabilities_FilesSharing _build() {
+    Capabilities_FilesSharing._validate(this);
     _$Capabilities_FilesSharing _$result;
     try {
       _$result = _$v ??
@@ -15874,7 +16102,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities_FilesSharingBuilder get filesSharing => _$this._filesSharing ??= Capabilities_FilesSharingBuilder();
   set filesSharing(covariant Capabilities_FilesSharingBuilder? filesSharing) => _$this._filesSharing = filesSharing;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -15900,6 +16130,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(filesSharing: filesSharing.build());

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -236,6 +236,10 @@ class _$PreviewGetPreviewASerializer implements PrimitiveSerializer<PreviewGetPr
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities_FilesInterface {
   bool get undelete;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_Files
@@ -264,11 +268,25 @@ abstract class Capabilities_Files
 
   /// Serializer for Capabilities_Files.
   static Serializer<Capabilities_Files> get serializer => _$capabilitiesFilesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesBuilder b) {
+    $Capabilities_FilesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesBuilder b) {
+    $Capabilities_FilesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   Capabilities_Files get files;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -295,6 +313,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.g.dart
@@ -158,7 +158,9 @@ class Capabilities_FilesBuilder
   bool? get undelete => _$this._undelete;
   set undelete(covariant bool? undelete) => _$this._undelete = undelete;
 
-  Capabilities_FilesBuilder();
+  Capabilities_FilesBuilder() {
+    Capabilities_Files._defaults(this);
+  }
 
   Capabilities_FilesBuilder get _$this {
     final $v = _$v;
@@ -184,6 +186,7 @@ class Capabilities_FilesBuilder
   Capabilities_Files build() => _build();
 
   _$Capabilities_Files _build() {
+    Capabilities_Files._validate(this);
     final _$result = _$v ??
         _$Capabilities_Files._(
             undelete: BuiltValueNullFieldError.checkNotNull(undelete, r'Capabilities_Files', 'undelete'));
@@ -243,7 +246,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities_FilesBuilder get files => _$this._files ??= Capabilities_FilesBuilder();
   set files(covariant Capabilities_FilesBuilder? files) => _$this._files = files;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -269,6 +274,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(files: files.build());

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.dart
@@ -176,6 +176,10 @@ abstract interface class $Capabilities_FilesInterface {
   bool get versionLabeling;
   @BuiltValueField(wireName: 'version_deletion')
   bool get versionDeletion;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_FilesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_FilesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_Files
@@ -204,11 +208,25 @@ abstract class Capabilities_Files
 
   /// Serializer for Capabilities_Files.
   static Serializer<Capabilities_Files> get serializer => _$capabilitiesFilesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_FilesBuilder b) {
+    $Capabilities_FilesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_FilesBuilder b) {
+    $Capabilities_FilesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   Capabilities_Files get files;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -235,6 +253,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.g.dart
@@ -179,7 +179,9 @@ class Capabilities_FilesBuilder
   bool? get versionDeletion => _$this._versionDeletion;
   set versionDeletion(covariant bool? versionDeletion) => _$this._versionDeletion = versionDeletion;
 
-  Capabilities_FilesBuilder();
+  Capabilities_FilesBuilder() {
+    Capabilities_Files._defaults(this);
+  }
 
   Capabilities_FilesBuilder get _$this {
     final $v = _$v;
@@ -207,6 +209,7 @@ class Capabilities_FilesBuilder
   Capabilities_Files build() => _build();
 
   _$Capabilities_Files _build() {
+    Capabilities_Files._validate(this);
     final _$result = _$v ??
         _$Capabilities_Files._(
             versioning: BuiltValueNullFieldError.checkNotNull(versioning, r'Capabilities_Files', 'versioning'),
@@ -270,7 +273,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities_FilesBuilder get files => _$this._files ??= Capabilities_FilesBuilder();
   set files(covariant Capabilities_FilesBuilder? files) => _$this._files = files;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -296,6 +301,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(files: files.build());

--- a/packages/nextcloud/lib/src/api/news.openapi.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.dart
@@ -1440,6 +1440,10 @@ class $Client extends _i1.DynamiteClient {
 @BuiltValue(instantiable: false)
 abstract interface class $SupportedAPIVersionsInterface {
   BuiltList<String>? get apiLevels;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SupportedAPIVersionsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SupportedAPIVersionsInterfaceBuilder b) {}
 }
 
 abstract class SupportedAPIVersions
@@ -1468,6 +1472,16 @@ abstract class SupportedAPIVersions
 
   /// Serializer for SupportedAPIVersions.
   static Serializer<SupportedAPIVersions> get serializer => _$supportedAPIVersionsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SupportedAPIVersionsBuilder b) {
+    $SupportedAPIVersionsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SupportedAPIVersionsBuilder b) {
+    $SupportedAPIVersionsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1492,6 +1506,10 @@ abstract interface class $ArticleInterface {
   bool get rtl;
   String get fingerprint;
   String get contentHash;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ArticleInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ArticleInterfaceBuilder b) {}
 }
 
 abstract class Article implements $ArticleInterface, Built<Article, ArticleBuilder> {
@@ -1518,6 +1536,16 @@ abstract class Article implements $ArticleInterface, Built<Article, ArticleBuild
 
   /// Serializer for Article.
   static Serializer<Article> get serializer => _$articleSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ArticleBuilder b) {
+    $ArticleInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ArticleBuilder b) {
+    $ArticleInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1535,6 +1563,10 @@ abstract interface class $FeedInterface {
   int get updateErrorCount;
   String? get lastUpdateError;
   BuiltList<Article> get items;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FeedInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FeedInterfaceBuilder b) {}
 }
 
 abstract class Feed implements $FeedInterface, Built<Feed, FeedBuilder> {
@@ -1561,6 +1593,16 @@ abstract class Feed implements $FeedInterface, Built<Feed, FeedBuilder> {
 
   /// Serializer for Feed.
   static Serializer<Feed> get serializer => _$feedSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FeedBuilder b) {
+    $FeedInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FeedBuilder b) {
+    $FeedInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1571,6 +1613,10 @@ abstract interface class $FolderInterface {
 
   /// This seems to be broken. In testing it is always empty.
   BuiltList<Feed> get feeds;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FolderInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FolderInterfaceBuilder b) {}
 }
 
 abstract class Folder implements $FolderInterface, Built<Folder, FolderBuilder> {
@@ -1597,11 +1643,25 @@ abstract class Folder implements $FolderInterface, Built<Folder, FolderBuilder> 
 
   /// Serializer for Folder.
   static Serializer<Folder> get serializer => _$folderSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FolderBuilder b) {
+    $FolderInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FolderBuilder b) {
+    $FolderInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ListFoldersInterface {
   BuiltList<Folder> get folders;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ListFoldersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ListFoldersInterfaceBuilder b) {}
 }
 
 abstract class ListFolders implements $ListFoldersInterface, Built<ListFolders, ListFoldersBuilder> {
@@ -1628,6 +1688,16 @@ abstract class ListFolders implements $ListFoldersInterface, Built<ListFolders, 
 
   /// Serializer for ListFolders.
   static Serializer<ListFolders> get serializer => _$listFoldersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ListFoldersBuilder b) {
+    $ListFoldersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ListFoldersBuilder b) {
+    $ListFoldersInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1635,6 +1705,10 @@ abstract interface class $ListFeedsInterface {
   int? get starredCount;
   int? get newestItemId;
   BuiltList<Feed> get feeds;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ListFeedsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ListFeedsInterfaceBuilder b) {}
 }
 
 abstract class ListFeeds implements $ListFeedsInterface, Built<ListFeeds, ListFeedsBuilder> {
@@ -1661,11 +1735,25 @@ abstract class ListFeeds implements $ListFeedsInterface, Built<ListFeeds, ListFe
 
   /// Serializer for ListFeeds.
   static Serializer<ListFeeds> get serializer => _$listFeedsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ListFeedsBuilder b) {
+    $ListFeedsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ListFeedsBuilder b) {
+    $ListFeedsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ListArticlesInterface {
   BuiltList<Article> get items;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ListArticlesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ListArticlesInterfaceBuilder b) {}
 }
 
 abstract class ListArticles implements $ListArticlesInterface, Built<ListArticles, ListArticlesBuilder> {
@@ -1692,6 +1780,16 @@ abstract class ListArticles implements $ListArticlesInterface, Built<ListArticle
 
   /// Serializer for ListArticles.
   static Serializer<ListArticles> get serializer => _$listArticlesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ListArticlesBuilder b) {
+    $ListArticlesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ListArticlesBuilder b) {
+    $ListArticlesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1701,6 +1799,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -1727,12 +1829,26 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EmptyOCS_OcsInterface {
   OCSMeta get meta;
   BuiltList<JsonObject> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EmptyOCS_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EmptyOCS_OcsInterfaceBuilder b) {}
 }
 
 abstract class EmptyOCS_Ocs implements $EmptyOCS_OcsInterface, Built<EmptyOCS_Ocs, EmptyOCS_OcsBuilder> {
@@ -1759,11 +1875,25 @@ abstract class EmptyOCS_Ocs implements $EmptyOCS_OcsInterface, Built<EmptyOCS_Oc
 
   /// Serializer for EmptyOCS_Ocs.
   static Serializer<EmptyOCS_Ocs> get serializer => _$emptyOCSOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EmptyOCS_OcsBuilder b) {
+    $EmptyOCS_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EmptyOCS_OcsBuilder b) {
+    $EmptyOCS_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EmptyOCSInterface {
   EmptyOCS_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EmptyOCSInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EmptyOCSInterfaceBuilder b) {}
 }
 
 abstract class EmptyOCS implements $EmptyOCSInterface, Built<EmptyOCS, EmptyOCSBuilder> {
@@ -1790,6 +1920,16 @@ abstract class EmptyOCS implements $EmptyOCSInterface, Built<EmptyOCS, EmptyOCSB
 
   /// Serializer for EmptyOCS.
   static Serializer<EmptyOCS> get serializer => _$emptyOCSSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EmptyOCSBuilder b) {
+    $EmptyOCSInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EmptyOCSBuilder b) {
+    $EmptyOCSInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/news.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.g.dart
@@ -730,7 +730,9 @@ class SupportedAPIVersionsBuilder
   ListBuilder<String> get apiLevels => _$this._apiLevels ??= ListBuilder<String>();
   set apiLevels(covariant ListBuilder<String>? apiLevels) => _$this._apiLevels = apiLevels;
 
-  SupportedAPIVersionsBuilder();
+  SupportedAPIVersionsBuilder() {
+    SupportedAPIVersions._defaults(this);
+  }
 
   SupportedAPIVersionsBuilder get _$this {
     final $v = _$v;
@@ -756,6 +758,7 @@ class SupportedAPIVersionsBuilder
   SupportedAPIVersions build() => _build();
 
   _$SupportedAPIVersions _build() {
+    SupportedAPIVersions._validate(this);
     _$SupportedAPIVersions _$result;
     try {
       _$result = _$v ?? _$SupportedAPIVersions._(apiLevels: _apiLevels?.build());
@@ -1088,7 +1091,9 @@ class ArticleBuilder implements Builder<Article, ArticleBuilder>, $ArticleInterf
   String? get contentHash => _$this._contentHash;
   set contentHash(covariant String? contentHash) => _$this._contentHash = contentHash;
 
-  ArticleBuilder();
+  ArticleBuilder() {
+    Article._defaults(this);
+  }
 
   ArticleBuilder get _$this {
     final $v = _$v;
@@ -1133,6 +1138,7 @@ class ArticleBuilder implements Builder<Article, ArticleBuilder>, $ArticleInterf
   Article build() => _build();
 
   _$Article _build() {
+    Article._validate(this);
     final _$result = _$v ??
         _$Article._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'Article', 'id'),
@@ -1378,7 +1384,9 @@ class FeedBuilder implements Builder<Feed, FeedBuilder>, $FeedInterfaceBuilder {
   ListBuilder<Article> get items => _$this._items ??= ListBuilder<Article>();
   set items(covariant ListBuilder<Article>? items) => _$this._items = items;
 
-  FeedBuilder();
+  FeedBuilder() {
+    Feed._defaults(this);
+  }
 
   FeedBuilder get _$this {
     final $v = _$v;
@@ -1416,6 +1424,7 @@ class FeedBuilder implements Builder<Feed, FeedBuilder>, $FeedInterfaceBuilder {
   Feed build() => _build();
 
   _$Feed _build() {
+    Feed._validate(this);
     _$Feed _$result;
     try {
       _$result = _$v ??
@@ -1536,7 +1545,9 @@ class FolderBuilder implements Builder<Folder, FolderBuilder>, $FolderInterfaceB
   ListBuilder<Feed> get feeds => _$this._feeds ??= ListBuilder<Feed>();
   set feeds(covariant ListBuilder<Feed>? feeds) => _$this._feeds = feeds;
 
-  FolderBuilder();
+  FolderBuilder() {
+    Folder._defaults(this);
+  }
 
   FolderBuilder get _$this {
     final $v = _$v;
@@ -1565,6 +1576,7 @@ class FolderBuilder implements Builder<Folder, FolderBuilder>, $FolderInterfaceB
   Folder build() => _build();
 
   _$Folder _build() {
+    Folder._validate(this);
     _$Folder _$result;
     try {
       _$result = _$v ??
@@ -1639,7 +1651,9 @@ class ListFoldersBuilder implements Builder<ListFolders, ListFoldersBuilder>, $L
   ListBuilder<Folder> get folders => _$this._folders ??= ListBuilder<Folder>();
   set folders(covariant ListBuilder<Folder>? folders) => _$this._folders = folders;
 
-  ListFoldersBuilder();
+  ListFoldersBuilder() {
+    ListFolders._defaults(this);
+  }
 
   ListFoldersBuilder get _$this {
     final $v = _$v;
@@ -1665,6 +1679,7 @@ class ListFoldersBuilder implements Builder<ListFolders, ListFoldersBuilder>, $L
   ListFolders build() => _build();
 
   _$ListFolders _build() {
+    ListFolders._validate(this);
     _$ListFolders _$result;
     try {
       _$result = _$v ?? _$ListFolders._(folders: folders.build());
@@ -1760,7 +1775,9 @@ class ListFeedsBuilder implements Builder<ListFeeds, ListFeedsBuilder>, $ListFee
   ListBuilder<Feed> get feeds => _$this._feeds ??= ListBuilder<Feed>();
   set feeds(covariant ListBuilder<Feed>? feeds) => _$this._feeds = feeds;
 
-  ListFeedsBuilder();
+  ListFeedsBuilder() {
+    ListFeeds._defaults(this);
+  }
 
   ListFeedsBuilder get _$this {
     final $v = _$v;
@@ -1788,6 +1805,7 @@ class ListFeedsBuilder implements Builder<ListFeeds, ListFeedsBuilder>, $ListFee
   ListFeeds build() => _build();
 
   _$ListFeeds _build() {
+    ListFeeds._validate(this);
     _$ListFeeds _$result;
     try {
       _$result = _$v ?? _$ListFeeds._(starredCount: starredCount, newestItemId: newestItemId, feeds: feeds.build());
@@ -1857,7 +1875,9 @@ class ListArticlesBuilder implements Builder<ListArticles, ListArticlesBuilder>,
   ListBuilder<Article> get items => _$this._items ??= ListBuilder<Article>();
   set items(covariant ListBuilder<Article>? items) => _$this._items = items;
 
-  ListArticlesBuilder();
+  ListArticlesBuilder() {
+    ListArticles._defaults(this);
+  }
 
   ListArticlesBuilder get _$this {
     final $v = _$v;
@@ -1883,6 +1903,7 @@ class ListArticlesBuilder implements Builder<ListArticles, ListArticlesBuilder>,
   ListArticles build() => _build();
 
   _$ListArticles _build() {
+    ListArticles._validate(this);
     _$ListArticles _$result;
     try {
       _$result = _$v ?? _$ListArticles._(items: items.build());
@@ -2004,7 +2025,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -2034,6 +2057,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -2111,7 +2135,9 @@ class EmptyOCS_OcsBuilder implements Builder<EmptyOCS_Ocs, EmptyOCS_OcsBuilder>,
   ListBuilder<JsonObject> get data => _$this._data ??= ListBuilder<JsonObject>();
   set data(covariant ListBuilder<JsonObject>? data) => _$this._data = data;
 
-  EmptyOCS_OcsBuilder();
+  EmptyOCS_OcsBuilder() {
+    EmptyOCS_Ocs._defaults(this);
+  }
 
   EmptyOCS_OcsBuilder get _$this {
     final $v = _$v;
@@ -2138,6 +2164,7 @@ class EmptyOCS_OcsBuilder implements Builder<EmptyOCS_Ocs, EmptyOCS_OcsBuilder>,
   EmptyOCS_Ocs build() => _build();
 
   _$EmptyOCS_Ocs _build() {
+    EmptyOCS_Ocs._validate(this);
     _$EmptyOCS_Ocs _$result;
     try {
       _$result = _$v ?? _$EmptyOCS_Ocs._(meta: meta.build(), data: data.build());
@@ -2208,7 +2235,9 @@ class EmptyOCSBuilder implements Builder<EmptyOCS, EmptyOCSBuilder>, $EmptyOCSIn
   EmptyOCS_OcsBuilder get ocs => _$this._ocs ??= EmptyOCS_OcsBuilder();
   set ocs(covariant EmptyOCS_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  EmptyOCSBuilder();
+  EmptyOCSBuilder() {
+    EmptyOCS._defaults(this);
+  }
 
   EmptyOCSBuilder get _$this {
     final $v = _$v;
@@ -2234,6 +2263,7 @@ class EmptyOCSBuilder implements Builder<EmptyOCS, EmptyOCSBuilder>, $EmptyOCSIn
   EmptyOCS build() => _build();
 
   _$EmptyOCS _build() {
+    EmptyOCS._validate(this);
     _$EmptyOCS _$result;
     try {
       _$result = _$v ?? _$EmptyOCS._(ocs: ocs.build());

--- a/packages/nextcloud/lib/src/api/notes.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.dart
@@ -722,6 +722,10 @@ abstract interface class $NoteInterface {
   int get modified;
   bool get error;
   String get errorType;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NoteInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NoteInterfaceBuilder b) {}
 }
 
 abstract class Note implements $NoteInterface, Built<Note, NoteBuilder> {
@@ -748,6 +752,16 @@ abstract class Note implements $NoteInterface, Built<Note, NoteBuilder> {
 
   /// Serializer for Note.
   static Serializer<Note> get serializer => _$noteSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NoteBuilder b) {
+    $NoteInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NoteBuilder b) {
+    $NoteInterface._validate(b);
+  }
 }
 
 class Settings_NoteMode extends EnumClass {
@@ -821,6 +835,10 @@ abstract interface class $SettingsInterface {
   String get notesPath;
   String get fileSuffix;
   Settings_NoteMode get noteMode;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsInterfaceBuilder b) {}
 }
 
 abstract class Settings implements $SettingsInterface, Built<Settings, SettingsBuilder> {
@@ -847,6 +865,16 @@ abstract class Settings implements $SettingsInterface, Built<Settings, SettingsB
 
   /// Serializer for Settings.
   static Serializer<Settings> get serializer => _$settingsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsBuilder b) {
+    $SettingsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsBuilder b) {
+    $SettingsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -854,6 +882,10 @@ abstract interface class $Capabilities_NotesInterface {
   @BuiltValueField(wireName: 'api_version')
   BuiltList<String>? get apiVersion;
   String? get version;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_NotesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_NotesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_Notes
@@ -882,11 +914,25 @@ abstract class Capabilities_Notes
 
   /// Serializer for Capabilities_Notes.
   static Serializer<Capabilities_Notes> get serializer => _$capabilitiesNotesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_NotesBuilder b) {
+    $Capabilities_NotesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_NotesBuilder b) {
+    $Capabilities_NotesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   Capabilities_Notes get notes;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -913,6 +959,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -922,6 +978,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -948,12 +1008,26 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EmptyOCS_OcsInterface {
   OCSMeta get meta;
   BuiltList<JsonObject> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EmptyOCS_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EmptyOCS_OcsInterfaceBuilder b) {}
 }
 
 abstract class EmptyOCS_Ocs implements $EmptyOCS_OcsInterface, Built<EmptyOCS_Ocs, EmptyOCS_OcsBuilder> {
@@ -980,11 +1054,25 @@ abstract class EmptyOCS_Ocs implements $EmptyOCS_OcsInterface, Built<EmptyOCS_Oc
 
   /// Serializer for EmptyOCS_Ocs.
   static Serializer<EmptyOCS_Ocs> get serializer => _$emptyOCSOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EmptyOCS_OcsBuilder b) {
+    $EmptyOCS_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EmptyOCS_OcsBuilder b) {
+    $EmptyOCS_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EmptyOCSInterface {
   EmptyOCS_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EmptyOCSInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EmptyOCSInterfaceBuilder b) {}
 }
 
 abstract class EmptyOCS implements $EmptyOCSInterface, Built<EmptyOCS, EmptyOCSBuilder> {
@@ -1011,6 +1099,16 @@ abstract class EmptyOCS implements $EmptyOCSInterface, Built<EmptyOCS, EmptyOCSB
 
   /// Serializer for EmptyOCS.
   static Serializer<EmptyOCS> get serializer => _$emptyOCSSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EmptyOCSBuilder b) {
+    $EmptyOCSInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EmptyOCSBuilder b) {
+    $EmptyOCSInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/notes.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.g.dart
@@ -592,7 +592,9 @@ class NoteBuilder implements Builder<Note, NoteBuilder>, $NoteInterfaceBuilder {
   String? get errorType => _$this._errorType;
   set errorType(covariant String? errorType) => _$this._errorType = errorType;
 
-  NoteBuilder();
+  NoteBuilder() {
+    Note._defaults(this);
+  }
 
   NoteBuilder get _$this {
     final $v = _$v;
@@ -627,6 +629,7 @@ class NoteBuilder implements Builder<Note, NoteBuilder>, $NoteInterfaceBuilder {
   Note build() => _build();
 
   _$Note _build() {
+    Note._validate(this);
     final _$result = _$v ??
         _$Note._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'Note', 'id'),
@@ -723,7 +726,9 @@ class SettingsBuilder implements Builder<Settings, SettingsBuilder>, $SettingsIn
   Settings_NoteMode? get noteMode => _$this._noteMode;
   set noteMode(covariant Settings_NoteMode? noteMode) => _$this._noteMode = noteMode;
 
-  SettingsBuilder();
+  SettingsBuilder() {
+    Settings._defaults(this);
+  }
 
   SettingsBuilder get _$this {
     final $v = _$v;
@@ -751,6 +756,7 @@ class SettingsBuilder implements Builder<Settings, SettingsBuilder>, $SettingsIn
   Settings build() => _build();
 
   _$Settings _build() {
+    Settings._validate(this);
     final _$result = _$v ??
         _$Settings._(
             notesPath: BuiltValueNullFieldError.checkNotNull(notesPath, r'Settings', 'notesPath'),
@@ -825,7 +831,9 @@ class Capabilities_NotesBuilder
   String? get version => _$this._version;
   set version(covariant String? version) => _$this._version = version;
 
-  Capabilities_NotesBuilder();
+  Capabilities_NotesBuilder() {
+    Capabilities_Notes._defaults(this);
+  }
 
   Capabilities_NotesBuilder get _$this {
     final $v = _$v;
@@ -852,6 +860,7 @@ class Capabilities_NotesBuilder
   Capabilities_Notes build() => _build();
 
   _$Capabilities_Notes _build() {
+    Capabilities_Notes._validate(this);
     _$Capabilities_Notes _$result;
     try {
       _$result = _$v ?? _$Capabilities_Notes._(apiVersion: _apiVersion?.build(), version: version);
@@ -921,7 +930,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities_NotesBuilder get notes => _$this._notes ??= Capabilities_NotesBuilder();
   set notes(covariant Capabilities_NotesBuilder? notes) => _$this._notes = notes;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -947,6 +958,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(notes: notes.build());
@@ -1068,7 +1080,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -1098,6 +1112,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -1175,7 +1190,9 @@ class EmptyOCS_OcsBuilder implements Builder<EmptyOCS_Ocs, EmptyOCS_OcsBuilder>,
   ListBuilder<JsonObject> get data => _$this._data ??= ListBuilder<JsonObject>();
   set data(covariant ListBuilder<JsonObject>? data) => _$this._data = data;
 
-  EmptyOCS_OcsBuilder();
+  EmptyOCS_OcsBuilder() {
+    EmptyOCS_Ocs._defaults(this);
+  }
 
   EmptyOCS_OcsBuilder get _$this {
     final $v = _$v;
@@ -1202,6 +1219,7 @@ class EmptyOCS_OcsBuilder implements Builder<EmptyOCS_Ocs, EmptyOCS_OcsBuilder>,
   EmptyOCS_Ocs build() => _build();
 
   _$EmptyOCS_Ocs _build() {
+    EmptyOCS_Ocs._validate(this);
     _$EmptyOCS_Ocs _$result;
     try {
       _$result = _$v ?? _$EmptyOCS_Ocs._(meta: meta.build(), data: data.build());
@@ -1272,7 +1290,9 @@ class EmptyOCSBuilder implements Builder<EmptyOCS, EmptyOCSBuilder>, $EmptyOCSIn
   EmptyOCS_OcsBuilder get ocs => _$this._ocs ??= EmptyOCS_OcsBuilder();
   set ocs(covariant EmptyOCS_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  EmptyOCSBuilder();
+  EmptyOCSBuilder() {
+    EmptyOCS._defaults(this);
+  }
 
   EmptyOCSBuilder get _$this {
     final $v = _$v;
@@ -1298,6 +1318,7 @@ class EmptyOCSBuilder implements Builder<EmptyOCS, EmptyOCSBuilder>, $EmptyOCSIn
   EmptyOCS build() => _build();
 
   _$EmptyOCS _build() {
+    EmptyOCS._validate(this);
     _$EmptyOCS _$result;
     try {
       _$result = _$v ?? _$EmptyOCS._(ocs: ocs.build());

--- a/packages/nextcloud/lib/src/api/notifications.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.dart
@@ -1279,6 +1279,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -1305,12 +1309,26 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiGenerateNotificationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGenerateNotificationResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGenerateNotificationResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ApiGenerateNotificationResponseApplicationJson_Ocs
@@ -1345,11 +1363,25 @@ abstract class ApiGenerateNotificationResponseApplicationJson_Ocs
   /// Serializer for ApiGenerateNotificationResponseApplicationJson_Ocs.
   static Serializer<ApiGenerateNotificationResponseApplicationJson_Ocs> get serializer =>
       _$apiGenerateNotificationResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGenerateNotificationResponseApplicationJson_OcsBuilder b) {
+    $ApiGenerateNotificationResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGenerateNotificationResponseApplicationJson_OcsBuilder b) {
+    $ApiGenerateNotificationResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiGenerateNotificationResponseApplicationJsonInterface {
   ApiGenerateNotificationResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGenerateNotificationResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGenerateNotificationResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ApiGenerateNotificationResponseApplicationJson
@@ -1383,6 +1415,16 @@ abstract class ApiGenerateNotificationResponseApplicationJson
   /// Serializer for ApiGenerateNotificationResponseApplicationJson.
   static Serializer<ApiGenerateNotificationResponseApplicationJson> get serializer =>
       _$apiGenerateNotificationResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGenerateNotificationResponseApplicationJsonBuilder b) {
+    $ApiGenerateNotificationResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGenerateNotificationResponseApplicationJsonBuilder b) {
+    $ApiGenerateNotificationResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class EndpointListNotificationsApiVersion extends EnumClass {
@@ -1455,6 +1497,10 @@ abstract interface class $NotificationActionInterface {
   String get link;
   String get type;
   bool get primary;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NotificationActionInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NotificationActionInterfaceBuilder b) {}
 }
 
 abstract class NotificationAction
@@ -1483,6 +1529,16 @@ abstract class NotificationAction
 
   /// Serializer for NotificationAction.
   static Serializer<NotificationAction> get serializer => _$notificationActionSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NotificationActionBuilder b) {
+    $NotificationActionInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NotificationActionBuilder b) {
+    $NotificationActionInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1506,6 +1562,10 @@ abstract interface class $NotificationInterface {
   BuiltMap<String, JsonObject>? get messageRichParameters;
   String? get icon;
   bool? get shouldNotify;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NotificationInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NotificationInterfaceBuilder b) {}
 }
 
 abstract class Notification implements $NotificationInterface, Built<Notification, NotificationBuilder> {
@@ -1532,12 +1592,26 @@ abstract class Notification implements $NotificationInterface, Built<Notificatio
 
   /// Serializer for Notification.
   static Serializer<Notification> get serializer => _$notificationSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NotificationBuilder b) {
+    $NotificationInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NotificationBuilder b) {
+    $NotificationInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EndpointListNotificationsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Notification> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointListNotificationsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointListNotificationsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class EndpointListNotificationsResponseApplicationJson_Ocs
@@ -1572,11 +1646,25 @@ abstract class EndpointListNotificationsResponseApplicationJson_Ocs
   /// Serializer for EndpointListNotificationsResponseApplicationJson_Ocs.
   static Serializer<EndpointListNotificationsResponseApplicationJson_Ocs> get serializer =>
       _$endpointListNotificationsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointListNotificationsResponseApplicationJson_OcsBuilder b) {
+    $EndpointListNotificationsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointListNotificationsResponseApplicationJson_OcsBuilder b) {
+    $EndpointListNotificationsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EndpointListNotificationsResponseApplicationJsonInterface {
   EndpointListNotificationsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointListNotificationsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointListNotificationsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class EndpointListNotificationsResponseApplicationJson
@@ -1611,12 +1699,26 @@ abstract class EndpointListNotificationsResponseApplicationJson
   /// Serializer for EndpointListNotificationsResponseApplicationJson.
   static Serializer<EndpointListNotificationsResponseApplicationJson> get serializer =>
       _$endpointListNotificationsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointListNotificationsResponseApplicationJsonBuilder b) {
+    $EndpointListNotificationsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointListNotificationsResponseApplicationJsonBuilder b) {
+    $EndpointListNotificationsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EndpointEndpointListNotificationsHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-user-status')
   String? get xNextcloudUserStatus;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointEndpointListNotificationsHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointEndpointListNotificationsHeadersInterfaceBuilder b) {}
 }
 
 abstract class EndpointEndpointListNotificationsHeaders
@@ -1650,6 +1752,16 @@ abstract class EndpointEndpointListNotificationsHeaders
   /// Serializer for EndpointEndpointListNotificationsHeaders.
   static Serializer<EndpointEndpointListNotificationsHeaders> get serializer =>
       _$endpointEndpointListNotificationsHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointEndpointListNotificationsHeadersBuilder b) {
+    $EndpointEndpointListNotificationsHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointEndpointListNotificationsHeadersBuilder b) {
+    $EndpointEndpointListNotificationsHeadersInterface._validate(b);
+  }
 }
 
 class EndpointDeleteAllNotificationsApiVersion extends EnumClass {
@@ -1723,6 +1835,10 @@ class _$EndpointDeleteAllNotificationsApiVersionSerializer
 abstract interface class $EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class EndpointDeleteAllNotificationsResponseApplicationJson_Ocs
@@ -1757,11 +1873,25 @@ abstract class EndpointDeleteAllNotificationsResponseApplicationJson_Ocs
   /// Serializer for EndpointDeleteAllNotificationsResponseApplicationJson_Ocs.
   static Serializer<EndpointDeleteAllNotificationsResponseApplicationJson_Ocs> get serializer =>
       _$endpointDeleteAllNotificationsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder b) {
+    $EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder b) {
+    $EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EndpointDeleteAllNotificationsResponseApplicationJsonInterface {
   EndpointDeleteAllNotificationsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointDeleteAllNotificationsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointDeleteAllNotificationsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class EndpointDeleteAllNotificationsResponseApplicationJson
@@ -1796,6 +1926,16 @@ abstract class EndpointDeleteAllNotificationsResponseApplicationJson
   /// Serializer for EndpointDeleteAllNotificationsResponseApplicationJson.
   static Serializer<EndpointDeleteAllNotificationsResponseApplicationJson> get serializer =>
       _$endpointDeleteAllNotificationsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointDeleteAllNotificationsResponseApplicationJsonBuilder b) {
+    $EndpointDeleteAllNotificationsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointDeleteAllNotificationsResponseApplicationJsonBuilder b) {
+    $EndpointDeleteAllNotificationsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class EndpointGetNotificationApiVersion extends EnumClass {
@@ -1864,6 +2004,10 @@ class _$EndpointGetNotificationApiVersionSerializer implements PrimitiveSerializ
 abstract interface class $EndpointGetNotificationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Notification get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointGetNotificationResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointGetNotificationResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class EndpointGetNotificationResponseApplicationJson_Ocs
@@ -1898,11 +2042,25 @@ abstract class EndpointGetNotificationResponseApplicationJson_Ocs
   /// Serializer for EndpointGetNotificationResponseApplicationJson_Ocs.
   static Serializer<EndpointGetNotificationResponseApplicationJson_Ocs> get serializer =>
       _$endpointGetNotificationResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointGetNotificationResponseApplicationJson_OcsBuilder b) {
+    $EndpointGetNotificationResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointGetNotificationResponseApplicationJson_OcsBuilder b) {
+    $EndpointGetNotificationResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EndpointGetNotificationResponseApplicationJsonInterface {
   EndpointGetNotificationResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointGetNotificationResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointGetNotificationResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class EndpointGetNotificationResponseApplicationJson
@@ -1936,6 +2094,16 @@ abstract class EndpointGetNotificationResponseApplicationJson
   /// Serializer for EndpointGetNotificationResponseApplicationJson.
   static Serializer<EndpointGetNotificationResponseApplicationJson> get serializer =>
       _$endpointGetNotificationResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointGetNotificationResponseApplicationJsonBuilder b) {
+    $EndpointGetNotificationResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointGetNotificationResponseApplicationJsonBuilder b) {
+    $EndpointGetNotificationResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class EndpointDeleteNotificationApiVersion extends EnumClass {
@@ -2008,6 +2176,10 @@ class _$EndpointDeleteNotificationApiVersionSerializer
 abstract interface class $EndpointDeleteNotificationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointDeleteNotificationResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointDeleteNotificationResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class EndpointDeleteNotificationResponseApplicationJson_Ocs
@@ -2042,11 +2214,25 @@ abstract class EndpointDeleteNotificationResponseApplicationJson_Ocs
   /// Serializer for EndpointDeleteNotificationResponseApplicationJson_Ocs.
   static Serializer<EndpointDeleteNotificationResponseApplicationJson_Ocs> get serializer =>
       _$endpointDeleteNotificationResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointDeleteNotificationResponseApplicationJson_OcsBuilder b) {
+    $EndpointDeleteNotificationResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointDeleteNotificationResponseApplicationJson_OcsBuilder b) {
+    $EndpointDeleteNotificationResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EndpointDeleteNotificationResponseApplicationJsonInterface {
   EndpointDeleteNotificationResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointDeleteNotificationResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointDeleteNotificationResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class EndpointDeleteNotificationResponseApplicationJson
@@ -2081,6 +2267,16 @@ abstract class EndpointDeleteNotificationResponseApplicationJson
   /// Serializer for EndpointDeleteNotificationResponseApplicationJson.
   static Serializer<EndpointDeleteNotificationResponseApplicationJson> get serializer =>
       _$endpointDeleteNotificationResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointDeleteNotificationResponseApplicationJsonBuilder b) {
+    $EndpointDeleteNotificationResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointDeleteNotificationResponseApplicationJsonBuilder b) {
+    $EndpointDeleteNotificationResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class EndpointConfirmIdsForUserApiVersion extends EnumClass {
@@ -2151,6 +2347,10 @@ class _$EndpointConfirmIdsForUserApiVersionSerializer
 abstract interface class $EndpointConfirmIdsForUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<int> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointConfirmIdsForUserResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointConfirmIdsForUserResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class EndpointConfirmIdsForUserResponseApplicationJson_Ocs
@@ -2185,11 +2385,25 @@ abstract class EndpointConfirmIdsForUserResponseApplicationJson_Ocs
   /// Serializer for EndpointConfirmIdsForUserResponseApplicationJson_Ocs.
   static Serializer<EndpointConfirmIdsForUserResponseApplicationJson_Ocs> get serializer =>
       _$endpointConfirmIdsForUserResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder b) {
+    $EndpointConfirmIdsForUserResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder b) {
+    $EndpointConfirmIdsForUserResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $EndpointConfirmIdsForUserResponseApplicationJsonInterface {
   EndpointConfirmIdsForUserResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointConfirmIdsForUserResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointConfirmIdsForUserResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class EndpointConfirmIdsForUserResponseApplicationJson
@@ -2224,6 +2438,16 @@ abstract class EndpointConfirmIdsForUserResponseApplicationJson
   /// Serializer for EndpointConfirmIdsForUserResponseApplicationJson.
   static Serializer<EndpointConfirmIdsForUserResponseApplicationJson> get serializer =>
       _$endpointConfirmIdsForUserResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointConfirmIdsForUserResponseApplicationJsonBuilder b) {
+    $EndpointConfirmIdsForUserResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointConfirmIdsForUserResponseApplicationJsonBuilder b) {
+    $EndpointConfirmIdsForUserResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class PushRegisterDeviceApiVersion extends EnumClass {
@@ -2287,6 +2511,10 @@ abstract interface class $PushDeviceInterface {
   String get publicKey;
   String get deviceIdentifier;
   String get signature;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PushDeviceInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PushDeviceInterfaceBuilder b) {}
 }
 
 abstract class PushDevice implements $PushDeviceInterface, Built<PushDevice, PushDeviceBuilder> {
@@ -2313,12 +2541,26 @@ abstract class PushDevice implements $PushDeviceInterface, Built<PushDevice, Pus
 
   /// Serializer for PushDevice.
   static Serializer<PushDevice> get serializer => _$pushDeviceSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PushDeviceBuilder b) {
+    $PushDeviceInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PushDeviceBuilder b) {
+    $PushDeviceInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PushRegisterDeviceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   PushDevice get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PushRegisterDeviceResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PushRegisterDeviceResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PushRegisterDeviceResponseApplicationJson_Ocs
@@ -2352,11 +2594,25 @@ abstract class PushRegisterDeviceResponseApplicationJson_Ocs
   /// Serializer for PushRegisterDeviceResponseApplicationJson_Ocs.
   static Serializer<PushRegisterDeviceResponseApplicationJson_Ocs> get serializer =>
       _$pushRegisterDeviceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PushRegisterDeviceResponseApplicationJson_OcsBuilder b) {
+    $PushRegisterDeviceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PushRegisterDeviceResponseApplicationJson_OcsBuilder b) {
+    $PushRegisterDeviceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PushRegisterDeviceResponseApplicationJsonInterface {
   PushRegisterDeviceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PushRegisterDeviceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PushRegisterDeviceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PushRegisterDeviceResponseApplicationJson
@@ -2390,6 +2646,16 @@ abstract class PushRegisterDeviceResponseApplicationJson
   /// Serializer for PushRegisterDeviceResponseApplicationJson.
   static Serializer<PushRegisterDeviceResponseApplicationJson> get serializer =>
       _$pushRegisterDeviceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PushRegisterDeviceResponseApplicationJsonBuilder b) {
+    $PushRegisterDeviceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PushRegisterDeviceResponseApplicationJsonBuilder b) {
+    $PushRegisterDeviceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class PushRemoveDeviceApiVersion extends EnumClass {
@@ -2452,6 +2718,10 @@ class _$PushRemoveDeviceApiVersionSerializer implements PrimitiveSerializer<Push
 abstract interface class $PushRemoveDeviceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PushRemoveDeviceResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PushRemoveDeviceResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PushRemoveDeviceResponseApplicationJson_Ocs
@@ -2485,11 +2755,25 @@ abstract class PushRemoveDeviceResponseApplicationJson_Ocs
   /// Serializer for PushRemoveDeviceResponseApplicationJson_Ocs.
   static Serializer<PushRemoveDeviceResponseApplicationJson_Ocs> get serializer =>
       _$pushRemoveDeviceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PushRemoveDeviceResponseApplicationJson_OcsBuilder b) {
+    $PushRemoveDeviceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PushRemoveDeviceResponseApplicationJson_OcsBuilder b) {
+    $PushRemoveDeviceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PushRemoveDeviceResponseApplicationJsonInterface {
   PushRemoveDeviceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PushRemoveDeviceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PushRemoveDeviceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PushRemoveDeviceResponseApplicationJson
@@ -2522,6 +2806,16 @@ abstract class PushRemoveDeviceResponseApplicationJson
   /// Serializer for PushRemoveDeviceResponseApplicationJson.
   static Serializer<PushRemoveDeviceResponseApplicationJson> get serializer =>
       _$pushRemoveDeviceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PushRemoveDeviceResponseApplicationJsonBuilder b) {
+    $PushRemoveDeviceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PushRemoveDeviceResponseApplicationJsonBuilder b) {
+    $PushRemoveDeviceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class SettingsPersonalApiVersion extends EnumClass {
@@ -2584,6 +2878,10 @@ class _$SettingsPersonalApiVersionSerializer implements PrimitiveSerializer<Sett
 abstract interface class $SettingsPersonalResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsPersonalResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsPersonalResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class SettingsPersonalResponseApplicationJson_Ocs
@@ -2617,11 +2915,25 @@ abstract class SettingsPersonalResponseApplicationJson_Ocs
   /// Serializer for SettingsPersonalResponseApplicationJson_Ocs.
   static Serializer<SettingsPersonalResponseApplicationJson_Ocs> get serializer =>
       _$settingsPersonalResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsPersonalResponseApplicationJson_OcsBuilder b) {
+    $SettingsPersonalResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsPersonalResponseApplicationJson_OcsBuilder b) {
+    $SettingsPersonalResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SettingsPersonalResponseApplicationJsonInterface {
   SettingsPersonalResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsPersonalResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsPersonalResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class SettingsPersonalResponseApplicationJson
@@ -2654,6 +2966,16 @@ abstract class SettingsPersonalResponseApplicationJson
   /// Serializer for SettingsPersonalResponseApplicationJson.
   static Serializer<SettingsPersonalResponseApplicationJson> get serializer =>
       _$settingsPersonalResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsPersonalResponseApplicationJsonBuilder b) {
+    $SettingsPersonalResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsPersonalResponseApplicationJsonBuilder b) {
+    $SettingsPersonalResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class SettingsAdminApiVersion extends EnumClass {
@@ -2716,6 +3038,10 @@ class _$SettingsAdminApiVersionSerializer implements PrimitiveSerializer<Setting
 abstract interface class $SettingsAdminResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsAdminResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsAdminResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class SettingsAdminResponseApplicationJson_Ocs
@@ -2749,11 +3075,25 @@ abstract class SettingsAdminResponseApplicationJson_Ocs
   /// Serializer for SettingsAdminResponseApplicationJson_Ocs.
   static Serializer<SettingsAdminResponseApplicationJson_Ocs> get serializer =>
       _$settingsAdminResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsAdminResponseApplicationJson_OcsBuilder b) {
+    $SettingsAdminResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsAdminResponseApplicationJson_OcsBuilder b) {
+    $SettingsAdminResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SettingsAdminResponseApplicationJsonInterface {
   SettingsAdminResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsAdminResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsAdminResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class SettingsAdminResponseApplicationJson
@@ -2786,6 +3126,16 @@ abstract class SettingsAdminResponseApplicationJson
   /// Serializer for SettingsAdminResponseApplicationJson.
   static Serializer<SettingsAdminResponseApplicationJson> get serializer =>
       _$settingsAdminResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsAdminResponseApplicationJsonBuilder b) {
+    $SettingsAdminResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsAdminResponseApplicationJsonBuilder b) {
+    $SettingsAdminResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -2795,6 +3145,10 @@ abstract interface class $Capabilities_NotificationsInterface {
   BuiltList<String> get push;
   @BuiltValueField(wireName: 'admin-notifications')
   BuiltList<String> get adminNotifications;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_NotificationsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_NotificationsInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_Notifications
@@ -2826,11 +3180,25 @@ abstract class Capabilities_Notifications
 
   /// Serializer for Capabilities_Notifications.
   static Serializer<Capabilities_Notifications> get serializer => _$capabilitiesNotificationsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_NotificationsBuilder b) {
+    $Capabilities_NotificationsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_NotificationsBuilder b) {
+    $Capabilities_NotificationsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   Capabilities_Notifications get notifications;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -2857,6 +3225,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/notifications.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.g.dart
@@ -1734,7 +1734,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -1764,6 +1766,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -1849,7 +1852,9 @@ class ApiGenerateNotificationResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ApiGenerateNotificationResponseApplicationJson_OcsBuilder();
+  ApiGenerateNotificationResponseApplicationJson_OcsBuilder() {
+    ApiGenerateNotificationResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ApiGenerateNotificationResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1876,6 +1881,7 @@ class ApiGenerateNotificationResponseApplicationJson_OcsBuilder
   ApiGenerateNotificationResponseApplicationJson_Ocs build() => _build();
 
   _$ApiGenerateNotificationResponseApplicationJson_Ocs _build() {
+    ApiGenerateNotificationResponseApplicationJson_Ocs._validate(this);
     _$ApiGenerateNotificationResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -1958,7 +1964,9 @@ class ApiGenerateNotificationResponseApplicationJsonBuilder
       _$this._ocs ??= ApiGenerateNotificationResponseApplicationJson_OcsBuilder();
   set ocs(covariant ApiGenerateNotificationResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ApiGenerateNotificationResponseApplicationJsonBuilder();
+  ApiGenerateNotificationResponseApplicationJsonBuilder() {
+    ApiGenerateNotificationResponseApplicationJson._defaults(this);
+  }
 
   ApiGenerateNotificationResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1984,6 +1992,7 @@ class ApiGenerateNotificationResponseApplicationJsonBuilder
   ApiGenerateNotificationResponseApplicationJson build() => _build();
 
   _$ApiGenerateNotificationResponseApplicationJson _build() {
+    ApiGenerateNotificationResponseApplicationJson._validate(this);
     _$ApiGenerateNotificationResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ApiGenerateNotificationResponseApplicationJson._(ocs: ocs.build());
@@ -2099,7 +2108,9 @@ class NotificationActionBuilder
   bool? get primary => _$this._primary;
   set primary(covariant bool? primary) => _$this._primary = primary;
 
-  NotificationActionBuilder();
+  NotificationActionBuilder() {
+    NotificationAction._defaults(this);
+  }
 
   NotificationActionBuilder get _$this {
     final $v = _$v;
@@ -2128,6 +2139,7 @@ class NotificationActionBuilder
   NotificationAction build() => _build();
 
   _$NotificationAction _build() {
+    NotificationAction._validate(this);
     final _$result = _$v ??
         _$NotificationAction._(
             label: BuiltValueNullFieldError.checkNotNull(label, r'NotificationAction', 'label'),
@@ -2403,7 +2415,9 @@ class NotificationBuilder implements Builder<Notification, NotificationBuilder>,
   bool? get shouldNotify => _$this._shouldNotify;
   set shouldNotify(covariant bool? shouldNotify) => _$this._shouldNotify = shouldNotify;
 
-  NotificationBuilder();
+  NotificationBuilder() {
+    Notification._defaults(this);
+  }
 
   NotificationBuilder get _$this {
     final $v = _$v;
@@ -2444,6 +2458,7 @@ class NotificationBuilder implements Builder<Notification, NotificationBuilder>,
   Notification build() => _build();
 
   _$Notification _build() {
+    Notification._validate(this);
     _$Notification _$result;
     try {
       _$result = _$v ??
@@ -2559,7 +2574,9 @@ class EndpointListNotificationsResponseApplicationJson_OcsBuilder
   ListBuilder<Notification> get data => _$this._data ??= ListBuilder<Notification>();
   set data(covariant ListBuilder<Notification>? data) => _$this._data = data;
 
-  EndpointListNotificationsResponseApplicationJson_OcsBuilder();
+  EndpointListNotificationsResponseApplicationJson_OcsBuilder() {
+    EndpointListNotificationsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   EndpointListNotificationsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2586,6 +2603,7 @@ class EndpointListNotificationsResponseApplicationJson_OcsBuilder
   EndpointListNotificationsResponseApplicationJson_Ocs build() => _build();
 
   _$EndpointListNotificationsResponseApplicationJson_Ocs _build() {
+    EndpointListNotificationsResponseApplicationJson_Ocs._validate(this);
     _$EndpointListNotificationsResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -2669,7 +2687,9 @@ class EndpointListNotificationsResponseApplicationJsonBuilder
       _$this._ocs ??= EndpointListNotificationsResponseApplicationJson_OcsBuilder();
   set ocs(covariant EndpointListNotificationsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  EndpointListNotificationsResponseApplicationJsonBuilder();
+  EndpointListNotificationsResponseApplicationJsonBuilder() {
+    EndpointListNotificationsResponseApplicationJson._defaults(this);
+  }
 
   EndpointListNotificationsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -2695,6 +2715,7 @@ class EndpointListNotificationsResponseApplicationJsonBuilder
   EndpointListNotificationsResponseApplicationJson build() => _build();
 
   _$EndpointListNotificationsResponseApplicationJson _build() {
+    EndpointListNotificationsResponseApplicationJson._validate(this);
     _$EndpointListNotificationsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$EndpointListNotificationsResponseApplicationJson._(ocs: ocs.build());
@@ -2773,7 +2794,9 @@ class EndpointEndpointListNotificationsHeadersBuilder
   set xNextcloudUserStatus(covariant String? xNextcloudUserStatus) =>
       _$this._xNextcloudUserStatus = xNextcloudUserStatus;
 
-  EndpointEndpointListNotificationsHeadersBuilder();
+  EndpointEndpointListNotificationsHeadersBuilder() {
+    EndpointEndpointListNotificationsHeaders._defaults(this);
+  }
 
   EndpointEndpointListNotificationsHeadersBuilder get _$this {
     final $v = _$v;
@@ -2799,6 +2822,7 @@ class EndpointEndpointListNotificationsHeadersBuilder
   EndpointEndpointListNotificationsHeaders build() => _build();
 
   _$EndpointEndpointListNotificationsHeaders _build() {
+    EndpointEndpointListNotificationsHeaders._validate(this);
     final _$result = _$v ?? _$EndpointEndpointListNotificationsHeaders._(xNextcloudUserStatus: xNextcloudUserStatus);
     replace(_$result);
     return _$result;
@@ -2881,7 +2905,9 @@ class EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder();
+  EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder() {
+    EndpointDeleteAllNotificationsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2908,6 +2934,7 @@ class EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder
   EndpointDeleteAllNotificationsResponseApplicationJson_Ocs build() => _build();
 
   _$EndpointDeleteAllNotificationsResponseApplicationJson_Ocs _build() {
+    EndpointDeleteAllNotificationsResponseApplicationJson_Ocs._validate(this);
     _$EndpointDeleteAllNotificationsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -2993,7 +3020,9 @@ class EndpointDeleteAllNotificationsResponseApplicationJsonBuilder
       _$this._ocs ??= EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder();
   set ocs(covariant EndpointDeleteAllNotificationsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  EndpointDeleteAllNotificationsResponseApplicationJsonBuilder();
+  EndpointDeleteAllNotificationsResponseApplicationJsonBuilder() {
+    EndpointDeleteAllNotificationsResponseApplicationJson._defaults(this);
+  }
 
   EndpointDeleteAllNotificationsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3019,6 +3048,7 @@ class EndpointDeleteAllNotificationsResponseApplicationJsonBuilder
   EndpointDeleteAllNotificationsResponseApplicationJson build() => _build();
 
   _$EndpointDeleteAllNotificationsResponseApplicationJson _build() {
+    EndpointDeleteAllNotificationsResponseApplicationJson._validate(this);
     _$EndpointDeleteAllNotificationsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$EndpointDeleteAllNotificationsResponseApplicationJson._(ocs: ocs.build());
@@ -3111,7 +3141,9 @@ class EndpointGetNotificationResponseApplicationJson_OcsBuilder
   NotificationBuilder get data => _$this._data ??= NotificationBuilder();
   set data(covariant NotificationBuilder? data) => _$this._data = data;
 
-  EndpointGetNotificationResponseApplicationJson_OcsBuilder();
+  EndpointGetNotificationResponseApplicationJson_OcsBuilder() {
+    EndpointGetNotificationResponseApplicationJson_Ocs._defaults(this);
+  }
 
   EndpointGetNotificationResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3138,6 +3170,7 @@ class EndpointGetNotificationResponseApplicationJson_OcsBuilder
   EndpointGetNotificationResponseApplicationJson_Ocs build() => _build();
 
   _$EndpointGetNotificationResponseApplicationJson_Ocs _build() {
+    EndpointGetNotificationResponseApplicationJson_Ocs._validate(this);
     _$EndpointGetNotificationResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$EndpointGetNotificationResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -3218,7 +3251,9 @@ class EndpointGetNotificationResponseApplicationJsonBuilder
       _$this._ocs ??= EndpointGetNotificationResponseApplicationJson_OcsBuilder();
   set ocs(covariant EndpointGetNotificationResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  EndpointGetNotificationResponseApplicationJsonBuilder();
+  EndpointGetNotificationResponseApplicationJsonBuilder() {
+    EndpointGetNotificationResponseApplicationJson._defaults(this);
+  }
 
   EndpointGetNotificationResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3244,6 +3279,7 @@ class EndpointGetNotificationResponseApplicationJsonBuilder
   EndpointGetNotificationResponseApplicationJson build() => _build();
 
   _$EndpointGetNotificationResponseApplicationJson _build() {
+    EndpointGetNotificationResponseApplicationJson._validate(this);
     _$EndpointGetNotificationResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$EndpointGetNotificationResponseApplicationJson._(ocs: ocs.build());
@@ -3337,7 +3373,9 @@ class EndpointDeleteNotificationResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  EndpointDeleteNotificationResponseApplicationJson_OcsBuilder();
+  EndpointDeleteNotificationResponseApplicationJson_OcsBuilder() {
+    EndpointDeleteNotificationResponseApplicationJson_Ocs._defaults(this);
+  }
 
   EndpointDeleteNotificationResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3364,6 +3402,7 @@ class EndpointDeleteNotificationResponseApplicationJson_OcsBuilder
   EndpointDeleteNotificationResponseApplicationJson_Ocs build() => _build();
 
   _$EndpointDeleteNotificationResponseApplicationJson_Ocs _build() {
+    EndpointDeleteNotificationResponseApplicationJson_Ocs._validate(this);
     _$EndpointDeleteNotificationResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -3448,7 +3487,9 @@ class EndpointDeleteNotificationResponseApplicationJsonBuilder
       _$this._ocs ??= EndpointDeleteNotificationResponseApplicationJson_OcsBuilder();
   set ocs(covariant EndpointDeleteNotificationResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  EndpointDeleteNotificationResponseApplicationJsonBuilder();
+  EndpointDeleteNotificationResponseApplicationJsonBuilder() {
+    EndpointDeleteNotificationResponseApplicationJson._defaults(this);
+  }
 
   EndpointDeleteNotificationResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3474,6 +3515,7 @@ class EndpointDeleteNotificationResponseApplicationJsonBuilder
   EndpointDeleteNotificationResponseApplicationJson build() => _build();
 
   _$EndpointDeleteNotificationResponseApplicationJson _build() {
+    EndpointDeleteNotificationResponseApplicationJson._validate(this);
     _$EndpointDeleteNotificationResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$EndpointDeleteNotificationResponseApplicationJson._(ocs: ocs.build());
@@ -3567,7 +3609,9 @@ class EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder
   ListBuilder<int> get data => _$this._data ??= ListBuilder<int>();
   set data(covariant ListBuilder<int>? data) => _$this._data = data;
 
-  EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder();
+  EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder() {
+    EndpointConfirmIdsForUserResponseApplicationJson_Ocs._defaults(this);
+  }
 
   EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3594,6 +3638,7 @@ class EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder
   EndpointConfirmIdsForUserResponseApplicationJson_Ocs build() => _build();
 
   _$EndpointConfirmIdsForUserResponseApplicationJson_Ocs _build() {
+    EndpointConfirmIdsForUserResponseApplicationJson_Ocs._validate(this);
     _$EndpointConfirmIdsForUserResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -3677,7 +3722,9 @@ class EndpointConfirmIdsForUserResponseApplicationJsonBuilder
       _$this._ocs ??= EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder();
   set ocs(covariant EndpointConfirmIdsForUserResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  EndpointConfirmIdsForUserResponseApplicationJsonBuilder();
+  EndpointConfirmIdsForUserResponseApplicationJsonBuilder() {
+    EndpointConfirmIdsForUserResponseApplicationJson._defaults(this);
+  }
 
   EndpointConfirmIdsForUserResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3703,6 +3750,7 @@ class EndpointConfirmIdsForUserResponseApplicationJsonBuilder
   EndpointConfirmIdsForUserResponseApplicationJson build() => _build();
 
   _$EndpointConfirmIdsForUserResponseApplicationJson _build() {
+    EndpointConfirmIdsForUserResponseApplicationJson._validate(this);
     _$EndpointConfirmIdsForUserResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$EndpointConfirmIdsForUserResponseApplicationJson._(ocs: ocs.build());
@@ -3801,7 +3849,9 @@ class PushDeviceBuilder implements Builder<PushDevice, PushDeviceBuilder>, $Push
   String? get signature => _$this._signature;
   set signature(covariant String? signature) => _$this._signature = signature;
 
-  PushDeviceBuilder();
+  PushDeviceBuilder() {
+    PushDevice._defaults(this);
+  }
 
   PushDeviceBuilder get _$this {
     final $v = _$v;
@@ -3829,6 +3879,7 @@ class PushDeviceBuilder implements Builder<PushDevice, PushDeviceBuilder>, $Push
   PushDevice build() => _build();
 
   _$PushDevice _build() {
+    PushDevice._validate(this);
     final _$result = _$v ??
         _$PushDevice._(
             publicKey: BuiltValueNullFieldError.checkNotNull(publicKey, r'PushDevice', 'publicKey'),
@@ -3912,7 +3963,9 @@ class PushRegisterDeviceResponseApplicationJson_OcsBuilder
   PushDeviceBuilder get data => _$this._data ??= PushDeviceBuilder();
   set data(covariant PushDeviceBuilder? data) => _$this._data = data;
 
-  PushRegisterDeviceResponseApplicationJson_OcsBuilder();
+  PushRegisterDeviceResponseApplicationJson_OcsBuilder() {
+    PushRegisterDeviceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PushRegisterDeviceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3939,6 +3992,7 @@ class PushRegisterDeviceResponseApplicationJson_OcsBuilder
   PushRegisterDeviceResponseApplicationJson_Ocs build() => _build();
 
   _$PushRegisterDeviceResponseApplicationJson_Ocs _build() {
+    PushRegisterDeviceResponseApplicationJson_Ocs._validate(this);
     _$PushRegisterDeviceResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$PushRegisterDeviceResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -4018,7 +4072,9 @@ class PushRegisterDeviceResponseApplicationJsonBuilder
       _$this._ocs ??= PushRegisterDeviceResponseApplicationJson_OcsBuilder();
   set ocs(covariant PushRegisterDeviceResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PushRegisterDeviceResponseApplicationJsonBuilder();
+  PushRegisterDeviceResponseApplicationJsonBuilder() {
+    PushRegisterDeviceResponseApplicationJson._defaults(this);
+  }
 
   PushRegisterDeviceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -4044,6 +4100,7 @@ class PushRegisterDeviceResponseApplicationJsonBuilder
   PushRegisterDeviceResponseApplicationJson build() => _build();
 
   _$PushRegisterDeviceResponseApplicationJson _build() {
+    PushRegisterDeviceResponseApplicationJson._validate(this);
     _$PushRegisterDeviceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PushRegisterDeviceResponseApplicationJson._(ocs: ocs.build());
@@ -4134,7 +4191,9 @@ class PushRemoveDeviceResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  PushRemoveDeviceResponseApplicationJson_OcsBuilder();
+  PushRemoveDeviceResponseApplicationJson_OcsBuilder() {
+    PushRemoveDeviceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PushRemoveDeviceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -4161,6 +4220,7 @@ class PushRemoveDeviceResponseApplicationJson_OcsBuilder
   PushRemoveDeviceResponseApplicationJson_Ocs build() => _build();
 
   _$PushRemoveDeviceResponseApplicationJson_Ocs _build() {
+    PushRemoveDeviceResponseApplicationJson_Ocs._validate(this);
     _$PushRemoveDeviceResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -4242,7 +4302,9 @@ class PushRemoveDeviceResponseApplicationJsonBuilder
       _$this._ocs ??= PushRemoveDeviceResponseApplicationJson_OcsBuilder();
   set ocs(covariant PushRemoveDeviceResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PushRemoveDeviceResponseApplicationJsonBuilder();
+  PushRemoveDeviceResponseApplicationJsonBuilder() {
+    PushRemoveDeviceResponseApplicationJson._defaults(this);
+  }
 
   PushRemoveDeviceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -4268,6 +4330,7 @@ class PushRemoveDeviceResponseApplicationJsonBuilder
   PushRemoveDeviceResponseApplicationJson build() => _build();
 
   _$PushRemoveDeviceResponseApplicationJson _build() {
+    PushRemoveDeviceResponseApplicationJson._validate(this);
     _$PushRemoveDeviceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PushRemoveDeviceResponseApplicationJson._(ocs: ocs.build());
@@ -4358,7 +4421,9 @@ class SettingsPersonalResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  SettingsPersonalResponseApplicationJson_OcsBuilder();
+  SettingsPersonalResponseApplicationJson_OcsBuilder() {
+    SettingsPersonalResponseApplicationJson_Ocs._defaults(this);
+  }
 
   SettingsPersonalResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -4385,6 +4450,7 @@ class SettingsPersonalResponseApplicationJson_OcsBuilder
   SettingsPersonalResponseApplicationJson_Ocs build() => _build();
 
   _$SettingsPersonalResponseApplicationJson_Ocs _build() {
+    SettingsPersonalResponseApplicationJson_Ocs._validate(this);
     _$SettingsPersonalResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -4466,7 +4532,9 @@ class SettingsPersonalResponseApplicationJsonBuilder
       _$this._ocs ??= SettingsPersonalResponseApplicationJson_OcsBuilder();
   set ocs(covariant SettingsPersonalResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  SettingsPersonalResponseApplicationJsonBuilder();
+  SettingsPersonalResponseApplicationJsonBuilder() {
+    SettingsPersonalResponseApplicationJson._defaults(this);
+  }
 
   SettingsPersonalResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -4492,6 +4560,7 @@ class SettingsPersonalResponseApplicationJsonBuilder
   SettingsPersonalResponseApplicationJson build() => _build();
 
   _$SettingsPersonalResponseApplicationJson _build() {
+    SettingsPersonalResponseApplicationJson._validate(this);
     _$SettingsPersonalResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$SettingsPersonalResponseApplicationJson._(ocs: ocs.build());
@@ -4582,7 +4651,9 @@ class SettingsAdminResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  SettingsAdminResponseApplicationJson_OcsBuilder();
+  SettingsAdminResponseApplicationJson_OcsBuilder() {
+    SettingsAdminResponseApplicationJson_Ocs._defaults(this);
+  }
 
   SettingsAdminResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -4609,6 +4680,7 @@ class SettingsAdminResponseApplicationJson_OcsBuilder
   SettingsAdminResponseApplicationJson_Ocs build() => _build();
 
   _$SettingsAdminResponseApplicationJson_Ocs _build() {
+    SettingsAdminResponseApplicationJson_Ocs._validate(this);
     _$SettingsAdminResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -4688,7 +4760,9 @@ class SettingsAdminResponseApplicationJsonBuilder
       _$this._ocs ??= SettingsAdminResponseApplicationJson_OcsBuilder();
   set ocs(covariant SettingsAdminResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  SettingsAdminResponseApplicationJsonBuilder();
+  SettingsAdminResponseApplicationJsonBuilder() {
+    SettingsAdminResponseApplicationJson._defaults(this);
+  }
 
   SettingsAdminResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -4714,6 +4788,7 @@ class SettingsAdminResponseApplicationJsonBuilder
   SettingsAdminResponseApplicationJson build() => _build();
 
   _$SettingsAdminResponseApplicationJson _build() {
+    SettingsAdminResponseApplicationJson._validate(this);
     _$SettingsAdminResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$SettingsAdminResponseApplicationJson._(ocs: ocs.build());
@@ -4818,7 +4893,9 @@ class Capabilities_NotificationsBuilder
   set adminNotifications(covariant ListBuilder<String>? adminNotifications) =>
       _$this._adminNotifications = adminNotifications;
 
-  Capabilities_NotificationsBuilder();
+  Capabilities_NotificationsBuilder() {
+    Capabilities_Notifications._defaults(this);
+  }
 
   Capabilities_NotificationsBuilder get _$this {
     final $v = _$v;
@@ -4846,6 +4923,7 @@ class Capabilities_NotificationsBuilder
   Capabilities_Notifications build() => _build();
 
   _$Capabilities_Notifications _build() {
+    Capabilities_Notifications._validate(this);
     _$Capabilities_Notifications _$result;
     try {
       _$result = _$v ??
@@ -4922,7 +5000,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   set notifications(covariant Capabilities_NotificationsBuilder? notifications) =>
       _$this._notifications = notifications;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -4948,6 +5028,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(notifications: notifications.build());

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -4120,6 +4120,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -4146,11 +4150,25 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppConfigGetAppsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppConfigGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppConfigGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class AppConfigGetAppsResponseApplicationJson_Ocs_Data
@@ -4185,12 +4203,26 @@ abstract class AppConfigGetAppsResponseApplicationJson_Ocs_Data
   /// Serializer for AppConfigGetAppsResponseApplicationJson_Ocs_Data.
   static Serializer<AppConfigGetAppsResponseApplicationJson_Ocs_Data> get serializer =>
       _$appConfigGetAppsResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder b) {
+    $AppConfigGetAppsResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder b) {
+    $AppConfigGetAppsResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppConfigGetAppsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppConfigGetAppsResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppConfigGetAppsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppConfigGetAppsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AppConfigGetAppsResponseApplicationJson_Ocs
@@ -4224,11 +4256,25 @@ abstract class AppConfigGetAppsResponseApplicationJson_Ocs
   /// Serializer for AppConfigGetAppsResponseApplicationJson_Ocs.
   static Serializer<AppConfigGetAppsResponseApplicationJson_Ocs> get serializer =>
       _$appConfigGetAppsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppConfigGetAppsResponseApplicationJson_OcsBuilder b) {
+    $AppConfigGetAppsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppConfigGetAppsResponseApplicationJson_OcsBuilder b) {
+    $AppConfigGetAppsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppConfigGetAppsResponseApplicationJsonInterface {
   AppConfigGetAppsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppConfigGetAppsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppConfigGetAppsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AppConfigGetAppsResponseApplicationJson
@@ -4261,11 +4307,25 @@ abstract class AppConfigGetAppsResponseApplicationJson
   /// Serializer for AppConfigGetAppsResponseApplicationJson.
   static Serializer<AppConfigGetAppsResponseApplicationJson> get serializer =>
       _$appConfigGetAppsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppConfigGetAppsResponseApplicationJsonBuilder b) {
+    $AppConfigGetAppsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppConfigGetAppsResponseApplicationJsonBuilder b) {
+    $AppConfigGetAppsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppConfigGetKeysResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppConfigGetKeysResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppConfigGetKeysResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class AppConfigGetKeysResponseApplicationJson_Ocs_Data
@@ -4300,12 +4360,26 @@ abstract class AppConfigGetKeysResponseApplicationJson_Ocs_Data
   /// Serializer for AppConfigGetKeysResponseApplicationJson_Ocs_Data.
   static Serializer<AppConfigGetKeysResponseApplicationJson_Ocs_Data> get serializer =>
       _$appConfigGetKeysResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder b) {
+    $AppConfigGetKeysResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder b) {
+    $AppConfigGetKeysResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppConfigGetKeysResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppConfigGetKeysResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppConfigGetKeysResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppConfigGetKeysResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AppConfigGetKeysResponseApplicationJson_Ocs
@@ -4339,11 +4413,25 @@ abstract class AppConfigGetKeysResponseApplicationJson_Ocs
   /// Serializer for AppConfigGetKeysResponseApplicationJson_Ocs.
   static Serializer<AppConfigGetKeysResponseApplicationJson_Ocs> get serializer =>
       _$appConfigGetKeysResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppConfigGetKeysResponseApplicationJson_OcsBuilder b) {
+    $AppConfigGetKeysResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppConfigGetKeysResponseApplicationJson_OcsBuilder b) {
+    $AppConfigGetKeysResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppConfigGetKeysResponseApplicationJsonInterface {
   AppConfigGetKeysResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppConfigGetKeysResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppConfigGetKeysResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AppConfigGetKeysResponseApplicationJson
@@ -4376,12 +4464,26 @@ abstract class AppConfigGetKeysResponseApplicationJson
   /// Serializer for AppConfigGetKeysResponseApplicationJson.
   static Serializer<AppConfigGetKeysResponseApplicationJson> get serializer =>
       _$appConfigGetKeysResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppConfigGetKeysResponseApplicationJsonBuilder b) {
+    $AppConfigGetKeysResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppConfigGetKeysResponseApplicationJsonBuilder b) {
+    $AppConfigGetKeysResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppConfigSetValueResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppConfigSetValueResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppConfigSetValueResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AppConfigSetValueResponseApplicationJson_Ocs
@@ -4415,11 +4517,25 @@ abstract class AppConfigSetValueResponseApplicationJson_Ocs
   /// Serializer for AppConfigSetValueResponseApplicationJson_Ocs.
   static Serializer<AppConfigSetValueResponseApplicationJson_Ocs> get serializer =>
       _$appConfigSetValueResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppConfigSetValueResponseApplicationJson_OcsBuilder b) {
+    $AppConfigSetValueResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppConfigSetValueResponseApplicationJson_OcsBuilder b) {
+    $AppConfigSetValueResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppConfigSetValueResponseApplicationJsonInterface {
   AppConfigSetValueResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppConfigSetValueResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppConfigSetValueResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AppConfigSetValueResponseApplicationJson
@@ -4453,11 +4569,25 @@ abstract class AppConfigSetValueResponseApplicationJson
   /// Serializer for AppConfigSetValueResponseApplicationJson.
   static Serializer<AppConfigSetValueResponseApplicationJson> get serializer =>
       _$appConfigSetValueResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppConfigSetValueResponseApplicationJsonBuilder b) {
+    $AppConfigSetValueResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppConfigSetValueResponseApplicationJsonBuilder b) {
+    $AppConfigSetValueResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppsGetAppsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get apps;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppsGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppsGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class AppsGetAppsResponseApplicationJson_Ocs_Data
@@ -4491,12 +4621,26 @@ abstract class AppsGetAppsResponseApplicationJson_Ocs_Data
   /// Serializer for AppsGetAppsResponseApplicationJson_Ocs_Data.
   static Serializer<AppsGetAppsResponseApplicationJson_Ocs_Data> get serializer =>
       _$appsGetAppsResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppsGetAppsResponseApplicationJson_Ocs_DataBuilder b) {
+    $AppsGetAppsResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppsGetAppsResponseApplicationJson_Ocs_DataBuilder b) {
+    $AppsGetAppsResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppsGetAppsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppsGetAppsResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppsGetAppsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppsGetAppsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AppsGetAppsResponseApplicationJson_Ocs
@@ -4529,11 +4673,25 @@ abstract class AppsGetAppsResponseApplicationJson_Ocs
   /// Serializer for AppsGetAppsResponseApplicationJson_Ocs.
   static Serializer<AppsGetAppsResponseApplicationJson_Ocs> get serializer =>
       _$appsGetAppsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppsGetAppsResponseApplicationJson_OcsBuilder b) {
+    $AppsGetAppsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppsGetAppsResponseApplicationJson_OcsBuilder b) {
+    $AppsGetAppsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppsGetAppsResponseApplicationJsonInterface {
   AppsGetAppsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppsGetAppsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppsGetAppsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AppsGetAppsResponseApplicationJson
@@ -4566,12 +4724,26 @@ abstract class AppsGetAppsResponseApplicationJson
   /// Serializer for AppsGetAppsResponseApplicationJson.
   static Serializer<AppsGetAppsResponseApplicationJson> get serializer =>
       _$appsGetAppsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppsGetAppsResponseApplicationJsonBuilder b) {
+    $AppsGetAppsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppsGetAppsResponseApplicationJsonBuilder b) {
+    $AppsGetAppsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppsGetAppInfoResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, JsonObject> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppsGetAppInfoResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppsGetAppInfoResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AppsGetAppInfoResponseApplicationJson_Ocs
@@ -4605,11 +4777,25 @@ abstract class AppsGetAppInfoResponseApplicationJson_Ocs
   /// Serializer for AppsGetAppInfoResponseApplicationJson_Ocs.
   static Serializer<AppsGetAppInfoResponseApplicationJson_Ocs> get serializer =>
       _$appsGetAppInfoResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppsGetAppInfoResponseApplicationJson_OcsBuilder b) {
+    $AppsGetAppInfoResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppsGetAppInfoResponseApplicationJson_OcsBuilder b) {
+    $AppsGetAppInfoResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppsGetAppInfoResponseApplicationJsonInterface {
   AppsGetAppInfoResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppsGetAppInfoResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppsGetAppInfoResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AppsGetAppInfoResponseApplicationJson
@@ -4642,12 +4828,26 @@ abstract class AppsGetAppInfoResponseApplicationJson
   /// Serializer for AppsGetAppInfoResponseApplicationJson.
   static Serializer<AppsGetAppInfoResponseApplicationJson> get serializer =>
       _$appsGetAppInfoResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppsGetAppInfoResponseApplicationJsonBuilder b) {
+    $AppsGetAppInfoResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppsGetAppInfoResponseApplicationJsonBuilder b) {
+    $AppsGetAppInfoResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppsEnableResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppsEnableResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppsEnableResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AppsEnableResponseApplicationJson_Ocs
@@ -4680,11 +4880,25 @@ abstract class AppsEnableResponseApplicationJson_Ocs
   /// Serializer for AppsEnableResponseApplicationJson_Ocs.
   static Serializer<AppsEnableResponseApplicationJson_Ocs> get serializer =>
       _$appsEnableResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppsEnableResponseApplicationJson_OcsBuilder b) {
+    $AppsEnableResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppsEnableResponseApplicationJson_OcsBuilder b) {
+    $AppsEnableResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppsEnableResponseApplicationJsonInterface {
   AppsEnableResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppsEnableResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppsEnableResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AppsEnableResponseApplicationJson
@@ -4716,12 +4930,26 @@ abstract class AppsEnableResponseApplicationJson
 
   /// Serializer for AppsEnableResponseApplicationJson.
   static Serializer<AppsEnableResponseApplicationJson> get serializer => _$appsEnableResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppsEnableResponseApplicationJsonBuilder b) {
+    $AppsEnableResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppsEnableResponseApplicationJsonBuilder b) {
+    $AppsEnableResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppsDisableResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppsDisableResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppsDisableResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AppsDisableResponseApplicationJson_Ocs
@@ -4754,11 +4982,25 @@ abstract class AppsDisableResponseApplicationJson_Ocs
   /// Serializer for AppsDisableResponseApplicationJson_Ocs.
   static Serializer<AppsDisableResponseApplicationJson_Ocs> get serializer =>
       _$appsDisableResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppsDisableResponseApplicationJson_OcsBuilder b) {
+    $AppsDisableResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppsDisableResponseApplicationJson_OcsBuilder b) {
+    $AppsDisableResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppsDisableResponseApplicationJsonInterface {
   AppsDisableResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppsDisableResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppsDisableResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AppsDisableResponseApplicationJson
@@ -4791,12 +5033,26 @@ abstract class AppsDisableResponseApplicationJson
   /// Serializer for AppsDisableResponseApplicationJson.
   static Serializer<AppsDisableResponseApplicationJson> get serializer =>
       _$appsDisableResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppsDisableResponseApplicationJsonBuilder b) {
+    $AppsDisableResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppsDisableResponseApplicationJsonBuilder b) {
+    $AppsDisableResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<String> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs
@@ -4831,11 +5087,25 @@ abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs
   /// Serializer for GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs.
   static Serializer<GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs> get serializer =>
       _$groupsGetSubAdminsOfGroupResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetSubAdminsOfGroupResponseApplicationJsonInterface {
   GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetSubAdminsOfGroupResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetSubAdminsOfGroupResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson
@@ -4870,11 +5140,25 @@ abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson
   /// Serializer for GroupsGetSubAdminsOfGroupResponseApplicationJson.
   static Serializer<GroupsGetSubAdminsOfGroupResponseApplicationJson> get serializer =>
       _$groupsGetSubAdminsOfGroupResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder b) {
+    $GroupsGetSubAdminsOfGroupResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder b) {
+    $GroupsGetSubAdminsOfGroupResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get groups;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupsResponseApplicationJson_Ocs_Data
@@ -4908,12 +5192,26 @@ abstract class GroupsGetGroupsResponseApplicationJson_Ocs_Data
   /// Serializer for GroupsGetGroupsResponseApplicationJson_Ocs_Data.
   static Serializer<GroupsGetGroupsResponseApplicationJson_Ocs_Data> get serializer =>
       _$groupsGetGroupsResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder b) {
+    $GroupsGetGroupsResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder b) {
+    $GroupsGetGroupsResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   GroupsGetGroupsResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupsResponseApplicationJson_Ocs
@@ -4947,11 +5245,25 @@ abstract class GroupsGetGroupsResponseApplicationJson_Ocs
   /// Serializer for GroupsGetGroupsResponseApplicationJson_Ocs.
   static Serializer<GroupsGetGroupsResponseApplicationJson_Ocs> get serializer =>
       _$groupsGetGroupsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupsResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetGroupsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupsResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetGroupsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupsResponseApplicationJsonInterface {
   GroupsGetGroupsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupsResponseApplicationJson
@@ -4984,11 +5296,25 @@ abstract class GroupsGetGroupsResponseApplicationJson
   /// Serializer for GroupsGetGroupsResponseApplicationJson.
   static Serializer<GroupsGetGroupsResponseApplicationJson> get serializer =>
       _$groupsGetGroupsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupsResponseApplicationJsonBuilder b) {
+    $GroupsGetGroupsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupsResponseApplicationJsonBuilder b) {
+    $GroupsGetGroupsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get users;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupResponseApplicationJson_Ocs_Data
@@ -5022,12 +5348,26 @@ abstract class GroupsGetGroupResponseApplicationJson_Ocs_Data
   /// Serializer for GroupsGetGroupResponseApplicationJson_Ocs_Data.
   static Serializer<GroupsGetGroupResponseApplicationJson_Ocs_Data> get serializer =>
       _$groupsGetGroupResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder b) {
+    $GroupsGetGroupResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder b) {
+    $GroupsGetGroupResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   GroupsGetGroupResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupResponseApplicationJson_Ocs
@@ -5061,11 +5401,25 @@ abstract class GroupsGetGroupResponseApplicationJson_Ocs
   /// Serializer for GroupsGetGroupResponseApplicationJson_Ocs.
   static Serializer<GroupsGetGroupResponseApplicationJson_Ocs> get serializer =>
       _$groupsGetGroupResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetGroupResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetGroupResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupResponseApplicationJsonInterface {
   GroupsGetGroupResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupResponseApplicationJson
@@ -5098,6 +5452,16 @@ abstract class GroupsGetGroupResponseApplicationJson
   /// Serializer for GroupsGetGroupResponseApplicationJson.
   static Serializer<GroupsGetGroupResponseApplicationJson> get serializer =>
       _$groupsGetGroupResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupResponseApplicationJsonBuilder b) {
+    $GroupsGetGroupResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupResponseApplicationJsonBuilder b) {
+    $GroupsGetGroupResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 typedef GroupDetails_Usercount = ({bool? $bool, int? $int});
@@ -5111,6 +5475,13 @@ abstract interface class $GroupDetailsInterface {
   GroupDetails_Disabled get disabled;
   bool get canAdd;
   bool get canRemove;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupDetailsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupDetailsInterfaceBuilder b) {
+    b.usercount?.validateOneOf();
+    b.disabled?.validateOneOf();
+  }
 }
 
 abstract class GroupDetails implements $GroupDetailsInterface, Built<GroupDetails, GroupDetailsBuilder> {
@@ -5138,16 +5509,24 @@ abstract class GroupDetails implements $GroupDetailsInterface, Built<GroupDetail
   /// Serializer for GroupDetails.
   static Serializer<GroupDetails> get serializer => _$groupDetailsSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupDetailsBuilder b) {
+    $GroupDetailsInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(GroupDetailsBuilder b) {
-    b.usercount?.validateOneOf();
-    b.disabled?.validateOneOf();
+    $GroupDetailsInterface._validate(b);
   }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<GroupDetails> get groups;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data
@@ -5182,12 +5561,26 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data
   /// Serializer for GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data.
   static Serializer<GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data> get serializer =>
       _$groupsGetGroupsDetailsResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder b) {
+    $GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder b) {
+    $GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupsDetailsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupsDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupsDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupsDetailsResponseApplicationJson_Ocs
@@ -5222,11 +5615,25 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson_Ocs
   /// Serializer for GroupsGetGroupsDetailsResponseApplicationJson_Ocs.
   static Serializer<GroupsGetGroupsDetailsResponseApplicationJson_Ocs> get serializer =>
       _$groupsGetGroupsDetailsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetGroupsDetailsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetGroupsDetailsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupsDetailsResponseApplicationJsonInterface {
   GroupsGetGroupsDetailsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupsDetailsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupsDetailsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupsDetailsResponseApplicationJson
@@ -5260,11 +5667,25 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson
   /// Serializer for GroupsGetGroupsDetailsResponseApplicationJson.
   static Serializer<GroupsGetGroupsDetailsResponseApplicationJson> get serializer =>
       _$groupsGetGroupsDetailsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupsDetailsResponseApplicationJsonBuilder b) {
+    $GroupsGetGroupsDetailsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupsDetailsResponseApplicationJsonBuilder b) {
+    $GroupsGetGroupsDetailsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get users;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupUsersResponseApplicationJson_Ocs_Data
@@ -5299,12 +5720,26 @@ abstract class GroupsGetGroupUsersResponseApplicationJson_Ocs_Data
   /// Serializer for GroupsGetGroupUsersResponseApplicationJson_Ocs_Data.
   static Serializer<GroupsGetGroupUsersResponseApplicationJson_Ocs_Data> get serializer =>
       _$groupsGetGroupUsersResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder b) {
+    $GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder b) {
+    $GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupUsersResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   GroupsGetGroupUsersResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupUsersResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupUsersResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupUsersResponseApplicationJson_Ocs
@@ -5338,11 +5773,25 @@ abstract class GroupsGetGroupUsersResponseApplicationJson_Ocs
   /// Serializer for GroupsGetGroupUsersResponseApplicationJson_Ocs.
   static Serializer<GroupsGetGroupUsersResponseApplicationJson_Ocs> get serializer =>
       _$groupsGetGroupUsersResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupUsersResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetGroupUsersResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupUsersResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetGroupUsersResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupUsersResponseApplicationJsonInterface {
   GroupsGetGroupUsersResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupUsersResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupUsersResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupUsersResponseApplicationJson
@@ -5376,12 +5825,26 @@ abstract class GroupsGetGroupUsersResponseApplicationJson
   /// Serializer for GroupsGetGroupUsersResponseApplicationJson.
   static Serializer<GroupsGetGroupUsersResponseApplicationJson> get serializer =>
       _$groupsGetGroupUsersResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupUsersResponseApplicationJsonBuilder b) {
+    $GroupsGetGroupUsersResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupUsersResponseApplicationJsonBuilder b) {
+    $GroupsGetGroupUsersResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserDetails_BackendCapabilitiesInterface {
   bool get setDisplayName;
   bool get setPassword;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserDetails_BackendCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserDetails_BackendCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class UserDetails_BackendCapabilities
@@ -5413,6 +5876,16 @@ abstract class UserDetails_BackendCapabilities
 
   /// Serializer for UserDetails_BackendCapabilities.
   static Serializer<UserDetails_BackendCapabilities> get serializer => _$userDetailsBackendCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserDetails_BackendCapabilitiesBuilder b) {
+    $UserDetails_BackendCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserDetails_BackendCapabilitiesBuilder b) {
+    $UserDetails_BackendCapabilitiesInterface._validate(b);
+  }
 }
 
 typedef UserDetailsQuota_Quota = ({num? $num, String? string});
@@ -5424,6 +5897,12 @@ abstract interface class $UserDetailsQuotaInterface {
   num get relative;
   num get total;
   num get used;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserDetailsQuotaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserDetailsQuotaInterfaceBuilder b) {
+    b.quota?.validateOneOf();
+  }
 }
 
 abstract class UserDetailsQuota
@@ -5452,9 +5931,14 @@ abstract class UserDetailsQuota
   /// Serializer for UserDetailsQuota.
   static Serializer<UserDetailsQuota> get serializer => _$userDetailsQuotaSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserDetailsQuotaBuilder b) {
+    $UserDetailsQuotaInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UserDetailsQuotaBuilder b) {
-    b.quota?.validateOneOf();
+    $UserDetailsQuotaInterface._validate(b);
   }
 }
 
@@ -5507,6 +5991,10 @@ abstract interface class $UserDetailsInterface {
   String? get twitterScope;
   String get website;
   String? get websiteScope;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserDetailsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserDetailsInterfaceBuilder b) {}
 }
 
 abstract class UserDetails implements $UserDetailsInterface, Built<UserDetails, UserDetailsBuilder> {
@@ -5533,11 +6021,25 @@ abstract class UserDetails implements $UserDetailsInterface, Built<UserDetails, 
 
   /// Serializer for UserDetails.
   static Serializer<UserDetails> get serializer => _$userDetailsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserDetailsBuilder b) {
+    $UserDetailsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserDetailsBuilder b) {
+    $UserDetailsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface {
   String get id;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1
@@ -5572,6 +6074,16 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1
   /// Serializer for GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1.
   static Serializer<GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1> get serializer =>
       _$groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataUsers1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder b) {
+    $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder b) {
+    $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface._validate(b);
+  }
 }
 
 typedef GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users = ({
@@ -5582,6 +6094,10 @@ typedef GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users = ({
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users> get users;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data
@@ -5616,12 +6132,26 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data
   /// Serializer for GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data.
   static Serializer<GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data> get serializer =>
       _$groupsGetGroupUsersDetailsResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder b) {
+    $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder b) {
+    $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs
@@ -5656,11 +6186,25 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs
   /// Serializer for GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs.
   static Serializer<GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs> get serializer =>
       _$groupsGetGroupUsersDetailsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder b) {
+    $GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GroupsGetGroupUsersDetailsResponseApplicationJsonInterface {
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupUsersDetailsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupUsersDetailsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class GroupsGetGroupUsersDetailsResponseApplicationJson
@@ -5695,12 +6239,26 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson
   /// Serializer for GroupsGetGroupUsersDetailsResponseApplicationJson.
   static Serializer<GroupsGetGroupUsersDetailsResponseApplicationJson> get serializer =>
       _$groupsGetGroupUsersDetailsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder b) {
+    $GroupsGetGroupUsersDetailsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder b) {
+    $GroupsGetGroupUsersDetailsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PreferencesSetPreferenceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesSetPreferenceResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesSetPreferenceResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PreferencesSetPreferenceResponseApplicationJson_Ocs
@@ -5735,11 +6293,25 @@ abstract class PreferencesSetPreferenceResponseApplicationJson_Ocs
   /// Serializer for PreferencesSetPreferenceResponseApplicationJson_Ocs.
   static Serializer<PreferencesSetPreferenceResponseApplicationJson_Ocs> get serializer =>
       _$preferencesSetPreferenceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesSetPreferenceResponseApplicationJson_OcsBuilder b) {
+    $PreferencesSetPreferenceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesSetPreferenceResponseApplicationJson_OcsBuilder b) {
+    $PreferencesSetPreferenceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PreferencesSetPreferenceResponseApplicationJsonInterface {
   PreferencesSetPreferenceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesSetPreferenceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesSetPreferenceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PreferencesSetPreferenceResponseApplicationJson
@@ -5773,12 +6345,26 @@ abstract class PreferencesSetPreferenceResponseApplicationJson
   /// Serializer for PreferencesSetPreferenceResponseApplicationJson.
   static Serializer<PreferencesSetPreferenceResponseApplicationJson> get serializer =>
       _$preferencesSetPreferenceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesSetPreferenceResponseApplicationJsonBuilder b) {
+    $PreferencesSetPreferenceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesSetPreferenceResponseApplicationJsonBuilder b) {
+    $PreferencesSetPreferenceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PreferencesDeletePreferenceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesDeletePreferenceResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesDeletePreferenceResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PreferencesDeletePreferenceResponseApplicationJson_Ocs
@@ -5813,11 +6399,25 @@ abstract class PreferencesDeletePreferenceResponseApplicationJson_Ocs
   /// Serializer for PreferencesDeletePreferenceResponseApplicationJson_Ocs.
   static Serializer<PreferencesDeletePreferenceResponseApplicationJson_Ocs> get serializer =>
       _$preferencesDeletePreferenceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder b) {
+    $PreferencesDeletePreferenceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder b) {
+    $PreferencesDeletePreferenceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PreferencesDeletePreferenceResponseApplicationJsonInterface {
   PreferencesDeletePreferenceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesDeletePreferenceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesDeletePreferenceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PreferencesDeletePreferenceResponseApplicationJson
@@ -5852,12 +6452,26 @@ abstract class PreferencesDeletePreferenceResponseApplicationJson
   /// Serializer for PreferencesDeletePreferenceResponseApplicationJson.
   static Serializer<PreferencesDeletePreferenceResponseApplicationJson> get serializer =>
       _$preferencesDeletePreferenceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesDeletePreferenceResponseApplicationJsonBuilder b) {
+    $PreferencesDeletePreferenceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesDeletePreferenceResponseApplicationJsonBuilder b) {
+    $PreferencesDeletePreferenceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs
@@ -5892,11 +6506,25 @@ abstract class PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs
   /// Serializer for PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs.
   static Serializer<PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs> get serializer =>
       _$preferencesSetMultiplePreferencesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder b) {
+    $PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder b) {
+    $PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PreferencesSetMultiplePreferencesResponseApplicationJsonInterface {
   PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesSetMultiplePreferencesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesSetMultiplePreferencesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PreferencesSetMultiplePreferencesResponseApplicationJson
@@ -5931,12 +6559,26 @@ abstract class PreferencesSetMultiplePreferencesResponseApplicationJson
   /// Serializer for PreferencesSetMultiplePreferencesResponseApplicationJson.
   static Serializer<PreferencesSetMultiplePreferencesResponseApplicationJson> get serializer =>
       _$preferencesSetMultiplePreferencesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder b) {
+    $PreferencesSetMultiplePreferencesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder b) {
+    $PreferencesSetMultiplePreferencesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs
@@ -5971,11 +6613,25 @@ abstract class PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs
   /// Serializer for PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs.
   static Serializer<PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs> get serializer =>
       _$preferencesDeleteMultiplePreferenceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder b) {
+    $PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder b) {
+    $PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterface {
   PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PreferencesDeleteMultiplePreferenceResponseApplicationJson
@@ -6010,12 +6666,26 @@ abstract class PreferencesDeleteMultiplePreferenceResponseApplicationJson
   /// Serializer for PreferencesDeleteMultiplePreferenceResponseApplicationJson.
   static Serializer<PreferencesDeleteMultiplePreferenceResponseApplicationJson> get serializer =>
       _$preferencesDeleteMultiplePreferenceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder b) {
+    $PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder b) {
+    $PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<String> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs
@@ -6050,11 +6720,25 @@ abstract class UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs
   /// Serializer for UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs.
   static Serializer<UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs> get serializer =>
       _$usersGetUserSubAdminGroupsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder b) {
+    $UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder b) {
+    $UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUserSubAdminGroupsResponseApplicationJsonInterface {
   UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUserSubAdminGroupsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUserSubAdminGroupsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUserSubAdminGroupsResponseApplicationJson
@@ -6089,12 +6773,26 @@ abstract class UsersGetUserSubAdminGroupsResponseApplicationJson
   /// Serializer for UsersGetUserSubAdminGroupsResponseApplicationJson.
   static Serializer<UsersGetUserSubAdminGroupsResponseApplicationJson> get serializer =>
       _$usersGetUserSubAdminGroupsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder b) {
+    $UsersGetUserSubAdminGroupsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder b) {
+    $UsersGetUserSubAdminGroupsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersAddSubAdminResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersAddSubAdminResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersAddSubAdminResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersAddSubAdminResponseApplicationJson_Ocs
@@ -6128,11 +6826,25 @@ abstract class UsersAddSubAdminResponseApplicationJson_Ocs
   /// Serializer for UsersAddSubAdminResponseApplicationJson_Ocs.
   static Serializer<UsersAddSubAdminResponseApplicationJson_Ocs> get serializer =>
       _$usersAddSubAdminResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersAddSubAdminResponseApplicationJson_OcsBuilder b) {
+    $UsersAddSubAdminResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersAddSubAdminResponseApplicationJson_OcsBuilder b) {
+    $UsersAddSubAdminResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersAddSubAdminResponseApplicationJsonInterface {
   UsersAddSubAdminResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersAddSubAdminResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersAddSubAdminResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersAddSubAdminResponseApplicationJson
@@ -6165,12 +6877,26 @@ abstract class UsersAddSubAdminResponseApplicationJson
   /// Serializer for UsersAddSubAdminResponseApplicationJson.
   static Serializer<UsersAddSubAdminResponseApplicationJson> get serializer =>
       _$usersAddSubAdminResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersAddSubAdminResponseApplicationJsonBuilder b) {
+    $UsersAddSubAdminResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersAddSubAdminResponseApplicationJsonBuilder b) {
+    $UsersAddSubAdminResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersRemoveSubAdminResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersRemoveSubAdminResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersRemoveSubAdminResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersRemoveSubAdminResponseApplicationJson_Ocs
@@ -6204,11 +6930,25 @@ abstract class UsersRemoveSubAdminResponseApplicationJson_Ocs
   /// Serializer for UsersRemoveSubAdminResponseApplicationJson_Ocs.
   static Serializer<UsersRemoveSubAdminResponseApplicationJson_Ocs> get serializer =>
       _$usersRemoveSubAdminResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersRemoveSubAdminResponseApplicationJson_OcsBuilder b) {
+    $UsersRemoveSubAdminResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersRemoveSubAdminResponseApplicationJson_OcsBuilder b) {
+    $UsersRemoveSubAdminResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersRemoveSubAdminResponseApplicationJsonInterface {
   UsersRemoveSubAdminResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersRemoveSubAdminResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersRemoveSubAdminResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersRemoveSubAdminResponseApplicationJson
@@ -6242,11 +6982,25 @@ abstract class UsersRemoveSubAdminResponseApplicationJson
   /// Serializer for UsersRemoveSubAdminResponseApplicationJson.
   static Serializer<UsersRemoveSubAdminResponseApplicationJson> get serializer =>
       _$usersRemoveSubAdminResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersRemoveSubAdminResponseApplicationJsonBuilder b) {
+    $UsersRemoveSubAdminResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersRemoveSubAdminResponseApplicationJsonBuilder b) {
+    $UsersRemoveSubAdminResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUsersResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get users;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUsersResponseApplicationJson_Ocs_Data
@@ -6280,12 +7034,26 @@ abstract class UsersGetUsersResponseApplicationJson_Ocs_Data
   /// Serializer for UsersGetUsersResponseApplicationJson_Ocs_Data.
   static Serializer<UsersGetUsersResponseApplicationJson_Ocs_Data> get serializer =>
       _$usersGetUsersResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersResponseApplicationJson_Ocs_DataBuilder b) {
+    $UsersGetUsersResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersResponseApplicationJson_Ocs_DataBuilder b) {
+    $UsersGetUsersResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUsersResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UsersGetUsersResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUsersResponseApplicationJson_Ocs
@@ -6319,11 +7087,25 @@ abstract class UsersGetUsersResponseApplicationJson_Ocs
   /// Serializer for UsersGetUsersResponseApplicationJson_Ocs.
   static Serializer<UsersGetUsersResponseApplicationJson_Ocs> get serializer =>
       _$usersGetUsersResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersResponseApplicationJson_OcsBuilder b) {
+    $UsersGetUsersResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersResponseApplicationJson_OcsBuilder b) {
+    $UsersGetUsersResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUsersResponseApplicationJsonInterface {
   UsersGetUsersResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUsersResponseApplicationJson
@@ -6356,11 +7138,25 @@ abstract class UsersGetUsersResponseApplicationJson
   /// Serializer for UsersGetUsersResponseApplicationJson.
   static Serializer<UsersGetUsersResponseApplicationJson> get serializer =>
       _$usersGetUsersResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersResponseApplicationJsonBuilder b) {
+    $UsersGetUsersResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersResponseApplicationJsonBuilder b) {
+    $UsersGetUsersResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersAddUserResponseApplicationJson_Ocs_DataInterface {
   String get id;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersAddUserResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersAddUserResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class UsersAddUserResponseApplicationJson_Ocs_Data
@@ -6394,12 +7190,26 @@ abstract class UsersAddUserResponseApplicationJson_Ocs_Data
   /// Serializer for UsersAddUserResponseApplicationJson_Ocs_Data.
   static Serializer<UsersAddUserResponseApplicationJson_Ocs_Data> get serializer =>
       _$usersAddUserResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersAddUserResponseApplicationJson_Ocs_DataBuilder b) {
+    $UsersAddUserResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersAddUserResponseApplicationJson_Ocs_DataBuilder b) {
+    $UsersAddUserResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersAddUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UsersAddUserResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersAddUserResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersAddUserResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersAddUserResponseApplicationJson_Ocs
@@ -6432,11 +7242,25 @@ abstract class UsersAddUserResponseApplicationJson_Ocs
   /// Serializer for UsersAddUserResponseApplicationJson_Ocs.
   static Serializer<UsersAddUserResponseApplicationJson_Ocs> get serializer =>
       _$usersAddUserResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersAddUserResponseApplicationJson_OcsBuilder b) {
+    $UsersAddUserResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersAddUserResponseApplicationJson_OcsBuilder b) {
+    $UsersAddUserResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersAddUserResponseApplicationJsonInterface {
   UsersAddUserResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersAddUserResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersAddUserResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersAddUserResponseApplicationJson
@@ -6469,11 +7293,25 @@ abstract class UsersAddUserResponseApplicationJson
   /// Serializer for UsersAddUserResponseApplicationJson.
   static Serializer<UsersAddUserResponseApplicationJson> get serializer =>
       _$usersAddUserResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersAddUserResponseApplicationJsonBuilder b) {
+    $UsersAddUserResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersAddUserResponseApplicationJsonBuilder b) {
+    $UsersAddUserResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface {
   String get id;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder b) {}
 }
 
 abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1
@@ -6508,6 +7346,16 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1
   /// Serializer for UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1.
   static Serializer<UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1> get serializer =>
       _$usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder b) {
+    $UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder b) {
+    $UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface._validate(b);
+  }
 }
 
 typedef UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users = ({
@@ -6518,6 +7366,10 @@ typedef UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users = ({
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users> get users;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data
@@ -6552,12 +7404,26 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data
   /// Serializer for UsersGetUsersDetailsResponseApplicationJson_Ocs_Data.
   static Serializer<UsersGetUsersDetailsResponseApplicationJson_Ocs_Data> get serializer =>
       _$usersGetUsersDetailsResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder b) {
+    $UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder b) {
+    $UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUsersDetailsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UsersGetUsersDetailsResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs
@@ -6591,11 +7457,25 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs
   /// Serializer for UsersGetUsersDetailsResponseApplicationJson_Ocs.
   static Serializer<UsersGetUsersDetailsResponseApplicationJson_Ocs> get serializer =>
       _$usersGetUsersDetailsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersDetailsResponseApplicationJson_OcsBuilder b) {
+    $UsersGetUsersDetailsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersDetailsResponseApplicationJson_OcsBuilder b) {
+    $UsersGetUsersDetailsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUsersDetailsResponseApplicationJsonInterface {
   UsersGetUsersDetailsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersDetailsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersDetailsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUsersDetailsResponseApplicationJson
@@ -6629,11 +7509,25 @@ abstract class UsersGetUsersDetailsResponseApplicationJson
   /// Serializer for UsersGetUsersDetailsResponseApplicationJson.
   static Serializer<UsersGetUsersDetailsResponseApplicationJson> get serializer =>
       _$usersGetUsersDetailsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersDetailsResponseApplicationJsonBuilder b) {
+    $UsersGetUsersDetailsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersDetailsResponseApplicationJsonBuilder b) {
+    $UsersGetUsersDetailsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface {
   String get id;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder b) {}
 }
 
 abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1
@@ -6668,6 +7562,16 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_User
   /// Serializer for UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1.
   static Serializer<UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1> get serializer =>
       _$usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder b) {
+    $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder b) {
+    $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface._validate(b);
+  }
 }
 
 typedef UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users = ({
@@ -6678,6 +7582,10 @@ typedef UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users = ({
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users> get users;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data
@@ -6712,12 +7620,26 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data
   /// Serializer for UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data.
   static Serializer<UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data> get serializer =>
       _$usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder b) {
+    $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder b) {
+    $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs
@@ -6752,11 +7674,25 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs
   /// Serializer for UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs.
   static Serializer<UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs> get serializer =>
       _$usersGetDisabledUsersDetailsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder b) {
+    $UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder b) {
+    $UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetDisabledUsersDetailsResponseApplicationJsonInterface {
   UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetDisabledUsersDetailsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetDisabledUsersDetailsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersGetDisabledUsersDetailsResponseApplicationJson
@@ -6791,12 +7727,26 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson
   /// Serializer for UsersGetDisabledUsersDetailsResponseApplicationJson.
   static Serializer<UsersGetDisabledUsersDetailsResponseApplicationJson> get serializer =>
       _$usersGetDisabledUsersDetailsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder b) {
+    $UsersGetDisabledUsersDetailsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder b) {
+    $UsersGetDisabledUsersDetailsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, String> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersSearchByPhoneNumbersResponseApplicationJson_Ocs
@@ -6831,11 +7781,25 @@ abstract class UsersSearchByPhoneNumbersResponseApplicationJson_Ocs
   /// Serializer for UsersSearchByPhoneNumbersResponseApplicationJson_Ocs.
   static Serializer<UsersSearchByPhoneNumbersResponseApplicationJson_Ocs> get serializer =>
       _$usersSearchByPhoneNumbersResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder b) {
+    $UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder b) {
+    $UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersSearchByPhoneNumbersResponseApplicationJsonInterface {
   UsersSearchByPhoneNumbersResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersSearchByPhoneNumbersResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersSearchByPhoneNumbersResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersSearchByPhoneNumbersResponseApplicationJson
@@ -6870,12 +7834,26 @@ abstract class UsersSearchByPhoneNumbersResponseApplicationJson
   /// Serializer for UsersSearchByPhoneNumbersResponseApplicationJson.
   static Serializer<UsersSearchByPhoneNumbersResponseApplicationJson> get serializer =>
       _$usersSearchByPhoneNumbersResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersSearchByPhoneNumbersResponseApplicationJsonBuilder b) {
+    $UsersSearchByPhoneNumbersResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersSearchByPhoneNumbersResponseApplicationJsonBuilder b) {
+    $UsersSearchByPhoneNumbersResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UserDetails get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUserResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUserResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUserResponseApplicationJson_Ocs
@@ -6908,11 +7886,25 @@ abstract class UsersGetUserResponseApplicationJson_Ocs
   /// Serializer for UsersGetUserResponseApplicationJson_Ocs.
   static Serializer<UsersGetUserResponseApplicationJson_Ocs> get serializer =>
       _$usersGetUserResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUserResponseApplicationJson_OcsBuilder b) {
+    $UsersGetUserResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUserResponseApplicationJson_OcsBuilder b) {
+    $UsersGetUserResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUserResponseApplicationJsonInterface {
   UsersGetUserResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUserResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUserResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUserResponseApplicationJson
@@ -6945,12 +7937,26 @@ abstract class UsersGetUserResponseApplicationJson
   /// Serializer for UsersGetUserResponseApplicationJson.
   static Serializer<UsersGetUserResponseApplicationJson> get serializer =>
       _$usersGetUserResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUserResponseApplicationJsonBuilder b) {
+    $UsersGetUserResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUserResponseApplicationJsonBuilder b) {
+    $UsersGetUserResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersEditUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersEditUserResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersEditUserResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersEditUserResponseApplicationJson_Ocs
@@ -6984,11 +7990,25 @@ abstract class UsersEditUserResponseApplicationJson_Ocs
   /// Serializer for UsersEditUserResponseApplicationJson_Ocs.
   static Serializer<UsersEditUserResponseApplicationJson_Ocs> get serializer =>
       _$usersEditUserResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersEditUserResponseApplicationJson_OcsBuilder b) {
+    $UsersEditUserResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersEditUserResponseApplicationJson_OcsBuilder b) {
+    $UsersEditUserResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersEditUserResponseApplicationJsonInterface {
   UsersEditUserResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersEditUserResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersEditUserResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersEditUserResponseApplicationJson
@@ -7021,12 +8041,26 @@ abstract class UsersEditUserResponseApplicationJson
   /// Serializer for UsersEditUserResponseApplicationJson.
   static Serializer<UsersEditUserResponseApplicationJson> get serializer =>
       _$usersEditUserResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersEditUserResponseApplicationJsonBuilder b) {
+    $UsersEditUserResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersEditUserResponseApplicationJsonBuilder b) {
+    $UsersEditUserResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersDeleteUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersDeleteUserResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersDeleteUserResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersDeleteUserResponseApplicationJson_Ocs
@@ -7060,11 +8094,25 @@ abstract class UsersDeleteUserResponseApplicationJson_Ocs
   /// Serializer for UsersDeleteUserResponseApplicationJson_Ocs.
   static Serializer<UsersDeleteUserResponseApplicationJson_Ocs> get serializer =>
       _$usersDeleteUserResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersDeleteUserResponseApplicationJson_OcsBuilder b) {
+    $UsersDeleteUserResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersDeleteUserResponseApplicationJson_OcsBuilder b) {
+    $UsersDeleteUserResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersDeleteUserResponseApplicationJsonInterface {
   UsersDeleteUserResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersDeleteUserResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersDeleteUserResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersDeleteUserResponseApplicationJson
@@ -7097,12 +8145,26 @@ abstract class UsersDeleteUserResponseApplicationJson
   /// Serializer for UsersDeleteUserResponseApplicationJson.
   static Serializer<UsersDeleteUserResponseApplicationJson> get serializer =>
       _$usersDeleteUserResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersDeleteUserResponseApplicationJsonBuilder b) {
+    $UsersDeleteUserResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersDeleteUserResponseApplicationJsonBuilder b) {
+    $UsersDeleteUserResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetCurrentUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UserDetails get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetCurrentUserResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetCurrentUserResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersGetCurrentUserResponseApplicationJson_Ocs
@@ -7136,11 +8198,25 @@ abstract class UsersGetCurrentUserResponseApplicationJson_Ocs
   /// Serializer for UsersGetCurrentUserResponseApplicationJson_Ocs.
   static Serializer<UsersGetCurrentUserResponseApplicationJson_Ocs> get serializer =>
       _$usersGetCurrentUserResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetCurrentUserResponseApplicationJson_OcsBuilder b) {
+    $UsersGetCurrentUserResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetCurrentUserResponseApplicationJson_OcsBuilder b) {
+    $UsersGetCurrentUserResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetCurrentUserResponseApplicationJsonInterface {
   UsersGetCurrentUserResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetCurrentUserResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetCurrentUserResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersGetCurrentUserResponseApplicationJson
@@ -7174,12 +8250,26 @@ abstract class UsersGetCurrentUserResponseApplicationJson
   /// Serializer for UsersGetCurrentUserResponseApplicationJson.
   static Serializer<UsersGetCurrentUserResponseApplicationJson> get serializer =>
       _$usersGetCurrentUserResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetCurrentUserResponseApplicationJsonBuilder b) {
+    $UsersGetCurrentUserResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetCurrentUserResponseApplicationJsonBuilder b) {
+    $UsersGetCurrentUserResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetEditableFieldsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<String> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetEditableFieldsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetEditableFieldsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersGetEditableFieldsResponseApplicationJson_Ocs
@@ -7214,11 +8304,25 @@ abstract class UsersGetEditableFieldsResponseApplicationJson_Ocs
   /// Serializer for UsersGetEditableFieldsResponseApplicationJson_Ocs.
   static Serializer<UsersGetEditableFieldsResponseApplicationJson_Ocs> get serializer =>
       _$usersGetEditableFieldsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetEditableFieldsResponseApplicationJson_OcsBuilder b) {
+    $UsersGetEditableFieldsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetEditableFieldsResponseApplicationJson_OcsBuilder b) {
+    $UsersGetEditableFieldsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetEditableFieldsResponseApplicationJsonInterface {
   UsersGetEditableFieldsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetEditableFieldsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetEditableFieldsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersGetEditableFieldsResponseApplicationJson
@@ -7252,12 +8356,26 @@ abstract class UsersGetEditableFieldsResponseApplicationJson
   /// Serializer for UsersGetEditableFieldsResponseApplicationJson.
   static Serializer<UsersGetEditableFieldsResponseApplicationJson> get serializer =>
       _$usersGetEditableFieldsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetEditableFieldsResponseApplicationJsonBuilder b) {
+    $UsersGetEditableFieldsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetEditableFieldsResponseApplicationJsonBuilder b) {
+    $UsersGetEditableFieldsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<String> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersGetEditableFieldsForUserResponseApplicationJson_Ocs
@@ -7292,11 +8410,25 @@ abstract class UsersGetEditableFieldsForUserResponseApplicationJson_Ocs
   /// Serializer for UsersGetEditableFieldsForUserResponseApplicationJson_Ocs.
   static Serializer<UsersGetEditableFieldsForUserResponseApplicationJson_Ocs> get serializer =>
       _$usersGetEditableFieldsForUserResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder b) {
+    $UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder b) {
+    $UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetEditableFieldsForUserResponseApplicationJsonInterface {
   UsersGetEditableFieldsForUserResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetEditableFieldsForUserResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetEditableFieldsForUserResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersGetEditableFieldsForUserResponseApplicationJson
@@ -7331,12 +8463,26 @@ abstract class UsersGetEditableFieldsForUserResponseApplicationJson
   /// Serializer for UsersGetEditableFieldsForUserResponseApplicationJson.
   static Serializer<UsersGetEditableFieldsForUserResponseApplicationJson> get serializer =>
       _$usersGetEditableFieldsForUserResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetEditableFieldsForUserResponseApplicationJsonBuilder b) {
+    $UsersGetEditableFieldsForUserResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetEditableFieldsForUserResponseApplicationJsonBuilder b) {
+    $UsersGetEditableFieldsForUserResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersEditUserMultiValueResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersEditUserMultiValueResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersEditUserMultiValueResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersEditUserMultiValueResponseApplicationJson_Ocs
@@ -7371,11 +8517,25 @@ abstract class UsersEditUserMultiValueResponseApplicationJson_Ocs
   /// Serializer for UsersEditUserMultiValueResponseApplicationJson_Ocs.
   static Serializer<UsersEditUserMultiValueResponseApplicationJson_Ocs> get serializer =>
       _$usersEditUserMultiValueResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersEditUserMultiValueResponseApplicationJson_OcsBuilder b) {
+    $UsersEditUserMultiValueResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersEditUserMultiValueResponseApplicationJson_OcsBuilder b) {
+    $UsersEditUserMultiValueResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersEditUserMultiValueResponseApplicationJsonInterface {
   UsersEditUserMultiValueResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersEditUserMultiValueResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersEditUserMultiValueResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersEditUserMultiValueResponseApplicationJson
@@ -7409,12 +8569,26 @@ abstract class UsersEditUserMultiValueResponseApplicationJson
   /// Serializer for UsersEditUserMultiValueResponseApplicationJson.
   static Serializer<UsersEditUserMultiValueResponseApplicationJson> get serializer =>
       _$usersEditUserMultiValueResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersEditUserMultiValueResponseApplicationJsonBuilder b) {
+    $UsersEditUserMultiValueResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersEditUserMultiValueResponseApplicationJsonBuilder b) {
+    $UsersEditUserMultiValueResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersWipeUserDevicesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersWipeUserDevicesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersWipeUserDevicesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersWipeUserDevicesResponseApplicationJson_Ocs
@@ -7448,11 +8622,25 @@ abstract class UsersWipeUserDevicesResponseApplicationJson_Ocs
   /// Serializer for UsersWipeUserDevicesResponseApplicationJson_Ocs.
   static Serializer<UsersWipeUserDevicesResponseApplicationJson_Ocs> get serializer =>
       _$usersWipeUserDevicesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersWipeUserDevicesResponseApplicationJson_OcsBuilder b) {
+    $UsersWipeUserDevicesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersWipeUserDevicesResponseApplicationJson_OcsBuilder b) {
+    $UsersWipeUserDevicesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersWipeUserDevicesResponseApplicationJsonInterface {
   UsersWipeUserDevicesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersWipeUserDevicesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersWipeUserDevicesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersWipeUserDevicesResponseApplicationJson
@@ -7486,12 +8674,26 @@ abstract class UsersWipeUserDevicesResponseApplicationJson
   /// Serializer for UsersWipeUserDevicesResponseApplicationJson.
   static Serializer<UsersWipeUserDevicesResponseApplicationJson> get serializer =>
       _$usersWipeUserDevicesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersWipeUserDevicesResponseApplicationJsonBuilder b) {
+    $UsersWipeUserDevicesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersWipeUserDevicesResponseApplicationJsonBuilder b) {
+    $UsersWipeUserDevicesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersEnableUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersEnableUserResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersEnableUserResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersEnableUserResponseApplicationJson_Ocs
@@ -7525,11 +8727,25 @@ abstract class UsersEnableUserResponseApplicationJson_Ocs
   /// Serializer for UsersEnableUserResponseApplicationJson_Ocs.
   static Serializer<UsersEnableUserResponseApplicationJson_Ocs> get serializer =>
       _$usersEnableUserResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersEnableUserResponseApplicationJson_OcsBuilder b) {
+    $UsersEnableUserResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersEnableUserResponseApplicationJson_OcsBuilder b) {
+    $UsersEnableUserResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersEnableUserResponseApplicationJsonInterface {
   UsersEnableUserResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersEnableUserResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersEnableUserResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersEnableUserResponseApplicationJson
@@ -7562,12 +8778,26 @@ abstract class UsersEnableUserResponseApplicationJson
   /// Serializer for UsersEnableUserResponseApplicationJson.
   static Serializer<UsersEnableUserResponseApplicationJson> get serializer =>
       _$usersEnableUserResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersEnableUserResponseApplicationJsonBuilder b) {
+    $UsersEnableUserResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersEnableUserResponseApplicationJsonBuilder b) {
+    $UsersEnableUserResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersDisableUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersDisableUserResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersDisableUserResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersDisableUserResponseApplicationJson_Ocs
@@ -7601,11 +8831,25 @@ abstract class UsersDisableUserResponseApplicationJson_Ocs
   /// Serializer for UsersDisableUserResponseApplicationJson_Ocs.
   static Serializer<UsersDisableUserResponseApplicationJson_Ocs> get serializer =>
       _$usersDisableUserResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersDisableUserResponseApplicationJson_OcsBuilder b) {
+    $UsersDisableUserResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersDisableUserResponseApplicationJson_OcsBuilder b) {
+    $UsersDisableUserResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersDisableUserResponseApplicationJsonInterface {
   UsersDisableUserResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersDisableUserResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersDisableUserResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersDisableUserResponseApplicationJson
@@ -7638,11 +8882,25 @@ abstract class UsersDisableUserResponseApplicationJson
   /// Serializer for UsersDisableUserResponseApplicationJson.
   static Serializer<UsersDisableUserResponseApplicationJson> get serializer =>
       _$usersDisableUserResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersDisableUserResponseApplicationJsonBuilder b) {
+    $UsersDisableUserResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersDisableUserResponseApplicationJsonBuilder b) {
+    $UsersDisableUserResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get groups;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUsersGroupsResponseApplicationJson_Ocs_Data
@@ -7677,12 +8935,26 @@ abstract class UsersGetUsersGroupsResponseApplicationJson_Ocs_Data
   /// Serializer for UsersGetUsersGroupsResponseApplicationJson_Ocs_Data.
   static Serializer<UsersGetUsersGroupsResponseApplicationJson_Ocs_Data> get serializer =>
       _$usersGetUsersGroupsResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder b) {
+    $UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder b) {
+    $UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUsersGroupsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UsersGetUsersGroupsResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersGroupsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersGroupsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUsersGroupsResponseApplicationJson_Ocs
@@ -7716,11 +8988,25 @@ abstract class UsersGetUsersGroupsResponseApplicationJson_Ocs
   /// Serializer for UsersGetUsersGroupsResponseApplicationJson_Ocs.
   static Serializer<UsersGetUsersGroupsResponseApplicationJson_Ocs> get serializer =>
       _$usersGetUsersGroupsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersGroupsResponseApplicationJson_OcsBuilder b) {
+    $UsersGetUsersGroupsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersGroupsResponseApplicationJson_OcsBuilder b) {
+    $UsersGetUsersGroupsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersGetUsersGroupsResponseApplicationJsonInterface {
   UsersGetUsersGroupsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersGroupsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersGroupsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersGetUsersGroupsResponseApplicationJson
@@ -7754,12 +9040,26 @@ abstract class UsersGetUsersGroupsResponseApplicationJson
   /// Serializer for UsersGetUsersGroupsResponseApplicationJson.
   static Serializer<UsersGetUsersGroupsResponseApplicationJson> get serializer =>
       _$usersGetUsersGroupsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersGroupsResponseApplicationJsonBuilder b) {
+    $UsersGetUsersGroupsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersGroupsResponseApplicationJsonBuilder b) {
+    $UsersGetUsersGroupsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersAddToGroupResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersAddToGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersAddToGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersAddToGroupResponseApplicationJson_Ocs
@@ -7793,11 +9093,25 @@ abstract class UsersAddToGroupResponseApplicationJson_Ocs
   /// Serializer for UsersAddToGroupResponseApplicationJson_Ocs.
   static Serializer<UsersAddToGroupResponseApplicationJson_Ocs> get serializer =>
       _$usersAddToGroupResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersAddToGroupResponseApplicationJson_OcsBuilder b) {
+    $UsersAddToGroupResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersAddToGroupResponseApplicationJson_OcsBuilder b) {
+    $UsersAddToGroupResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersAddToGroupResponseApplicationJsonInterface {
   UsersAddToGroupResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersAddToGroupResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersAddToGroupResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersAddToGroupResponseApplicationJson
@@ -7830,12 +9144,26 @@ abstract class UsersAddToGroupResponseApplicationJson
   /// Serializer for UsersAddToGroupResponseApplicationJson.
   static Serializer<UsersAddToGroupResponseApplicationJson> get serializer =>
       _$usersAddToGroupResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersAddToGroupResponseApplicationJsonBuilder b) {
+    $UsersAddToGroupResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersAddToGroupResponseApplicationJsonBuilder b) {
+    $UsersAddToGroupResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersRemoveFromGroupResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersRemoveFromGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersRemoveFromGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersRemoveFromGroupResponseApplicationJson_Ocs
@@ -7869,11 +9197,25 @@ abstract class UsersRemoveFromGroupResponseApplicationJson_Ocs
   /// Serializer for UsersRemoveFromGroupResponseApplicationJson_Ocs.
   static Serializer<UsersRemoveFromGroupResponseApplicationJson_Ocs> get serializer =>
       _$usersRemoveFromGroupResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersRemoveFromGroupResponseApplicationJson_OcsBuilder b) {
+    $UsersRemoveFromGroupResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersRemoveFromGroupResponseApplicationJson_OcsBuilder b) {
+    $UsersRemoveFromGroupResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersRemoveFromGroupResponseApplicationJsonInterface {
   UsersRemoveFromGroupResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersRemoveFromGroupResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersRemoveFromGroupResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersRemoveFromGroupResponseApplicationJson
@@ -7907,12 +9249,26 @@ abstract class UsersRemoveFromGroupResponseApplicationJson
   /// Serializer for UsersRemoveFromGroupResponseApplicationJson.
   static Serializer<UsersRemoveFromGroupResponseApplicationJson> get serializer =>
       _$usersRemoveFromGroupResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersRemoveFromGroupResponseApplicationJsonBuilder b) {
+    $UsersRemoveFromGroupResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersRemoveFromGroupResponseApplicationJsonBuilder b) {
+    $UsersRemoveFromGroupResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersResendWelcomeMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersResendWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersResendWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UsersResendWelcomeMessageResponseApplicationJson_Ocs
@@ -7947,11 +9303,25 @@ abstract class UsersResendWelcomeMessageResponseApplicationJson_Ocs
   /// Serializer for UsersResendWelcomeMessageResponseApplicationJson_Ocs.
   static Serializer<UsersResendWelcomeMessageResponseApplicationJson_Ocs> get serializer =>
       _$usersResendWelcomeMessageResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder b) {
+    $UsersResendWelcomeMessageResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder b) {
+    $UsersResendWelcomeMessageResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UsersResendWelcomeMessageResponseApplicationJsonInterface {
   UsersResendWelcomeMessageResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersResendWelcomeMessageResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersResendWelcomeMessageResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UsersResendWelcomeMessageResponseApplicationJson
@@ -7986,6 +9356,16 @@ abstract class UsersResendWelcomeMessageResponseApplicationJson
   /// Serializer for UsersResendWelcomeMessageResponseApplicationJson.
   static Serializer<UsersResendWelcomeMessageResponseApplicationJson> get serializer =>
       _$usersResendWelcomeMessageResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersResendWelcomeMessageResponseApplicationJsonBuilder b) {
+    $UsersResendWelcomeMessageResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersResendWelcomeMessageResponseApplicationJsonBuilder b) {
+    $UsersResendWelcomeMessageResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -7997,6 +9377,10 @@ abstract interface class $Capabilities_ProvisioningApiInterface {
   bool get accountPropertyScopesFederatedEnabled;
   @BuiltValueField(wireName: 'AccountPropertyScopesPublishedEnabled')
   bool get accountPropertyScopesPublishedEnabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_ProvisioningApiInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_ProvisioningApiInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_ProvisioningApi
@@ -8028,12 +9412,26 @@ abstract class Capabilities_ProvisioningApi
 
   /// Serializer for Capabilities_ProvisioningApi.
   static Serializer<Capabilities_ProvisioningApi> get serializer => _$capabilitiesProvisioningApiSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_ProvisioningApiBuilder b) {
+    $Capabilities_ProvisioningApiInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_ProvisioningApiBuilder b) {
+    $Capabilities_ProvisioningApiInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   @BuiltValueField(wireName: 'provisioning_api')
   Capabilities_ProvisioningApi get provisioningApi;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -8060,6 +9458,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 /// Serialization extension for `GroupDetails_Usercount`.

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
@@ -5274,7 +5274,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -5304,6 +5306,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -5376,7 +5379,9 @@ class AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
   set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
-  AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder();
+  AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder() {
+    AppConfigGetAppsResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -5402,6 +5407,7 @@ class AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder
   AppConfigGetAppsResponseApplicationJson_Ocs_Data build() => _build();
 
   _$AppConfigGetAppsResponseApplicationJson_Ocs_Data _build() {
+    AppConfigGetAppsResponseApplicationJson_Ocs_Data._validate(this);
     _$AppConfigGetAppsResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$AppConfigGetAppsResponseApplicationJson_Ocs_Data._(data: data.build());
@@ -5494,7 +5500,9 @@ class AppConfigGetAppsResponseApplicationJson_OcsBuilder
       _$this._data ??= AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant AppConfigGetAppsResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  AppConfigGetAppsResponseApplicationJson_OcsBuilder();
+  AppConfigGetAppsResponseApplicationJson_OcsBuilder() {
+    AppConfigGetAppsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AppConfigGetAppsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -5521,6 +5529,7 @@ class AppConfigGetAppsResponseApplicationJson_OcsBuilder
   AppConfigGetAppsResponseApplicationJson_Ocs build() => _build();
 
   _$AppConfigGetAppsResponseApplicationJson_Ocs _build() {
+    AppConfigGetAppsResponseApplicationJson_Ocs._validate(this);
     _$AppConfigGetAppsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$AppConfigGetAppsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -5600,7 +5609,9 @@ class AppConfigGetAppsResponseApplicationJsonBuilder
       _$this._ocs ??= AppConfigGetAppsResponseApplicationJson_OcsBuilder();
   set ocs(covariant AppConfigGetAppsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AppConfigGetAppsResponseApplicationJsonBuilder();
+  AppConfigGetAppsResponseApplicationJsonBuilder() {
+    AppConfigGetAppsResponseApplicationJson._defaults(this);
+  }
 
   AppConfigGetAppsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -5626,6 +5637,7 @@ class AppConfigGetAppsResponseApplicationJsonBuilder
   AppConfigGetAppsResponseApplicationJson build() => _build();
 
   _$AppConfigGetAppsResponseApplicationJson _build() {
+    AppConfigGetAppsResponseApplicationJson._validate(this);
     _$AppConfigGetAppsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AppConfigGetAppsResponseApplicationJson._(ocs: ocs.build());
@@ -5704,7 +5716,9 @@ class AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
   set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
-  AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder();
+  AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder() {
+    AppConfigGetKeysResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -5730,6 +5744,7 @@ class AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder
   AppConfigGetKeysResponseApplicationJson_Ocs_Data build() => _build();
 
   _$AppConfigGetKeysResponseApplicationJson_Ocs_Data _build() {
+    AppConfigGetKeysResponseApplicationJson_Ocs_Data._validate(this);
     _$AppConfigGetKeysResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$AppConfigGetKeysResponseApplicationJson_Ocs_Data._(data: data.build());
@@ -5822,7 +5837,9 @@ class AppConfigGetKeysResponseApplicationJson_OcsBuilder
       _$this._data ??= AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant AppConfigGetKeysResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  AppConfigGetKeysResponseApplicationJson_OcsBuilder();
+  AppConfigGetKeysResponseApplicationJson_OcsBuilder() {
+    AppConfigGetKeysResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AppConfigGetKeysResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -5849,6 +5866,7 @@ class AppConfigGetKeysResponseApplicationJson_OcsBuilder
   AppConfigGetKeysResponseApplicationJson_Ocs build() => _build();
 
   _$AppConfigGetKeysResponseApplicationJson_Ocs _build() {
+    AppConfigGetKeysResponseApplicationJson_Ocs._validate(this);
     _$AppConfigGetKeysResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$AppConfigGetKeysResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -5928,7 +5946,9 @@ class AppConfigGetKeysResponseApplicationJsonBuilder
       _$this._ocs ??= AppConfigGetKeysResponseApplicationJson_OcsBuilder();
   set ocs(covariant AppConfigGetKeysResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AppConfigGetKeysResponseApplicationJsonBuilder();
+  AppConfigGetKeysResponseApplicationJsonBuilder() {
+    AppConfigGetKeysResponseApplicationJson._defaults(this);
+  }
 
   AppConfigGetKeysResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -5954,6 +5974,7 @@ class AppConfigGetKeysResponseApplicationJsonBuilder
   AppConfigGetKeysResponseApplicationJson build() => _build();
 
   _$AppConfigGetKeysResponseApplicationJson _build() {
+    AppConfigGetKeysResponseApplicationJson._validate(this);
     _$AppConfigGetKeysResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AppConfigGetKeysResponseApplicationJson._(ocs: ocs.build());
@@ -6044,7 +6065,9 @@ class AppConfigSetValueResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  AppConfigSetValueResponseApplicationJson_OcsBuilder();
+  AppConfigSetValueResponseApplicationJson_OcsBuilder() {
+    AppConfigSetValueResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AppConfigSetValueResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6071,6 +6094,7 @@ class AppConfigSetValueResponseApplicationJson_OcsBuilder
   AppConfigSetValueResponseApplicationJson_Ocs build() => _build();
 
   _$AppConfigSetValueResponseApplicationJson_Ocs _build() {
+    AppConfigSetValueResponseApplicationJson_Ocs._validate(this);
     _$AppConfigSetValueResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -6152,7 +6176,9 @@ class AppConfigSetValueResponseApplicationJsonBuilder
       _$this._ocs ??= AppConfigSetValueResponseApplicationJson_OcsBuilder();
   set ocs(covariant AppConfigSetValueResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AppConfigSetValueResponseApplicationJsonBuilder();
+  AppConfigSetValueResponseApplicationJsonBuilder() {
+    AppConfigSetValueResponseApplicationJson._defaults(this);
+  }
 
   AppConfigSetValueResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6178,6 +6204,7 @@ class AppConfigSetValueResponseApplicationJsonBuilder
   AppConfigSetValueResponseApplicationJson build() => _build();
 
   _$AppConfigSetValueResponseApplicationJson _build() {
+    AppConfigSetValueResponseApplicationJson._validate(this);
     _$AppConfigSetValueResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AppConfigSetValueResponseApplicationJson._(ocs: ocs.build());
@@ -6254,7 +6281,9 @@ class AppsGetAppsResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<String> get apps => _$this._apps ??= ListBuilder<String>();
   set apps(covariant ListBuilder<String>? apps) => _$this._apps = apps;
 
-  AppsGetAppsResponseApplicationJson_Ocs_DataBuilder();
+  AppsGetAppsResponseApplicationJson_Ocs_DataBuilder() {
+    AppsGetAppsResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   AppsGetAppsResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -6280,6 +6309,7 @@ class AppsGetAppsResponseApplicationJson_Ocs_DataBuilder
   AppsGetAppsResponseApplicationJson_Ocs_Data build() => _build();
 
   _$AppsGetAppsResponseApplicationJson_Ocs_Data _build() {
+    AppsGetAppsResponseApplicationJson_Ocs_Data._validate(this);
     _$AppsGetAppsResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$AppsGetAppsResponseApplicationJson_Ocs_Data._(apps: apps.build());
@@ -6371,7 +6401,9 @@ class AppsGetAppsResponseApplicationJson_OcsBuilder
       _$this._data ??= AppsGetAppsResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant AppsGetAppsResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  AppsGetAppsResponseApplicationJson_OcsBuilder();
+  AppsGetAppsResponseApplicationJson_OcsBuilder() {
+    AppsGetAppsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AppsGetAppsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6398,6 +6430,7 @@ class AppsGetAppsResponseApplicationJson_OcsBuilder
   AppsGetAppsResponseApplicationJson_Ocs build() => _build();
 
   _$AppsGetAppsResponseApplicationJson_Ocs _build() {
+    AppsGetAppsResponseApplicationJson_Ocs._validate(this);
     _$AppsGetAppsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$AppsGetAppsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -6474,7 +6507,9 @@ class AppsGetAppsResponseApplicationJsonBuilder
       _$this._ocs ??= AppsGetAppsResponseApplicationJson_OcsBuilder();
   set ocs(covariant AppsGetAppsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AppsGetAppsResponseApplicationJsonBuilder();
+  AppsGetAppsResponseApplicationJsonBuilder() {
+    AppsGetAppsResponseApplicationJson._defaults(this);
+  }
 
   AppsGetAppsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6500,6 +6535,7 @@ class AppsGetAppsResponseApplicationJsonBuilder
   AppsGetAppsResponseApplicationJson build() => _build();
 
   _$AppsGetAppsResponseApplicationJson _build() {
+    AppsGetAppsResponseApplicationJson._validate(this);
     _$AppsGetAppsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AppsGetAppsResponseApplicationJson._(ocs: ocs.build());
@@ -6590,7 +6626,9 @@ class AppsGetAppInfoResponseApplicationJson_OcsBuilder
   MapBuilder<String, JsonObject> get data => _$this._data ??= MapBuilder<String, JsonObject>();
   set data(covariant MapBuilder<String, JsonObject>? data) => _$this._data = data;
 
-  AppsGetAppInfoResponseApplicationJson_OcsBuilder();
+  AppsGetAppInfoResponseApplicationJson_OcsBuilder() {
+    AppsGetAppInfoResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AppsGetAppInfoResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6617,6 +6655,7 @@ class AppsGetAppInfoResponseApplicationJson_OcsBuilder
   AppsGetAppInfoResponseApplicationJson_Ocs build() => _build();
 
   _$AppsGetAppInfoResponseApplicationJson_Ocs _build() {
+    AppsGetAppInfoResponseApplicationJson_Ocs._validate(this);
     _$AppsGetAppInfoResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$AppsGetAppInfoResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -6695,7 +6734,9 @@ class AppsGetAppInfoResponseApplicationJsonBuilder
       _$this._ocs ??= AppsGetAppInfoResponseApplicationJson_OcsBuilder();
   set ocs(covariant AppsGetAppInfoResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AppsGetAppInfoResponseApplicationJsonBuilder();
+  AppsGetAppInfoResponseApplicationJsonBuilder() {
+    AppsGetAppInfoResponseApplicationJson._defaults(this);
+  }
 
   AppsGetAppInfoResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6721,6 +6762,7 @@ class AppsGetAppInfoResponseApplicationJsonBuilder
   AppsGetAppInfoResponseApplicationJson build() => _build();
 
   _$AppsGetAppInfoResponseApplicationJson _build() {
+    AppsGetAppInfoResponseApplicationJson._validate(this);
     _$AppsGetAppInfoResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AppsGetAppInfoResponseApplicationJson._(ocs: ocs.build());
@@ -6810,7 +6852,9 @@ class AppsEnableResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  AppsEnableResponseApplicationJson_OcsBuilder();
+  AppsEnableResponseApplicationJson_OcsBuilder() {
+    AppsEnableResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AppsEnableResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -6837,6 +6881,7 @@ class AppsEnableResponseApplicationJson_OcsBuilder
   AppsEnableResponseApplicationJson_Ocs build() => _build();
 
   _$AppsEnableResponseApplicationJson_Ocs _build() {
+    AppsEnableResponseApplicationJson_Ocs._validate(this);
     _$AppsEnableResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -6914,7 +6959,9 @@ class AppsEnableResponseApplicationJsonBuilder
       _$this._ocs ??= AppsEnableResponseApplicationJson_OcsBuilder();
   set ocs(covariant AppsEnableResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AppsEnableResponseApplicationJsonBuilder();
+  AppsEnableResponseApplicationJsonBuilder() {
+    AppsEnableResponseApplicationJson._defaults(this);
+  }
 
   AppsEnableResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -6940,6 +6987,7 @@ class AppsEnableResponseApplicationJsonBuilder
   AppsEnableResponseApplicationJson build() => _build();
 
   _$AppsEnableResponseApplicationJson _build() {
+    AppsEnableResponseApplicationJson._validate(this);
     _$AppsEnableResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AppsEnableResponseApplicationJson._(ocs: ocs.build());
@@ -7030,7 +7078,9 @@ class AppsDisableResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  AppsDisableResponseApplicationJson_OcsBuilder();
+  AppsDisableResponseApplicationJson_OcsBuilder() {
+    AppsDisableResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AppsDisableResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -7057,6 +7107,7 @@ class AppsDisableResponseApplicationJson_OcsBuilder
   AppsDisableResponseApplicationJson_Ocs build() => _build();
 
   _$AppsDisableResponseApplicationJson_Ocs _build() {
+    AppsDisableResponseApplicationJson_Ocs._validate(this);
     _$AppsDisableResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -7134,7 +7185,9 @@ class AppsDisableResponseApplicationJsonBuilder
       _$this._ocs ??= AppsDisableResponseApplicationJson_OcsBuilder();
   set ocs(covariant AppsDisableResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AppsDisableResponseApplicationJsonBuilder();
+  AppsDisableResponseApplicationJsonBuilder() {
+    AppsDisableResponseApplicationJson._defaults(this);
+  }
 
   AppsDisableResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -7160,6 +7213,7 @@ class AppsDisableResponseApplicationJsonBuilder
   AppsDisableResponseApplicationJson build() => _build();
 
   _$AppsDisableResponseApplicationJson _build() {
+    AppsDisableResponseApplicationJson._validate(this);
     _$AppsDisableResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AppsDisableResponseApplicationJson._(ocs: ocs.build());
@@ -7252,7 +7306,9 @@ class GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
   set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
-  GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder();
+  GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder() {
+    GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs._defaults(this);
+  }
 
   GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -7279,6 +7335,7 @@ class GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder
   GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs build() => _build();
 
   _$GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs _build() {
+    GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs._validate(this);
     _$GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -7362,7 +7419,9 @@ class GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder
       _$this._ocs ??= GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder();
   set ocs(covariant GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder();
+  GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder() {
+    GroupsGetSubAdminsOfGroupResponseApplicationJson._defaults(this);
+  }
 
   GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -7388,6 +7447,7 @@ class GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder
   GroupsGetSubAdminsOfGroupResponseApplicationJson build() => _build();
 
   _$GroupsGetSubAdminsOfGroupResponseApplicationJson _build() {
+    GroupsGetSubAdminsOfGroupResponseApplicationJson._validate(this);
     _$GroupsGetSubAdminsOfGroupResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$GroupsGetSubAdminsOfGroupResponseApplicationJson._(ocs: ocs.build());
@@ -7467,7 +7527,9 @@ class GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<String> get groups => _$this._groups ??= ListBuilder<String>();
   set groups(covariant ListBuilder<String>? groups) => _$this._groups = groups;
 
-  GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder();
+  GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder() {
+    GroupsGetGroupsResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -7493,6 +7555,7 @@ class GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder
   GroupsGetGroupsResponseApplicationJson_Ocs_Data build() => _build();
 
   _$GroupsGetGroupsResponseApplicationJson_Ocs_Data _build() {
+    GroupsGetGroupsResponseApplicationJson_Ocs_Data._validate(this);
     _$GroupsGetGroupsResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupsResponseApplicationJson_Ocs_Data._(groups: groups.build());
@@ -7585,7 +7648,9 @@ class GroupsGetGroupsResponseApplicationJson_OcsBuilder
       _$this._data ??= GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant GroupsGetGroupsResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  GroupsGetGroupsResponseApplicationJson_OcsBuilder();
+  GroupsGetGroupsResponseApplicationJson_OcsBuilder() {
+    GroupsGetGroupsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   GroupsGetGroupsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -7612,6 +7677,7 @@ class GroupsGetGroupsResponseApplicationJson_OcsBuilder
   GroupsGetGroupsResponseApplicationJson_Ocs build() => _build();
 
   _$GroupsGetGroupsResponseApplicationJson_Ocs _build() {
+    GroupsGetGroupsResponseApplicationJson_Ocs._validate(this);
     _$GroupsGetGroupsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -7691,7 +7757,9 @@ class GroupsGetGroupsResponseApplicationJsonBuilder
       _$this._ocs ??= GroupsGetGroupsResponseApplicationJson_OcsBuilder();
   set ocs(covariant GroupsGetGroupsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  GroupsGetGroupsResponseApplicationJsonBuilder();
+  GroupsGetGroupsResponseApplicationJsonBuilder() {
+    GroupsGetGroupsResponseApplicationJson._defaults(this);
+  }
 
   GroupsGetGroupsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -7717,6 +7785,7 @@ class GroupsGetGroupsResponseApplicationJsonBuilder
   GroupsGetGroupsResponseApplicationJson build() => _build();
 
   _$GroupsGetGroupsResponseApplicationJson _build() {
+    GroupsGetGroupsResponseApplicationJson._validate(this);
     _$GroupsGetGroupsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupsResponseApplicationJson._(ocs: ocs.build());
@@ -7794,7 +7863,9 @@ class GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<String> get users => _$this._users ??= ListBuilder<String>();
   set users(covariant ListBuilder<String>? users) => _$this._users = users;
 
-  GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder();
+  GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder() {
+    GroupsGetGroupResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -7820,6 +7891,7 @@ class GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder
   GroupsGetGroupResponseApplicationJson_Ocs_Data build() => _build();
 
   _$GroupsGetGroupResponseApplicationJson_Ocs_Data _build() {
+    GroupsGetGroupResponseApplicationJson_Ocs_Data._validate(this);
     _$GroupsGetGroupResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupResponseApplicationJson_Ocs_Data._(users: users.build());
@@ -7912,7 +7984,9 @@ class GroupsGetGroupResponseApplicationJson_OcsBuilder
       _$this._data ??= GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  GroupsGetGroupResponseApplicationJson_OcsBuilder();
+  GroupsGetGroupResponseApplicationJson_OcsBuilder() {
+    GroupsGetGroupResponseApplicationJson_Ocs._defaults(this);
+  }
 
   GroupsGetGroupResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -7939,6 +8013,7 @@ class GroupsGetGroupResponseApplicationJson_OcsBuilder
   GroupsGetGroupResponseApplicationJson_Ocs build() => _build();
 
   _$GroupsGetGroupResponseApplicationJson_Ocs _build() {
+    GroupsGetGroupResponseApplicationJson_Ocs._validate(this);
     _$GroupsGetGroupResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -8017,7 +8092,9 @@ class GroupsGetGroupResponseApplicationJsonBuilder
       _$this._ocs ??= GroupsGetGroupResponseApplicationJson_OcsBuilder();
   set ocs(covariant GroupsGetGroupResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  GroupsGetGroupResponseApplicationJsonBuilder();
+  GroupsGetGroupResponseApplicationJsonBuilder() {
+    GroupsGetGroupResponseApplicationJson._defaults(this);
+  }
 
   GroupsGetGroupResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -8043,6 +8120,7 @@ class GroupsGetGroupResponseApplicationJsonBuilder
   GroupsGetGroupResponseApplicationJson build() => _build();
 
   _$GroupsGetGroupResponseApplicationJson _build() {
+    GroupsGetGroupResponseApplicationJson._validate(this);
     _$GroupsGetGroupResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupResponseApplicationJson._(ocs: ocs.build());
@@ -8188,7 +8266,9 @@ class GroupDetailsBuilder implements Builder<GroupDetails, GroupDetailsBuilder>,
   bool? get canRemove => _$this._canRemove;
   set canRemove(covariant bool? canRemove) => _$this._canRemove = canRemove;
 
-  GroupDetailsBuilder();
+  GroupDetailsBuilder() {
+    GroupDetails._defaults(this);
+  }
 
   GroupDetailsBuilder get _$this {
     final $v = _$v;
@@ -8295,7 +8375,9 @@ class GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<GroupDetails> get groups => _$this._groups ??= ListBuilder<GroupDetails>();
   set groups(covariant ListBuilder<GroupDetails>? groups) => _$this._groups = groups;
 
-  GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder();
+  GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder() {
+    GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -8321,6 +8403,7 @@ class GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder
   GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data build() => _build();
 
   _$GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data _build() {
+    GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data._validate(this);
     _$GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data._(groups: groups.build());
@@ -8414,7 +8497,9 @@ class GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder
       _$this._data ??= GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder();
+  GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder() {
+    GroupsGetGroupsDetailsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -8441,6 +8526,7 @@ class GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder
   GroupsGetGroupsDetailsResponseApplicationJson_Ocs build() => _build();
 
   _$GroupsGetGroupsDetailsResponseApplicationJson_Ocs _build() {
+    GroupsGetGroupsDetailsResponseApplicationJson_Ocs._validate(this);
     _$GroupsGetGroupsDetailsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupsDetailsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -8521,7 +8607,9 @@ class GroupsGetGroupsDetailsResponseApplicationJsonBuilder
       _$this._ocs ??= GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder();
   set ocs(covariant GroupsGetGroupsDetailsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  GroupsGetGroupsDetailsResponseApplicationJsonBuilder();
+  GroupsGetGroupsDetailsResponseApplicationJsonBuilder() {
+    GroupsGetGroupsDetailsResponseApplicationJson._defaults(this);
+  }
 
   GroupsGetGroupsDetailsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -8547,6 +8635,7 @@ class GroupsGetGroupsDetailsResponseApplicationJsonBuilder
   GroupsGetGroupsDetailsResponseApplicationJson build() => _build();
 
   _$GroupsGetGroupsDetailsResponseApplicationJson _build() {
+    GroupsGetGroupsDetailsResponseApplicationJson._validate(this);
     _$GroupsGetGroupsDetailsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupsDetailsResponseApplicationJson._(ocs: ocs.build());
@@ -8626,7 +8715,9 @@ class GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<String> get users => _$this._users ??= ListBuilder<String>();
   set users(covariant ListBuilder<String>? users) => _$this._users = users;
 
-  GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder();
+  GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder() {
+    GroupsGetGroupUsersResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -8652,6 +8743,7 @@ class GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder
   GroupsGetGroupUsersResponseApplicationJson_Ocs_Data build() => _build();
 
   _$GroupsGetGroupUsersResponseApplicationJson_Ocs_Data _build() {
+    GroupsGetGroupUsersResponseApplicationJson_Ocs_Data._validate(this);
     _$GroupsGetGroupUsersResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupUsersResponseApplicationJson_Ocs_Data._(users: users.build());
@@ -8744,7 +8836,9 @@ class GroupsGetGroupUsersResponseApplicationJson_OcsBuilder
       _$this._data ??= GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  GroupsGetGroupUsersResponseApplicationJson_OcsBuilder();
+  GroupsGetGroupUsersResponseApplicationJson_OcsBuilder() {
+    GroupsGetGroupUsersResponseApplicationJson_Ocs._defaults(this);
+  }
 
   GroupsGetGroupUsersResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -8771,6 +8865,7 @@ class GroupsGetGroupUsersResponseApplicationJson_OcsBuilder
   GroupsGetGroupUsersResponseApplicationJson_Ocs build() => _build();
 
   _$GroupsGetGroupUsersResponseApplicationJson_Ocs _build() {
+    GroupsGetGroupUsersResponseApplicationJson_Ocs._validate(this);
     _$GroupsGetGroupUsersResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupUsersResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -8851,7 +8946,9 @@ class GroupsGetGroupUsersResponseApplicationJsonBuilder
       _$this._ocs ??= GroupsGetGroupUsersResponseApplicationJson_OcsBuilder();
   set ocs(covariant GroupsGetGroupUsersResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  GroupsGetGroupUsersResponseApplicationJsonBuilder();
+  GroupsGetGroupUsersResponseApplicationJsonBuilder() {
+    GroupsGetGroupUsersResponseApplicationJson._defaults(this);
+  }
 
   GroupsGetGroupUsersResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -8877,6 +8974,7 @@ class GroupsGetGroupUsersResponseApplicationJsonBuilder
   GroupsGetGroupUsersResponseApplicationJson build() => _build();
 
   _$GroupsGetGroupUsersResponseApplicationJson _build() {
+    GroupsGetGroupUsersResponseApplicationJson._validate(this);
     _$GroupsGetGroupUsersResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupUsersResponseApplicationJson._(ocs: ocs.build());
@@ -8966,7 +9064,9 @@ class UserDetails_BackendCapabilitiesBuilder
   bool? get setPassword => _$this._setPassword;
   set setPassword(covariant bool? setPassword) => _$this._setPassword = setPassword;
 
-  UserDetails_BackendCapabilitiesBuilder();
+  UserDetails_BackendCapabilitiesBuilder() {
+    UserDetails_BackendCapabilities._defaults(this);
+  }
 
   UserDetails_BackendCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -8993,6 +9093,7 @@ class UserDetails_BackendCapabilitiesBuilder
   UserDetails_BackendCapabilities build() => _build();
 
   _$UserDetails_BackendCapabilities _build() {
+    UserDetails_BackendCapabilities._validate(this);
     final _$result = _$v ??
         _$UserDetails_BackendCapabilities._(
             setDisplayName: BuiltValueNullFieldError.checkNotNull(
@@ -9113,7 +9214,9 @@ class UserDetailsQuotaBuilder
   num? get used => _$this._used;
   set used(covariant num? used) => _$this._used = used;
 
-  UserDetailsQuotaBuilder();
+  UserDetailsQuotaBuilder() {
+    UserDetailsQuota._defaults(this);
+  }
 
   UserDetailsQuotaBuilder get _$this {
     final $v = _$v;
@@ -9757,7 +9860,9 @@ class UserDetailsBuilder implements Builder<UserDetails, UserDetailsBuilder>, $U
   String? get websiteScope => _$this._websiteScope;
   set websiteScope(covariant String? websiteScope) => _$this._websiteScope = websiteScope;
 
-  UserDetailsBuilder();
+  UserDetailsBuilder() {
+    UserDetails._defaults(this);
+  }
 
   UserDetailsBuilder get _$this {
     final $v = _$v;
@@ -9823,6 +9928,7 @@ class UserDetailsBuilder implements Builder<UserDetails, UserDetailsBuilder>, $U
   UserDetails build() => _build();
 
   _$UserDetails _build() {
+    UserDetails._validate(this);
     _$UserDetails _$result;
     try {
       _$result = _$v ??
@@ -9961,7 +10067,9 @@ class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder
   String? get id => _$this._id;
   set id(covariant String? id) => _$this._id = id;
 
-  GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder();
+  GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder() {
+    GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1._defaults(this);
+  }
 
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder get _$this {
     final $v = _$v;
@@ -9987,6 +10095,7 @@ class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1 build() => _build();
 
   _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1 _build() {
+    GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1._validate(this);
     final _$result = _$v ??
         _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1._(
             id: BuiltValueNullFieldError.checkNotNull(
@@ -10062,7 +10171,9 @@ class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder
   set users(covariant MapBuilder<String, GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users>? users) =>
       _$this._users = users;
 
-  GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder();
+  GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder() {
+    GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -10088,6 +10199,7 @@ class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data build() => _build();
 
   _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data _build() {
+    GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data._validate(this);
     _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data._(users: users.build());
@@ -10182,7 +10294,9 @@ class GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder
       _$this._data ??= GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder();
+  GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder() {
+    GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -10209,6 +10323,7 @@ class GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs build() => _build();
 
   _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs _build() {
+    GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs._validate(this);
     _$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -10292,7 +10407,9 @@ class GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder
       _$this._ocs ??= GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder();
   set ocs(covariant GroupsGetGroupUsersDetailsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder();
+  GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder() {
+    GroupsGetGroupUsersDetailsResponseApplicationJson._defaults(this);
+  }
 
   GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -10318,6 +10435,7 @@ class GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder
   GroupsGetGroupUsersDetailsResponseApplicationJson build() => _build();
 
   _$GroupsGetGroupUsersDetailsResponseApplicationJson _build() {
+    GroupsGetGroupUsersDetailsResponseApplicationJson._validate(this);
     _$GroupsGetGroupUsersDetailsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$GroupsGetGroupUsersDetailsResponseApplicationJson._(ocs: ocs.build());
@@ -10411,7 +10529,9 @@ class PreferencesSetPreferenceResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  PreferencesSetPreferenceResponseApplicationJson_OcsBuilder();
+  PreferencesSetPreferenceResponseApplicationJson_OcsBuilder() {
+    PreferencesSetPreferenceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PreferencesSetPreferenceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -10438,6 +10558,7 @@ class PreferencesSetPreferenceResponseApplicationJson_OcsBuilder
   PreferencesSetPreferenceResponseApplicationJson_Ocs build() => _build();
 
   _$PreferencesSetPreferenceResponseApplicationJson_Ocs _build() {
+    PreferencesSetPreferenceResponseApplicationJson_Ocs._validate(this);
     _$PreferencesSetPreferenceResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -10522,7 +10643,9 @@ class PreferencesSetPreferenceResponseApplicationJsonBuilder
       _$this._ocs ??= PreferencesSetPreferenceResponseApplicationJson_OcsBuilder();
   set ocs(covariant PreferencesSetPreferenceResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PreferencesSetPreferenceResponseApplicationJsonBuilder();
+  PreferencesSetPreferenceResponseApplicationJsonBuilder() {
+    PreferencesSetPreferenceResponseApplicationJson._defaults(this);
+  }
 
   PreferencesSetPreferenceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -10548,6 +10671,7 @@ class PreferencesSetPreferenceResponseApplicationJsonBuilder
   PreferencesSetPreferenceResponseApplicationJson build() => _build();
 
   _$PreferencesSetPreferenceResponseApplicationJson _build() {
+    PreferencesSetPreferenceResponseApplicationJson._validate(this);
     _$PreferencesSetPreferenceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PreferencesSetPreferenceResponseApplicationJson._(ocs: ocs.build());
@@ -10641,7 +10765,9 @@ class PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder();
+  PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder() {
+    PreferencesDeletePreferenceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -10668,6 +10794,7 @@ class PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder
   PreferencesDeletePreferenceResponseApplicationJson_Ocs build() => _build();
 
   _$PreferencesDeletePreferenceResponseApplicationJson_Ocs _build() {
+    PreferencesDeletePreferenceResponseApplicationJson_Ocs._validate(this);
     _$PreferencesDeletePreferenceResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -10752,7 +10879,9 @@ class PreferencesDeletePreferenceResponseApplicationJsonBuilder
       _$this._ocs ??= PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder();
   set ocs(covariant PreferencesDeletePreferenceResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PreferencesDeletePreferenceResponseApplicationJsonBuilder();
+  PreferencesDeletePreferenceResponseApplicationJsonBuilder() {
+    PreferencesDeletePreferenceResponseApplicationJson._defaults(this);
+  }
 
   PreferencesDeletePreferenceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -10778,6 +10907,7 @@ class PreferencesDeletePreferenceResponseApplicationJsonBuilder
   PreferencesDeletePreferenceResponseApplicationJson build() => _build();
 
   _$PreferencesDeletePreferenceResponseApplicationJson _build() {
+    PreferencesDeletePreferenceResponseApplicationJson._validate(this);
     _$PreferencesDeletePreferenceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PreferencesDeletePreferenceResponseApplicationJson._(ocs: ocs.build());
@@ -10876,7 +11006,9 @@ class PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder();
+  PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder() {
+    PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -10903,6 +11035,7 @@ class PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder
   PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs build() => _build();
 
   _$PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs _build() {
+    PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs._validate(this);
     _$PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -10988,7 +11121,9 @@ class PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder
       _$this._ocs ??= PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder();
   set ocs(covariant PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder();
+  PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder() {
+    PreferencesSetMultiplePreferencesResponseApplicationJson._defaults(this);
+  }
 
   PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -11014,6 +11149,7 @@ class PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder
   PreferencesSetMultiplePreferencesResponseApplicationJson build() => _build();
 
   _$PreferencesSetMultiplePreferencesResponseApplicationJson _build() {
+    PreferencesSetMultiplePreferencesResponseApplicationJson._validate(this);
     _$PreferencesSetMultiplePreferencesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PreferencesSetMultiplePreferencesResponseApplicationJson._(ocs: ocs.build());
@@ -11112,7 +11248,9 @@ class PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder();
+  PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder() {
+    PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -11139,6 +11277,7 @@ class PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder
   PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs build() => _build();
 
   _$PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs _build() {
+    PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs._validate(this);
     _$PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -11224,7 +11363,9 @@ class PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder
       _$this._ocs ??= PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder();
   set ocs(covariant PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder();
+  PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder() {
+    PreferencesDeleteMultiplePreferenceResponseApplicationJson._defaults(this);
+  }
 
   PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -11250,6 +11391,7 @@ class PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder
   PreferencesDeleteMultiplePreferenceResponseApplicationJson build() => _build();
 
   _$PreferencesDeleteMultiplePreferenceResponseApplicationJson _build() {
+    PreferencesDeleteMultiplePreferenceResponseApplicationJson._validate(this);
     _$PreferencesDeleteMultiplePreferenceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PreferencesDeleteMultiplePreferenceResponseApplicationJson._(ocs: ocs.build());
@@ -11343,7 +11485,9 @@ class UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
   set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
-  UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder();
+  UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder() {
+    UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -11370,6 +11514,7 @@ class UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder
   UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs build() => _build();
 
   _$UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs _build() {
+    UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs._validate(this);
     _$UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -11453,7 +11598,9 @@ class UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder
       _$this._ocs ??= UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersGetUserSubAdminGroupsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder();
+  UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder() {
+    UsersGetUserSubAdminGroupsResponseApplicationJson._defaults(this);
+  }
 
   UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -11479,6 +11626,7 @@ class UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder
   UsersGetUserSubAdminGroupsResponseApplicationJson build() => _build();
 
   _$UsersGetUserSubAdminGroupsResponseApplicationJson _build() {
+    UsersGetUserSubAdminGroupsResponseApplicationJson._validate(this);
     _$UsersGetUserSubAdminGroupsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersGetUserSubAdminGroupsResponseApplicationJson._(ocs: ocs.build());
@@ -11570,7 +11718,9 @@ class UsersAddSubAdminResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersAddSubAdminResponseApplicationJson_OcsBuilder();
+  UsersAddSubAdminResponseApplicationJson_OcsBuilder() {
+    UsersAddSubAdminResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersAddSubAdminResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -11597,6 +11747,7 @@ class UsersAddSubAdminResponseApplicationJson_OcsBuilder
   UsersAddSubAdminResponseApplicationJson_Ocs build() => _build();
 
   _$UsersAddSubAdminResponseApplicationJson_Ocs _build() {
+    UsersAddSubAdminResponseApplicationJson_Ocs._validate(this);
     _$UsersAddSubAdminResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -11678,7 +11829,9 @@ class UsersAddSubAdminResponseApplicationJsonBuilder
       _$this._ocs ??= UsersAddSubAdminResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersAddSubAdminResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersAddSubAdminResponseApplicationJsonBuilder();
+  UsersAddSubAdminResponseApplicationJsonBuilder() {
+    UsersAddSubAdminResponseApplicationJson._defaults(this);
+  }
 
   UsersAddSubAdminResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -11704,6 +11857,7 @@ class UsersAddSubAdminResponseApplicationJsonBuilder
   UsersAddSubAdminResponseApplicationJson build() => _build();
 
   _$UsersAddSubAdminResponseApplicationJson _build() {
+    UsersAddSubAdminResponseApplicationJson._validate(this);
     _$UsersAddSubAdminResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersAddSubAdminResponseApplicationJson._(ocs: ocs.build());
@@ -11794,7 +11948,9 @@ class UsersRemoveSubAdminResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersRemoveSubAdminResponseApplicationJson_OcsBuilder();
+  UsersRemoveSubAdminResponseApplicationJson_OcsBuilder() {
+    UsersRemoveSubAdminResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersRemoveSubAdminResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -11821,6 +11977,7 @@ class UsersRemoveSubAdminResponseApplicationJson_OcsBuilder
   UsersRemoveSubAdminResponseApplicationJson_Ocs build() => _build();
 
   _$UsersRemoveSubAdminResponseApplicationJson_Ocs _build() {
+    UsersRemoveSubAdminResponseApplicationJson_Ocs._validate(this);
     _$UsersRemoveSubAdminResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -11903,7 +12060,9 @@ class UsersRemoveSubAdminResponseApplicationJsonBuilder
       _$this._ocs ??= UsersRemoveSubAdminResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersRemoveSubAdminResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersRemoveSubAdminResponseApplicationJsonBuilder();
+  UsersRemoveSubAdminResponseApplicationJsonBuilder() {
+    UsersRemoveSubAdminResponseApplicationJson._defaults(this);
+  }
 
   UsersRemoveSubAdminResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -11929,6 +12088,7 @@ class UsersRemoveSubAdminResponseApplicationJsonBuilder
   UsersRemoveSubAdminResponseApplicationJson build() => _build();
 
   _$UsersRemoveSubAdminResponseApplicationJson _build() {
+    UsersRemoveSubAdminResponseApplicationJson._validate(this);
     _$UsersRemoveSubAdminResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersRemoveSubAdminResponseApplicationJson._(ocs: ocs.build());
@@ -12006,7 +12166,9 @@ class UsersGetUsersResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<String> get users => _$this._users ??= ListBuilder<String>();
   set users(covariant ListBuilder<String>? users) => _$this._users = users;
 
-  UsersGetUsersResponseApplicationJson_Ocs_DataBuilder();
+  UsersGetUsersResponseApplicationJson_Ocs_DataBuilder() {
+    UsersGetUsersResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   UsersGetUsersResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -12032,6 +12194,7 @@ class UsersGetUsersResponseApplicationJson_Ocs_DataBuilder
   UsersGetUsersResponseApplicationJson_Ocs_Data build() => _build();
 
   _$UsersGetUsersResponseApplicationJson_Ocs_Data _build() {
+    UsersGetUsersResponseApplicationJson_Ocs_Data._validate(this);
     _$UsersGetUsersResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$UsersGetUsersResponseApplicationJson_Ocs_Data._(users: users.build());
@@ -12123,7 +12286,9 @@ class UsersGetUsersResponseApplicationJson_OcsBuilder
       _$this._data ??= UsersGetUsersResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant UsersGetUsersResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  UsersGetUsersResponseApplicationJson_OcsBuilder();
+  UsersGetUsersResponseApplicationJson_OcsBuilder() {
+    UsersGetUsersResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersGetUsersResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -12150,6 +12315,7 @@ class UsersGetUsersResponseApplicationJson_OcsBuilder
   UsersGetUsersResponseApplicationJson_Ocs build() => _build();
 
   _$UsersGetUsersResponseApplicationJson_Ocs _build() {
+    UsersGetUsersResponseApplicationJson_Ocs._validate(this);
     _$UsersGetUsersResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$UsersGetUsersResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -12228,7 +12394,9 @@ class UsersGetUsersResponseApplicationJsonBuilder
       _$this._ocs ??= UsersGetUsersResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersGetUsersResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersGetUsersResponseApplicationJsonBuilder();
+  UsersGetUsersResponseApplicationJsonBuilder() {
+    UsersGetUsersResponseApplicationJson._defaults(this);
+  }
 
   UsersGetUsersResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -12254,6 +12422,7 @@ class UsersGetUsersResponseApplicationJsonBuilder
   UsersGetUsersResponseApplicationJson build() => _build();
 
   _$UsersGetUsersResponseApplicationJson _build() {
+    UsersGetUsersResponseApplicationJson._validate(this);
     _$UsersGetUsersResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersGetUsersResponseApplicationJson._(ocs: ocs.build());
@@ -12330,7 +12499,9 @@ class UsersAddUserResponseApplicationJson_Ocs_DataBuilder
   String? get id => _$this._id;
   set id(covariant String? id) => _$this._id = id;
 
-  UsersAddUserResponseApplicationJson_Ocs_DataBuilder();
+  UsersAddUserResponseApplicationJson_Ocs_DataBuilder() {
+    UsersAddUserResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   UsersAddUserResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -12356,6 +12527,7 @@ class UsersAddUserResponseApplicationJson_Ocs_DataBuilder
   UsersAddUserResponseApplicationJson_Ocs_Data build() => _build();
 
   _$UsersAddUserResponseApplicationJson_Ocs_Data _build() {
+    UsersAddUserResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$UsersAddUserResponseApplicationJson_Ocs_Data._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'UsersAddUserResponseApplicationJson_Ocs_Data', 'id'));
@@ -12437,7 +12609,9 @@ class UsersAddUserResponseApplicationJson_OcsBuilder
       _$this._data ??= UsersAddUserResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant UsersAddUserResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  UsersAddUserResponseApplicationJson_OcsBuilder();
+  UsersAddUserResponseApplicationJson_OcsBuilder() {
+    UsersAddUserResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersAddUserResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -12464,6 +12638,7 @@ class UsersAddUserResponseApplicationJson_OcsBuilder
   UsersAddUserResponseApplicationJson_Ocs build() => _build();
 
   _$UsersAddUserResponseApplicationJson_Ocs _build() {
+    UsersAddUserResponseApplicationJson_Ocs._validate(this);
     _$UsersAddUserResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$UsersAddUserResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -12540,7 +12715,9 @@ class UsersAddUserResponseApplicationJsonBuilder
       _$this._ocs ??= UsersAddUserResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersAddUserResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersAddUserResponseApplicationJsonBuilder();
+  UsersAddUserResponseApplicationJsonBuilder() {
+    UsersAddUserResponseApplicationJson._defaults(this);
+  }
 
   UsersAddUserResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -12566,6 +12743,7 @@ class UsersAddUserResponseApplicationJsonBuilder
   UsersAddUserResponseApplicationJson build() => _build();
 
   _$UsersAddUserResponseApplicationJson _build() {
+    UsersAddUserResponseApplicationJson._validate(this);
     _$UsersAddUserResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersAddUserResponseApplicationJson._(ocs: ocs.build());
@@ -12645,7 +12823,9 @@ class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder
   String? get id => _$this._id;
   set id(covariant String? id) => _$this._id = id;
 
-  UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder();
+  UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder() {
+    UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1._defaults(this);
+  }
 
   UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder get _$this {
     final $v = _$v;
@@ -12671,6 +12851,7 @@ class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder
   UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1 build() => _build();
 
   _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1 _build() {
+    UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1._validate(this);
     final _$result = _$v ??
         _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1._(
             id: BuiltValueNullFieldError.checkNotNull(
@@ -12744,7 +12925,9 @@ class UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder
   set users(covariant MapBuilder<String, UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users>? users) =>
       _$this._users = users;
 
-  UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder();
+  UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder() {
+    UsersGetUsersDetailsResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -12770,6 +12953,7 @@ class UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder
   UsersGetUsersDetailsResponseApplicationJson_Ocs_Data build() => _build();
 
   _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data _build() {
+    UsersGetUsersDetailsResponseApplicationJson_Ocs_Data._validate(this);
     _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data._(users: users.build());
@@ -12863,7 +13047,9 @@ class UsersGetUsersDetailsResponseApplicationJson_OcsBuilder
       _$this._data ??= UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant UsersGetUsersDetailsResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  UsersGetUsersDetailsResponseApplicationJson_OcsBuilder();
+  UsersGetUsersDetailsResponseApplicationJson_OcsBuilder() {
+    UsersGetUsersDetailsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersGetUsersDetailsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -12890,6 +13076,7 @@ class UsersGetUsersDetailsResponseApplicationJson_OcsBuilder
   UsersGetUsersDetailsResponseApplicationJson_Ocs build() => _build();
 
   _$UsersGetUsersDetailsResponseApplicationJson_Ocs _build() {
+    UsersGetUsersDetailsResponseApplicationJson_Ocs._validate(this);
     _$UsersGetUsersDetailsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$UsersGetUsersDetailsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -12970,7 +13157,9 @@ class UsersGetUsersDetailsResponseApplicationJsonBuilder
       _$this._ocs ??= UsersGetUsersDetailsResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersGetUsersDetailsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersGetUsersDetailsResponseApplicationJsonBuilder();
+  UsersGetUsersDetailsResponseApplicationJsonBuilder() {
+    UsersGetUsersDetailsResponseApplicationJson._defaults(this);
+  }
 
   UsersGetUsersDetailsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -12996,6 +13185,7 @@ class UsersGetUsersDetailsResponseApplicationJsonBuilder
   UsersGetUsersDetailsResponseApplicationJson build() => _build();
 
   _$UsersGetUsersDetailsResponseApplicationJson _build() {
+    UsersGetUsersDetailsResponseApplicationJson._validate(this);
     _$UsersGetUsersDetailsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersGetUsersDetailsResponseApplicationJson._(ocs: ocs.build());
@@ -13078,7 +13268,9 @@ class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder
   String? get id => _$this._id;
   set id(covariant String? id) => _$this._id = id;
 
-  UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder();
+  UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder() {
+    UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1._defaults(this);
+  }
 
   UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder get _$this {
     final $v = _$v;
@@ -13104,6 +13296,7 @@ class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Builder
   UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1 build() => _build();
 
   _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1 _build() {
+    UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1._validate(this);
     final _$result = _$v ??
         _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1._(
             id: BuiltValueNullFieldError.checkNotNull(
@@ -13179,7 +13372,9 @@ class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder
   set users(covariant MapBuilder<String, UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users>? users) =>
       _$this._users = users;
 
-  UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder();
+  UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder() {
+    UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -13205,6 +13400,7 @@ class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder
   UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data build() => _build();
 
   _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data _build() {
+    UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data._validate(this);
     _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data._(users: users.build());
@@ -13299,7 +13495,9 @@ class UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder
       _$this._data ??= UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder();
+  UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder() {
+    UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -13326,6 +13524,7 @@ class UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder
   UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs build() => _build();
 
   _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs _build() {
+    UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs._validate(this);
     _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -13410,7 +13609,9 @@ class UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder
       _$this._ocs ??= UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersGetDisabledUsersDetailsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder();
+  UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder() {
+    UsersGetDisabledUsersDetailsResponseApplicationJson._defaults(this);
+  }
 
   UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -13436,6 +13637,7 @@ class UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder
   UsersGetDisabledUsersDetailsResponseApplicationJson build() => _build();
 
   _$UsersGetDisabledUsersDetailsResponseApplicationJson _build() {
+    UsersGetDisabledUsersDetailsResponseApplicationJson._validate(this);
     _$UsersGetDisabledUsersDetailsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersGetDisabledUsersDetailsResponseApplicationJson._(ocs: ocs.build());
@@ -13529,7 +13731,9 @@ class UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder
   MapBuilder<String, String> get data => _$this._data ??= MapBuilder<String, String>();
   set data(covariant MapBuilder<String, String>? data) => _$this._data = data;
 
-  UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder();
+  UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder() {
+    UsersSearchByPhoneNumbersResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -13556,6 +13760,7 @@ class UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder
   UsersSearchByPhoneNumbersResponseApplicationJson_Ocs build() => _build();
 
   _$UsersSearchByPhoneNumbersResponseApplicationJson_Ocs _build() {
+    UsersSearchByPhoneNumbersResponseApplicationJson_Ocs._validate(this);
     _$UsersSearchByPhoneNumbersResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -13639,7 +13844,9 @@ class UsersSearchByPhoneNumbersResponseApplicationJsonBuilder
       _$this._ocs ??= UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersSearchByPhoneNumbersResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersSearchByPhoneNumbersResponseApplicationJsonBuilder();
+  UsersSearchByPhoneNumbersResponseApplicationJsonBuilder() {
+    UsersSearchByPhoneNumbersResponseApplicationJson._defaults(this);
+  }
 
   UsersSearchByPhoneNumbersResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -13665,6 +13872,7 @@ class UsersSearchByPhoneNumbersResponseApplicationJsonBuilder
   UsersSearchByPhoneNumbersResponseApplicationJson build() => _build();
 
   _$UsersSearchByPhoneNumbersResponseApplicationJson _build() {
+    UsersSearchByPhoneNumbersResponseApplicationJson._validate(this);
     _$UsersSearchByPhoneNumbersResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersSearchByPhoneNumbersResponseApplicationJson._(ocs: ocs.build());
@@ -13756,7 +13964,9 @@ class UsersGetUserResponseApplicationJson_OcsBuilder
   UserDetailsBuilder get data => _$this._data ??= UserDetailsBuilder();
   set data(covariant UserDetailsBuilder? data) => _$this._data = data;
 
-  UsersGetUserResponseApplicationJson_OcsBuilder();
+  UsersGetUserResponseApplicationJson_OcsBuilder() {
+    UsersGetUserResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersGetUserResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -13783,6 +13993,7 @@ class UsersGetUserResponseApplicationJson_OcsBuilder
   UsersGetUserResponseApplicationJson_Ocs build() => _build();
 
   _$UsersGetUserResponseApplicationJson_Ocs _build() {
+    UsersGetUserResponseApplicationJson_Ocs._validate(this);
     _$UsersGetUserResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$UsersGetUserResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -13859,7 +14070,9 @@ class UsersGetUserResponseApplicationJsonBuilder
       _$this._ocs ??= UsersGetUserResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersGetUserResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersGetUserResponseApplicationJsonBuilder();
+  UsersGetUserResponseApplicationJsonBuilder() {
+    UsersGetUserResponseApplicationJson._defaults(this);
+  }
 
   UsersGetUserResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -13885,6 +14098,7 @@ class UsersGetUserResponseApplicationJsonBuilder
   UsersGetUserResponseApplicationJson build() => _build();
 
   _$UsersGetUserResponseApplicationJson _build() {
+    UsersGetUserResponseApplicationJson._validate(this);
     _$UsersGetUserResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersGetUserResponseApplicationJson._(ocs: ocs.build());
@@ -13975,7 +14189,9 @@ class UsersEditUserResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersEditUserResponseApplicationJson_OcsBuilder();
+  UsersEditUserResponseApplicationJson_OcsBuilder() {
+    UsersEditUserResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersEditUserResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -14002,6 +14218,7 @@ class UsersEditUserResponseApplicationJson_OcsBuilder
   UsersEditUserResponseApplicationJson_Ocs build() => _build();
 
   _$UsersEditUserResponseApplicationJson_Ocs _build() {
+    UsersEditUserResponseApplicationJson_Ocs._validate(this);
     _$UsersEditUserResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -14081,7 +14298,9 @@ class UsersEditUserResponseApplicationJsonBuilder
       _$this._ocs ??= UsersEditUserResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersEditUserResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersEditUserResponseApplicationJsonBuilder();
+  UsersEditUserResponseApplicationJsonBuilder() {
+    UsersEditUserResponseApplicationJson._defaults(this);
+  }
 
   UsersEditUserResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -14107,6 +14326,7 @@ class UsersEditUserResponseApplicationJsonBuilder
   UsersEditUserResponseApplicationJson build() => _build();
 
   _$UsersEditUserResponseApplicationJson _build() {
+    UsersEditUserResponseApplicationJson._validate(this);
     _$UsersEditUserResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersEditUserResponseApplicationJson._(ocs: ocs.build());
@@ -14197,7 +14417,9 @@ class UsersDeleteUserResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersDeleteUserResponseApplicationJson_OcsBuilder();
+  UsersDeleteUserResponseApplicationJson_OcsBuilder() {
+    UsersDeleteUserResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersDeleteUserResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -14224,6 +14446,7 @@ class UsersDeleteUserResponseApplicationJson_OcsBuilder
   UsersDeleteUserResponseApplicationJson_Ocs build() => _build();
 
   _$UsersDeleteUserResponseApplicationJson_Ocs _build() {
+    UsersDeleteUserResponseApplicationJson_Ocs._validate(this);
     _$UsersDeleteUserResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -14304,7 +14527,9 @@ class UsersDeleteUserResponseApplicationJsonBuilder
       _$this._ocs ??= UsersDeleteUserResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersDeleteUserResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersDeleteUserResponseApplicationJsonBuilder();
+  UsersDeleteUserResponseApplicationJsonBuilder() {
+    UsersDeleteUserResponseApplicationJson._defaults(this);
+  }
 
   UsersDeleteUserResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -14330,6 +14555,7 @@ class UsersDeleteUserResponseApplicationJsonBuilder
   UsersDeleteUserResponseApplicationJson build() => _build();
 
   _$UsersDeleteUserResponseApplicationJson _build() {
+    UsersDeleteUserResponseApplicationJson._validate(this);
     _$UsersDeleteUserResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersDeleteUserResponseApplicationJson._(ocs: ocs.build());
@@ -14420,7 +14646,9 @@ class UsersGetCurrentUserResponseApplicationJson_OcsBuilder
   UserDetailsBuilder get data => _$this._data ??= UserDetailsBuilder();
   set data(covariant UserDetailsBuilder? data) => _$this._data = data;
 
-  UsersGetCurrentUserResponseApplicationJson_OcsBuilder();
+  UsersGetCurrentUserResponseApplicationJson_OcsBuilder() {
+    UsersGetCurrentUserResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersGetCurrentUserResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -14447,6 +14675,7 @@ class UsersGetCurrentUserResponseApplicationJson_OcsBuilder
   UsersGetCurrentUserResponseApplicationJson_Ocs build() => _build();
 
   _$UsersGetCurrentUserResponseApplicationJson_Ocs _build() {
+    UsersGetCurrentUserResponseApplicationJson_Ocs._validate(this);
     _$UsersGetCurrentUserResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$UsersGetCurrentUserResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -14527,7 +14756,9 @@ class UsersGetCurrentUserResponseApplicationJsonBuilder
       _$this._ocs ??= UsersGetCurrentUserResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersGetCurrentUserResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersGetCurrentUserResponseApplicationJsonBuilder();
+  UsersGetCurrentUserResponseApplicationJsonBuilder() {
+    UsersGetCurrentUserResponseApplicationJson._defaults(this);
+  }
 
   UsersGetCurrentUserResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -14553,6 +14784,7 @@ class UsersGetCurrentUserResponseApplicationJsonBuilder
   UsersGetCurrentUserResponseApplicationJson build() => _build();
 
   _$UsersGetCurrentUserResponseApplicationJson _build() {
+    UsersGetCurrentUserResponseApplicationJson._validate(this);
     _$UsersGetCurrentUserResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersGetCurrentUserResponseApplicationJson._(ocs: ocs.build());
@@ -14644,7 +14876,9 @@ class UsersGetEditableFieldsResponseApplicationJson_OcsBuilder
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
   set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
-  UsersGetEditableFieldsResponseApplicationJson_OcsBuilder();
+  UsersGetEditableFieldsResponseApplicationJson_OcsBuilder() {
+    UsersGetEditableFieldsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersGetEditableFieldsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -14671,6 +14905,7 @@ class UsersGetEditableFieldsResponseApplicationJson_OcsBuilder
   UsersGetEditableFieldsResponseApplicationJson_Ocs build() => _build();
 
   _$UsersGetEditableFieldsResponseApplicationJson_Ocs _build() {
+    UsersGetEditableFieldsResponseApplicationJson_Ocs._validate(this);
     _$UsersGetEditableFieldsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$UsersGetEditableFieldsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -14751,7 +14986,9 @@ class UsersGetEditableFieldsResponseApplicationJsonBuilder
       _$this._ocs ??= UsersGetEditableFieldsResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersGetEditableFieldsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersGetEditableFieldsResponseApplicationJsonBuilder();
+  UsersGetEditableFieldsResponseApplicationJsonBuilder() {
+    UsersGetEditableFieldsResponseApplicationJson._defaults(this);
+  }
 
   UsersGetEditableFieldsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -14777,6 +15014,7 @@ class UsersGetEditableFieldsResponseApplicationJsonBuilder
   UsersGetEditableFieldsResponseApplicationJson build() => _build();
 
   _$UsersGetEditableFieldsResponseApplicationJson _build() {
+    UsersGetEditableFieldsResponseApplicationJson._validate(this);
     _$UsersGetEditableFieldsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersGetEditableFieldsResponseApplicationJson._(ocs: ocs.build());
@@ -14871,7 +15109,9 @@ class UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
   set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
-  UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder();
+  UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder() {
+    UsersGetEditableFieldsForUserResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -14898,6 +15138,7 @@ class UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder
   UsersGetEditableFieldsForUserResponseApplicationJson_Ocs build() => _build();
 
   _$UsersGetEditableFieldsForUserResponseApplicationJson_Ocs _build() {
+    UsersGetEditableFieldsForUserResponseApplicationJson_Ocs._validate(this);
     _$UsersGetEditableFieldsForUserResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -14982,7 +15223,9 @@ class UsersGetEditableFieldsForUserResponseApplicationJsonBuilder
       _$this._ocs ??= UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersGetEditableFieldsForUserResponseApplicationJsonBuilder();
+  UsersGetEditableFieldsForUserResponseApplicationJsonBuilder() {
+    UsersGetEditableFieldsForUserResponseApplicationJson._defaults(this);
+  }
 
   UsersGetEditableFieldsForUserResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -15008,6 +15251,7 @@ class UsersGetEditableFieldsForUserResponseApplicationJsonBuilder
   UsersGetEditableFieldsForUserResponseApplicationJson build() => _build();
 
   _$UsersGetEditableFieldsForUserResponseApplicationJson _build() {
+    UsersGetEditableFieldsForUserResponseApplicationJson._validate(this);
     _$UsersGetEditableFieldsForUserResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersGetEditableFieldsForUserResponseApplicationJson._(ocs: ocs.build());
@@ -15100,7 +15344,9 @@ class UsersEditUserMultiValueResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersEditUserMultiValueResponseApplicationJson_OcsBuilder();
+  UsersEditUserMultiValueResponseApplicationJson_OcsBuilder() {
+    UsersEditUserMultiValueResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersEditUserMultiValueResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -15127,6 +15373,7 @@ class UsersEditUserMultiValueResponseApplicationJson_OcsBuilder
   UsersEditUserMultiValueResponseApplicationJson_Ocs build() => _build();
 
   _$UsersEditUserMultiValueResponseApplicationJson_Ocs _build() {
+    UsersEditUserMultiValueResponseApplicationJson_Ocs._validate(this);
     _$UsersEditUserMultiValueResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -15209,7 +15456,9 @@ class UsersEditUserMultiValueResponseApplicationJsonBuilder
       _$this._ocs ??= UsersEditUserMultiValueResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersEditUserMultiValueResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersEditUserMultiValueResponseApplicationJsonBuilder();
+  UsersEditUserMultiValueResponseApplicationJsonBuilder() {
+    UsersEditUserMultiValueResponseApplicationJson._defaults(this);
+  }
 
   UsersEditUserMultiValueResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -15235,6 +15484,7 @@ class UsersEditUserMultiValueResponseApplicationJsonBuilder
   UsersEditUserMultiValueResponseApplicationJson build() => _build();
 
   _$UsersEditUserMultiValueResponseApplicationJson _build() {
+    UsersEditUserMultiValueResponseApplicationJson._validate(this);
     _$UsersEditUserMultiValueResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersEditUserMultiValueResponseApplicationJson._(ocs: ocs.build());
@@ -15327,7 +15577,9 @@ class UsersWipeUserDevicesResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersWipeUserDevicesResponseApplicationJson_OcsBuilder();
+  UsersWipeUserDevicesResponseApplicationJson_OcsBuilder() {
+    UsersWipeUserDevicesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersWipeUserDevicesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -15354,6 +15606,7 @@ class UsersWipeUserDevicesResponseApplicationJson_OcsBuilder
   UsersWipeUserDevicesResponseApplicationJson_Ocs build() => _build();
 
   _$UsersWipeUserDevicesResponseApplicationJson_Ocs _build() {
+    UsersWipeUserDevicesResponseApplicationJson_Ocs._validate(this);
     _$UsersWipeUserDevicesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -15436,7 +15689,9 @@ class UsersWipeUserDevicesResponseApplicationJsonBuilder
       _$this._ocs ??= UsersWipeUserDevicesResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersWipeUserDevicesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersWipeUserDevicesResponseApplicationJsonBuilder();
+  UsersWipeUserDevicesResponseApplicationJsonBuilder() {
+    UsersWipeUserDevicesResponseApplicationJson._defaults(this);
+  }
 
   UsersWipeUserDevicesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -15462,6 +15717,7 @@ class UsersWipeUserDevicesResponseApplicationJsonBuilder
   UsersWipeUserDevicesResponseApplicationJson build() => _build();
 
   _$UsersWipeUserDevicesResponseApplicationJson _build() {
+    UsersWipeUserDevicesResponseApplicationJson._validate(this);
     _$UsersWipeUserDevicesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersWipeUserDevicesResponseApplicationJson._(ocs: ocs.build());
@@ -15552,7 +15808,9 @@ class UsersEnableUserResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersEnableUserResponseApplicationJson_OcsBuilder();
+  UsersEnableUserResponseApplicationJson_OcsBuilder() {
+    UsersEnableUserResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersEnableUserResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -15579,6 +15837,7 @@ class UsersEnableUserResponseApplicationJson_OcsBuilder
   UsersEnableUserResponseApplicationJson_Ocs build() => _build();
 
   _$UsersEnableUserResponseApplicationJson_Ocs _build() {
+    UsersEnableUserResponseApplicationJson_Ocs._validate(this);
     _$UsersEnableUserResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -15659,7 +15918,9 @@ class UsersEnableUserResponseApplicationJsonBuilder
       _$this._ocs ??= UsersEnableUserResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersEnableUserResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersEnableUserResponseApplicationJsonBuilder();
+  UsersEnableUserResponseApplicationJsonBuilder() {
+    UsersEnableUserResponseApplicationJson._defaults(this);
+  }
 
   UsersEnableUserResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -15685,6 +15946,7 @@ class UsersEnableUserResponseApplicationJsonBuilder
   UsersEnableUserResponseApplicationJson build() => _build();
 
   _$UsersEnableUserResponseApplicationJson _build() {
+    UsersEnableUserResponseApplicationJson._validate(this);
     _$UsersEnableUserResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersEnableUserResponseApplicationJson._(ocs: ocs.build());
@@ -15775,7 +16037,9 @@ class UsersDisableUserResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersDisableUserResponseApplicationJson_OcsBuilder();
+  UsersDisableUserResponseApplicationJson_OcsBuilder() {
+    UsersDisableUserResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersDisableUserResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -15802,6 +16066,7 @@ class UsersDisableUserResponseApplicationJson_OcsBuilder
   UsersDisableUserResponseApplicationJson_Ocs build() => _build();
 
   _$UsersDisableUserResponseApplicationJson_Ocs _build() {
+    UsersDisableUserResponseApplicationJson_Ocs._validate(this);
     _$UsersDisableUserResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -15883,7 +16148,9 @@ class UsersDisableUserResponseApplicationJsonBuilder
       _$this._ocs ??= UsersDisableUserResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersDisableUserResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersDisableUserResponseApplicationJsonBuilder();
+  UsersDisableUserResponseApplicationJsonBuilder() {
+    UsersDisableUserResponseApplicationJson._defaults(this);
+  }
 
   UsersDisableUserResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -15909,6 +16176,7 @@ class UsersDisableUserResponseApplicationJsonBuilder
   UsersDisableUserResponseApplicationJson build() => _build();
 
   _$UsersDisableUserResponseApplicationJson _build() {
+    UsersDisableUserResponseApplicationJson._validate(this);
     _$UsersDisableUserResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersDisableUserResponseApplicationJson._(ocs: ocs.build());
@@ -15988,7 +16256,9 @@ class UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<String> get groups => _$this._groups ??= ListBuilder<String>();
   set groups(covariant ListBuilder<String>? groups) => _$this._groups = groups;
 
-  UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder();
+  UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder() {
+    UsersGetUsersGroupsResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -16014,6 +16284,7 @@ class UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder
   UsersGetUsersGroupsResponseApplicationJson_Ocs_Data build() => _build();
 
   _$UsersGetUsersGroupsResponseApplicationJson_Ocs_Data _build() {
+    UsersGetUsersGroupsResponseApplicationJson_Ocs_Data._validate(this);
     _$UsersGetUsersGroupsResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ?? _$UsersGetUsersGroupsResponseApplicationJson_Ocs_Data._(groups: groups.build());
@@ -16106,7 +16377,9 @@ class UsersGetUsersGroupsResponseApplicationJson_OcsBuilder
       _$this._data ??= UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant UsersGetUsersGroupsResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  UsersGetUsersGroupsResponseApplicationJson_OcsBuilder();
+  UsersGetUsersGroupsResponseApplicationJson_OcsBuilder() {
+    UsersGetUsersGroupsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersGetUsersGroupsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -16133,6 +16406,7 @@ class UsersGetUsersGroupsResponseApplicationJson_OcsBuilder
   UsersGetUsersGroupsResponseApplicationJson_Ocs build() => _build();
 
   _$UsersGetUsersGroupsResponseApplicationJson_Ocs _build() {
+    UsersGetUsersGroupsResponseApplicationJson_Ocs._validate(this);
     _$UsersGetUsersGroupsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$UsersGetUsersGroupsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -16213,7 +16487,9 @@ class UsersGetUsersGroupsResponseApplicationJsonBuilder
       _$this._ocs ??= UsersGetUsersGroupsResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersGetUsersGroupsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersGetUsersGroupsResponseApplicationJsonBuilder();
+  UsersGetUsersGroupsResponseApplicationJsonBuilder() {
+    UsersGetUsersGroupsResponseApplicationJson._defaults(this);
+  }
 
   UsersGetUsersGroupsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -16239,6 +16515,7 @@ class UsersGetUsersGroupsResponseApplicationJsonBuilder
   UsersGetUsersGroupsResponseApplicationJson build() => _build();
 
   _$UsersGetUsersGroupsResponseApplicationJson _build() {
+    UsersGetUsersGroupsResponseApplicationJson._validate(this);
     _$UsersGetUsersGroupsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersGetUsersGroupsResponseApplicationJson._(ocs: ocs.build());
@@ -16329,7 +16606,9 @@ class UsersAddToGroupResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersAddToGroupResponseApplicationJson_OcsBuilder();
+  UsersAddToGroupResponseApplicationJson_OcsBuilder() {
+    UsersAddToGroupResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersAddToGroupResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -16356,6 +16635,7 @@ class UsersAddToGroupResponseApplicationJson_OcsBuilder
   UsersAddToGroupResponseApplicationJson_Ocs build() => _build();
 
   _$UsersAddToGroupResponseApplicationJson_Ocs _build() {
+    UsersAddToGroupResponseApplicationJson_Ocs._validate(this);
     _$UsersAddToGroupResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -16436,7 +16716,9 @@ class UsersAddToGroupResponseApplicationJsonBuilder
       _$this._ocs ??= UsersAddToGroupResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersAddToGroupResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersAddToGroupResponseApplicationJsonBuilder();
+  UsersAddToGroupResponseApplicationJsonBuilder() {
+    UsersAddToGroupResponseApplicationJson._defaults(this);
+  }
 
   UsersAddToGroupResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -16462,6 +16744,7 @@ class UsersAddToGroupResponseApplicationJsonBuilder
   UsersAddToGroupResponseApplicationJson build() => _build();
 
   _$UsersAddToGroupResponseApplicationJson _build() {
+    UsersAddToGroupResponseApplicationJson._validate(this);
     _$UsersAddToGroupResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersAddToGroupResponseApplicationJson._(ocs: ocs.build());
@@ -16553,7 +16836,9 @@ class UsersRemoveFromGroupResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersRemoveFromGroupResponseApplicationJson_OcsBuilder();
+  UsersRemoveFromGroupResponseApplicationJson_OcsBuilder() {
+    UsersRemoveFromGroupResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersRemoveFromGroupResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -16580,6 +16865,7 @@ class UsersRemoveFromGroupResponseApplicationJson_OcsBuilder
   UsersRemoveFromGroupResponseApplicationJson_Ocs build() => _build();
 
   _$UsersRemoveFromGroupResponseApplicationJson_Ocs _build() {
+    UsersRemoveFromGroupResponseApplicationJson_Ocs._validate(this);
     _$UsersRemoveFromGroupResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -16662,7 +16948,9 @@ class UsersRemoveFromGroupResponseApplicationJsonBuilder
       _$this._ocs ??= UsersRemoveFromGroupResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersRemoveFromGroupResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersRemoveFromGroupResponseApplicationJsonBuilder();
+  UsersRemoveFromGroupResponseApplicationJsonBuilder() {
+    UsersRemoveFromGroupResponseApplicationJson._defaults(this);
+  }
 
   UsersRemoveFromGroupResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -16688,6 +16976,7 @@ class UsersRemoveFromGroupResponseApplicationJsonBuilder
   UsersRemoveFromGroupResponseApplicationJson build() => _build();
 
   _$UsersRemoveFromGroupResponseApplicationJson _build() {
+    UsersRemoveFromGroupResponseApplicationJson._validate(this);
     _$UsersRemoveFromGroupResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersRemoveFromGroupResponseApplicationJson._(ocs: ocs.build());
@@ -16780,7 +17069,9 @@ class UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder();
+  UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder() {
+    UsersResendWelcomeMessageResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -16807,6 +17098,7 @@ class UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder
   UsersResendWelcomeMessageResponseApplicationJson_Ocs build() => _build();
 
   _$UsersResendWelcomeMessageResponseApplicationJson_Ocs _build() {
+    UsersResendWelcomeMessageResponseApplicationJson_Ocs._validate(this);
     _$UsersResendWelcomeMessageResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -16891,7 +17183,9 @@ class UsersResendWelcomeMessageResponseApplicationJsonBuilder
       _$this._ocs ??= UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder();
   set ocs(covariant UsersResendWelcomeMessageResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UsersResendWelcomeMessageResponseApplicationJsonBuilder();
+  UsersResendWelcomeMessageResponseApplicationJsonBuilder() {
+    UsersResendWelcomeMessageResponseApplicationJson._defaults(this);
+  }
 
   UsersResendWelcomeMessageResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -16917,6 +17211,7 @@ class UsersResendWelcomeMessageResponseApplicationJsonBuilder
   UsersResendWelcomeMessageResponseApplicationJson build() => _build();
 
   _$UsersResendWelcomeMessageResponseApplicationJson _build() {
+    UsersResendWelcomeMessageResponseApplicationJson._validate(this);
     _$UsersResendWelcomeMessageResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UsersResendWelcomeMessageResponseApplicationJson._(ocs: ocs.build());
@@ -17044,7 +17339,9 @@ class Capabilities_ProvisioningApiBuilder
   set accountPropertyScopesPublishedEnabled(covariant bool? accountPropertyScopesPublishedEnabled) =>
       _$this._accountPropertyScopesPublishedEnabled = accountPropertyScopesPublishedEnabled;
 
-  Capabilities_ProvisioningApiBuilder();
+  Capabilities_ProvisioningApiBuilder() {
+    Capabilities_ProvisioningApi._defaults(this);
+  }
 
   Capabilities_ProvisioningApiBuilder get _$this {
     final $v = _$v;
@@ -17073,6 +17370,7 @@ class Capabilities_ProvisioningApiBuilder
   Capabilities_ProvisioningApi build() => _build();
 
   _$Capabilities_ProvisioningApi _build() {
+    Capabilities_ProvisioningApi._validate(this);
     final _$result = _$v ??
         _$Capabilities_ProvisioningApi._(
             version: BuiltValueNullFieldError.checkNotNull(version, r'Capabilities_ProvisioningApi', 'version'),
@@ -17144,7 +17442,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   set provisioningApi(covariant Capabilities_ProvisioningApiBuilder? provisioningApi) =>
       _$this._provisioningApi = provisioningApi;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -17170,6 +17470,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(provisioningApi: provisioningApi.build());

--- a/packages/nextcloud/lib/src/api/settings.openapi.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.dart
@@ -130,6 +130,10 @@ class $LogSettingsClient {
 abstract interface class $LogSettingsLogSettingsDownloadHeadersInterface {
   @BuiltValueField(wireName: 'content-disposition')
   String? get contentDisposition;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($LogSettingsLogSettingsDownloadHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($LogSettingsLogSettingsDownloadHeadersInterfaceBuilder b) {}
 }
 
 abstract class LogSettingsLogSettingsDownloadHeaders
@@ -162,6 +166,16 @@ abstract class LogSettingsLogSettingsDownloadHeaders
   /// Serializer for LogSettingsLogSettingsDownloadHeaders.
   static Serializer<LogSettingsLogSettingsDownloadHeaders> get serializer =>
       _$logSettingsLogSettingsDownloadHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(LogSettingsLogSettingsDownloadHeadersBuilder b) {
+    $LogSettingsLogSettingsDownloadHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(LogSettingsLogSettingsDownloadHeadersBuilder b) {
+    $LogSettingsLogSettingsDownloadHeadersInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/settings.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.g.dart
@@ -108,7 +108,9 @@ class LogSettingsLogSettingsDownloadHeadersBuilder
   String? get contentDisposition => _$this._contentDisposition;
   set contentDisposition(covariant String? contentDisposition) => _$this._contentDisposition = contentDisposition;
 
-  LogSettingsLogSettingsDownloadHeadersBuilder();
+  LogSettingsLogSettingsDownloadHeadersBuilder() {
+    LogSettingsLogSettingsDownloadHeaders._defaults(this);
+  }
 
   LogSettingsLogSettingsDownloadHeadersBuilder get _$this {
     final $v = _$v;
@@ -134,6 +136,7 @@ class LogSettingsLogSettingsDownloadHeadersBuilder
   LogSettingsLogSettingsDownloadHeaders build() => _build();
 
   _$LogSettingsLogSettingsDownloadHeaders _build() {
+    LogSettingsLogSettingsDownloadHeaders._validate(this);
     final _$result = _$v ?? _$LogSettingsLogSettingsDownloadHeaders._(contentDisposition: contentDisposition);
     replace(_$result);
     return _$result;

--- a/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
+++ b/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
@@ -28,6 +28,10 @@ part 'sharebymail.openapi.g.dart';
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder b) {}
 }
 
 abstract class Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop
@@ -62,12 +66,26 @@ abstract class Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop
   /// Serializer for Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop.
   static Serializer<Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop> get serializer =>
       _$capabilities0FilesSharingSharebymailUploadFilesDropSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder b) {
+    $Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder b) {
+    $Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities0_FilesSharing_Sharebymail_PasswordInterface {
   bool get enabled;
   bool get enforced;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder b) {}
 }
 
 abstract class Capabilities0_FilesSharing_Sharebymail_Password
@@ -101,12 +119,26 @@ abstract class Capabilities0_FilesSharing_Sharebymail_Password
   /// Serializer for Capabilities0_FilesSharing_Sharebymail_Password.
   static Serializer<Capabilities0_FilesSharing_Sharebymail_Password> get serializer =>
       _$capabilities0FilesSharingSharebymailPasswordSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities0_FilesSharing_Sharebymail_PasswordBuilder b) {
+    $Capabilities0_FilesSharing_Sharebymail_PasswordInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities0_FilesSharing_Sharebymail_PasswordBuilder b) {
+    $Capabilities0_FilesSharing_Sharebymail_PasswordInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities0_FilesSharing_Sharebymail_ExpireDateInterface {
   bool get enabled;
   bool get enforced;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder b) {}
 }
 
 abstract class Capabilities0_FilesSharing_Sharebymail_ExpireDate
@@ -141,6 +173,16 @@ abstract class Capabilities0_FilesSharing_Sharebymail_ExpireDate
   /// Serializer for Capabilities0_FilesSharing_Sharebymail_ExpireDate.
   static Serializer<Capabilities0_FilesSharing_Sharebymail_ExpireDate> get serializer =>
       _$capabilities0FilesSharingSharebymailExpireDateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder b) {
+    $Capabilities0_FilesSharing_Sharebymail_ExpireDateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder b) {
+    $Capabilities0_FilesSharing_Sharebymail_ExpireDateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -153,6 +195,10 @@ abstract interface class $Capabilities0_FilesSharing_SharebymailInterface {
   Capabilities0_FilesSharing_Sharebymail_Password get password;
   @BuiltValueField(wireName: 'expire_date')
   Capabilities0_FilesSharing_Sharebymail_ExpireDate get expireDate;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities0_FilesSharing_SharebymailInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities0_FilesSharing_SharebymailInterfaceBuilder b) {}
 }
 
 abstract class Capabilities0_FilesSharing_Sharebymail
@@ -185,11 +231,25 @@ abstract class Capabilities0_FilesSharing_Sharebymail
   /// Serializer for Capabilities0_FilesSharing_Sharebymail.
   static Serializer<Capabilities0_FilesSharing_Sharebymail> get serializer =>
       _$capabilities0FilesSharingSharebymailSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities0_FilesSharing_SharebymailBuilder b) {
+    $Capabilities0_FilesSharing_SharebymailInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities0_FilesSharing_SharebymailBuilder b) {
+    $Capabilities0_FilesSharing_SharebymailInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities0_FilesSharingInterface {
   Capabilities0_FilesSharing_Sharebymail get sharebymail;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities0_FilesSharingInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities0_FilesSharingInterfaceBuilder b) {}
 }
 
 abstract class Capabilities0_FilesSharing
@@ -221,12 +281,26 @@ abstract class Capabilities0_FilesSharing
 
   /// Serializer for Capabilities0_FilesSharing.
   static Serializer<Capabilities0_FilesSharing> get serializer => _$capabilities0FilesSharingSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities0_FilesSharingBuilder b) {
+    $Capabilities0_FilesSharingInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities0_FilesSharingBuilder b) {
+    $Capabilities0_FilesSharingInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities0Interface {
   @BuiltValueField(wireName: 'files_sharing')
   Capabilities0_FilesSharing get filesSharing;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities0InterfaceBuilder b) {}
 }
 
 abstract class Capabilities0 implements $Capabilities0Interface, Built<Capabilities0, Capabilities0Builder> {
@@ -253,6 +327,16 @@ abstract class Capabilities0 implements $Capabilities0Interface, Built<Capabilit
 
   /// Serializer for Capabilities0.
   static Serializer<Capabilities0> get serializer => _$capabilities0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities0Builder b) {
+    $Capabilities0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities0Builder b) {
+    $Capabilities0Interface._validate(b);
+  }
 }
 
 typedef Capabilities = ({BuiltList<Never>? builtListNever, Capabilities0? capabilities0});

--- a/packages/nextcloud/lib/src/api/sharebymail.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/sharebymail.openapi.g.dart
@@ -366,7 +366,9 @@ class Capabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  Capabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder();
+  Capabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder() {
+    Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop._defaults(this);
+  }
 
   Capabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder get _$this {
     final $v = _$v;
@@ -392,6 +394,7 @@ class Capabilities0_FilesSharing_Sharebymail_UploadFilesDropBuilder
   Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop build() => _build();
 
   _$Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop _build() {
+    Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop._validate(this);
     final _$result = _$v ??
         _$Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -476,7 +479,9 @@ class Capabilities0_FilesSharing_Sharebymail_PasswordBuilder
   bool? get enforced => _$this._enforced;
   set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
-  Capabilities0_FilesSharing_Sharebymail_PasswordBuilder();
+  Capabilities0_FilesSharing_Sharebymail_PasswordBuilder() {
+    Capabilities0_FilesSharing_Sharebymail_Password._defaults(this);
+  }
 
   Capabilities0_FilesSharing_Sharebymail_PasswordBuilder get _$this {
     final $v = _$v;
@@ -503,6 +508,7 @@ class Capabilities0_FilesSharing_Sharebymail_PasswordBuilder
   Capabilities0_FilesSharing_Sharebymail_Password build() => _build();
 
   _$Capabilities0_FilesSharing_Sharebymail_Password _build() {
+    Capabilities0_FilesSharing_Sharebymail_Password._validate(this);
     final _$result = _$v ??
         _$Capabilities0_FilesSharing_Sharebymail_Password._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -589,7 +595,9 @@ class Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder
   bool? get enforced => _$this._enforced;
   set enforced(covariant bool? enforced) => _$this._enforced = enforced;
 
-  Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder();
+  Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder() {
+    Capabilities0_FilesSharing_Sharebymail_ExpireDate._defaults(this);
+  }
 
   Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder get _$this {
     final $v = _$v;
@@ -616,6 +624,7 @@ class Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder
   Capabilities0_FilesSharing_Sharebymail_ExpireDate build() => _build();
 
   _$Capabilities0_FilesSharing_Sharebymail_ExpireDate _build() {
+    Capabilities0_FilesSharing_Sharebymail_ExpireDate._validate(this);
     final _$result = _$v ??
         _$Capabilities0_FilesSharing_Sharebymail_ExpireDate._(
             enabled: BuiltValueNullFieldError.checkNotNull(
@@ -754,7 +763,9 @@ class Capabilities0_FilesSharing_SharebymailBuilder
   set expireDate(covariant Capabilities0_FilesSharing_Sharebymail_ExpireDateBuilder? expireDate) =>
       _$this._expireDate = expireDate;
 
-  Capabilities0_FilesSharing_SharebymailBuilder();
+  Capabilities0_FilesSharing_SharebymailBuilder() {
+    Capabilities0_FilesSharing_Sharebymail._defaults(this);
+  }
 
   Capabilities0_FilesSharing_SharebymailBuilder get _$this {
     final $v = _$v;
@@ -784,6 +795,7 @@ class Capabilities0_FilesSharing_SharebymailBuilder
   Capabilities0_FilesSharing_Sharebymail build() => _build();
 
   _$Capabilities0_FilesSharing_Sharebymail _build() {
+    Capabilities0_FilesSharing_Sharebymail._validate(this);
     _$Capabilities0_FilesSharing_Sharebymail _$result;
     try {
       _$result = _$v ??
@@ -871,7 +883,9 @@ class Capabilities0_FilesSharingBuilder
   set sharebymail(covariant Capabilities0_FilesSharing_SharebymailBuilder? sharebymail) =>
       _$this._sharebymail = sharebymail;
 
-  Capabilities0_FilesSharingBuilder();
+  Capabilities0_FilesSharingBuilder() {
+    Capabilities0_FilesSharing._defaults(this);
+  }
 
   Capabilities0_FilesSharingBuilder get _$this {
     final $v = _$v;
@@ -897,6 +911,7 @@ class Capabilities0_FilesSharingBuilder
   Capabilities0_FilesSharing build() => _build();
 
   _$Capabilities0_FilesSharing _build() {
+    Capabilities0_FilesSharing._validate(this);
     _$Capabilities0_FilesSharing _$result;
     try {
       _$result = _$v ?? _$Capabilities0_FilesSharing._(sharebymail: sharebymail.build());
@@ -966,7 +981,9 @@ class Capabilities0Builder implements Builder<Capabilities0, Capabilities0Builde
   Capabilities0_FilesSharingBuilder get filesSharing => _$this._filesSharing ??= Capabilities0_FilesSharingBuilder();
   set filesSharing(covariant Capabilities0_FilesSharingBuilder? filesSharing) => _$this._filesSharing = filesSharing;
 
-  Capabilities0Builder();
+  Capabilities0Builder() {
+    Capabilities0._defaults(this);
+  }
 
   Capabilities0Builder get _$this {
     final $v = _$v;
@@ -992,6 +1009,7 @@ class Capabilities0Builder implements Builder<Capabilities0, Capabilities0Builde
   Capabilities0 build() => _build();
 
   _$Capabilities0 _build() {
+    Capabilities0._validate(this);
     _$Capabilities0 _$result;
     try {
       _$result = _$v ?? _$Capabilities0._(filesSharing: filesSharing.build());

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -13778,6 +13778,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -13804,6 +13808,16 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 class ActorType extends EnumClass {
@@ -14252,6 +14266,10 @@ abstract interface class $RichObjectParameterInterface {
   String? get etag;
   int? get width;
   int? get height;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RichObjectParameterInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RichObjectParameterInterfaceBuilder b) {}
 }
 
 abstract class RichObjectParameter
@@ -14280,6 +14298,16 @@ abstract class RichObjectParameter
 
   /// Serializer for RichObjectParameter.
   static Serializer<RichObjectParameter> get serializer => _$richObjectParameterSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RichObjectParameterBuilder b) {
+    $RichObjectParameterInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RichObjectParameterBuilder b) {
+    $RichObjectParameterInterface._validate(b);
+  }
 }
 
 class MessageType extends EnumClass {
@@ -14407,6 +14435,10 @@ abstract interface class $ChatMessageInterface {
   String get systemMessage;
   int get timestamp;
   String get token;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatMessageInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatMessageInterfaceBuilder b) {}
 }
 
 abstract class ChatMessage implements $ChatMessageInterface, Built<ChatMessage, ChatMessageBuilder> {
@@ -14433,6 +14465,16 @@ abstract class ChatMessage implements $ChatMessageInterface, Built<ChatMessage, 
 
   /// Serializer for ChatMessage.
   static Serializer<ChatMessage> get serializer => _$chatMessageSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatMessageBuilder b) {
+    $ChatMessageInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatMessageBuilder b) {
+    $ChatMessageInterface._validate(b);
+  }
 }
 
 typedef Room_LastMessage = ({BuiltList<Never>? builtListNever, ChatMessage? chatMessage});
@@ -14493,6 +14535,12 @@ abstract interface class $RoomInterface {
   bool get unreadMention;
   bool get unreadMentionDirect;
   int get unreadMessages;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomInterfaceBuilder b) {
+    b.lastMessage?.validateOneOf();
+  }
 }
 
 abstract class Room implements $RoomInterface, Built<Room, RoomBuilder> {
@@ -14520,9 +14568,14 @@ abstract class Room implements $RoomInterface, Built<Room, RoomBuilder> {
   /// Serializer for Room.
   static Serializer<Room> get serializer => _$roomSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomBuilder b) {
+    $RoomInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(RoomBuilder b) {
-    b.lastMessage?.validateOneOf();
+    $RoomInterface._validate(b);
   }
 }
 
@@ -14530,6 +14583,10 @@ abstract class Room implements $RoomInterface, Built<Room, RoomBuilder> {
 abstract interface class $AvatarUploadAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarUploadAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarUploadAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AvatarUploadAvatarResponseApplicationJson_Ocs
@@ -14563,11 +14620,25 @@ abstract class AvatarUploadAvatarResponseApplicationJson_Ocs
   /// Serializer for AvatarUploadAvatarResponseApplicationJson_Ocs.
   static Serializer<AvatarUploadAvatarResponseApplicationJson_Ocs> get serializer =>
       _$avatarUploadAvatarResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarUploadAvatarResponseApplicationJson_OcsBuilder b) {
+    $AvatarUploadAvatarResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarUploadAvatarResponseApplicationJson_OcsBuilder b) {
+    $AvatarUploadAvatarResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AvatarUploadAvatarResponseApplicationJsonInterface {
   AvatarUploadAvatarResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarUploadAvatarResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarUploadAvatarResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AvatarUploadAvatarResponseApplicationJson
@@ -14601,6 +14672,16 @@ abstract class AvatarUploadAvatarResponseApplicationJson
   /// Serializer for AvatarUploadAvatarResponseApplicationJson.
   static Serializer<AvatarUploadAvatarResponseApplicationJson> get serializer =>
       _$avatarUploadAvatarResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarUploadAvatarResponseApplicationJsonBuilder b) {
+    $AvatarUploadAvatarResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarUploadAvatarResponseApplicationJsonBuilder b) {
+    $AvatarUploadAvatarResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class AvatarDeleteAvatarApiVersion extends EnumClass {
@@ -14663,6 +14744,10 @@ class _$AvatarDeleteAvatarApiVersionSerializer implements PrimitiveSerializer<Av
 abstract interface class $AvatarDeleteAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AvatarDeleteAvatarResponseApplicationJson_Ocs
@@ -14696,11 +14781,25 @@ abstract class AvatarDeleteAvatarResponseApplicationJson_Ocs
   /// Serializer for AvatarDeleteAvatarResponseApplicationJson_Ocs.
   static Serializer<AvatarDeleteAvatarResponseApplicationJson_Ocs> get serializer =>
       _$avatarDeleteAvatarResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarDeleteAvatarResponseApplicationJson_OcsBuilder b) {
+    $AvatarDeleteAvatarResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarDeleteAvatarResponseApplicationJson_OcsBuilder b) {
+    $AvatarDeleteAvatarResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AvatarDeleteAvatarResponseApplicationJsonInterface {
   AvatarDeleteAvatarResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AvatarDeleteAvatarResponseApplicationJson
@@ -14734,6 +14833,16 @@ abstract class AvatarDeleteAvatarResponseApplicationJson
   /// Serializer for AvatarDeleteAvatarResponseApplicationJson.
   static Serializer<AvatarDeleteAvatarResponseApplicationJson> get serializer =>
       _$avatarDeleteAvatarResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarDeleteAvatarResponseApplicationJsonBuilder b) {
+    $AvatarDeleteAvatarResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarDeleteAvatarResponseApplicationJsonBuilder b) {
+    $AvatarDeleteAvatarResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class AvatarEmojiAvatarApiVersion extends EnumClass {
@@ -14796,6 +14905,10 @@ class _$AvatarEmojiAvatarApiVersionSerializer implements PrimitiveSerializer<Ava
 abstract interface class $AvatarEmojiAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarEmojiAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarEmojiAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class AvatarEmojiAvatarResponseApplicationJson_Ocs
@@ -14829,11 +14942,25 @@ abstract class AvatarEmojiAvatarResponseApplicationJson_Ocs
   /// Serializer for AvatarEmojiAvatarResponseApplicationJson_Ocs.
   static Serializer<AvatarEmojiAvatarResponseApplicationJson_Ocs> get serializer =>
       _$avatarEmojiAvatarResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarEmojiAvatarResponseApplicationJson_OcsBuilder b) {
+    $AvatarEmojiAvatarResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarEmojiAvatarResponseApplicationJson_OcsBuilder b) {
+    $AvatarEmojiAvatarResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AvatarEmojiAvatarResponseApplicationJsonInterface {
   AvatarEmojiAvatarResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarEmojiAvatarResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarEmojiAvatarResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class AvatarEmojiAvatarResponseApplicationJson
@@ -14867,6 +14994,16 @@ abstract class AvatarEmojiAvatarResponseApplicationJson
   /// Serializer for AvatarEmojiAvatarResponseApplicationJson.
   static Serializer<AvatarEmojiAvatarResponseApplicationJson> get serializer =>
       _$avatarEmojiAvatarResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarEmojiAvatarResponseApplicationJsonBuilder b) {
+    $AvatarEmojiAvatarResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarEmojiAvatarResponseApplicationJsonBuilder b) {
+    $AvatarEmojiAvatarResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class AvatarGetAvatarDarkApiVersion extends EnumClass {
@@ -15048,6 +15185,10 @@ class _$BotSendMessageApiVersionSerializer implements PrimitiveSerializer<BotSen
 abstract interface class $BotSendMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotSendMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotSendMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BotSendMessageResponseApplicationJson_Ocs
@@ -15081,11 +15222,25 @@ abstract class BotSendMessageResponseApplicationJson_Ocs
   /// Serializer for BotSendMessageResponseApplicationJson_Ocs.
   static Serializer<BotSendMessageResponseApplicationJson_Ocs> get serializer =>
       _$botSendMessageResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotSendMessageResponseApplicationJson_OcsBuilder b) {
+    $BotSendMessageResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotSendMessageResponseApplicationJson_OcsBuilder b) {
+    $BotSendMessageResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BotSendMessageResponseApplicationJsonInterface {
   BotSendMessageResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotSendMessageResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotSendMessageResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BotSendMessageResponseApplicationJson
@@ -15118,6 +15273,16 @@ abstract class BotSendMessageResponseApplicationJson
   /// Serializer for BotSendMessageResponseApplicationJson.
   static Serializer<BotSendMessageResponseApplicationJson> get serializer =>
       _$botSendMessageResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotSendMessageResponseApplicationJsonBuilder b) {
+    $BotSendMessageResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotSendMessageResponseApplicationJsonBuilder b) {
+    $BotSendMessageResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BotReactApiVersion extends EnumClass {
@@ -15180,6 +15345,10 @@ class _$BotReactApiVersionSerializer implements PrimitiveSerializer<BotReactApiV
 abstract interface class $BotReactResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotReactResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotReactResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BotReactResponseApplicationJson_Ocs
@@ -15212,11 +15381,25 @@ abstract class BotReactResponseApplicationJson_Ocs
   /// Serializer for BotReactResponseApplicationJson_Ocs.
   static Serializer<BotReactResponseApplicationJson_Ocs> get serializer =>
       _$botReactResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotReactResponseApplicationJson_OcsBuilder b) {
+    $BotReactResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotReactResponseApplicationJson_OcsBuilder b) {
+    $BotReactResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BotReactResponseApplicationJsonInterface {
   BotReactResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotReactResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotReactResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BotReactResponseApplicationJson
@@ -15248,6 +15431,16 @@ abstract class BotReactResponseApplicationJson
 
   /// Serializer for BotReactResponseApplicationJson.
   static Serializer<BotReactResponseApplicationJson> get serializer => _$botReactResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotReactResponseApplicationJsonBuilder b) {
+    $BotReactResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotReactResponseApplicationJsonBuilder b) {
+    $BotReactResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BotDeleteReactionApiVersion extends EnumClass {
@@ -15310,6 +15503,10 @@ class _$BotDeleteReactionApiVersionSerializer implements PrimitiveSerializer<Bot
 abstract interface class $BotDeleteReactionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotDeleteReactionResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotDeleteReactionResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BotDeleteReactionResponseApplicationJson_Ocs
@@ -15343,11 +15540,25 @@ abstract class BotDeleteReactionResponseApplicationJson_Ocs
   /// Serializer for BotDeleteReactionResponseApplicationJson_Ocs.
   static Serializer<BotDeleteReactionResponseApplicationJson_Ocs> get serializer =>
       _$botDeleteReactionResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotDeleteReactionResponseApplicationJson_OcsBuilder b) {
+    $BotDeleteReactionResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotDeleteReactionResponseApplicationJson_OcsBuilder b) {
+    $BotDeleteReactionResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BotDeleteReactionResponseApplicationJsonInterface {
   BotDeleteReactionResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotDeleteReactionResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotDeleteReactionResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BotDeleteReactionResponseApplicationJson
@@ -15381,6 +15592,16 @@ abstract class BotDeleteReactionResponseApplicationJson
   /// Serializer for BotDeleteReactionResponseApplicationJson.
   static Serializer<BotDeleteReactionResponseApplicationJson> get serializer =>
       _$botDeleteReactionResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotDeleteReactionResponseApplicationJsonBuilder b) {
+    $BotDeleteReactionResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotDeleteReactionResponseApplicationJsonBuilder b) {
+    $BotDeleteReactionResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BotListBotsApiVersion extends EnumClass {
@@ -15445,6 +15666,10 @@ abstract interface class $BotInterface {
   int get id;
   String get name;
   int get state;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotInterfaceBuilder b) {}
 }
 
 abstract class Bot implements $BotInterface, Built<Bot, BotBuilder> {
@@ -15471,12 +15696,26 @@ abstract class Bot implements $BotInterface, Built<Bot, BotBuilder> {
 
   /// Serializer for Bot.
   static Serializer<Bot> get serializer => _$botSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotBuilder b) {
+    $BotInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotBuilder b) {
+    $BotInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BotListBotsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Bot> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotListBotsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotListBotsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BotListBotsResponseApplicationJson_Ocs
@@ -15509,11 +15748,25 @@ abstract class BotListBotsResponseApplicationJson_Ocs
   /// Serializer for BotListBotsResponseApplicationJson_Ocs.
   static Serializer<BotListBotsResponseApplicationJson_Ocs> get serializer =>
       _$botListBotsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotListBotsResponseApplicationJson_OcsBuilder b) {
+    $BotListBotsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotListBotsResponseApplicationJson_OcsBuilder b) {
+    $BotListBotsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BotListBotsResponseApplicationJsonInterface {
   BotListBotsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotListBotsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotListBotsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BotListBotsResponseApplicationJson
@@ -15546,6 +15799,16 @@ abstract class BotListBotsResponseApplicationJson
   /// Serializer for BotListBotsResponseApplicationJson.
   static Serializer<BotListBotsResponseApplicationJson> get serializer =>
       _$botListBotsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotListBotsResponseApplicationJsonBuilder b) {
+    $BotListBotsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotListBotsResponseApplicationJsonBuilder b) {
+    $BotListBotsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BotEnableBotApiVersion extends EnumClass {
@@ -15608,6 +15871,10 @@ class _$BotEnableBotApiVersionSerializer implements PrimitiveSerializer<BotEnabl
 abstract interface class $BotEnableBotResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Bot? get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotEnableBotResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotEnableBotResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BotEnableBotResponseApplicationJson_Ocs
@@ -15640,11 +15907,25 @@ abstract class BotEnableBotResponseApplicationJson_Ocs
   /// Serializer for BotEnableBotResponseApplicationJson_Ocs.
   static Serializer<BotEnableBotResponseApplicationJson_Ocs> get serializer =>
       _$botEnableBotResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotEnableBotResponseApplicationJson_OcsBuilder b) {
+    $BotEnableBotResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotEnableBotResponseApplicationJson_OcsBuilder b) {
+    $BotEnableBotResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BotEnableBotResponseApplicationJsonInterface {
   BotEnableBotResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotEnableBotResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotEnableBotResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BotEnableBotResponseApplicationJson
@@ -15677,6 +15958,16 @@ abstract class BotEnableBotResponseApplicationJson
   /// Serializer for BotEnableBotResponseApplicationJson.
   static Serializer<BotEnableBotResponseApplicationJson> get serializer =>
       _$botEnableBotResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotEnableBotResponseApplicationJsonBuilder b) {
+    $BotEnableBotResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotEnableBotResponseApplicationJsonBuilder b) {
+    $BotEnableBotResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BotDisableBotApiVersion extends EnumClass {
@@ -15739,6 +16030,10 @@ class _$BotDisableBotApiVersionSerializer implements PrimitiveSerializer<BotDisa
 abstract interface class $BotDisableBotResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Bot? get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotDisableBotResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotDisableBotResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BotDisableBotResponseApplicationJson_Ocs
@@ -15772,11 +16067,25 @@ abstract class BotDisableBotResponseApplicationJson_Ocs
   /// Serializer for BotDisableBotResponseApplicationJson_Ocs.
   static Serializer<BotDisableBotResponseApplicationJson_Ocs> get serializer =>
       _$botDisableBotResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotDisableBotResponseApplicationJson_OcsBuilder b) {
+    $BotDisableBotResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotDisableBotResponseApplicationJson_OcsBuilder b) {
+    $BotDisableBotResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BotDisableBotResponseApplicationJsonInterface {
   BotDisableBotResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotDisableBotResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotDisableBotResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BotDisableBotResponseApplicationJson
@@ -15809,6 +16118,16 @@ abstract class BotDisableBotResponseApplicationJson
   /// Serializer for BotDisableBotResponseApplicationJson.
   static Serializer<BotDisableBotResponseApplicationJson> get serializer =>
       _$botDisableBotResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotDisableBotResponseApplicationJsonBuilder b) {
+    $BotDisableBotResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotDisableBotResponseApplicationJsonBuilder b) {
+    $BotDisableBotResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BotAdminListBotsApiVersion extends EnumClass {
@@ -15879,6 +16198,10 @@ abstract interface class $BotWithDetailsInterface implements $BotInterface {
   String get url;
   @BuiltValueField(wireName: 'url_hash')
   String get urlHash;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotWithDetailsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotWithDetailsInterfaceBuilder b) {}
 }
 
 abstract class BotWithDetails implements $BotWithDetailsInterface, Built<BotWithDetails, BotWithDetailsBuilder> {
@@ -15905,12 +16228,26 @@ abstract class BotWithDetails implements $BotWithDetailsInterface, Built<BotWith
 
   /// Serializer for BotWithDetails.
   static Serializer<BotWithDetails> get serializer => _$botWithDetailsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotWithDetailsBuilder b) {
+    $BotWithDetailsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotWithDetailsBuilder b) {
+    $BotWithDetailsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BotAdminListBotsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<BotWithDetails> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotAdminListBotsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotAdminListBotsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BotAdminListBotsResponseApplicationJson_Ocs
@@ -15944,11 +16281,25 @@ abstract class BotAdminListBotsResponseApplicationJson_Ocs
   /// Serializer for BotAdminListBotsResponseApplicationJson_Ocs.
   static Serializer<BotAdminListBotsResponseApplicationJson_Ocs> get serializer =>
       _$botAdminListBotsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotAdminListBotsResponseApplicationJson_OcsBuilder b) {
+    $BotAdminListBotsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotAdminListBotsResponseApplicationJson_OcsBuilder b) {
+    $BotAdminListBotsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BotAdminListBotsResponseApplicationJsonInterface {
   BotAdminListBotsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotAdminListBotsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotAdminListBotsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BotAdminListBotsResponseApplicationJson
@@ -15981,6 +16332,16 @@ abstract class BotAdminListBotsResponseApplicationJson
   /// Serializer for BotAdminListBotsResponseApplicationJson.
   static Serializer<BotAdminListBotsResponseApplicationJson> get serializer =>
       _$botAdminListBotsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotAdminListBotsResponseApplicationJsonBuilder b) {
+    $BotAdminListBotsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotAdminListBotsResponseApplicationJsonBuilder b) {
+    $BotAdminListBotsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BreakoutRoomConfigureBreakoutRoomsMode extends EnumClass {
@@ -16129,6 +16490,10 @@ class _$BreakoutRoomConfigureBreakoutRoomsApiVersionSerializer
 abstract interface class $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs
@@ -16163,11 +16528,25 @@ abstract class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs
   /// Serializer for BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs.
   static Serializer<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs> get serializer =>
       _$breakoutRoomConfigureBreakoutRoomsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterface {
   BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson
@@ -16202,6 +16581,16 @@ abstract class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson
   /// Serializer for BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson.
   static Serializer<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson> get serializer =>
       _$breakoutRoomConfigureBreakoutRoomsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder b) {
+    $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder b) {
+    $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BreakoutRoomRemoveBreakoutRoomsApiVersion extends EnumClass {
@@ -16270,6 +16659,10 @@ class _$BreakoutRoomRemoveBreakoutRoomsApiVersionSerializer
 abstract interface class $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs
@@ -16304,11 +16697,25 @@ abstract class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs
   /// Serializer for BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs.
   static Serializer<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs> get serializer =>
       _$breakoutRoomRemoveBreakoutRoomsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterface {
   BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson
@@ -16343,6 +16750,16 @@ abstract class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson
   /// Serializer for BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson.
   static Serializer<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson> get serializer =>
       _$breakoutRoomRemoveBreakoutRoomsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder b) {
+    $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder b) {
+    $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BreakoutRoomBroadcastChatMessageApiVersion extends EnumClass {
@@ -16411,6 +16828,10 @@ class _$BreakoutRoomBroadcastChatMessageApiVersionSerializer
 abstract interface class $BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs
@@ -16445,11 +16866,25 @@ abstract class BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs
   /// Serializer for BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs.
   static Serializer<BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs> get serializer =>
       _$breakoutRoomBroadcastChatMessageResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterface {
   BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomBroadcastChatMessageResponseApplicationJson
@@ -16484,6 +16919,16 @@ abstract class BreakoutRoomBroadcastChatMessageResponseApplicationJson
   /// Serializer for BreakoutRoomBroadcastChatMessageResponseApplicationJson.
   static Serializer<BreakoutRoomBroadcastChatMessageResponseApplicationJson> get serializer =>
       _$breakoutRoomBroadcastChatMessageResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder b) {
+    $BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder b) {
+    $BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BreakoutRoomApplyAttendeeMapApiVersion extends EnumClass {
@@ -16551,6 +16996,10 @@ class _$BreakoutRoomApplyAttendeeMapApiVersionSerializer
 abstract interface class $BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs
@@ -16585,11 +17034,25 @@ abstract class BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs
   /// Serializer for BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs.
   static Serializer<BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs> get serializer =>
       _$breakoutRoomApplyAttendeeMapResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterface {
   BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomApplyAttendeeMapResponseApplicationJson
@@ -16624,6 +17087,16 @@ abstract class BreakoutRoomApplyAttendeeMapResponseApplicationJson
   /// Serializer for BreakoutRoomApplyAttendeeMapResponseApplicationJson.
   static Serializer<BreakoutRoomApplyAttendeeMapResponseApplicationJson> get serializer =>
       _$breakoutRoomApplyAttendeeMapResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder b) {
+    $BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder b) {
+    $BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BreakoutRoomRequestAssistanceApiVersion extends EnumClass {
@@ -16692,6 +17165,10 @@ class _$BreakoutRoomRequestAssistanceApiVersionSerializer
 abstract interface class $BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs
@@ -16726,11 +17203,25 @@ abstract class BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs
   /// Serializer for BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs.
   static Serializer<BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs> get serializer =>
       _$breakoutRoomRequestAssistanceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BreakoutRoomRequestAssistanceResponseApplicationJsonInterface {
   BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomRequestAssistanceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomRequestAssistanceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomRequestAssistanceResponseApplicationJson
@@ -16765,6 +17256,16 @@ abstract class BreakoutRoomRequestAssistanceResponseApplicationJson
   /// Serializer for BreakoutRoomRequestAssistanceResponseApplicationJson.
   static Serializer<BreakoutRoomRequestAssistanceResponseApplicationJson> get serializer =>
       _$breakoutRoomRequestAssistanceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomRequestAssistanceResponseApplicationJsonBuilder b) {
+    $BreakoutRoomRequestAssistanceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomRequestAssistanceResponseApplicationJsonBuilder b) {
+    $BreakoutRoomRequestAssistanceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BreakoutRoomResetRequestForAssistanceApiVersion extends EnumClass {
@@ -16833,6 +17334,10 @@ class _$BreakoutRoomResetRequestForAssistanceApiVersionSerializer
 abstract interface class $BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs
@@ -16867,11 +17372,25 @@ abstract class BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs
   /// Serializer for BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs.
   static Serializer<BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs> get serializer =>
       _$breakoutRoomResetRequestForAssistanceResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterface {
   BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomResetRequestForAssistanceResponseApplicationJson
@@ -16906,6 +17425,16 @@ abstract class BreakoutRoomResetRequestForAssistanceResponseApplicationJson
   /// Serializer for BreakoutRoomResetRequestForAssistanceResponseApplicationJson.
   static Serializer<BreakoutRoomResetRequestForAssistanceResponseApplicationJson> get serializer =>
       _$breakoutRoomResetRequestForAssistanceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomResetRequestForAssistanceResponseApplicationJsonBuilder b) {
+    $BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomResetRequestForAssistanceResponseApplicationJsonBuilder b) {
+    $BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BreakoutRoomStartBreakoutRoomsApiVersion extends EnumClass {
@@ -16974,6 +17503,10 @@ class _$BreakoutRoomStartBreakoutRoomsApiVersionSerializer
 abstract interface class $BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs
@@ -17008,11 +17541,25 @@ abstract class BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs
   /// Serializer for BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs.
   static Serializer<BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs> get serializer =>
       _$breakoutRoomStartBreakoutRoomsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterface {
   BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomStartBreakoutRoomsResponseApplicationJson
@@ -17047,6 +17594,16 @@ abstract class BreakoutRoomStartBreakoutRoomsResponseApplicationJson
   /// Serializer for BreakoutRoomStartBreakoutRoomsResponseApplicationJson.
   static Serializer<BreakoutRoomStartBreakoutRoomsResponseApplicationJson> get serializer =>
       _$breakoutRoomStartBreakoutRoomsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomStartBreakoutRoomsResponseApplicationJsonBuilder b) {
+    $BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomStartBreakoutRoomsResponseApplicationJsonBuilder b) {
+    $BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BreakoutRoomStopBreakoutRoomsApiVersion extends EnumClass {
@@ -17115,6 +17672,10 @@ class _$BreakoutRoomStopBreakoutRoomsApiVersionSerializer
 abstract interface class $BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs
@@ -17149,11 +17710,25 @@ abstract class BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs
   /// Serializer for BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs.
   static Serializer<BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs> get serializer =>
       _$breakoutRoomStopBreakoutRoomsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterface {
   BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomStopBreakoutRoomsResponseApplicationJson
@@ -17188,6 +17763,16 @@ abstract class BreakoutRoomStopBreakoutRoomsResponseApplicationJson
   /// Serializer for BreakoutRoomStopBreakoutRoomsResponseApplicationJson.
   static Serializer<BreakoutRoomStopBreakoutRoomsResponseApplicationJson> get serializer =>
       _$breakoutRoomStopBreakoutRoomsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder b) {
+    $BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder b) {
+    $BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class BreakoutRoomSwitchBreakoutRoomApiVersion extends EnumClass {
@@ -17256,6 +17841,10 @@ class _$BreakoutRoomSwitchBreakoutRoomApiVersionSerializer
 abstract interface class $BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs
@@ -17290,11 +17879,25 @@ abstract class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs
   /// Serializer for BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs.
   static Serializer<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs> get serializer =>
       _$breakoutRoomSwitchBreakoutRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder b) {
+    $BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterface {
   BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson
@@ -17329,6 +17932,16 @@ abstract class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson
   /// Serializer for BreakoutRoomSwitchBreakoutRoomResponseApplicationJson.
   static Serializer<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson> get serializer =>
       _$breakoutRoomSwitchBreakoutRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder b) {
+    $BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder b) {
+    $BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class CallGetPeersForCallApiVersion extends EnumClass {
@@ -17395,6 +18008,10 @@ abstract interface class $CallPeerInterface {
   int get lastPing;
   String get sessionId;
   String get token;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallPeerInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallPeerInterfaceBuilder b) {}
 }
 
 abstract class CallPeer implements $CallPeerInterface, Built<CallPeer, CallPeerBuilder> {
@@ -17421,12 +18038,26 @@ abstract class CallPeer implements $CallPeerInterface, Built<CallPeer, CallPeerB
 
   /// Serializer for CallPeer.
   static Serializer<CallPeer> get serializer => _$callPeerSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallPeerBuilder b) {
+    $CallPeerInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallPeerBuilder b) {
+    $CallPeerInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CallGetPeersForCallResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<CallPeer> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallGetPeersForCallResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallGetPeersForCallResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CallGetPeersForCallResponseApplicationJson_Ocs
@@ -17460,11 +18091,25 @@ abstract class CallGetPeersForCallResponseApplicationJson_Ocs
   /// Serializer for CallGetPeersForCallResponseApplicationJson_Ocs.
   static Serializer<CallGetPeersForCallResponseApplicationJson_Ocs> get serializer =>
       _$callGetPeersForCallResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallGetPeersForCallResponseApplicationJson_OcsBuilder b) {
+    $CallGetPeersForCallResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallGetPeersForCallResponseApplicationJson_OcsBuilder b) {
+    $CallGetPeersForCallResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CallGetPeersForCallResponseApplicationJsonInterface {
   CallGetPeersForCallResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallGetPeersForCallResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallGetPeersForCallResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CallGetPeersForCallResponseApplicationJson
@@ -17498,6 +18143,16 @@ abstract class CallGetPeersForCallResponseApplicationJson
   /// Serializer for CallGetPeersForCallResponseApplicationJson.
   static Serializer<CallGetPeersForCallResponseApplicationJson> get serializer =>
       _$callGetPeersForCallResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallGetPeersForCallResponseApplicationJsonBuilder b) {
+    $CallGetPeersForCallResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallGetPeersForCallResponseApplicationJsonBuilder b) {
+    $CallGetPeersForCallResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class CallUpdateCallFlagsApiVersion extends EnumClass {
@@ -17560,6 +18215,10 @@ class _$CallUpdateCallFlagsApiVersionSerializer implements PrimitiveSerializer<C
 abstract interface class $CallUpdateCallFlagsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallUpdateCallFlagsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallUpdateCallFlagsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CallUpdateCallFlagsResponseApplicationJson_Ocs
@@ -17593,11 +18252,25 @@ abstract class CallUpdateCallFlagsResponseApplicationJson_Ocs
   /// Serializer for CallUpdateCallFlagsResponseApplicationJson_Ocs.
   static Serializer<CallUpdateCallFlagsResponseApplicationJson_Ocs> get serializer =>
       _$callUpdateCallFlagsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallUpdateCallFlagsResponseApplicationJson_OcsBuilder b) {
+    $CallUpdateCallFlagsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallUpdateCallFlagsResponseApplicationJson_OcsBuilder b) {
+    $CallUpdateCallFlagsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CallUpdateCallFlagsResponseApplicationJsonInterface {
   CallUpdateCallFlagsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallUpdateCallFlagsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallUpdateCallFlagsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CallUpdateCallFlagsResponseApplicationJson
@@ -17631,6 +18304,16 @@ abstract class CallUpdateCallFlagsResponseApplicationJson
   /// Serializer for CallUpdateCallFlagsResponseApplicationJson.
   static Serializer<CallUpdateCallFlagsResponseApplicationJson> get serializer =>
       _$callUpdateCallFlagsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallUpdateCallFlagsResponseApplicationJsonBuilder b) {
+    $CallUpdateCallFlagsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallUpdateCallFlagsResponseApplicationJsonBuilder b) {
+    $CallUpdateCallFlagsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class CallJoinCallFlags extends EnumClass {
@@ -19553,6 +20236,10 @@ class _$CallJoinCallApiVersionSerializer implements PrimitiveSerializer<CallJoin
 abstract interface class $CallJoinCallResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallJoinCallResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallJoinCallResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CallJoinCallResponseApplicationJson_Ocs
@@ -19585,11 +20272,25 @@ abstract class CallJoinCallResponseApplicationJson_Ocs
   /// Serializer for CallJoinCallResponseApplicationJson_Ocs.
   static Serializer<CallJoinCallResponseApplicationJson_Ocs> get serializer =>
       _$callJoinCallResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallJoinCallResponseApplicationJson_OcsBuilder b) {
+    $CallJoinCallResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallJoinCallResponseApplicationJson_OcsBuilder b) {
+    $CallJoinCallResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CallJoinCallResponseApplicationJsonInterface {
   CallJoinCallResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallJoinCallResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallJoinCallResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CallJoinCallResponseApplicationJson
@@ -19622,6 +20323,16 @@ abstract class CallJoinCallResponseApplicationJson
   /// Serializer for CallJoinCallResponseApplicationJson.
   static Serializer<CallJoinCallResponseApplicationJson> get serializer =>
       _$callJoinCallResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallJoinCallResponseApplicationJsonBuilder b) {
+    $CallJoinCallResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallJoinCallResponseApplicationJsonBuilder b) {
+    $CallJoinCallResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class CallLeaveCallAll extends EnumClass {
@@ -19747,6 +20458,10 @@ class _$CallLeaveCallApiVersionSerializer implements PrimitiveSerializer<CallLea
 abstract interface class $CallLeaveCallResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallLeaveCallResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallLeaveCallResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CallLeaveCallResponseApplicationJson_Ocs
@@ -19780,11 +20495,25 @@ abstract class CallLeaveCallResponseApplicationJson_Ocs
   /// Serializer for CallLeaveCallResponseApplicationJson_Ocs.
   static Serializer<CallLeaveCallResponseApplicationJson_Ocs> get serializer =>
       _$callLeaveCallResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallLeaveCallResponseApplicationJson_OcsBuilder b) {
+    $CallLeaveCallResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallLeaveCallResponseApplicationJson_OcsBuilder b) {
+    $CallLeaveCallResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CallLeaveCallResponseApplicationJsonInterface {
   CallLeaveCallResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallLeaveCallResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallLeaveCallResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CallLeaveCallResponseApplicationJson
@@ -19817,6 +20546,16 @@ abstract class CallLeaveCallResponseApplicationJson
   /// Serializer for CallLeaveCallResponseApplicationJson.
   static Serializer<CallLeaveCallResponseApplicationJson> get serializer =>
       _$callLeaveCallResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallLeaveCallResponseApplicationJsonBuilder b) {
+    $CallLeaveCallResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallLeaveCallResponseApplicationJsonBuilder b) {
+    $CallLeaveCallResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class CallRingAttendeeApiVersion extends EnumClass {
@@ -19879,6 +20618,10 @@ class _$CallRingAttendeeApiVersionSerializer implements PrimitiveSerializer<Call
 abstract interface class $CallRingAttendeeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallRingAttendeeResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallRingAttendeeResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CallRingAttendeeResponseApplicationJson_Ocs
@@ -19912,11 +20655,25 @@ abstract class CallRingAttendeeResponseApplicationJson_Ocs
   /// Serializer for CallRingAttendeeResponseApplicationJson_Ocs.
   static Serializer<CallRingAttendeeResponseApplicationJson_Ocs> get serializer =>
       _$callRingAttendeeResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallRingAttendeeResponseApplicationJson_OcsBuilder b) {
+    $CallRingAttendeeResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallRingAttendeeResponseApplicationJson_OcsBuilder b) {
+    $CallRingAttendeeResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CallRingAttendeeResponseApplicationJsonInterface {
   CallRingAttendeeResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallRingAttendeeResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallRingAttendeeResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CallRingAttendeeResponseApplicationJson
@@ -19949,6 +20706,16 @@ abstract class CallRingAttendeeResponseApplicationJson
   /// Serializer for CallRingAttendeeResponseApplicationJson.
   static Serializer<CallRingAttendeeResponseApplicationJson> get serializer =>
       _$callRingAttendeeResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallRingAttendeeResponseApplicationJsonBuilder b) {
+    $CallRingAttendeeResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallRingAttendeeResponseApplicationJsonBuilder b) {
+    $CallRingAttendeeResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class CallSipDialOutApiVersion extends EnumClass {
@@ -20011,6 +20778,10 @@ class _$CallSipDialOutApiVersionSerializer implements PrimitiveSerializer<CallSi
 abstract interface class $CallSipDialOutResponseApplicationJson_Ocs_DataInterface {
   String? get error;
   String? get message;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallSipDialOutResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallSipDialOutResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class CallSipDialOutResponseApplicationJson_Ocs_Data
@@ -20044,12 +20815,26 @@ abstract class CallSipDialOutResponseApplicationJson_Ocs_Data
   /// Serializer for CallSipDialOutResponseApplicationJson_Ocs_Data.
   static Serializer<CallSipDialOutResponseApplicationJson_Ocs_Data> get serializer =>
       _$callSipDialOutResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallSipDialOutResponseApplicationJson_Ocs_DataBuilder b) {
+    $CallSipDialOutResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallSipDialOutResponseApplicationJson_Ocs_DataBuilder b) {
+    $CallSipDialOutResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CallSipDialOutResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   CallSipDialOutResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallSipDialOutResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallSipDialOutResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CallSipDialOutResponseApplicationJson_Ocs
@@ -20083,11 +20868,25 @@ abstract class CallSipDialOutResponseApplicationJson_Ocs
   /// Serializer for CallSipDialOutResponseApplicationJson_Ocs.
   static Serializer<CallSipDialOutResponseApplicationJson_Ocs> get serializer =>
       _$callSipDialOutResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallSipDialOutResponseApplicationJson_OcsBuilder b) {
+    $CallSipDialOutResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallSipDialOutResponseApplicationJson_OcsBuilder b) {
+    $CallSipDialOutResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CallSipDialOutResponseApplicationJsonInterface {
   CallSipDialOutResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallSipDialOutResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallSipDialOutResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CallSipDialOutResponseApplicationJson
@@ -20120,6 +20919,16 @@ abstract class CallSipDialOutResponseApplicationJson
   /// Serializer for CallSipDialOutResponseApplicationJson.
   static Serializer<CallSipDialOutResponseApplicationJson> get serializer =>
       _$callSipDialOutResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallSipDialOutResponseApplicationJsonBuilder b) {
+    $CallSipDialOutResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallSipDialOutResponseApplicationJsonBuilder b) {
+    $CallSipDialOutResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class CertificateGetCertificateExpirationApiVersion extends EnumClass {
@@ -20188,6 +20997,10 @@ class _$CertificateGetCertificateExpirationApiVersionSerializer
 abstract interface class $CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterface {
   @BuiltValueField(wireName: 'expiration_in_days')
   int? get expirationInDays;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data
@@ -20222,12 +21035,26 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Da
   /// Serializer for CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data.
   static Serializer<CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data> get serializer =>
       _$certificateGetCertificateExpirationResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder b) {
+    $CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder b) {
+    $CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CertificateGetCertificateExpirationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CertificateGetCertificateExpirationResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CertificateGetCertificateExpirationResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class CertificateGetCertificateExpirationResponseApplicationJson_Ocs
@@ -20262,11 +21089,25 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson_Ocs
   /// Serializer for CertificateGetCertificateExpirationResponseApplicationJson_Ocs.
   static Serializer<CertificateGetCertificateExpirationResponseApplicationJson_Ocs> get serializer =>
       _$certificateGetCertificateExpirationResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder b) {
+    $CertificateGetCertificateExpirationResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder b) {
+    $CertificateGetCertificateExpirationResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CertificateGetCertificateExpirationResponseApplicationJsonInterface {
   CertificateGetCertificateExpirationResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CertificateGetCertificateExpirationResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CertificateGetCertificateExpirationResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CertificateGetCertificateExpirationResponseApplicationJson
@@ -20301,6 +21142,16 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson
   /// Serializer for CertificateGetCertificateExpirationResponseApplicationJson.
   static Serializer<CertificateGetCertificateExpirationResponseApplicationJson> get serializer =>
       _$certificateGetCertificateExpirationResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CertificateGetCertificateExpirationResponseApplicationJsonBuilder b) {
+    $CertificateGetCertificateExpirationResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CertificateGetCertificateExpirationResponseApplicationJsonBuilder b) {
+    $CertificateGetCertificateExpirationResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ChatReceiveMessagesLookIntoFuture extends EnumClass {
@@ -20689,6 +21540,10 @@ class _$ChatReceiveMessagesApiVersionSerializer implements PrimitiveSerializer<C
 @BuiltValue(instantiable: false)
 abstract interface class $ChatMessageWithParentInterface implements $ChatMessageInterface {
   ChatMessage? get parent;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatMessageWithParentInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatMessageWithParentInterfaceBuilder b) {}
 }
 
 abstract class ChatMessageWithParent
@@ -20717,12 +21572,26 @@ abstract class ChatMessageWithParent
 
   /// Serializer for ChatMessageWithParent.
   static Serializer<ChatMessageWithParent> get serializer => _$chatMessageWithParentSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatMessageWithParentBuilder b) {
+    $ChatMessageWithParentInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatMessageWithParentBuilder b) {
+    $ChatMessageWithParentInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatReceiveMessagesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ChatMessageWithParent> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatReceiveMessagesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatReceiveMessagesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatReceiveMessagesResponseApplicationJson_Ocs
@@ -20756,11 +21625,25 @@ abstract class ChatReceiveMessagesResponseApplicationJson_Ocs
   /// Serializer for ChatReceiveMessagesResponseApplicationJson_Ocs.
   static Serializer<ChatReceiveMessagesResponseApplicationJson_Ocs> get serializer =>
       _$chatReceiveMessagesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatReceiveMessagesResponseApplicationJson_OcsBuilder b) {
+    $ChatReceiveMessagesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatReceiveMessagesResponseApplicationJson_OcsBuilder b) {
+    $ChatReceiveMessagesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatReceiveMessagesResponseApplicationJsonInterface {
   ChatReceiveMessagesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatReceiveMessagesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatReceiveMessagesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatReceiveMessagesResponseApplicationJson
@@ -20794,6 +21677,16 @@ abstract class ChatReceiveMessagesResponseApplicationJson
   /// Serializer for ChatReceiveMessagesResponseApplicationJson.
   static Serializer<ChatReceiveMessagesResponseApplicationJson> get serializer =>
       _$chatReceiveMessagesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatReceiveMessagesResponseApplicationJsonBuilder b) {
+    $ChatReceiveMessagesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatReceiveMessagesResponseApplicationJsonBuilder b) {
+    $ChatReceiveMessagesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -20802,6 +21695,10 @@ abstract interface class $ChatChatReceiveMessagesHeadersInterface {
   String? get xChatLastCommonRead;
   @BuiltValueField(wireName: 'x-chat-last-given')
   String? get xChatLastGiven;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatChatReceiveMessagesHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatChatReceiveMessagesHeadersInterfaceBuilder b) {}
 }
 
 abstract class ChatChatReceiveMessagesHeaders
@@ -20833,6 +21730,16 @@ abstract class ChatChatReceiveMessagesHeaders
 
   /// Serializer for ChatChatReceiveMessagesHeaders.
   static Serializer<ChatChatReceiveMessagesHeaders> get serializer => _$chatChatReceiveMessagesHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatChatReceiveMessagesHeadersBuilder b) {
+    $ChatChatReceiveMessagesHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatChatReceiveMessagesHeadersBuilder b) {
+    $ChatChatReceiveMessagesHeadersInterface._validate(b);
+  }
 }
 
 class ChatSendMessageSilent extends EnumClass {
@@ -20958,6 +21865,10 @@ class _$ChatSendMessageApiVersionSerializer implements PrimitiveSerializer<ChatS
 abstract interface class $ChatSendMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessageWithParent? get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatSendMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatSendMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatSendMessageResponseApplicationJson_Ocs
@@ -20991,11 +21902,25 @@ abstract class ChatSendMessageResponseApplicationJson_Ocs
   /// Serializer for ChatSendMessageResponseApplicationJson_Ocs.
   static Serializer<ChatSendMessageResponseApplicationJson_Ocs> get serializer =>
       _$chatSendMessageResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatSendMessageResponseApplicationJson_OcsBuilder b) {
+    $ChatSendMessageResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatSendMessageResponseApplicationJson_OcsBuilder b) {
+    $ChatSendMessageResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatSendMessageResponseApplicationJsonInterface {
   ChatSendMessageResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatSendMessageResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatSendMessageResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatSendMessageResponseApplicationJson
@@ -21028,12 +21953,26 @@ abstract class ChatSendMessageResponseApplicationJson
   /// Serializer for ChatSendMessageResponseApplicationJson.
   static Serializer<ChatSendMessageResponseApplicationJson> get serializer =>
       _$chatSendMessageResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatSendMessageResponseApplicationJsonBuilder b) {
+    $ChatSendMessageResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatSendMessageResponseApplicationJsonBuilder b) {
+    $ChatSendMessageResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatChatSendMessageHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatChatSendMessageHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatChatSendMessageHeadersInterfaceBuilder b) {}
 }
 
 abstract class ChatChatSendMessageHeaders
@@ -21065,6 +22004,16 @@ abstract class ChatChatSendMessageHeaders
 
   /// Serializer for ChatChatSendMessageHeaders.
   static Serializer<ChatChatSendMessageHeaders> get serializer => _$chatChatSendMessageHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatChatSendMessageHeadersBuilder b) {
+    $ChatChatSendMessageHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatChatSendMessageHeadersBuilder b) {
+    $ChatChatSendMessageHeadersInterface._validate(b);
+  }
 }
 
 class ChatClearHistoryApiVersion extends EnumClass {
@@ -21127,6 +22076,10 @@ class _$ChatClearHistoryApiVersionSerializer implements PrimitiveSerializer<Chat
 abstract interface class $ChatClearHistoryResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessage get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatClearHistoryResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatClearHistoryResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatClearHistoryResponseApplicationJson_Ocs
@@ -21160,11 +22113,25 @@ abstract class ChatClearHistoryResponseApplicationJson_Ocs
   /// Serializer for ChatClearHistoryResponseApplicationJson_Ocs.
   static Serializer<ChatClearHistoryResponseApplicationJson_Ocs> get serializer =>
       _$chatClearHistoryResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatClearHistoryResponseApplicationJson_OcsBuilder b) {
+    $ChatClearHistoryResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatClearHistoryResponseApplicationJson_OcsBuilder b) {
+    $ChatClearHistoryResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatClearHistoryResponseApplicationJsonInterface {
   ChatClearHistoryResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatClearHistoryResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatClearHistoryResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatClearHistoryResponseApplicationJson
@@ -21197,12 +22164,26 @@ abstract class ChatClearHistoryResponseApplicationJson
   /// Serializer for ChatClearHistoryResponseApplicationJson.
   static Serializer<ChatClearHistoryResponseApplicationJson> get serializer =>
       _$chatClearHistoryResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatClearHistoryResponseApplicationJsonBuilder b) {
+    $ChatClearHistoryResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatClearHistoryResponseApplicationJsonBuilder b) {
+    $ChatClearHistoryResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatChatClearHistoryHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatChatClearHistoryHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatChatClearHistoryHeadersInterfaceBuilder b) {}
 }
 
 abstract class ChatChatClearHistoryHeaders
@@ -21234,6 +22215,16 @@ abstract class ChatChatClearHistoryHeaders
 
   /// Serializer for ChatChatClearHistoryHeaders.
   static Serializer<ChatChatClearHistoryHeaders> get serializer => _$chatChatClearHistoryHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatChatClearHistoryHeadersBuilder b) {
+    $ChatChatClearHistoryHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatChatClearHistoryHeadersBuilder b) {
+    $ChatChatClearHistoryHeadersInterface._validate(b);
+  }
 }
 
 class ChatDeleteMessageApiVersion extends EnumClass {
@@ -21296,6 +22287,10 @@ class _$ChatDeleteMessageApiVersionSerializer implements PrimitiveSerializer<Cha
 abstract interface class $ChatDeleteMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessageWithParent get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatDeleteMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatDeleteMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatDeleteMessageResponseApplicationJson_Ocs
@@ -21329,11 +22324,25 @@ abstract class ChatDeleteMessageResponseApplicationJson_Ocs
   /// Serializer for ChatDeleteMessageResponseApplicationJson_Ocs.
   static Serializer<ChatDeleteMessageResponseApplicationJson_Ocs> get serializer =>
       _$chatDeleteMessageResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatDeleteMessageResponseApplicationJson_OcsBuilder b) {
+    $ChatDeleteMessageResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatDeleteMessageResponseApplicationJson_OcsBuilder b) {
+    $ChatDeleteMessageResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatDeleteMessageResponseApplicationJsonInterface {
   ChatDeleteMessageResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatDeleteMessageResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatDeleteMessageResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatDeleteMessageResponseApplicationJson
@@ -21367,12 +22376,26 @@ abstract class ChatDeleteMessageResponseApplicationJson
   /// Serializer for ChatDeleteMessageResponseApplicationJson.
   static Serializer<ChatDeleteMessageResponseApplicationJson> get serializer =>
       _$chatDeleteMessageResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatDeleteMessageResponseApplicationJsonBuilder b) {
+    $ChatDeleteMessageResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatDeleteMessageResponseApplicationJsonBuilder b) {
+    $ChatDeleteMessageResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatChatDeleteMessageHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatChatDeleteMessageHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatChatDeleteMessageHeadersInterfaceBuilder b) {}
 }
 
 abstract class ChatChatDeleteMessageHeaders
@@ -21404,6 +22427,16 @@ abstract class ChatChatDeleteMessageHeaders
 
   /// Serializer for ChatChatDeleteMessageHeaders.
   static Serializer<ChatChatDeleteMessageHeaders> get serializer => _$chatChatDeleteMessageHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatChatDeleteMessageHeadersBuilder b) {
+    $ChatChatDeleteMessageHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatChatDeleteMessageHeadersBuilder b) {
+    $ChatChatDeleteMessageHeadersInterface._validate(b);
+  }
 }
 
 class ChatGetMessageContextApiVersion extends EnumClass {
@@ -21467,6 +22500,10 @@ class _$ChatGetMessageContextApiVersionSerializer implements PrimitiveSerializer
 abstract interface class $ChatGetMessageContextResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ChatMessageWithParent> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetMessageContextResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetMessageContextResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatGetMessageContextResponseApplicationJson_Ocs
@@ -21501,11 +22538,25 @@ abstract class ChatGetMessageContextResponseApplicationJson_Ocs
   /// Serializer for ChatGetMessageContextResponseApplicationJson_Ocs.
   static Serializer<ChatGetMessageContextResponseApplicationJson_Ocs> get serializer =>
       _$chatGetMessageContextResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetMessageContextResponseApplicationJson_OcsBuilder b) {
+    $ChatGetMessageContextResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetMessageContextResponseApplicationJson_OcsBuilder b) {
+    $ChatGetMessageContextResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatGetMessageContextResponseApplicationJsonInterface {
   ChatGetMessageContextResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetMessageContextResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetMessageContextResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatGetMessageContextResponseApplicationJson
@@ -21539,6 +22590,16 @@ abstract class ChatGetMessageContextResponseApplicationJson
   /// Serializer for ChatGetMessageContextResponseApplicationJson.
   static Serializer<ChatGetMessageContextResponseApplicationJson> get serializer =>
       _$chatGetMessageContextResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetMessageContextResponseApplicationJsonBuilder b) {
+    $ChatGetMessageContextResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetMessageContextResponseApplicationJsonBuilder b) {
+    $ChatGetMessageContextResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -21547,6 +22608,10 @@ abstract interface class $ChatChatGetMessageContextHeadersInterface {
   String? get xChatLastCommonRead;
   @BuiltValueField(wireName: 'x-chat-last-given')
   String? get xChatLastGiven;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatChatGetMessageContextHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatChatGetMessageContextHeadersInterfaceBuilder b) {}
 }
 
 abstract class ChatChatGetMessageContextHeaders
@@ -21578,6 +22643,16 @@ abstract class ChatChatGetMessageContextHeaders
 
   /// Serializer for ChatChatGetMessageContextHeaders.
   static Serializer<ChatChatGetMessageContextHeaders> get serializer => _$chatChatGetMessageContextHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatChatGetMessageContextHeadersBuilder b) {
+    $ChatChatGetMessageContextHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatChatGetMessageContextHeadersBuilder b) {
+    $ChatChatGetMessageContextHeadersInterface._validate(b);
+  }
 }
 
 class ChatGetReminderApiVersion extends EnumClass {
@@ -21642,6 +22717,10 @@ abstract interface class $ChatReminderInterface {
   int get timestamp;
   String get token;
   String get userId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatReminderInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatReminderInterfaceBuilder b) {}
 }
 
 abstract class ChatReminder implements $ChatReminderInterface, Built<ChatReminder, ChatReminderBuilder> {
@@ -21668,12 +22747,26 @@ abstract class ChatReminder implements $ChatReminderInterface, Built<ChatReminde
 
   /// Serializer for ChatReminder.
   static Serializer<ChatReminder> get serializer => _$chatReminderSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatReminderBuilder b) {
+    $ChatReminderInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatReminderBuilder b) {
+    $ChatReminderInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatGetReminderResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatReminder get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetReminderResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetReminderResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatGetReminderResponseApplicationJson_Ocs
@@ -21707,11 +22800,25 @@ abstract class ChatGetReminderResponseApplicationJson_Ocs
   /// Serializer for ChatGetReminderResponseApplicationJson_Ocs.
   static Serializer<ChatGetReminderResponseApplicationJson_Ocs> get serializer =>
       _$chatGetReminderResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetReminderResponseApplicationJson_OcsBuilder b) {
+    $ChatGetReminderResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetReminderResponseApplicationJson_OcsBuilder b) {
+    $ChatGetReminderResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatGetReminderResponseApplicationJsonInterface {
   ChatGetReminderResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetReminderResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetReminderResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatGetReminderResponseApplicationJson
@@ -21744,6 +22851,16 @@ abstract class ChatGetReminderResponseApplicationJson
   /// Serializer for ChatGetReminderResponseApplicationJson.
   static Serializer<ChatGetReminderResponseApplicationJson> get serializer =>
       _$chatGetReminderResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetReminderResponseApplicationJsonBuilder b) {
+    $ChatGetReminderResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetReminderResponseApplicationJsonBuilder b) {
+    $ChatGetReminderResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ChatSetReminderApiVersion extends EnumClass {
@@ -21806,6 +22923,10 @@ class _$ChatSetReminderApiVersionSerializer implements PrimitiveSerializer<ChatS
 abstract interface class $ChatSetReminderResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatReminder get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatSetReminderResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatSetReminderResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatSetReminderResponseApplicationJson_Ocs
@@ -21839,11 +22960,25 @@ abstract class ChatSetReminderResponseApplicationJson_Ocs
   /// Serializer for ChatSetReminderResponseApplicationJson_Ocs.
   static Serializer<ChatSetReminderResponseApplicationJson_Ocs> get serializer =>
       _$chatSetReminderResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatSetReminderResponseApplicationJson_OcsBuilder b) {
+    $ChatSetReminderResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatSetReminderResponseApplicationJson_OcsBuilder b) {
+    $ChatSetReminderResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatSetReminderResponseApplicationJsonInterface {
   ChatSetReminderResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatSetReminderResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatSetReminderResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatSetReminderResponseApplicationJson
@@ -21876,6 +23011,16 @@ abstract class ChatSetReminderResponseApplicationJson
   /// Serializer for ChatSetReminderResponseApplicationJson.
   static Serializer<ChatSetReminderResponseApplicationJson> get serializer =>
       _$chatSetReminderResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatSetReminderResponseApplicationJsonBuilder b) {
+    $ChatSetReminderResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatSetReminderResponseApplicationJsonBuilder b) {
+    $ChatSetReminderResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ChatDeleteReminderApiVersion extends EnumClass {
@@ -21938,6 +23083,10 @@ class _$ChatDeleteReminderApiVersionSerializer implements PrimitiveSerializer<Ch
 abstract interface class $ChatDeleteReminderResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatDeleteReminderResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatDeleteReminderResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatDeleteReminderResponseApplicationJson_Ocs
@@ -21971,11 +23120,25 @@ abstract class ChatDeleteReminderResponseApplicationJson_Ocs
   /// Serializer for ChatDeleteReminderResponseApplicationJson_Ocs.
   static Serializer<ChatDeleteReminderResponseApplicationJson_Ocs> get serializer =>
       _$chatDeleteReminderResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatDeleteReminderResponseApplicationJson_OcsBuilder b) {
+    $ChatDeleteReminderResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatDeleteReminderResponseApplicationJson_OcsBuilder b) {
+    $ChatDeleteReminderResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatDeleteReminderResponseApplicationJsonInterface {
   ChatDeleteReminderResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatDeleteReminderResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatDeleteReminderResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatDeleteReminderResponseApplicationJson
@@ -22009,6 +23172,16 @@ abstract class ChatDeleteReminderResponseApplicationJson
   /// Serializer for ChatDeleteReminderResponseApplicationJson.
   static Serializer<ChatDeleteReminderResponseApplicationJson> get serializer =>
       _$chatDeleteReminderResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatDeleteReminderResponseApplicationJsonBuilder b) {
+    $ChatDeleteReminderResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatDeleteReminderResponseApplicationJsonBuilder b) {
+    $ChatDeleteReminderResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ChatSetReadMarkerApiVersion extends EnumClass {
@@ -22071,6 +23244,10 @@ class _$ChatSetReadMarkerApiVersionSerializer implements PrimitiveSerializer<Cha
 abstract interface class $ChatSetReadMarkerResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatSetReadMarkerResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatSetReadMarkerResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatSetReadMarkerResponseApplicationJson_Ocs
@@ -22104,11 +23281,25 @@ abstract class ChatSetReadMarkerResponseApplicationJson_Ocs
   /// Serializer for ChatSetReadMarkerResponseApplicationJson_Ocs.
   static Serializer<ChatSetReadMarkerResponseApplicationJson_Ocs> get serializer =>
       _$chatSetReadMarkerResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatSetReadMarkerResponseApplicationJson_OcsBuilder b) {
+    $ChatSetReadMarkerResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatSetReadMarkerResponseApplicationJson_OcsBuilder b) {
+    $ChatSetReadMarkerResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatSetReadMarkerResponseApplicationJsonInterface {
   ChatSetReadMarkerResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatSetReadMarkerResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatSetReadMarkerResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatSetReadMarkerResponseApplicationJson
@@ -22142,12 +23333,26 @@ abstract class ChatSetReadMarkerResponseApplicationJson
   /// Serializer for ChatSetReadMarkerResponseApplicationJson.
   static Serializer<ChatSetReadMarkerResponseApplicationJson> get serializer =>
       _$chatSetReadMarkerResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatSetReadMarkerResponseApplicationJsonBuilder b) {
+    $ChatSetReadMarkerResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatSetReadMarkerResponseApplicationJsonBuilder b) {
+    $ChatSetReadMarkerResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatChatSetReadMarkerHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatChatSetReadMarkerHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatChatSetReadMarkerHeadersInterfaceBuilder b) {}
 }
 
 abstract class ChatChatSetReadMarkerHeaders
@@ -22179,6 +23384,16 @@ abstract class ChatChatSetReadMarkerHeaders
 
   /// Serializer for ChatChatSetReadMarkerHeaders.
   static Serializer<ChatChatSetReadMarkerHeaders> get serializer => _$chatChatSetReadMarkerHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatChatSetReadMarkerHeadersBuilder b) {
+    $ChatChatSetReadMarkerHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatChatSetReadMarkerHeadersBuilder b) {
+    $ChatChatSetReadMarkerHeadersInterface._validate(b);
+  }
 }
 
 class ChatMarkUnreadApiVersion extends EnumClass {
@@ -22241,6 +23456,10 @@ class _$ChatMarkUnreadApiVersionSerializer implements PrimitiveSerializer<ChatMa
 abstract interface class $ChatMarkUnreadResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatMarkUnreadResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatMarkUnreadResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatMarkUnreadResponseApplicationJson_Ocs
@@ -22274,11 +23493,25 @@ abstract class ChatMarkUnreadResponseApplicationJson_Ocs
   /// Serializer for ChatMarkUnreadResponseApplicationJson_Ocs.
   static Serializer<ChatMarkUnreadResponseApplicationJson_Ocs> get serializer =>
       _$chatMarkUnreadResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatMarkUnreadResponseApplicationJson_OcsBuilder b) {
+    $ChatMarkUnreadResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatMarkUnreadResponseApplicationJson_OcsBuilder b) {
+    $ChatMarkUnreadResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatMarkUnreadResponseApplicationJsonInterface {
   ChatMarkUnreadResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatMarkUnreadResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatMarkUnreadResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatMarkUnreadResponseApplicationJson
@@ -22311,12 +23544,26 @@ abstract class ChatMarkUnreadResponseApplicationJson
   /// Serializer for ChatMarkUnreadResponseApplicationJson.
   static Serializer<ChatMarkUnreadResponseApplicationJson> get serializer =>
       _$chatMarkUnreadResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatMarkUnreadResponseApplicationJsonBuilder b) {
+    $ChatMarkUnreadResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatMarkUnreadResponseApplicationJsonBuilder b) {
+    $ChatMarkUnreadResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatChatMarkUnreadHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatChatMarkUnreadHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatChatMarkUnreadHeadersInterfaceBuilder b) {}
 }
 
 abstract class ChatChatMarkUnreadHeaders
@@ -22345,6 +23592,16 @@ abstract class ChatChatMarkUnreadHeaders
 
   /// Serializer for ChatChatMarkUnreadHeaders.
   static Serializer<ChatChatMarkUnreadHeaders> get serializer => _$chatChatMarkUnreadHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatChatMarkUnreadHeadersBuilder b) {
+    $ChatChatMarkUnreadHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatChatMarkUnreadHeadersBuilder b) {
+    $ChatChatMarkUnreadHeadersInterface._validate(b);
+  }
 }
 
 class ChatMentionsIncludeStatus extends EnumClass {
@@ -22475,6 +23732,10 @@ abstract interface class $ChatMentionSuggestionInterface {
   int? get statusClearAt;
   String? get statusIcon;
   String? get statusMessage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatMentionSuggestionInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatMentionSuggestionInterfaceBuilder b) {}
 }
 
 abstract class ChatMentionSuggestion
@@ -22503,12 +23764,26 @@ abstract class ChatMentionSuggestion
 
   /// Serializer for ChatMentionSuggestion.
   static Serializer<ChatMentionSuggestion> get serializer => _$chatMentionSuggestionSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatMentionSuggestionBuilder b) {
+    $ChatMentionSuggestionInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatMentionSuggestionBuilder b) {
+    $ChatMentionSuggestionInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatMentionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ChatMentionSuggestion> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatMentionsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatMentionsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatMentionsResponseApplicationJson_Ocs
@@ -22541,11 +23816,25 @@ abstract class ChatMentionsResponseApplicationJson_Ocs
   /// Serializer for ChatMentionsResponseApplicationJson_Ocs.
   static Serializer<ChatMentionsResponseApplicationJson_Ocs> get serializer =>
       _$chatMentionsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatMentionsResponseApplicationJson_OcsBuilder b) {
+    $ChatMentionsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatMentionsResponseApplicationJson_OcsBuilder b) {
+    $ChatMentionsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatMentionsResponseApplicationJsonInterface {
   ChatMentionsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatMentionsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatMentionsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatMentionsResponseApplicationJson
@@ -22578,6 +23867,16 @@ abstract class ChatMentionsResponseApplicationJson
   /// Serializer for ChatMentionsResponseApplicationJson.
   static Serializer<ChatMentionsResponseApplicationJson> get serializer =>
       _$chatMentionsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatMentionsResponseApplicationJsonBuilder b) {
+    $ChatMentionsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatMentionsResponseApplicationJsonBuilder b) {
+    $ChatMentionsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ChatGetObjectsSharedInRoomApiVersion extends EnumClass {
@@ -22645,6 +23944,10 @@ class _$ChatGetObjectsSharedInRoomApiVersionSerializer
 abstract interface class $ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ChatMessage> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs
@@ -22679,11 +23982,25 @@ abstract class ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs
   /// Serializer for ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs.
   static Serializer<ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs> get serializer =>
       _$chatGetObjectsSharedInRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder b) {
+    $ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder b) {
+    $ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatGetObjectsSharedInRoomResponseApplicationJsonInterface {
   ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetObjectsSharedInRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetObjectsSharedInRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatGetObjectsSharedInRoomResponseApplicationJson
@@ -22718,12 +24035,26 @@ abstract class ChatGetObjectsSharedInRoomResponseApplicationJson
   /// Serializer for ChatGetObjectsSharedInRoomResponseApplicationJson.
   static Serializer<ChatGetObjectsSharedInRoomResponseApplicationJson> get serializer =>
       _$chatGetObjectsSharedInRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder b) {
+    $ChatGetObjectsSharedInRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder b) {
+    $ChatGetObjectsSharedInRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatChatGetObjectsSharedInRoomHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-given')
   String? get xChatLastGiven;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder b) {}
 }
 
 abstract class ChatChatGetObjectsSharedInRoomHeaders
@@ -22756,6 +24087,16 @@ abstract class ChatChatGetObjectsSharedInRoomHeaders
   /// Serializer for ChatChatGetObjectsSharedInRoomHeaders.
   static Serializer<ChatChatGetObjectsSharedInRoomHeaders> get serializer =>
       _$chatChatGetObjectsSharedInRoomHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatChatGetObjectsSharedInRoomHeadersBuilder b) {
+    $ChatChatGetObjectsSharedInRoomHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatChatGetObjectsSharedInRoomHeadersBuilder b) {
+    $ChatChatGetObjectsSharedInRoomHeadersInterface._validate(b);
+  }
 }
 
 class ChatShareObjectToChatApiVersion extends EnumClass {
@@ -22819,6 +24160,10 @@ class _$ChatShareObjectToChatApiVersionSerializer implements PrimitiveSerializer
 abstract interface class $ChatShareObjectToChatResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessageWithParent? get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatShareObjectToChatResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatShareObjectToChatResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatShareObjectToChatResponseApplicationJson_Ocs
@@ -22853,11 +24198,25 @@ abstract class ChatShareObjectToChatResponseApplicationJson_Ocs
   /// Serializer for ChatShareObjectToChatResponseApplicationJson_Ocs.
   static Serializer<ChatShareObjectToChatResponseApplicationJson_Ocs> get serializer =>
       _$chatShareObjectToChatResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatShareObjectToChatResponseApplicationJson_OcsBuilder b) {
+    $ChatShareObjectToChatResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatShareObjectToChatResponseApplicationJson_OcsBuilder b) {
+    $ChatShareObjectToChatResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatShareObjectToChatResponseApplicationJsonInterface {
   ChatShareObjectToChatResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatShareObjectToChatResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatShareObjectToChatResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatShareObjectToChatResponseApplicationJson
@@ -22891,12 +24250,26 @@ abstract class ChatShareObjectToChatResponseApplicationJson
   /// Serializer for ChatShareObjectToChatResponseApplicationJson.
   static Serializer<ChatShareObjectToChatResponseApplicationJson> get serializer =>
       _$chatShareObjectToChatResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatShareObjectToChatResponseApplicationJsonBuilder b) {
+    $ChatShareObjectToChatResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatShareObjectToChatResponseApplicationJsonBuilder b) {
+    $ChatShareObjectToChatResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatChatShareObjectToChatHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatChatShareObjectToChatHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatChatShareObjectToChatHeadersInterfaceBuilder b) {}
 }
 
 abstract class ChatChatShareObjectToChatHeaders
@@ -22928,6 +24301,16 @@ abstract class ChatChatShareObjectToChatHeaders
 
   /// Serializer for ChatChatShareObjectToChatHeaders.
   static Serializer<ChatChatShareObjectToChatHeaders> get serializer => _$chatChatShareObjectToChatHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatChatShareObjectToChatHeadersBuilder b) {
+    $ChatChatShareObjectToChatHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatChatShareObjectToChatHeadersBuilder b) {
+    $ChatChatShareObjectToChatHeadersInterface._validate(b);
+  }
 }
 
 class ChatGetObjectsSharedInRoomOverviewApiVersion extends EnumClass {
@@ -22996,6 +24379,10 @@ class _$ChatGetObjectsSharedInRoomOverviewApiVersionSerializer
 abstract interface class $ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<ChatMessage>> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs
@@ -23030,11 +24417,25 @@ abstract class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs
   /// Serializer for ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs.
   static Serializer<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs> get serializer =>
       _$chatGetObjectsSharedInRoomOverviewResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder b) {
+    $ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder b) {
+    $ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterface {
   ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson
@@ -23069,6 +24470,16 @@ abstract class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson
   /// Serializer for ChatGetObjectsSharedInRoomOverviewResponseApplicationJson.
   static Serializer<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson> get serializer =>
       _$chatGetObjectsSharedInRoomOverviewResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder b) {
+    $ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder b) {
+    $ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class FilesIntegrationGetRoomByFileIdApiVersion extends EnumClass {
@@ -23136,6 +24547,10 @@ class _$FilesIntegrationGetRoomByFileIdApiVersionSerializer
 @BuiltValue(instantiable: false)
 abstract interface class $FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterface {
   String get token;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data
@@ -23170,12 +24585,26 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data
   /// Serializer for FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data.
   static Serializer<FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data> get serializer =>
       _$filesIntegrationGetRoomByFileIdResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder b) {
+    $FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder b) {
+    $FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs
@@ -23210,11 +24639,25 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs
   /// Serializer for FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs.
   static Serializer<FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs> get serializer =>
       _$filesIntegrationGetRoomByFileIdResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder b) {
+    $FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder b) {
+    $FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterface {
   FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson
@@ -23249,6 +24692,16 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson
   /// Serializer for FilesIntegrationGetRoomByFileIdResponseApplicationJson.
   static Serializer<FilesIntegrationGetRoomByFileIdResponseApplicationJson> get serializer =>
       _$filesIntegrationGetRoomByFileIdResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesIntegrationGetRoomByFileIdResponseApplicationJsonBuilder b) {
+    $FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesIntegrationGetRoomByFileIdResponseApplicationJsonBuilder b) {
+    $FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class FilesIntegrationGetRoomByShareTokenApiVersion extends EnumClass {
@@ -23318,6 +24771,10 @@ abstract interface class $FilesIntegrationGetRoomByShareTokenResponseApplication
   String get token;
   String get userId;
   String get userDisplayName;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data
@@ -23352,12 +24809,26 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Da
   /// Serializer for FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data.
   static Serializer<FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data> get serializer =>
       _$filesIntegrationGetRoomByShareTokenResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder b) {
+    $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder b) {
+    $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs
@@ -23392,11 +24863,25 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs
   /// Serializer for FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs.
   static Serializer<FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs> get serializer =>
       _$filesIntegrationGetRoomByShareTokenResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder b) {
+    $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder b) {
+    $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterface {
   FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson
@@ -23431,6 +24916,16 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson
   /// Serializer for FilesIntegrationGetRoomByShareTokenResponseApplicationJson.
   static Serializer<FilesIntegrationGetRoomByShareTokenResponseApplicationJson> get serializer =>
       _$filesIntegrationGetRoomByShareTokenResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder b) {
+    $FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder b) {
+    $FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class GuestSetDisplayNameApiVersion extends EnumClass {
@@ -23493,6 +24988,10 @@ class _$GuestSetDisplayNameApiVersionSerializer implements PrimitiveSerializer<G
 abstract interface class $GuestSetDisplayNameResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GuestSetDisplayNameResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GuestSetDisplayNameResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class GuestSetDisplayNameResponseApplicationJson_Ocs
@@ -23526,11 +25025,25 @@ abstract class GuestSetDisplayNameResponseApplicationJson_Ocs
   /// Serializer for GuestSetDisplayNameResponseApplicationJson_Ocs.
   static Serializer<GuestSetDisplayNameResponseApplicationJson_Ocs> get serializer =>
       _$guestSetDisplayNameResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GuestSetDisplayNameResponseApplicationJson_OcsBuilder b) {
+    $GuestSetDisplayNameResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GuestSetDisplayNameResponseApplicationJson_OcsBuilder b) {
+    $GuestSetDisplayNameResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GuestSetDisplayNameResponseApplicationJsonInterface {
   GuestSetDisplayNameResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GuestSetDisplayNameResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GuestSetDisplayNameResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class GuestSetDisplayNameResponseApplicationJson
@@ -23564,6 +25077,16 @@ abstract class GuestSetDisplayNameResponseApplicationJson
   /// Serializer for GuestSetDisplayNameResponseApplicationJson.
   static Serializer<GuestSetDisplayNameResponseApplicationJson> get serializer =>
       _$guestSetDisplayNameResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GuestSetDisplayNameResponseApplicationJsonBuilder b) {
+    $GuestSetDisplayNameResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GuestSetDisplayNameResponseApplicationJsonBuilder b) {
+    $GuestSetDisplayNameResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class HostedSignalingServerRequestTrialApiVersion extends EnumClass {
@@ -23632,6 +25155,10 @@ class _$HostedSignalingServerRequestTrialApiVersionSerializer
 abstract interface class $HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, JsonObject> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class HostedSignalingServerRequestTrialResponseApplicationJson_Ocs
@@ -23666,11 +25193,25 @@ abstract class HostedSignalingServerRequestTrialResponseApplicationJson_Ocs
   /// Serializer for HostedSignalingServerRequestTrialResponseApplicationJson_Ocs.
   static Serializer<HostedSignalingServerRequestTrialResponseApplicationJson_Ocs> get serializer =>
       _$hostedSignalingServerRequestTrialResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder b) {
+    $HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder b) {
+    $HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $HostedSignalingServerRequestTrialResponseApplicationJsonInterface {
   HostedSignalingServerRequestTrialResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HostedSignalingServerRequestTrialResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HostedSignalingServerRequestTrialResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class HostedSignalingServerRequestTrialResponseApplicationJson
@@ -23705,6 +25246,16 @@ abstract class HostedSignalingServerRequestTrialResponseApplicationJson
   /// Serializer for HostedSignalingServerRequestTrialResponseApplicationJson.
   static Serializer<HostedSignalingServerRequestTrialResponseApplicationJson> get serializer =>
       _$hostedSignalingServerRequestTrialResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HostedSignalingServerRequestTrialResponseApplicationJsonBuilder b) {
+    $HostedSignalingServerRequestTrialResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HostedSignalingServerRequestTrialResponseApplicationJsonBuilder b) {
+    $HostedSignalingServerRequestTrialResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class HostedSignalingServerDeleteAccountApiVersion extends EnumClass {
@@ -23773,6 +25324,10 @@ class _$HostedSignalingServerDeleteAccountApiVersionSerializer
 abstract interface class $HostedSignalingServerDeleteAccountResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HostedSignalingServerDeleteAccountResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HostedSignalingServerDeleteAccountResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs
@@ -23807,11 +25362,25 @@ abstract class HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs
   /// Serializer for HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs.
   static Serializer<HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs> get serializer =>
       _$hostedSignalingServerDeleteAccountResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder b) {
+    $HostedSignalingServerDeleteAccountResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder b) {
+    $HostedSignalingServerDeleteAccountResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $HostedSignalingServerDeleteAccountResponseApplicationJsonInterface {
   HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HostedSignalingServerDeleteAccountResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HostedSignalingServerDeleteAccountResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class HostedSignalingServerDeleteAccountResponseApplicationJson
@@ -23846,6 +25415,16 @@ abstract class HostedSignalingServerDeleteAccountResponseApplicationJson
   /// Serializer for HostedSignalingServerDeleteAccountResponseApplicationJson.
   static Serializer<HostedSignalingServerDeleteAccountResponseApplicationJson> get serializer =>
       _$hostedSignalingServerDeleteAccountResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HostedSignalingServerDeleteAccountResponseApplicationJsonBuilder b) {
+    $HostedSignalingServerDeleteAccountResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HostedSignalingServerDeleteAccountResponseApplicationJsonBuilder b) {
+    $HostedSignalingServerDeleteAccountResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class MatterbridgeGetBridgeOfRoomApiVersion extends EnumClass {
@@ -23914,6 +25493,10 @@ abstract interface class $MatterbridgeInterface {
   bool get enabled;
   BuiltList<BuiltMap<String, JsonObject>> get parts;
   int get pid;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeInterfaceBuilder b) {}
 }
 
 abstract class Matterbridge implements $MatterbridgeInterface, Built<Matterbridge, MatterbridgeBuilder> {
@@ -23940,12 +25523,26 @@ abstract class Matterbridge implements $MatterbridgeInterface, Built<Matterbridg
 
   /// Serializer for Matterbridge.
   static Serializer<Matterbridge> get serializer => _$matterbridgeSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeBuilder b) {
+    $MatterbridgeInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeBuilder b) {
+    $MatterbridgeInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeProcessStateInterface {
   String get log;
   bool get running;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeProcessStateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeProcessStateInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeProcessState
@@ -23974,11 +25571,26 @@ abstract class MatterbridgeProcessState
 
   /// Serializer for MatterbridgeProcessState.
   static Serializer<MatterbridgeProcessState> get serializer => _$matterbridgeProcessStateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeProcessStateBuilder b) {
+    $MatterbridgeProcessStateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeProcessStateBuilder b) {
+    $MatterbridgeProcessStateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeWithProcessStateInterface
-    implements $MatterbridgeInterface, $MatterbridgeProcessStateInterface {}
+    implements $MatterbridgeInterface, $MatterbridgeProcessStateInterface {
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeWithProcessStateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeWithProcessStateInterfaceBuilder b) {}
+}
 
 abstract class MatterbridgeWithProcessState
     implements
@@ -24009,12 +25621,26 @@ abstract class MatterbridgeWithProcessState
 
   /// Serializer for MatterbridgeWithProcessState.
   static Serializer<MatterbridgeWithProcessState> get serializer => _$matterbridgeWithProcessStateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeWithProcessStateBuilder b) {
+    $MatterbridgeWithProcessStateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeWithProcessStateBuilder b) {
+    $MatterbridgeWithProcessStateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   MatterbridgeWithProcessState get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs
@@ -24049,11 +25675,25 @@ abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs
   /// Serializer for MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs.
   static Serializer<MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs> get serializer =>
       _$matterbridgeGetBridgeOfRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterface {
   MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson
@@ -24088,6 +25728,16 @@ abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson
   /// Serializer for MatterbridgeGetBridgeOfRoomResponseApplicationJson.
   static Serializer<MatterbridgeGetBridgeOfRoomResponseApplicationJson> get serializer =>
       _$matterbridgeGetBridgeOfRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder b) {
+    $MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder b) {
+    $MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class MatterbridgeEditBridgeOfRoomEnabled extends EnumClass {
@@ -24221,6 +25871,10 @@ class _$MatterbridgeEditBridgeOfRoomApiVersionSerializer
 abstract interface class $MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   MatterbridgeProcessState get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs
@@ -24255,11 +25909,25 @@ abstract class MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs
   /// Serializer for MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs.
   static Serializer<MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs> get serializer =>
       _$matterbridgeEditBridgeOfRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterface {
   MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeEditBridgeOfRoomResponseApplicationJson
@@ -24294,6 +25962,16 @@ abstract class MatterbridgeEditBridgeOfRoomResponseApplicationJson
   /// Serializer for MatterbridgeEditBridgeOfRoomResponseApplicationJson.
   static Serializer<MatterbridgeEditBridgeOfRoomResponseApplicationJson> get serializer =>
       _$matterbridgeEditBridgeOfRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder b) {
+    $MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder b) {
+    $MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class MatterbridgeDeleteBridgeOfRoomApiVersion extends EnumClass {
@@ -24362,6 +26040,10 @@ class _$MatterbridgeDeleteBridgeOfRoomApiVersionSerializer
 abstract interface class $MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   bool get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs
@@ -24396,11 +26078,25 @@ abstract class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs
   /// Serializer for MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs.
   static Serializer<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs> get serializer =>
       _$matterbridgeDeleteBridgeOfRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterface {
   MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson
@@ -24435,6 +26131,16 @@ abstract class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson
   /// Serializer for MatterbridgeDeleteBridgeOfRoomResponseApplicationJson.
   static Serializer<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson> get serializer =>
       _$matterbridgeDeleteBridgeOfRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonBuilder b) {
+    $MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonBuilder b) {
+    $MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class MatterbridgeGetBridgeProcessStateApiVersion extends EnumClass {
@@ -24503,6 +26209,10 @@ class _$MatterbridgeGetBridgeProcessStateApiVersionSerializer
 abstract interface class $MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   MatterbridgeProcessState get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs
@@ -24537,11 +26247,25 @@ abstract class MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs
   /// Serializer for MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs.
   static Serializer<MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs> get serializer =>
       _$matterbridgeGetBridgeProcessStateResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterface {
   MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeGetBridgeProcessStateResponseApplicationJson
@@ -24576,6 +26300,16 @@ abstract class MatterbridgeGetBridgeProcessStateResponseApplicationJson
   /// Serializer for MatterbridgeGetBridgeProcessStateResponseApplicationJson.
   static Serializer<MatterbridgeGetBridgeProcessStateResponseApplicationJson> get serializer =>
       _$matterbridgeGetBridgeProcessStateResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeGetBridgeProcessStateResponseApplicationJsonBuilder b) {
+    $MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeGetBridgeProcessStateResponseApplicationJsonBuilder b) {
+    $MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class MatterbridgeSettingsStopAllBridgesApiVersion extends EnumClass {
@@ -24644,6 +26378,10 @@ class _$MatterbridgeSettingsStopAllBridgesApiVersionSerializer
 abstract interface class $MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   bool get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs
@@ -24678,11 +26416,25 @@ abstract class MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs
   /// Serializer for MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs.
   static Serializer<MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs> get serializer =>
       _$matterbridgeSettingsStopAllBridgesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterface {
   MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeSettingsStopAllBridgesResponseApplicationJson
@@ -24717,6 +26469,16 @@ abstract class MatterbridgeSettingsStopAllBridgesResponseApplicationJson
   /// Serializer for MatterbridgeSettingsStopAllBridgesResponseApplicationJson.
   static Serializer<MatterbridgeSettingsStopAllBridgesResponseApplicationJson> get serializer =>
       _$matterbridgeSettingsStopAllBridgesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeSettingsStopAllBridgesResponseApplicationJsonBuilder b) {
+    $MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeSettingsStopAllBridgesResponseApplicationJsonBuilder b) {
+    $MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class MatterbridgeSettingsGetMatterbridgeVersionApiVersion extends EnumClass {
@@ -24785,6 +26547,14 @@ class _$MatterbridgeSettingsGetMatterbridgeVersionApiVersionSerializer
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterface {
   String get version;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(
+    $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterfaceBuilder b,
+  ) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(
+    $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterfaceBuilder b,
+  ) {}
 }
 
 abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data
@@ -24821,12 +26591,26 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
   /// Serializer for MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data.
   static Serializer<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data> get serializer =>
       _$matterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataBuilder b) {
+    $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataBuilder b) {
+    $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs
@@ -24861,11 +26645,25 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
   /// Serializer for MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs.
   static Serializer<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs> get serializer =>
       _$matterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuilder b) {
+    $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterface {
   MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
@@ -24900,6 +26698,16 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
   /// Serializer for MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson.
   static Serializer<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson> get serializer =>
       _$matterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder b) {
+    $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder b) {
+    $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class PollCreatePollResultMode extends EnumClass {
@@ -25027,6 +26835,10 @@ abstract interface class $PollVoteInterface {
   String get actorId;
   ActorType get actorType;
   int get optionId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollVoteInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollVoteInterfaceBuilder b) {}
 }
 
 abstract class PollVote implements $PollVoteInterface, Built<PollVote, PollVoteBuilder> {
@@ -25053,6 +26865,16 @@ abstract class PollVote implements $PollVoteInterface, Built<PollVote, PollVoteB
 
   /// Serializer for PollVote.
   static Serializer<PollVote> get serializer => _$pollVoteSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollVoteBuilder b) {
+    $PollVoteInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollVoteBuilder b) {
+    $PollVoteInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -25070,6 +26892,10 @@ abstract interface class $PollInterface {
   int get status;
   BuiltList<int>? get votedSelf;
   BuiltMap<String, int>? get votes;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollInterfaceBuilder b) {}
 }
 
 abstract class Poll implements $PollInterface, Built<Poll, PollBuilder> {
@@ -25096,12 +26922,26 @@ abstract class Poll implements $PollInterface, Built<Poll, PollBuilder> {
 
   /// Serializer for Poll.
   static Serializer<Poll> get serializer => _$pollSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollBuilder b) {
+    $PollInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollBuilder b) {
+    $PollInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PollCreatePollResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Poll get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollCreatePollResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollCreatePollResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PollCreatePollResponseApplicationJson_Ocs
@@ -25135,11 +26975,25 @@ abstract class PollCreatePollResponseApplicationJson_Ocs
   /// Serializer for PollCreatePollResponseApplicationJson_Ocs.
   static Serializer<PollCreatePollResponseApplicationJson_Ocs> get serializer =>
       _$pollCreatePollResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollCreatePollResponseApplicationJson_OcsBuilder b) {
+    $PollCreatePollResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollCreatePollResponseApplicationJson_OcsBuilder b) {
+    $PollCreatePollResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PollCreatePollResponseApplicationJsonInterface {
   PollCreatePollResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollCreatePollResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollCreatePollResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PollCreatePollResponseApplicationJson
@@ -25172,6 +27026,16 @@ abstract class PollCreatePollResponseApplicationJson
   /// Serializer for PollCreatePollResponseApplicationJson.
   static Serializer<PollCreatePollResponseApplicationJson> get serializer =>
       _$pollCreatePollResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollCreatePollResponseApplicationJsonBuilder b) {
+    $PollCreatePollResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollCreatePollResponseApplicationJsonBuilder b) {
+    $PollCreatePollResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class PollShowPollApiVersion extends EnumClass {
@@ -25234,6 +27098,10 @@ class _$PollShowPollApiVersionSerializer implements PrimitiveSerializer<PollShow
 abstract interface class $PollShowPollResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Poll get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollShowPollResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollShowPollResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PollShowPollResponseApplicationJson_Ocs
@@ -25266,11 +27134,25 @@ abstract class PollShowPollResponseApplicationJson_Ocs
   /// Serializer for PollShowPollResponseApplicationJson_Ocs.
   static Serializer<PollShowPollResponseApplicationJson_Ocs> get serializer =>
       _$pollShowPollResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollShowPollResponseApplicationJson_OcsBuilder b) {
+    $PollShowPollResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollShowPollResponseApplicationJson_OcsBuilder b) {
+    $PollShowPollResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PollShowPollResponseApplicationJsonInterface {
   PollShowPollResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollShowPollResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollShowPollResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PollShowPollResponseApplicationJson
@@ -25303,6 +27185,16 @@ abstract class PollShowPollResponseApplicationJson
   /// Serializer for PollShowPollResponseApplicationJson.
   static Serializer<PollShowPollResponseApplicationJson> get serializer =>
       _$pollShowPollResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollShowPollResponseApplicationJsonBuilder b) {
+    $PollShowPollResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollShowPollResponseApplicationJsonBuilder b) {
+    $PollShowPollResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class PollVotePollApiVersion extends EnumClass {
@@ -25365,6 +27257,10 @@ class _$PollVotePollApiVersionSerializer implements PrimitiveSerializer<PollVote
 abstract interface class $PollVotePollResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Poll get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollVotePollResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollVotePollResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PollVotePollResponseApplicationJson_Ocs
@@ -25397,11 +27293,25 @@ abstract class PollVotePollResponseApplicationJson_Ocs
   /// Serializer for PollVotePollResponseApplicationJson_Ocs.
   static Serializer<PollVotePollResponseApplicationJson_Ocs> get serializer =>
       _$pollVotePollResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollVotePollResponseApplicationJson_OcsBuilder b) {
+    $PollVotePollResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollVotePollResponseApplicationJson_OcsBuilder b) {
+    $PollVotePollResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PollVotePollResponseApplicationJsonInterface {
   PollVotePollResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollVotePollResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollVotePollResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PollVotePollResponseApplicationJson
@@ -25434,6 +27344,16 @@ abstract class PollVotePollResponseApplicationJson
   /// Serializer for PollVotePollResponseApplicationJson.
   static Serializer<PollVotePollResponseApplicationJson> get serializer =>
       _$pollVotePollResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollVotePollResponseApplicationJsonBuilder b) {
+    $PollVotePollResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollVotePollResponseApplicationJsonBuilder b) {
+    $PollVotePollResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class PollClosePollApiVersion extends EnumClass {
@@ -25496,6 +27416,10 @@ class _$PollClosePollApiVersionSerializer implements PrimitiveSerializer<PollClo
 abstract interface class $PollClosePollResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Poll get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollClosePollResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollClosePollResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PollClosePollResponseApplicationJson_Ocs
@@ -25529,11 +27453,25 @@ abstract class PollClosePollResponseApplicationJson_Ocs
   /// Serializer for PollClosePollResponseApplicationJson_Ocs.
   static Serializer<PollClosePollResponseApplicationJson_Ocs> get serializer =>
       _$pollClosePollResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollClosePollResponseApplicationJson_OcsBuilder b) {
+    $PollClosePollResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollClosePollResponseApplicationJson_OcsBuilder b) {
+    $PollClosePollResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PollClosePollResponseApplicationJsonInterface {
   PollClosePollResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollClosePollResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollClosePollResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PollClosePollResponseApplicationJson
@@ -25566,6 +27504,16 @@ abstract class PollClosePollResponseApplicationJson
   /// Serializer for PollClosePollResponseApplicationJson.
   static Serializer<PollClosePollResponseApplicationJson> get serializer =>
       _$pollClosePollResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollClosePollResponseApplicationJsonBuilder b) {
+    $PollClosePollResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollClosePollResponseApplicationJsonBuilder b) {
+    $PollClosePollResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class PublicShareAuthCreateRoomApiVersion extends EnumClass {
@@ -25632,6 +27580,10 @@ abstract interface class $PublicShareAuthCreateRoomResponseApplicationJson_Ocs_D
   String get token;
   String get name;
   String get displayName;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data
@@ -25666,12 +27618,26 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data
   /// Serializer for PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data.
   static Serializer<PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data> get serializer =>
       _$publicShareAuthCreateRoomResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder b) {
+    $PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder b) {
+    $PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PublicShareAuthCreateRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicShareAuthCreateRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicShareAuthCreateRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PublicShareAuthCreateRoomResponseApplicationJson_Ocs
@@ -25706,11 +27672,25 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson_Ocs
   /// Serializer for PublicShareAuthCreateRoomResponseApplicationJson_Ocs.
   static Serializer<PublicShareAuthCreateRoomResponseApplicationJson_Ocs> get serializer =>
       _$publicShareAuthCreateRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder b) {
+    $PublicShareAuthCreateRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder b) {
+    $PublicShareAuthCreateRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PublicShareAuthCreateRoomResponseApplicationJsonInterface {
   PublicShareAuthCreateRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicShareAuthCreateRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicShareAuthCreateRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PublicShareAuthCreateRoomResponseApplicationJson
@@ -25745,6 +27725,16 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson
   /// Serializer for PublicShareAuthCreateRoomResponseApplicationJson.
   static Serializer<PublicShareAuthCreateRoomResponseApplicationJson> get serializer =>
       _$publicShareAuthCreateRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicShareAuthCreateRoomResponseApplicationJsonBuilder b) {
+    $PublicShareAuthCreateRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicShareAuthCreateRoomResponseApplicationJsonBuilder b) {
+    $PublicShareAuthCreateRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ReactionGetReactionsApiVersion extends EnumClass {
@@ -25810,6 +27800,10 @@ abstract interface class $ReactionInterface {
   String get actorId;
   ActorType get actorType;
   int get timestamp;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReactionInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReactionInterfaceBuilder b) {}
 }
 
 abstract class Reaction implements $ReactionInterface, Built<Reaction, ReactionBuilder> {
@@ -25836,12 +27830,26 @@ abstract class Reaction implements $ReactionInterface, Built<Reaction, ReactionB
 
   /// Serializer for Reaction.
   static Serializer<Reaction> get serializer => _$reactionSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReactionBuilder b) {
+    $ReactionInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReactionBuilder b) {
+    $ReactionInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReactionGetReactionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<Reaction>> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReactionGetReactionsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReactionGetReactionsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ReactionGetReactionsResponseApplicationJson_Ocs
@@ -25875,11 +27883,25 @@ abstract class ReactionGetReactionsResponseApplicationJson_Ocs
   /// Serializer for ReactionGetReactionsResponseApplicationJson_Ocs.
   static Serializer<ReactionGetReactionsResponseApplicationJson_Ocs> get serializer =>
       _$reactionGetReactionsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReactionGetReactionsResponseApplicationJson_OcsBuilder b) {
+    $ReactionGetReactionsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReactionGetReactionsResponseApplicationJson_OcsBuilder b) {
+    $ReactionGetReactionsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReactionGetReactionsResponseApplicationJsonInterface {
   ReactionGetReactionsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReactionGetReactionsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReactionGetReactionsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ReactionGetReactionsResponseApplicationJson
@@ -25913,6 +27935,16 @@ abstract class ReactionGetReactionsResponseApplicationJson
   /// Serializer for ReactionGetReactionsResponseApplicationJson.
   static Serializer<ReactionGetReactionsResponseApplicationJson> get serializer =>
       _$reactionGetReactionsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReactionGetReactionsResponseApplicationJsonBuilder b) {
+    $ReactionGetReactionsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReactionGetReactionsResponseApplicationJsonBuilder b) {
+    $ReactionGetReactionsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ReactionReactApiVersion extends EnumClass {
@@ -25975,6 +28007,10 @@ class _$ReactionReactApiVersionSerializer implements PrimitiveSerializer<Reactio
 abstract interface class $ReactionReactResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<Reaction>> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReactionReactResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReactionReactResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ReactionReactResponseApplicationJson_Ocs
@@ -26008,11 +28044,25 @@ abstract class ReactionReactResponseApplicationJson_Ocs
   /// Serializer for ReactionReactResponseApplicationJson_Ocs.
   static Serializer<ReactionReactResponseApplicationJson_Ocs> get serializer =>
       _$reactionReactResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReactionReactResponseApplicationJson_OcsBuilder b) {
+    $ReactionReactResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReactionReactResponseApplicationJson_OcsBuilder b) {
+    $ReactionReactResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReactionReactResponseApplicationJsonInterface {
   ReactionReactResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReactionReactResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReactionReactResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ReactionReactResponseApplicationJson
@@ -26045,6 +28095,16 @@ abstract class ReactionReactResponseApplicationJson
   /// Serializer for ReactionReactResponseApplicationJson.
   static Serializer<ReactionReactResponseApplicationJson> get serializer =>
       _$reactionReactResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReactionReactResponseApplicationJsonBuilder b) {
+    $ReactionReactResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReactionReactResponseApplicationJsonBuilder b) {
+    $ReactionReactResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ReactionDeleteApiVersion extends EnumClass {
@@ -26107,6 +28167,10 @@ class _$ReactionDeleteApiVersionSerializer implements PrimitiveSerializer<Reacti
 abstract interface class $ReactionDeleteResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<Reaction>> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReactionDeleteResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReactionDeleteResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ReactionDeleteResponseApplicationJson_Ocs
@@ -26140,11 +28204,25 @@ abstract class ReactionDeleteResponseApplicationJson_Ocs
   /// Serializer for ReactionDeleteResponseApplicationJson_Ocs.
   static Serializer<ReactionDeleteResponseApplicationJson_Ocs> get serializer =>
       _$reactionDeleteResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReactionDeleteResponseApplicationJson_OcsBuilder b) {
+    $ReactionDeleteResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReactionDeleteResponseApplicationJson_OcsBuilder b) {
+    $ReactionDeleteResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReactionDeleteResponseApplicationJsonInterface {
   ReactionDeleteResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReactionDeleteResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReactionDeleteResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ReactionDeleteResponseApplicationJson
@@ -26177,6 +28255,16 @@ abstract class ReactionDeleteResponseApplicationJson
   /// Serializer for ReactionDeleteResponseApplicationJson.
   static Serializer<ReactionDeleteResponseApplicationJson> get serializer =>
       _$reactionDeleteResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReactionDeleteResponseApplicationJsonBuilder b) {
+    $ReactionDeleteResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReactionDeleteResponseApplicationJsonBuilder b) {
+    $ReactionDeleteResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RecordingStartApiVersion extends EnumClass {
@@ -26239,6 +28327,10 @@ class _$RecordingStartApiVersionSerializer implements PrimitiveSerializer<Record
 abstract interface class $RecordingStartResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingStartResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingStartResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RecordingStartResponseApplicationJson_Ocs
@@ -26272,11 +28364,25 @@ abstract class RecordingStartResponseApplicationJson_Ocs
   /// Serializer for RecordingStartResponseApplicationJson_Ocs.
   static Serializer<RecordingStartResponseApplicationJson_Ocs> get serializer =>
       _$recordingStartResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingStartResponseApplicationJson_OcsBuilder b) {
+    $RecordingStartResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingStartResponseApplicationJson_OcsBuilder b) {
+    $RecordingStartResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RecordingStartResponseApplicationJsonInterface {
   RecordingStartResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingStartResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingStartResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RecordingStartResponseApplicationJson
@@ -26309,6 +28415,16 @@ abstract class RecordingStartResponseApplicationJson
   /// Serializer for RecordingStartResponseApplicationJson.
   static Serializer<RecordingStartResponseApplicationJson> get serializer =>
       _$recordingStartResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingStartResponseApplicationJsonBuilder b) {
+    $RecordingStartResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingStartResponseApplicationJsonBuilder b) {
+    $RecordingStartResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RecordingStopApiVersion extends EnumClass {
@@ -26371,6 +28487,10 @@ class _$RecordingStopApiVersionSerializer implements PrimitiveSerializer<Recordi
 abstract interface class $RecordingStopResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingStopResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingStopResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RecordingStopResponseApplicationJson_Ocs
@@ -26404,11 +28524,25 @@ abstract class RecordingStopResponseApplicationJson_Ocs
   /// Serializer for RecordingStopResponseApplicationJson_Ocs.
   static Serializer<RecordingStopResponseApplicationJson_Ocs> get serializer =>
       _$recordingStopResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingStopResponseApplicationJson_OcsBuilder b) {
+    $RecordingStopResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingStopResponseApplicationJson_OcsBuilder b) {
+    $RecordingStopResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RecordingStopResponseApplicationJsonInterface {
   RecordingStopResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingStopResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingStopResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RecordingStopResponseApplicationJson
@@ -26441,6 +28575,16 @@ abstract class RecordingStopResponseApplicationJson
   /// Serializer for RecordingStopResponseApplicationJson.
   static Serializer<RecordingStopResponseApplicationJson> get serializer =>
       _$recordingStopResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingStopResponseApplicationJsonBuilder b) {
+    $RecordingStopResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingStopResponseApplicationJsonBuilder b) {
+    $RecordingStopResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RecordingStoreApiVersion extends EnumClass {
@@ -26503,6 +28647,10 @@ class _$RecordingStoreApiVersionSerializer implements PrimitiveSerializer<Record
 abstract interface class $RecordingStoreResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingStoreResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingStoreResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RecordingStoreResponseApplicationJson_Ocs
@@ -26536,11 +28684,25 @@ abstract class RecordingStoreResponseApplicationJson_Ocs
   /// Serializer for RecordingStoreResponseApplicationJson_Ocs.
   static Serializer<RecordingStoreResponseApplicationJson_Ocs> get serializer =>
       _$recordingStoreResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingStoreResponseApplicationJson_OcsBuilder b) {
+    $RecordingStoreResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingStoreResponseApplicationJson_OcsBuilder b) {
+    $RecordingStoreResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RecordingStoreResponseApplicationJsonInterface {
   RecordingStoreResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingStoreResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingStoreResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RecordingStoreResponseApplicationJson
@@ -26573,6 +28735,16 @@ abstract class RecordingStoreResponseApplicationJson
   /// Serializer for RecordingStoreResponseApplicationJson.
   static Serializer<RecordingStoreResponseApplicationJson> get serializer =>
       _$recordingStoreResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingStoreResponseApplicationJsonBuilder b) {
+    $RecordingStoreResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingStoreResponseApplicationJsonBuilder b) {
+    $RecordingStoreResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RecordingNotificationDismissApiVersion extends EnumClass {
@@ -26640,6 +28812,10 @@ class _$RecordingNotificationDismissApiVersionSerializer
 abstract interface class $RecordingNotificationDismissResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingNotificationDismissResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingNotificationDismissResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RecordingNotificationDismissResponseApplicationJson_Ocs
@@ -26674,11 +28850,25 @@ abstract class RecordingNotificationDismissResponseApplicationJson_Ocs
   /// Serializer for RecordingNotificationDismissResponseApplicationJson_Ocs.
   static Serializer<RecordingNotificationDismissResponseApplicationJson_Ocs> get serializer =>
       _$recordingNotificationDismissResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingNotificationDismissResponseApplicationJson_OcsBuilder b) {
+    $RecordingNotificationDismissResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingNotificationDismissResponseApplicationJson_OcsBuilder b) {
+    $RecordingNotificationDismissResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RecordingNotificationDismissResponseApplicationJsonInterface {
   RecordingNotificationDismissResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingNotificationDismissResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingNotificationDismissResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RecordingNotificationDismissResponseApplicationJson
@@ -26713,6 +28903,16 @@ abstract class RecordingNotificationDismissResponseApplicationJson
   /// Serializer for RecordingNotificationDismissResponseApplicationJson.
   static Serializer<RecordingNotificationDismissResponseApplicationJson> get serializer =>
       _$recordingNotificationDismissResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingNotificationDismissResponseApplicationJsonBuilder b) {
+    $RecordingNotificationDismissResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingNotificationDismissResponseApplicationJsonBuilder b) {
+    $RecordingNotificationDismissResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RecordingShareToChatApiVersion extends EnumClass {
@@ -26776,6 +28976,10 @@ class _$RecordingShareToChatApiVersionSerializer implements PrimitiveSerializer<
 abstract interface class $RecordingShareToChatResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingShareToChatResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingShareToChatResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RecordingShareToChatResponseApplicationJson_Ocs
@@ -26809,11 +29013,25 @@ abstract class RecordingShareToChatResponseApplicationJson_Ocs
   /// Serializer for RecordingShareToChatResponseApplicationJson_Ocs.
   static Serializer<RecordingShareToChatResponseApplicationJson_Ocs> get serializer =>
       _$recordingShareToChatResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingShareToChatResponseApplicationJson_OcsBuilder b) {
+    $RecordingShareToChatResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingShareToChatResponseApplicationJson_OcsBuilder b) {
+    $RecordingShareToChatResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RecordingShareToChatResponseApplicationJsonInterface {
   RecordingShareToChatResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingShareToChatResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingShareToChatResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RecordingShareToChatResponseApplicationJson
@@ -26847,6 +29065,16 @@ abstract class RecordingShareToChatResponseApplicationJson
   /// Serializer for RecordingShareToChatResponseApplicationJson.
   static Serializer<RecordingShareToChatResponseApplicationJson> get serializer =>
       _$recordingShareToChatResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingShareToChatResponseApplicationJsonBuilder b) {
+    $RecordingShareToChatResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingShareToChatResponseApplicationJsonBuilder b) {
+    $RecordingShareToChatResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RecordingGetWelcomeMessageApiVersion extends EnumClass {
@@ -26913,6 +29141,10 @@ class _$RecordingGetWelcomeMessageApiVersionSerializer
 @BuiltValue(instantiable: false)
 abstract interface class $RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterface {
   double get version;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data
@@ -26947,12 +29179,26 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data
   /// Serializer for RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data.
   static Serializer<RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data> get serializer =>
       _$recordingGetWelcomeMessageResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder b) {
+    $RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder b) {
+    $RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RecordingGetWelcomeMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RecordingGetWelcomeMessageResponseApplicationJson_Ocs
@@ -26987,11 +29233,25 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson_Ocs
   /// Serializer for RecordingGetWelcomeMessageResponseApplicationJson_Ocs.
   static Serializer<RecordingGetWelcomeMessageResponseApplicationJson_Ocs> get serializer =>
       _$recordingGetWelcomeMessageResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder b) {
+    $RecordingGetWelcomeMessageResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder b) {
+    $RecordingGetWelcomeMessageResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RecordingGetWelcomeMessageResponseApplicationJsonInterface {
   RecordingGetWelcomeMessageResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RecordingGetWelcomeMessageResponseApplicationJson
@@ -27026,6 +29286,16 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson
   /// Serializer for RecordingGetWelcomeMessageResponseApplicationJson.
   static Serializer<RecordingGetWelcomeMessageResponseApplicationJson> get serializer =>
       _$recordingGetWelcomeMessageResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingGetWelcomeMessageResponseApplicationJsonBuilder b) {
+    $RecordingGetWelcomeMessageResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingGetWelcomeMessageResponseApplicationJsonBuilder b) {
+    $RecordingGetWelcomeMessageResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomGetRoomsNoStatusUpdate extends EnumClass {
@@ -27214,6 +29484,10 @@ class _$RoomGetRoomsApiVersionSerializer implements PrimitiveSerializer<RoomGetR
 abstract interface class $RoomGetRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomGetRoomsResponseApplicationJson_Ocs
@@ -27246,11 +29520,25 @@ abstract class RoomGetRoomsResponseApplicationJson_Ocs
   /// Serializer for RoomGetRoomsResponseApplicationJson_Ocs.
   static Serializer<RoomGetRoomsResponseApplicationJson_Ocs> get serializer =>
       _$roomGetRoomsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetRoomsResponseApplicationJson_OcsBuilder b) {
+    $RoomGetRoomsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetRoomsResponseApplicationJson_OcsBuilder b) {
+    $RoomGetRoomsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomGetRoomsResponseApplicationJsonInterface {
   RoomGetRoomsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetRoomsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetRoomsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomGetRoomsResponseApplicationJson
@@ -27283,6 +29571,16 @@ abstract class RoomGetRoomsResponseApplicationJson
   /// Serializer for RoomGetRoomsResponseApplicationJson.
   static Serializer<RoomGetRoomsResponseApplicationJson> get serializer =>
       _$roomGetRoomsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetRoomsResponseApplicationJsonBuilder b) {
+    $RoomGetRoomsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetRoomsResponseApplicationJsonBuilder b) {
+    $RoomGetRoomsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -27291,6 +29589,10 @@ abstract interface class $RoomRoomGetRoomsHeadersInterface {
   String? get xNextcloudTalkHash;
   @BuiltValueField(wireName: 'x-nextcloud-talk-modified-before')
   String? get xNextcloudTalkModifiedBefore;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRoomGetRoomsHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRoomGetRoomsHeadersInterfaceBuilder b) {}
 }
 
 abstract class RoomRoomGetRoomsHeaders
@@ -27319,6 +29621,16 @@ abstract class RoomRoomGetRoomsHeaders
 
   /// Serializer for RoomRoomGetRoomsHeaders.
   static Serializer<RoomRoomGetRoomsHeaders> get serializer => _$roomRoomGetRoomsHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRoomGetRoomsHeadersBuilder b) {
+    $RoomRoomGetRoomsHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRoomGetRoomsHeadersBuilder b) {
+    $RoomRoomGetRoomsHeadersInterface._validate(b);
+  }
 }
 
 class RoomCreateRoomApiVersion extends EnumClass {
@@ -27381,6 +29693,10 @@ class _$RoomCreateRoomApiVersionSerializer implements PrimitiveSerializer<RoomCr
 abstract interface class $RoomCreateRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomCreateRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomCreateRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomCreateRoomResponseApplicationJson_Ocs
@@ -27414,11 +29730,25 @@ abstract class RoomCreateRoomResponseApplicationJson_Ocs
   /// Serializer for RoomCreateRoomResponseApplicationJson_Ocs.
   static Serializer<RoomCreateRoomResponseApplicationJson_Ocs> get serializer =>
       _$roomCreateRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomCreateRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomCreateRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomCreateRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomCreateRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomCreateRoomResponseApplicationJsonInterface {
   RoomCreateRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomCreateRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomCreateRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomCreateRoomResponseApplicationJson
@@ -27451,6 +29781,16 @@ abstract class RoomCreateRoomResponseApplicationJson
   /// Serializer for RoomCreateRoomResponseApplicationJson.
   static Serializer<RoomCreateRoomResponseApplicationJson> get serializer =>
       _$roomCreateRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomCreateRoomResponseApplicationJsonBuilder b) {
+    $RoomCreateRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomCreateRoomResponseApplicationJsonBuilder b) {
+    $RoomCreateRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomGetListedRoomsApiVersion extends EnumClass {
@@ -27513,6 +29853,10 @@ class _$RoomGetListedRoomsApiVersionSerializer implements PrimitiveSerializer<Ro
 abstract interface class $RoomGetListedRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetListedRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetListedRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomGetListedRoomsResponseApplicationJson_Ocs
@@ -27546,11 +29890,25 @@ abstract class RoomGetListedRoomsResponseApplicationJson_Ocs
   /// Serializer for RoomGetListedRoomsResponseApplicationJson_Ocs.
   static Serializer<RoomGetListedRoomsResponseApplicationJson_Ocs> get serializer =>
       _$roomGetListedRoomsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetListedRoomsResponseApplicationJson_OcsBuilder b) {
+    $RoomGetListedRoomsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetListedRoomsResponseApplicationJson_OcsBuilder b) {
+    $RoomGetListedRoomsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomGetListedRoomsResponseApplicationJsonInterface {
   RoomGetListedRoomsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetListedRoomsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetListedRoomsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomGetListedRoomsResponseApplicationJson
@@ -27584,6 +29942,16 @@ abstract class RoomGetListedRoomsResponseApplicationJson
   /// Serializer for RoomGetListedRoomsResponseApplicationJson.
   static Serializer<RoomGetListedRoomsResponseApplicationJson> get serializer =>
       _$roomGetListedRoomsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetListedRoomsResponseApplicationJsonBuilder b) {
+    $RoomGetListedRoomsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetListedRoomsResponseApplicationJsonBuilder b) {
+    $RoomGetListedRoomsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomGetNoteToSelfConversationApiVersion extends EnumClass {
@@ -27652,6 +30020,10 @@ class _$RoomGetNoteToSelfConversationApiVersionSerializer
 abstract interface class $RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomGetNoteToSelfConversationResponseApplicationJson_Ocs
@@ -27686,11 +30058,25 @@ abstract class RoomGetNoteToSelfConversationResponseApplicationJson_Ocs
   /// Serializer for RoomGetNoteToSelfConversationResponseApplicationJson_Ocs.
   static Serializer<RoomGetNoteToSelfConversationResponseApplicationJson_Ocs> get serializer =>
       _$roomGetNoteToSelfConversationResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder b) {
+    $RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder b) {
+    $RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomGetNoteToSelfConversationResponseApplicationJsonInterface {
   RoomGetNoteToSelfConversationResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetNoteToSelfConversationResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetNoteToSelfConversationResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomGetNoteToSelfConversationResponseApplicationJson
@@ -27725,12 +30111,26 @@ abstract class RoomGetNoteToSelfConversationResponseApplicationJson
   /// Serializer for RoomGetNoteToSelfConversationResponseApplicationJson.
   static Serializer<RoomGetNoteToSelfConversationResponseApplicationJson> get serializer =>
       _$roomGetNoteToSelfConversationResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetNoteToSelfConversationResponseApplicationJsonBuilder b) {
+    $RoomGetNoteToSelfConversationResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetNoteToSelfConversationResponseApplicationJsonBuilder b) {
+    $RoomGetNoteToSelfConversationResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomRoomGetNoteToSelfConversationHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
   String? get xNextcloudTalkHash;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder b) {}
 }
 
 abstract class RoomRoomGetNoteToSelfConversationHeaders
@@ -27764,6 +30164,16 @@ abstract class RoomRoomGetNoteToSelfConversationHeaders
   /// Serializer for RoomRoomGetNoteToSelfConversationHeaders.
   static Serializer<RoomRoomGetNoteToSelfConversationHeaders> get serializer =>
       _$roomRoomGetNoteToSelfConversationHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRoomGetNoteToSelfConversationHeadersBuilder b) {
+    $RoomRoomGetNoteToSelfConversationHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRoomGetNoteToSelfConversationHeadersBuilder b) {
+    $RoomRoomGetNoteToSelfConversationHeadersInterface._validate(b);
+  }
 }
 
 class RoomGetSingleRoomApiVersion extends EnumClass {
@@ -27826,6 +30236,10 @@ class _$RoomGetSingleRoomApiVersionSerializer implements PrimitiveSerializer<Roo
 abstract interface class $RoomGetSingleRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetSingleRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetSingleRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomGetSingleRoomResponseApplicationJson_Ocs
@@ -27859,11 +30273,25 @@ abstract class RoomGetSingleRoomResponseApplicationJson_Ocs
   /// Serializer for RoomGetSingleRoomResponseApplicationJson_Ocs.
   static Serializer<RoomGetSingleRoomResponseApplicationJson_Ocs> get serializer =>
       _$roomGetSingleRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetSingleRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomGetSingleRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetSingleRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomGetSingleRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomGetSingleRoomResponseApplicationJsonInterface {
   RoomGetSingleRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetSingleRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetSingleRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomGetSingleRoomResponseApplicationJson
@@ -27897,12 +30325,26 @@ abstract class RoomGetSingleRoomResponseApplicationJson
   /// Serializer for RoomGetSingleRoomResponseApplicationJson.
   static Serializer<RoomGetSingleRoomResponseApplicationJson> get serializer =>
       _$roomGetSingleRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetSingleRoomResponseApplicationJsonBuilder b) {
+    $RoomGetSingleRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetSingleRoomResponseApplicationJsonBuilder b) {
+    $RoomGetSingleRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomRoomGetSingleRoomHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
   String? get xNextcloudTalkHash;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRoomGetSingleRoomHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRoomGetSingleRoomHeadersInterfaceBuilder b) {}
 }
 
 abstract class RoomRoomGetSingleRoomHeaders
@@ -27934,6 +30376,16 @@ abstract class RoomRoomGetSingleRoomHeaders
 
   /// Serializer for RoomRoomGetSingleRoomHeaders.
   static Serializer<RoomRoomGetSingleRoomHeaders> get serializer => _$roomRoomGetSingleRoomHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRoomGetSingleRoomHeadersBuilder b) {
+    $RoomRoomGetSingleRoomHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRoomGetSingleRoomHeadersBuilder b) {
+    $RoomRoomGetSingleRoomHeadersInterface._validate(b);
+  }
 }
 
 class RoomRenameRoomApiVersion extends EnumClass {
@@ -27996,6 +30448,10 @@ class _$RoomRenameRoomApiVersionSerializer implements PrimitiveSerializer<RoomRe
 abstract interface class $RoomRenameRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRenameRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRenameRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomRenameRoomResponseApplicationJson_Ocs
@@ -28029,11 +30485,25 @@ abstract class RoomRenameRoomResponseApplicationJson_Ocs
   /// Serializer for RoomRenameRoomResponseApplicationJson_Ocs.
   static Serializer<RoomRenameRoomResponseApplicationJson_Ocs> get serializer =>
       _$roomRenameRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRenameRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomRenameRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRenameRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomRenameRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomRenameRoomResponseApplicationJsonInterface {
   RoomRenameRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRenameRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRenameRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomRenameRoomResponseApplicationJson
@@ -28066,6 +30536,16 @@ abstract class RoomRenameRoomResponseApplicationJson
   /// Serializer for RoomRenameRoomResponseApplicationJson.
   static Serializer<RoomRenameRoomResponseApplicationJson> get serializer =>
       _$roomRenameRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRenameRoomResponseApplicationJsonBuilder b) {
+    $RoomRenameRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRenameRoomResponseApplicationJsonBuilder b) {
+    $RoomRenameRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomDeleteRoomApiVersion extends EnumClass {
@@ -28128,6 +30608,10 @@ class _$RoomDeleteRoomApiVersionSerializer implements PrimitiveSerializer<RoomDe
 abstract interface class $RoomDeleteRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomDeleteRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomDeleteRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomDeleteRoomResponseApplicationJson_Ocs
@@ -28161,11 +30645,25 @@ abstract class RoomDeleteRoomResponseApplicationJson_Ocs
   /// Serializer for RoomDeleteRoomResponseApplicationJson_Ocs.
   static Serializer<RoomDeleteRoomResponseApplicationJson_Ocs> get serializer =>
       _$roomDeleteRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomDeleteRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomDeleteRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomDeleteRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomDeleteRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomDeleteRoomResponseApplicationJsonInterface {
   RoomDeleteRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomDeleteRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomDeleteRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomDeleteRoomResponseApplicationJson
@@ -28198,6 +30696,16 @@ abstract class RoomDeleteRoomResponseApplicationJson
   /// Serializer for RoomDeleteRoomResponseApplicationJson.
   static Serializer<RoomDeleteRoomResponseApplicationJson> get serializer =>
       _$roomDeleteRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomDeleteRoomResponseApplicationJsonBuilder b) {
+    $RoomDeleteRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomDeleteRoomResponseApplicationJsonBuilder b) {
+    $RoomDeleteRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomGetBreakoutRoomsApiVersion extends EnumClass {
@@ -28261,6 +30769,10 @@ class _$RoomGetBreakoutRoomsApiVersionSerializer implements PrimitiveSerializer<
 abstract interface class $RoomGetBreakoutRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomGetBreakoutRoomsResponseApplicationJson_Ocs
@@ -28294,11 +30806,25 @@ abstract class RoomGetBreakoutRoomsResponseApplicationJson_Ocs
   /// Serializer for RoomGetBreakoutRoomsResponseApplicationJson_Ocs.
   static Serializer<RoomGetBreakoutRoomsResponseApplicationJson_Ocs> get serializer =>
       _$roomGetBreakoutRoomsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder b) {
+    $RoomGetBreakoutRoomsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder b) {
+    $RoomGetBreakoutRoomsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomGetBreakoutRoomsResponseApplicationJsonInterface {
   RoomGetBreakoutRoomsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomGetBreakoutRoomsResponseApplicationJson
@@ -28332,6 +30858,16 @@ abstract class RoomGetBreakoutRoomsResponseApplicationJson
   /// Serializer for RoomGetBreakoutRoomsResponseApplicationJson.
   static Serializer<RoomGetBreakoutRoomsResponseApplicationJson> get serializer =>
       _$roomGetBreakoutRoomsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetBreakoutRoomsResponseApplicationJsonBuilder b) {
+    $RoomGetBreakoutRoomsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetBreakoutRoomsResponseApplicationJsonBuilder b) {
+    $RoomGetBreakoutRoomsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomMakePublicApiVersion extends EnumClass {
@@ -28394,6 +30930,10 @@ class _$RoomMakePublicApiVersionSerializer implements PrimitiveSerializer<RoomMa
 abstract interface class $RoomMakePublicResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomMakePublicResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomMakePublicResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomMakePublicResponseApplicationJson_Ocs
@@ -28427,11 +30967,25 @@ abstract class RoomMakePublicResponseApplicationJson_Ocs
   /// Serializer for RoomMakePublicResponseApplicationJson_Ocs.
   static Serializer<RoomMakePublicResponseApplicationJson_Ocs> get serializer =>
       _$roomMakePublicResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomMakePublicResponseApplicationJson_OcsBuilder b) {
+    $RoomMakePublicResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomMakePublicResponseApplicationJson_OcsBuilder b) {
+    $RoomMakePublicResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomMakePublicResponseApplicationJsonInterface {
   RoomMakePublicResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomMakePublicResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomMakePublicResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomMakePublicResponseApplicationJson
@@ -28464,6 +31018,16 @@ abstract class RoomMakePublicResponseApplicationJson
   /// Serializer for RoomMakePublicResponseApplicationJson.
   static Serializer<RoomMakePublicResponseApplicationJson> get serializer =>
       _$roomMakePublicResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomMakePublicResponseApplicationJsonBuilder b) {
+    $RoomMakePublicResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomMakePublicResponseApplicationJsonBuilder b) {
+    $RoomMakePublicResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomMakePrivateApiVersion extends EnumClass {
@@ -28526,6 +31090,10 @@ class _$RoomMakePrivateApiVersionSerializer implements PrimitiveSerializer<RoomM
 abstract interface class $RoomMakePrivateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomMakePrivateResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomMakePrivateResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomMakePrivateResponseApplicationJson_Ocs
@@ -28559,11 +31127,25 @@ abstract class RoomMakePrivateResponseApplicationJson_Ocs
   /// Serializer for RoomMakePrivateResponseApplicationJson_Ocs.
   static Serializer<RoomMakePrivateResponseApplicationJson_Ocs> get serializer =>
       _$roomMakePrivateResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomMakePrivateResponseApplicationJson_OcsBuilder b) {
+    $RoomMakePrivateResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomMakePrivateResponseApplicationJson_OcsBuilder b) {
+    $RoomMakePrivateResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomMakePrivateResponseApplicationJsonInterface {
   RoomMakePrivateResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomMakePrivateResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomMakePrivateResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomMakePrivateResponseApplicationJson
@@ -28596,6 +31178,16 @@ abstract class RoomMakePrivateResponseApplicationJson
   /// Serializer for RoomMakePrivateResponseApplicationJson.
   static Serializer<RoomMakePrivateResponseApplicationJson> get serializer =>
       _$roomMakePrivateResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomMakePrivateResponseApplicationJsonBuilder b) {
+    $RoomMakePrivateResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomMakePrivateResponseApplicationJsonBuilder b) {
+    $RoomMakePrivateResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetDescriptionApiVersion extends EnumClass {
@@ -28658,6 +31250,10 @@ class _$RoomSetDescriptionApiVersionSerializer implements PrimitiveSerializer<Ro
 abstract interface class $RoomSetDescriptionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetDescriptionResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetDescriptionResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetDescriptionResponseApplicationJson_Ocs
@@ -28691,11 +31287,25 @@ abstract class RoomSetDescriptionResponseApplicationJson_Ocs
   /// Serializer for RoomSetDescriptionResponseApplicationJson_Ocs.
   static Serializer<RoomSetDescriptionResponseApplicationJson_Ocs> get serializer =>
       _$roomSetDescriptionResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetDescriptionResponseApplicationJson_OcsBuilder b) {
+    $RoomSetDescriptionResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetDescriptionResponseApplicationJson_OcsBuilder b) {
+    $RoomSetDescriptionResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetDescriptionResponseApplicationJsonInterface {
   RoomSetDescriptionResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetDescriptionResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetDescriptionResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetDescriptionResponseApplicationJson
@@ -28729,6 +31339,16 @@ abstract class RoomSetDescriptionResponseApplicationJson
   /// Serializer for RoomSetDescriptionResponseApplicationJson.
   static Serializer<RoomSetDescriptionResponseApplicationJson> get serializer =>
       _$roomSetDescriptionResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetDescriptionResponseApplicationJsonBuilder b) {
+    $RoomSetDescriptionResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetDescriptionResponseApplicationJsonBuilder b) {
+    $RoomSetDescriptionResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetReadOnlyState extends EnumClass {
@@ -28854,6 +31474,10 @@ class _$RoomSetReadOnlyApiVersionSerializer implements PrimitiveSerializer<RoomS
 abstract interface class $RoomSetReadOnlyResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetReadOnlyResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetReadOnlyResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetReadOnlyResponseApplicationJson_Ocs
@@ -28887,11 +31511,25 @@ abstract class RoomSetReadOnlyResponseApplicationJson_Ocs
   /// Serializer for RoomSetReadOnlyResponseApplicationJson_Ocs.
   static Serializer<RoomSetReadOnlyResponseApplicationJson_Ocs> get serializer =>
       _$roomSetReadOnlyResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetReadOnlyResponseApplicationJson_OcsBuilder b) {
+    $RoomSetReadOnlyResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetReadOnlyResponseApplicationJson_OcsBuilder b) {
+    $RoomSetReadOnlyResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetReadOnlyResponseApplicationJsonInterface {
   RoomSetReadOnlyResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetReadOnlyResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetReadOnlyResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetReadOnlyResponseApplicationJson
@@ -28924,6 +31562,16 @@ abstract class RoomSetReadOnlyResponseApplicationJson
   /// Serializer for RoomSetReadOnlyResponseApplicationJson.
   static Serializer<RoomSetReadOnlyResponseApplicationJson> get serializer =>
       _$roomSetReadOnlyResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetReadOnlyResponseApplicationJsonBuilder b) {
+    $RoomSetReadOnlyResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetReadOnlyResponseApplicationJsonBuilder b) {
+    $RoomSetReadOnlyResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetListableScope extends EnumClass {
@@ -29055,6 +31703,10 @@ class _$RoomSetListableApiVersionSerializer implements PrimitiveSerializer<RoomS
 abstract interface class $RoomSetListableResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetListableResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetListableResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetListableResponseApplicationJson_Ocs
@@ -29088,11 +31740,25 @@ abstract class RoomSetListableResponseApplicationJson_Ocs
   /// Serializer for RoomSetListableResponseApplicationJson_Ocs.
   static Serializer<RoomSetListableResponseApplicationJson_Ocs> get serializer =>
       _$roomSetListableResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetListableResponseApplicationJson_OcsBuilder b) {
+    $RoomSetListableResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetListableResponseApplicationJson_OcsBuilder b) {
+    $RoomSetListableResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetListableResponseApplicationJsonInterface {
   RoomSetListableResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetListableResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetListableResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetListableResponseApplicationJson
@@ -29125,6 +31791,16 @@ abstract class RoomSetListableResponseApplicationJson
   /// Serializer for RoomSetListableResponseApplicationJson.
   static Serializer<RoomSetListableResponseApplicationJson> get serializer =>
       _$roomSetListableResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetListableResponseApplicationJsonBuilder b) {
+    $RoomSetListableResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetListableResponseApplicationJsonBuilder b) {
+    $RoomSetListableResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetPasswordApiVersion extends EnumClass {
@@ -29187,6 +31863,10 @@ class _$RoomSetPasswordApiVersionSerializer implements PrimitiveSerializer<RoomS
 abstract interface class $RoomSetPasswordResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetPasswordResponseApplicationJson_Ocs
@@ -29220,11 +31900,25 @@ abstract class RoomSetPasswordResponseApplicationJson_Ocs
   /// Serializer for RoomSetPasswordResponseApplicationJson_Ocs.
   static Serializer<RoomSetPasswordResponseApplicationJson_Ocs> get serializer =>
       _$roomSetPasswordResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetPasswordResponseApplicationJson_OcsBuilder b) {
+    $RoomSetPasswordResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetPasswordResponseApplicationJson_OcsBuilder b) {
+    $RoomSetPasswordResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetPasswordResponseApplicationJsonInterface {
   RoomSetPasswordResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetPasswordResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetPasswordResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetPasswordResponseApplicationJson
@@ -29257,6 +31951,16 @@ abstract class RoomSetPasswordResponseApplicationJson
   /// Serializer for RoomSetPasswordResponseApplicationJson.
   static Serializer<RoomSetPasswordResponseApplicationJson> get serializer =>
       _$roomSetPasswordResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetPasswordResponseApplicationJsonBuilder b) {
+    $RoomSetPasswordResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetPasswordResponseApplicationJsonBuilder b) {
+    $RoomSetPasswordResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetPermissionsPermissions extends EnumClass {
@@ -30968,6 +33672,10 @@ class _$RoomSetPermissionsApiVersionSerializer implements PrimitiveSerializer<Ro
 abstract interface class $RoomSetPermissionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetPermissionsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetPermissionsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetPermissionsResponseApplicationJson_Ocs
@@ -31001,11 +33709,25 @@ abstract class RoomSetPermissionsResponseApplicationJson_Ocs
   /// Serializer for RoomSetPermissionsResponseApplicationJson_Ocs.
   static Serializer<RoomSetPermissionsResponseApplicationJson_Ocs> get serializer =>
       _$roomSetPermissionsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetPermissionsResponseApplicationJson_OcsBuilder b) {
+    $RoomSetPermissionsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetPermissionsResponseApplicationJson_OcsBuilder b) {
+    $RoomSetPermissionsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetPermissionsResponseApplicationJsonInterface {
   RoomSetPermissionsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetPermissionsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetPermissionsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetPermissionsResponseApplicationJson
@@ -31039,6 +33761,16 @@ abstract class RoomSetPermissionsResponseApplicationJson
   /// Serializer for RoomSetPermissionsResponseApplicationJson.
   static Serializer<RoomSetPermissionsResponseApplicationJson> get serializer =>
       _$roomSetPermissionsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetPermissionsResponseApplicationJsonBuilder b) {
+    $RoomSetPermissionsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetPermissionsResponseApplicationJsonBuilder b) {
+    $RoomSetPermissionsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomGetParticipantsIncludeStatus extends EnumClass {
@@ -31181,6 +33913,10 @@ abstract interface class $ParticipantInterface {
   String? get statusMessage;
   String? get phoneNumber;
   String? get callId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ParticipantInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ParticipantInterfaceBuilder b) {}
 }
 
 abstract class Participant implements $ParticipantInterface, Built<Participant, ParticipantBuilder> {
@@ -31207,12 +33943,26 @@ abstract class Participant implements $ParticipantInterface, Built<Participant, 
 
   /// Serializer for Participant.
   static Serializer<Participant> get serializer => _$participantSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ParticipantBuilder b) {
+    $ParticipantInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ParticipantBuilder b) {
+    $ParticipantInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomGetParticipantsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Participant> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetParticipantsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetParticipantsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomGetParticipantsResponseApplicationJson_Ocs
@@ -31246,11 +33996,25 @@ abstract class RoomGetParticipantsResponseApplicationJson_Ocs
   /// Serializer for RoomGetParticipantsResponseApplicationJson_Ocs.
   static Serializer<RoomGetParticipantsResponseApplicationJson_Ocs> get serializer =>
       _$roomGetParticipantsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetParticipantsResponseApplicationJson_OcsBuilder b) {
+    $RoomGetParticipantsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetParticipantsResponseApplicationJson_OcsBuilder b) {
+    $RoomGetParticipantsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomGetParticipantsResponseApplicationJsonInterface {
   RoomGetParticipantsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetParticipantsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetParticipantsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomGetParticipantsResponseApplicationJson
@@ -31284,12 +34048,26 @@ abstract class RoomGetParticipantsResponseApplicationJson
   /// Serializer for RoomGetParticipantsResponseApplicationJson.
   static Serializer<RoomGetParticipantsResponseApplicationJson> get serializer =>
       _$roomGetParticipantsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetParticipantsResponseApplicationJsonBuilder b) {
+    $RoomGetParticipantsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetParticipantsResponseApplicationJsonBuilder b) {
+    $RoomGetParticipantsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomRoomGetParticipantsHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-has-user-statuses')
   Header<bool>? get xNextcloudHasUserStatuses;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRoomGetParticipantsHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRoomGetParticipantsHeadersInterfaceBuilder b) {}
 }
 
 abstract class RoomRoomGetParticipantsHeaders
@@ -31321,6 +34099,16 @@ abstract class RoomRoomGetParticipantsHeaders
 
   /// Serializer for RoomRoomGetParticipantsHeaders.
   static Serializer<RoomRoomGetParticipantsHeaders> get serializer => _$roomRoomGetParticipantsHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRoomGetParticipantsHeadersBuilder b) {
+    $RoomRoomGetParticipantsHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRoomGetParticipantsHeadersBuilder b) {
+    $RoomRoomGetParticipantsHeadersInterface._validate(b);
+  }
 }
 
 class RoomAddParticipantToRoomSource extends EnumClass {
@@ -31466,6 +34254,10 @@ class _$RoomAddParticipantToRoomApiVersionSerializer
 @BuiltValue(instantiable: false)
 abstract interface class $RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Interface {
   int get type;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder b) {}
 }
 
 abstract class RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0
@@ -31500,6 +34292,16 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0
   /// Serializer for RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0.
   static Serializer<RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0> get serializer =>
       _$roomAddParticipantToRoomResponseApplicationJsonOcsData0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Builder b) {
+    $RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Builder b) {
+    $RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Interface._validate(b);
+  }
 }
 
 typedef RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data = ({
@@ -31511,6 +34313,12 @@ typedef RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data = ({
 abstract interface class $RoomAddParticipantToRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomAddParticipantToRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomAddParticipantToRoomResponseApplicationJson_OcsInterfaceBuilder b) {
+    b.data?.validateOneOf();
+  }
 }
 
 abstract class RoomAddParticipantToRoomResponseApplicationJson_Ocs
@@ -31546,15 +34354,24 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson_Ocs
   static Serializer<RoomAddParticipantToRoomResponseApplicationJson_Ocs> get serializer =>
       _$roomAddParticipantToRoomResponseApplicationJsonOcsSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomAddParticipantToRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder b) {
-    b.data?.validateOneOf();
+    $RoomAddParticipantToRoomResponseApplicationJson_OcsInterface._validate(b);
   }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomAddParticipantToRoomResponseApplicationJsonInterface {
   RoomAddParticipantToRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomAddParticipantToRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomAddParticipantToRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomAddParticipantToRoomResponseApplicationJson
@@ -31588,6 +34405,16 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson
   /// Serializer for RoomAddParticipantToRoomResponseApplicationJson.
   static Serializer<RoomAddParticipantToRoomResponseApplicationJson> get serializer =>
       _$roomAddParticipantToRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomAddParticipantToRoomResponseApplicationJsonBuilder b) {
+    $RoomAddParticipantToRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomAddParticipantToRoomResponseApplicationJsonBuilder b) {
+    $RoomAddParticipantToRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomGetBreakoutRoomParticipantsIncludeStatus extends EnumClass {
@@ -31725,6 +34552,10 @@ class _$RoomGetBreakoutRoomParticipantsApiVersionSerializer
 abstract interface class $RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Participant> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs
@@ -31759,11 +34590,25 @@ abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs
   /// Serializer for RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs.
   static Serializer<RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs> get serializer =>
       _$roomGetBreakoutRoomParticipantsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder b) {
+    $RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder b) {
+    $RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterface {
   RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson
@@ -31798,12 +34643,26 @@ abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson
   /// Serializer for RoomGetBreakoutRoomParticipantsResponseApplicationJson.
   static Serializer<RoomGetBreakoutRoomParticipantsResponseApplicationJson> get serializer =>
       _$roomGetBreakoutRoomParticipantsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder b) {
+    $RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder b) {
+    $RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomRoomGetBreakoutRoomParticipantsHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-has-user-statuses')
   Header<bool>? get xNextcloudHasUserStatuses;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder b) {}
 }
 
 abstract class RoomRoomGetBreakoutRoomParticipantsHeaders
@@ -31837,6 +34696,16 @@ abstract class RoomRoomGetBreakoutRoomParticipantsHeaders
   /// Serializer for RoomRoomGetBreakoutRoomParticipantsHeaders.
   static Serializer<RoomRoomGetBreakoutRoomParticipantsHeaders> get serializer =>
       _$roomRoomGetBreakoutRoomParticipantsHeadersSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder b) {
+    $RoomRoomGetBreakoutRoomParticipantsHeadersInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder b) {
+    $RoomRoomGetBreakoutRoomParticipantsHeadersInterface._validate(b);
+  }
 }
 
 class RoomRemoveSelfFromRoomApiVersion extends EnumClass {
@@ -31900,6 +34769,10 @@ class _$RoomRemoveSelfFromRoomApiVersionSerializer implements PrimitiveSerialize
 abstract interface class $RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomRemoveSelfFromRoomResponseApplicationJson_Ocs
@@ -31934,11 +34807,25 @@ abstract class RoomRemoveSelfFromRoomResponseApplicationJson_Ocs
   /// Serializer for RoomRemoveSelfFromRoomResponseApplicationJson_Ocs.
   static Serializer<RoomRemoveSelfFromRoomResponseApplicationJson_Ocs> get serializer =>
       _$roomRemoveSelfFromRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomRemoveSelfFromRoomResponseApplicationJsonInterface {
   RoomRemoveSelfFromRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRemoveSelfFromRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRemoveSelfFromRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomRemoveSelfFromRoomResponseApplicationJson
@@ -31972,6 +34859,16 @@ abstract class RoomRemoveSelfFromRoomResponseApplicationJson
   /// Serializer for RoomRemoveSelfFromRoomResponseApplicationJson.
   static Serializer<RoomRemoveSelfFromRoomResponseApplicationJson> get serializer =>
       _$roomRemoveSelfFromRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRemoveSelfFromRoomResponseApplicationJsonBuilder b) {
+    $RoomRemoveSelfFromRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRemoveSelfFromRoomResponseApplicationJsonBuilder b) {
+    $RoomRemoveSelfFromRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomRemoveAttendeeFromRoomApiVersion extends EnumClass {
@@ -32039,6 +34936,10 @@ class _$RoomRemoveAttendeeFromRoomApiVersionSerializer
 abstract interface class $RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs
@@ -32073,11 +34974,25 @@ abstract class RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs
   /// Serializer for RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs.
   static Serializer<RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs> get serializer =>
       _$roomRemoveAttendeeFromRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomRemoveAttendeeFromRoomResponseApplicationJsonInterface {
   RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRemoveAttendeeFromRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRemoveAttendeeFromRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomRemoveAttendeeFromRoomResponseApplicationJson
@@ -32112,6 +35027,16 @@ abstract class RoomRemoveAttendeeFromRoomResponseApplicationJson
   /// Serializer for RoomRemoveAttendeeFromRoomResponseApplicationJson.
   static Serializer<RoomRemoveAttendeeFromRoomResponseApplicationJson> get serializer =>
       _$roomRemoveAttendeeFromRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder b) {
+    $RoomRemoveAttendeeFromRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder b) {
+    $RoomRemoveAttendeeFromRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetAttendeePermissionsMethod extends EnumClass {
@@ -33839,6 +36764,10 @@ class _$RoomSetAttendeePermissionsApiVersionSerializer
 abstract interface class $RoomSetAttendeePermissionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetAttendeePermissionsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetAttendeePermissionsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetAttendeePermissionsResponseApplicationJson_Ocs
@@ -33873,11 +36802,25 @@ abstract class RoomSetAttendeePermissionsResponseApplicationJson_Ocs
   /// Serializer for RoomSetAttendeePermissionsResponseApplicationJson_Ocs.
   static Serializer<RoomSetAttendeePermissionsResponseApplicationJson_Ocs> get serializer =>
       _$roomSetAttendeePermissionsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder b) {
+    $RoomSetAttendeePermissionsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder b) {
+    $RoomSetAttendeePermissionsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetAttendeePermissionsResponseApplicationJsonInterface {
   RoomSetAttendeePermissionsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetAttendeePermissionsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetAttendeePermissionsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetAttendeePermissionsResponseApplicationJson
@@ -33912,6 +36855,16 @@ abstract class RoomSetAttendeePermissionsResponseApplicationJson
   /// Serializer for RoomSetAttendeePermissionsResponseApplicationJson.
   static Serializer<RoomSetAttendeePermissionsResponseApplicationJson> get serializer =>
       _$roomSetAttendeePermissionsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetAttendeePermissionsResponseApplicationJsonBuilder b) {
+    $RoomSetAttendeePermissionsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetAttendeePermissionsResponseApplicationJsonBuilder b) {
+    $RoomSetAttendeePermissionsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetAllAttendeesPermissionsMethod extends EnumClass {
@@ -35645,6 +38598,10 @@ class _$RoomSetAllAttendeesPermissionsApiVersionSerializer
 abstract interface class $RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs
@@ -35679,11 +38636,25 @@ abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs
   /// Serializer for RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs.
   static Serializer<RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs> get serializer =>
       _$roomSetAllAttendeesPermissionsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder b) {
+    $RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder b) {
+    $RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetAllAttendeesPermissionsResponseApplicationJsonInterface {
   RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetAllAttendeesPermissionsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetAllAttendeesPermissionsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson
@@ -35718,6 +38689,16 @@ abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson
   /// Serializer for RoomSetAllAttendeesPermissionsResponseApplicationJson.
   static Serializer<RoomSetAllAttendeesPermissionsResponseApplicationJson> get serializer =>
       _$roomSetAllAttendeesPermissionsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder b) {
+    $RoomSetAllAttendeesPermissionsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder b) {
+    $RoomSetAllAttendeesPermissionsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomJoinRoomForce extends EnumClass {
@@ -35843,6 +38824,10 @@ class _$RoomJoinRoomApiVersionSerializer implements PrimitiveSerializer<RoomJoin
 abstract interface class $RoomJoinRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomJoinRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomJoinRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomJoinRoomResponseApplicationJson_Ocs
@@ -35875,11 +38860,25 @@ abstract class RoomJoinRoomResponseApplicationJson_Ocs
   /// Serializer for RoomJoinRoomResponseApplicationJson_Ocs.
   static Serializer<RoomJoinRoomResponseApplicationJson_Ocs> get serializer =>
       _$roomJoinRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomJoinRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomJoinRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomJoinRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomJoinRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomJoinRoomResponseApplicationJsonInterface {
   RoomJoinRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomJoinRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomJoinRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomJoinRoomResponseApplicationJson
@@ -35912,6 +38911,16 @@ abstract class RoomJoinRoomResponseApplicationJson
   /// Serializer for RoomJoinRoomResponseApplicationJson.
   static Serializer<RoomJoinRoomResponseApplicationJson> get serializer =>
       _$roomJoinRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomJoinRoomResponseApplicationJsonBuilder b) {
+    $RoomJoinRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomJoinRoomResponseApplicationJsonBuilder b) {
+    $RoomJoinRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomLeaveRoomApiVersion extends EnumClass {
@@ -35974,6 +38983,10 @@ class _$RoomLeaveRoomApiVersionSerializer implements PrimitiveSerializer<RoomLea
 abstract interface class $RoomLeaveRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomLeaveRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomLeaveRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomLeaveRoomResponseApplicationJson_Ocs
@@ -36007,11 +39020,25 @@ abstract class RoomLeaveRoomResponseApplicationJson_Ocs
   /// Serializer for RoomLeaveRoomResponseApplicationJson_Ocs.
   static Serializer<RoomLeaveRoomResponseApplicationJson_Ocs> get serializer =>
       _$roomLeaveRoomResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomLeaveRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomLeaveRoomResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomLeaveRoomResponseApplicationJson_OcsBuilder b) {
+    $RoomLeaveRoomResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomLeaveRoomResponseApplicationJsonInterface {
   RoomLeaveRoomResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomLeaveRoomResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomLeaveRoomResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomLeaveRoomResponseApplicationJson
@@ -36044,6 +39071,16 @@ abstract class RoomLeaveRoomResponseApplicationJson
   /// Serializer for RoomLeaveRoomResponseApplicationJson.
   static Serializer<RoomLeaveRoomResponseApplicationJson> get serializer =>
       _$roomLeaveRoomResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomLeaveRoomResponseApplicationJsonBuilder b) {
+    $RoomLeaveRoomResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomLeaveRoomResponseApplicationJsonBuilder b) {
+    $RoomLeaveRoomResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomResendInvitationsApiVersion extends EnumClass {
@@ -36107,6 +39144,10 @@ class _$RoomResendInvitationsApiVersionSerializer implements PrimitiveSerializer
 abstract interface class $RoomResendInvitationsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomResendInvitationsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomResendInvitationsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomResendInvitationsResponseApplicationJson_Ocs
@@ -36141,11 +39182,25 @@ abstract class RoomResendInvitationsResponseApplicationJson_Ocs
   /// Serializer for RoomResendInvitationsResponseApplicationJson_Ocs.
   static Serializer<RoomResendInvitationsResponseApplicationJson_Ocs> get serializer =>
       _$roomResendInvitationsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomResendInvitationsResponseApplicationJson_OcsBuilder b) {
+    $RoomResendInvitationsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomResendInvitationsResponseApplicationJson_OcsBuilder b) {
+    $RoomResendInvitationsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomResendInvitationsResponseApplicationJsonInterface {
   RoomResendInvitationsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomResendInvitationsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomResendInvitationsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomResendInvitationsResponseApplicationJson
@@ -36179,6 +39234,16 @@ abstract class RoomResendInvitationsResponseApplicationJson
   /// Serializer for RoomResendInvitationsResponseApplicationJson.
   static Serializer<RoomResendInvitationsResponseApplicationJson> get serializer =>
       _$roomResendInvitationsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomResendInvitationsResponseApplicationJsonBuilder b) {
+    $RoomResendInvitationsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomResendInvitationsResponseApplicationJsonBuilder b) {
+    $RoomResendInvitationsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetSessionStateState extends EnumClass {
@@ -36304,6 +39369,10 @@ class _$RoomSetSessionStateApiVersionSerializer implements PrimitiveSerializer<R
 abstract interface class $RoomSetSessionStateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetSessionStateResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetSessionStateResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetSessionStateResponseApplicationJson_Ocs
@@ -36337,11 +39406,25 @@ abstract class RoomSetSessionStateResponseApplicationJson_Ocs
   /// Serializer for RoomSetSessionStateResponseApplicationJson_Ocs.
   static Serializer<RoomSetSessionStateResponseApplicationJson_Ocs> get serializer =>
       _$roomSetSessionStateResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetSessionStateResponseApplicationJson_OcsBuilder b) {
+    $RoomSetSessionStateResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetSessionStateResponseApplicationJson_OcsBuilder b) {
+    $RoomSetSessionStateResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetSessionStateResponseApplicationJsonInterface {
   RoomSetSessionStateResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetSessionStateResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetSessionStateResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetSessionStateResponseApplicationJson
@@ -36375,6 +39458,16 @@ abstract class RoomSetSessionStateResponseApplicationJson
   /// Serializer for RoomSetSessionStateResponseApplicationJson.
   static Serializer<RoomSetSessionStateResponseApplicationJson> get serializer =>
       _$roomSetSessionStateResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetSessionStateResponseApplicationJsonBuilder b) {
+    $RoomSetSessionStateResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetSessionStateResponseApplicationJsonBuilder b) {
+    $RoomSetSessionStateResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomPromoteModeratorApiVersion extends EnumClass {
@@ -36438,6 +39531,10 @@ class _$RoomPromoteModeratorApiVersionSerializer implements PrimitiveSerializer<
 abstract interface class $RoomPromoteModeratorResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomPromoteModeratorResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomPromoteModeratorResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomPromoteModeratorResponseApplicationJson_Ocs
@@ -36471,11 +39568,25 @@ abstract class RoomPromoteModeratorResponseApplicationJson_Ocs
   /// Serializer for RoomPromoteModeratorResponseApplicationJson_Ocs.
   static Serializer<RoomPromoteModeratorResponseApplicationJson_Ocs> get serializer =>
       _$roomPromoteModeratorResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomPromoteModeratorResponseApplicationJson_OcsBuilder b) {
+    $RoomPromoteModeratorResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomPromoteModeratorResponseApplicationJson_OcsBuilder b) {
+    $RoomPromoteModeratorResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomPromoteModeratorResponseApplicationJsonInterface {
   RoomPromoteModeratorResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomPromoteModeratorResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomPromoteModeratorResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomPromoteModeratorResponseApplicationJson
@@ -36509,6 +39620,16 @@ abstract class RoomPromoteModeratorResponseApplicationJson
   /// Serializer for RoomPromoteModeratorResponseApplicationJson.
   static Serializer<RoomPromoteModeratorResponseApplicationJson> get serializer =>
       _$roomPromoteModeratorResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomPromoteModeratorResponseApplicationJsonBuilder b) {
+    $RoomPromoteModeratorResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomPromoteModeratorResponseApplicationJsonBuilder b) {
+    $RoomPromoteModeratorResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomDemoteModeratorApiVersion extends EnumClass {
@@ -36571,6 +39692,10 @@ class _$RoomDemoteModeratorApiVersionSerializer implements PrimitiveSerializer<R
 abstract interface class $RoomDemoteModeratorResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomDemoteModeratorResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomDemoteModeratorResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomDemoteModeratorResponseApplicationJson_Ocs
@@ -36604,11 +39729,25 @@ abstract class RoomDemoteModeratorResponseApplicationJson_Ocs
   /// Serializer for RoomDemoteModeratorResponseApplicationJson_Ocs.
   static Serializer<RoomDemoteModeratorResponseApplicationJson_Ocs> get serializer =>
       _$roomDemoteModeratorResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomDemoteModeratorResponseApplicationJson_OcsBuilder b) {
+    $RoomDemoteModeratorResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomDemoteModeratorResponseApplicationJson_OcsBuilder b) {
+    $RoomDemoteModeratorResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomDemoteModeratorResponseApplicationJsonInterface {
   RoomDemoteModeratorResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomDemoteModeratorResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomDemoteModeratorResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomDemoteModeratorResponseApplicationJson
@@ -36642,6 +39781,16 @@ abstract class RoomDemoteModeratorResponseApplicationJson
   /// Serializer for RoomDemoteModeratorResponseApplicationJson.
   static Serializer<RoomDemoteModeratorResponseApplicationJson> get serializer =>
       _$roomDemoteModeratorResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomDemoteModeratorResponseApplicationJsonBuilder b) {
+    $RoomDemoteModeratorResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomDemoteModeratorResponseApplicationJsonBuilder b) {
+    $RoomDemoteModeratorResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomAddToFavoritesApiVersion extends EnumClass {
@@ -36704,6 +39853,10 @@ class _$RoomAddToFavoritesApiVersionSerializer implements PrimitiveSerializer<Ro
 abstract interface class $RoomAddToFavoritesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomAddToFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomAddToFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomAddToFavoritesResponseApplicationJson_Ocs
@@ -36737,11 +39890,25 @@ abstract class RoomAddToFavoritesResponseApplicationJson_Ocs
   /// Serializer for RoomAddToFavoritesResponseApplicationJson_Ocs.
   static Serializer<RoomAddToFavoritesResponseApplicationJson_Ocs> get serializer =>
       _$roomAddToFavoritesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomAddToFavoritesResponseApplicationJson_OcsBuilder b) {
+    $RoomAddToFavoritesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomAddToFavoritesResponseApplicationJson_OcsBuilder b) {
+    $RoomAddToFavoritesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomAddToFavoritesResponseApplicationJsonInterface {
   RoomAddToFavoritesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomAddToFavoritesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomAddToFavoritesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomAddToFavoritesResponseApplicationJson
@@ -36775,6 +39942,16 @@ abstract class RoomAddToFavoritesResponseApplicationJson
   /// Serializer for RoomAddToFavoritesResponseApplicationJson.
   static Serializer<RoomAddToFavoritesResponseApplicationJson> get serializer =>
       _$roomAddToFavoritesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomAddToFavoritesResponseApplicationJsonBuilder b) {
+    $RoomAddToFavoritesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomAddToFavoritesResponseApplicationJsonBuilder b) {
+    $RoomAddToFavoritesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomRemoveFromFavoritesApiVersion extends EnumClass {
@@ -36838,6 +40015,10 @@ class _$RoomRemoveFromFavoritesApiVersionSerializer implements PrimitiveSerializ
 abstract interface class $RoomRemoveFromFavoritesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRemoveFromFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRemoveFromFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomRemoveFromFavoritesResponseApplicationJson_Ocs
@@ -36872,11 +40053,25 @@ abstract class RoomRemoveFromFavoritesResponseApplicationJson_Ocs
   /// Serializer for RoomRemoveFromFavoritesResponseApplicationJson_Ocs.
   static Serializer<RoomRemoveFromFavoritesResponseApplicationJson_Ocs> get serializer =>
       _$roomRemoveFromFavoritesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder b) {
+    $RoomRemoveFromFavoritesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder b) {
+    $RoomRemoveFromFavoritesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomRemoveFromFavoritesResponseApplicationJsonInterface {
   RoomRemoveFromFavoritesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRemoveFromFavoritesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRemoveFromFavoritesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomRemoveFromFavoritesResponseApplicationJson
@@ -36910,6 +40105,16 @@ abstract class RoomRemoveFromFavoritesResponseApplicationJson
   /// Serializer for RoomRemoveFromFavoritesResponseApplicationJson.
   static Serializer<RoomRemoveFromFavoritesResponseApplicationJson> get serializer =>
       _$roomRemoveFromFavoritesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRemoveFromFavoritesResponseApplicationJsonBuilder b) {
+    $RoomRemoveFromFavoritesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRemoveFromFavoritesResponseApplicationJsonBuilder b) {
+    $RoomRemoveFromFavoritesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetNotificationLevelApiVersion extends EnumClass {
@@ -36974,6 +40179,10 @@ class _$RoomSetNotificationLevelApiVersionSerializer
 abstract interface class $RoomSetNotificationLevelResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetNotificationLevelResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetNotificationLevelResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetNotificationLevelResponseApplicationJson_Ocs
@@ -37008,11 +40217,25 @@ abstract class RoomSetNotificationLevelResponseApplicationJson_Ocs
   /// Serializer for RoomSetNotificationLevelResponseApplicationJson_Ocs.
   static Serializer<RoomSetNotificationLevelResponseApplicationJson_Ocs> get serializer =>
       _$roomSetNotificationLevelResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetNotificationLevelResponseApplicationJson_OcsBuilder b) {
+    $RoomSetNotificationLevelResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetNotificationLevelResponseApplicationJson_OcsBuilder b) {
+    $RoomSetNotificationLevelResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetNotificationLevelResponseApplicationJsonInterface {
   RoomSetNotificationLevelResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetNotificationLevelResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetNotificationLevelResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetNotificationLevelResponseApplicationJson
@@ -37046,6 +40269,16 @@ abstract class RoomSetNotificationLevelResponseApplicationJson
   /// Serializer for RoomSetNotificationLevelResponseApplicationJson.
   static Serializer<RoomSetNotificationLevelResponseApplicationJson> get serializer =>
       _$roomSetNotificationLevelResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetNotificationLevelResponseApplicationJsonBuilder b) {
+    $RoomSetNotificationLevelResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetNotificationLevelResponseApplicationJsonBuilder b) {
+    $RoomSetNotificationLevelResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetNotificationCallsApiVersion extends EnumClass {
@@ -37110,6 +40343,10 @@ class _$RoomSetNotificationCallsApiVersionSerializer
 abstract interface class $RoomSetNotificationCallsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetNotificationCallsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetNotificationCallsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetNotificationCallsResponseApplicationJson_Ocs
@@ -37144,11 +40381,25 @@ abstract class RoomSetNotificationCallsResponseApplicationJson_Ocs
   /// Serializer for RoomSetNotificationCallsResponseApplicationJson_Ocs.
   static Serializer<RoomSetNotificationCallsResponseApplicationJson_Ocs> get serializer =>
       _$roomSetNotificationCallsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetNotificationCallsResponseApplicationJson_OcsBuilder b) {
+    $RoomSetNotificationCallsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetNotificationCallsResponseApplicationJson_OcsBuilder b) {
+    $RoomSetNotificationCallsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetNotificationCallsResponseApplicationJsonInterface {
   RoomSetNotificationCallsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetNotificationCallsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetNotificationCallsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetNotificationCallsResponseApplicationJson
@@ -37182,6 +40433,16 @@ abstract class RoomSetNotificationCallsResponseApplicationJson
   /// Serializer for RoomSetNotificationCallsResponseApplicationJson.
   static Serializer<RoomSetNotificationCallsResponseApplicationJson> get serializer =>
       _$roomSetNotificationCallsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetNotificationCallsResponseApplicationJsonBuilder b) {
+    $RoomSetNotificationCallsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetNotificationCallsResponseApplicationJsonBuilder b) {
+    $RoomSetNotificationCallsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetLobbyApiVersion extends EnumClass {
@@ -37244,6 +40505,10 @@ class _$RoomSetLobbyApiVersionSerializer implements PrimitiveSerializer<RoomSetL
 abstract interface class $RoomSetLobbyResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetLobbyResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetLobbyResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetLobbyResponseApplicationJson_Ocs
@@ -37276,11 +40541,25 @@ abstract class RoomSetLobbyResponseApplicationJson_Ocs
   /// Serializer for RoomSetLobbyResponseApplicationJson_Ocs.
   static Serializer<RoomSetLobbyResponseApplicationJson_Ocs> get serializer =>
       _$roomSetLobbyResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetLobbyResponseApplicationJson_OcsBuilder b) {
+    $RoomSetLobbyResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetLobbyResponseApplicationJson_OcsBuilder b) {
+    $RoomSetLobbyResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetLobbyResponseApplicationJsonInterface {
   RoomSetLobbyResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetLobbyResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetLobbyResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetLobbyResponseApplicationJson
@@ -37313,6 +40592,16 @@ abstract class RoomSetLobbyResponseApplicationJson
   /// Serializer for RoomSetLobbyResponseApplicationJson.
   static Serializer<RoomSetLobbyResponseApplicationJson> get serializer =>
       _$roomSetLobbyResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetLobbyResponseApplicationJsonBuilder b) {
+    $RoomSetLobbyResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetLobbyResponseApplicationJsonBuilder b) {
+    $RoomSetLobbyResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetsipEnabledState extends EnumClass {
@@ -37444,6 +40733,10 @@ class _$RoomSetsipEnabledApiVersionSerializer implements PrimitiveSerializer<Roo
 abstract interface class $RoomSetsipEnabledResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetsipEnabledResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetsipEnabledResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetsipEnabledResponseApplicationJson_Ocs
@@ -37477,11 +40770,25 @@ abstract class RoomSetsipEnabledResponseApplicationJson_Ocs
   /// Serializer for RoomSetsipEnabledResponseApplicationJson_Ocs.
   static Serializer<RoomSetsipEnabledResponseApplicationJson_Ocs> get serializer =>
       _$roomSetsipEnabledResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetsipEnabledResponseApplicationJson_OcsBuilder b) {
+    $RoomSetsipEnabledResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetsipEnabledResponseApplicationJson_OcsBuilder b) {
+    $RoomSetsipEnabledResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetsipEnabledResponseApplicationJsonInterface {
   RoomSetsipEnabledResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetsipEnabledResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetsipEnabledResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetsipEnabledResponseApplicationJson
@@ -37515,6 +40822,16 @@ abstract class RoomSetsipEnabledResponseApplicationJson
   /// Serializer for RoomSetsipEnabledResponseApplicationJson.
   static Serializer<RoomSetsipEnabledResponseApplicationJson> get serializer =>
       _$roomSetsipEnabledResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetsipEnabledResponseApplicationJsonBuilder b) {
+    $RoomSetsipEnabledResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetsipEnabledResponseApplicationJsonBuilder b) {
+    $RoomSetsipEnabledResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetRecordingConsentApiVersion extends EnumClass {
@@ -37578,6 +40895,10 @@ class _$RoomSetRecordingConsentApiVersionSerializer implements PrimitiveSerializ
 abstract interface class $RoomSetRecordingConsentResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetRecordingConsentResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetRecordingConsentResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetRecordingConsentResponseApplicationJson_Ocs
@@ -37612,11 +40933,25 @@ abstract class RoomSetRecordingConsentResponseApplicationJson_Ocs
   /// Serializer for RoomSetRecordingConsentResponseApplicationJson_Ocs.
   static Serializer<RoomSetRecordingConsentResponseApplicationJson_Ocs> get serializer =>
       _$roomSetRecordingConsentResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetRecordingConsentResponseApplicationJson_OcsBuilder b) {
+    $RoomSetRecordingConsentResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetRecordingConsentResponseApplicationJson_OcsBuilder b) {
+    $RoomSetRecordingConsentResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetRecordingConsentResponseApplicationJsonInterface {
   RoomSetRecordingConsentResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetRecordingConsentResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetRecordingConsentResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetRecordingConsentResponseApplicationJson
@@ -37650,6 +40985,16 @@ abstract class RoomSetRecordingConsentResponseApplicationJson
   /// Serializer for RoomSetRecordingConsentResponseApplicationJson.
   static Serializer<RoomSetRecordingConsentResponseApplicationJson> get serializer =>
       _$roomSetRecordingConsentResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetRecordingConsentResponseApplicationJsonBuilder b) {
+    $RoomSetRecordingConsentResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetRecordingConsentResponseApplicationJsonBuilder b) {
+    $RoomSetRecordingConsentResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class RoomSetMessageExpirationApiVersion extends EnumClass {
@@ -37714,6 +41059,10 @@ class _$RoomSetMessageExpirationApiVersionSerializer
 abstract interface class $RoomSetMessageExpirationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetMessageExpirationResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetMessageExpirationResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class RoomSetMessageExpirationResponseApplicationJson_Ocs
@@ -37748,11 +41097,25 @@ abstract class RoomSetMessageExpirationResponseApplicationJson_Ocs
   /// Serializer for RoomSetMessageExpirationResponseApplicationJson_Ocs.
   static Serializer<RoomSetMessageExpirationResponseApplicationJson_Ocs> get serializer =>
       _$roomSetMessageExpirationResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetMessageExpirationResponseApplicationJson_OcsBuilder b) {
+    $RoomSetMessageExpirationResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetMessageExpirationResponseApplicationJson_OcsBuilder b) {
+    $RoomSetMessageExpirationResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $RoomSetMessageExpirationResponseApplicationJsonInterface {
   RoomSetMessageExpirationResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetMessageExpirationResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetMessageExpirationResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class RoomSetMessageExpirationResponseApplicationJson
@@ -37786,6 +41149,16 @@ abstract class RoomSetMessageExpirationResponseApplicationJson
   /// Serializer for RoomSetMessageExpirationResponseApplicationJson.
   static Serializer<RoomSetMessageExpirationResponseApplicationJson> get serializer =>
       _$roomSetMessageExpirationResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetMessageExpirationResponseApplicationJsonBuilder b) {
+    $RoomSetMessageExpirationResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetMessageExpirationResponseApplicationJsonBuilder b) {
+    $RoomSetMessageExpirationResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class SettingsSetUserSettingKey extends EnumClass {
@@ -37926,6 +41299,10 @@ class _$SettingsSetUserSettingApiVersionSerializer implements PrimitiveSerialize
 abstract interface class $SettingsSetUserSettingResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsSetUserSettingResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsSetUserSettingResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class SettingsSetUserSettingResponseApplicationJson_Ocs
@@ -37960,11 +41337,25 @@ abstract class SettingsSetUserSettingResponseApplicationJson_Ocs
   /// Serializer for SettingsSetUserSettingResponseApplicationJson_Ocs.
   static Serializer<SettingsSetUserSettingResponseApplicationJson_Ocs> get serializer =>
       _$settingsSetUserSettingResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsSetUserSettingResponseApplicationJson_OcsBuilder b) {
+    $SettingsSetUserSettingResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsSetUserSettingResponseApplicationJson_OcsBuilder b) {
+    $SettingsSetUserSettingResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SettingsSetUserSettingResponseApplicationJsonInterface {
   SettingsSetUserSettingResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsSetUserSettingResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsSetUserSettingResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class SettingsSetUserSettingResponseApplicationJson
@@ -37998,6 +41389,16 @@ abstract class SettingsSetUserSettingResponseApplicationJson
   /// Serializer for SettingsSetUserSettingResponseApplicationJson.
   static Serializer<SettingsSetUserSettingResponseApplicationJson> get serializer =>
       _$settingsSetUserSettingResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsSetUserSettingResponseApplicationJsonBuilder b) {
+    $SettingsSetUserSettingResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsSetUserSettingResponseApplicationJsonBuilder b) {
+    $SettingsSetUserSettingResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class SettingsSetsipSettingsApiVersion extends EnumClass {
@@ -38061,6 +41462,10 @@ class _$SettingsSetsipSettingsApiVersionSerializer implements PrimitiveSerialize
 abstract interface class $SettingsSetsipSettingsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsSetsipSettingsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsSetsipSettingsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class SettingsSetsipSettingsResponseApplicationJson_Ocs
@@ -38095,11 +41500,25 @@ abstract class SettingsSetsipSettingsResponseApplicationJson_Ocs
   /// Serializer for SettingsSetsipSettingsResponseApplicationJson_Ocs.
   static Serializer<SettingsSetsipSettingsResponseApplicationJson_Ocs> get serializer =>
       _$settingsSetsipSettingsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsSetsipSettingsResponseApplicationJson_OcsBuilder b) {
+    $SettingsSetsipSettingsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsSetsipSettingsResponseApplicationJson_OcsBuilder b) {
+    $SettingsSetsipSettingsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SettingsSetsipSettingsResponseApplicationJsonInterface {
   SettingsSetsipSettingsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsSetsipSettingsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsSetsipSettingsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class SettingsSetsipSettingsResponseApplicationJson
@@ -38133,6 +41552,16 @@ abstract class SettingsSetsipSettingsResponseApplicationJson
   /// Serializer for SettingsSetsipSettingsResponseApplicationJson.
   static Serializer<SettingsSetsipSettingsResponseApplicationJson> get serializer =>
       _$settingsSetsipSettingsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsSetsipSettingsResponseApplicationJsonBuilder b) {
+    $SettingsSetsipSettingsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsSetsipSettingsResponseApplicationJsonBuilder b) {
+    $SettingsSetsipSettingsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class SignalingGetSettingsApiVersion extends EnumClass {
@@ -38196,6 +41625,10 @@ class _$SignalingGetSettingsApiVersionSerializer implements PrimitiveSerializer<
 abstract interface class $SignalingSettings_HelloAuthParams_10Interface {
   String? get userid;
   String get ticket;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingSettings_HelloAuthParams_10InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingSettings_HelloAuthParams_10InterfaceBuilder b) {}
 }
 
 abstract class SignalingSettings_HelloAuthParams_10
@@ -38228,11 +41661,25 @@ abstract class SignalingSettings_HelloAuthParams_10
   /// Serializer for SignalingSettings_HelloAuthParams_10.
   static Serializer<SignalingSettings_HelloAuthParams_10> get serializer =>
       _$signalingSettingsHelloAuthParams10Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingSettings_HelloAuthParams_10Builder b) {
+    $SignalingSettings_HelloAuthParams_10Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingSettings_HelloAuthParams_10Builder b) {
+    $SignalingSettings_HelloAuthParams_10Interface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SignalingSettings_HelloAuthParams_20Interface {
   String get token;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingSettings_HelloAuthParams_20InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingSettings_HelloAuthParams_20InterfaceBuilder b) {}
 }
 
 abstract class SignalingSettings_HelloAuthParams_20
@@ -38265,6 +41712,16 @@ abstract class SignalingSettings_HelloAuthParams_20
   /// Serializer for SignalingSettings_HelloAuthParams_20.
   static Serializer<SignalingSettings_HelloAuthParams_20> get serializer =>
       _$signalingSettingsHelloAuthParams20Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingSettings_HelloAuthParams_20Builder b) {
+    $SignalingSettings_HelloAuthParams_20Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingSettings_HelloAuthParams_20Builder b) {
+    $SignalingSettings_HelloAuthParams_20Interface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -38273,6 +41730,10 @@ abstract interface class $SignalingSettings_HelloAuthParamsInterface {
   SignalingSettings_HelloAuthParams_10 get $10;
   @BuiltValueField(wireName: '2.0')
   SignalingSettings_HelloAuthParams_20 get $20;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingSettings_HelloAuthParamsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingSettings_HelloAuthParamsInterfaceBuilder b) {}
 }
 
 abstract class SignalingSettings_HelloAuthParams
@@ -38304,11 +41765,25 @@ abstract class SignalingSettings_HelloAuthParams
 
   /// Serializer for SignalingSettings_HelloAuthParams.
   static Serializer<SignalingSettings_HelloAuthParams> get serializer => _$signalingSettingsHelloAuthParamsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingSettings_HelloAuthParamsBuilder b) {
+    $SignalingSettings_HelloAuthParamsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingSettings_HelloAuthParamsBuilder b) {
+    $SignalingSettings_HelloAuthParamsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SignalingSettings_StunserversInterface {
   BuiltList<String> get urls;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingSettings_StunserversInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingSettings_StunserversInterfaceBuilder b) {}
 }
 
 abstract class SignalingSettings_Stunservers
@@ -38340,6 +41815,16 @@ abstract class SignalingSettings_Stunservers
 
   /// Serializer for SignalingSettings_Stunservers.
   static Serializer<SignalingSettings_Stunservers> get serializer => _$signalingSettingsStunserversSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingSettings_StunserversBuilder b) {
+    $SignalingSettings_StunserversInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingSettings_StunserversBuilder b) {
+    $SignalingSettings_StunserversInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -38347,6 +41832,10 @@ abstract interface class $SignalingSettings_TurnserversInterface {
   BuiltList<String> get urls;
   String get username;
   JsonObject get credential;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingSettings_TurnserversInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingSettings_TurnserversInterfaceBuilder b) {}
 }
 
 abstract class SignalingSettings_Turnservers
@@ -38378,6 +41867,16 @@ abstract class SignalingSettings_Turnservers
 
   /// Serializer for SignalingSettings_Turnservers.
   static Serializer<SignalingSettings_Turnservers> get serializer => _$signalingSettingsTurnserversSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingSettings_TurnserversBuilder b) {
+    $SignalingSettings_TurnserversInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingSettings_TurnserversBuilder b) {
+    $SignalingSettings_TurnserversInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -38391,6 +41890,10 @@ abstract interface class $SignalingSettingsInterface {
   String get ticket;
   BuiltList<SignalingSettings_Turnservers> get turnservers;
   String? get userId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingSettingsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingSettingsInterfaceBuilder b) {}
 }
 
 abstract class SignalingSettings
@@ -38418,12 +41921,26 @@ abstract class SignalingSettings
 
   /// Serializer for SignalingSettings.
   static Serializer<SignalingSettings> get serializer => _$signalingSettingsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingSettingsBuilder b) {
+    $SignalingSettingsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingSettingsBuilder b) {
+    $SignalingSettingsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SignalingGetSettingsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   SignalingSettings get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingGetSettingsResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingGetSettingsResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class SignalingGetSettingsResponseApplicationJson_Ocs
@@ -38457,11 +41974,25 @@ abstract class SignalingGetSettingsResponseApplicationJson_Ocs
   /// Serializer for SignalingGetSettingsResponseApplicationJson_Ocs.
   static Serializer<SignalingGetSettingsResponseApplicationJson_Ocs> get serializer =>
       _$signalingGetSettingsResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingGetSettingsResponseApplicationJson_OcsBuilder b) {
+    $SignalingGetSettingsResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingGetSettingsResponseApplicationJson_OcsBuilder b) {
+    $SignalingGetSettingsResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SignalingGetSettingsResponseApplicationJsonInterface {
   SignalingGetSettingsResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingGetSettingsResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingGetSettingsResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class SignalingGetSettingsResponseApplicationJson
@@ -38495,6 +42026,16 @@ abstract class SignalingGetSettingsResponseApplicationJson
   /// Serializer for SignalingGetSettingsResponseApplicationJson.
   static Serializer<SignalingGetSettingsResponseApplicationJson> get serializer =>
       _$signalingGetSettingsResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingGetSettingsResponseApplicationJsonBuilder b) {
+    $SignalingGetSettingsResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingGetSettingsResponseApplicationJsonBuilder b) {
+    $SignalingGetSettingsResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class SignalingPullMessagesApiVersion extends EnumClass {
@@ -38562,6 +42103,10 @@ abstract interface class $SignalingSessionInterface {
   int get roomId;
   String get sessionId;
   String get userId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingSessionInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingSessionInterfaceBuilder b) {}
 }
 
 abstract class SignalingSession
@@ -38589,6 +42134,16 @@ abstract class SignalingSession
 
   /// Serializer for SignalingSession.
   static Serializer<SignalingSession> get serializer => _$signalingSessionSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingSessionBuilder b) {
+    $SignalingSessionInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingSessionBuilder b) {
+    $SignalingSessionInterface._validate(b);
+  }
 }
 
 typedef SignalingPullMessagesResponseApplicationJson_Ocs_Data_Data = ({
@@ -38600,6 +42155,12 @@ typedef SignalingPullMessagesResponseApplicationJson_Ocs_Data_Data = ({
 abstract interface class $SignalingPullMessagesResponseApplicationJson_Ocs_DataInterface {
   String get type;
   SignalingPullMessagesResponseApplicationJson_Ocs_Data_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingPullMessagesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingPullMessagesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {
+    b.data?.validateOneOf();
+  }
 }
 
 abstract class SignalingPullMessagesResponseApplicationJson_Ocs_Data
@@ -38635,9 +42196,14 @@ abstract class SignalingPullMessagesResponseApplicationJson_Ocs_Data
   static Serializer<SignalingPullMessagesResponseApplicationJson_Ocs_Data> get serializer =>
       _$signalingPullMessagesResponseApplicationJsonOcsDataSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder b) {
+    $SignalingPullMessagesResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder b) {
-    b.data?.validateOneOf();
+    $SignalingPullMessagesResponseApplicationJson_Ocs_DataInterface._validate(b);
   }
 }
 
@@ -38645,6 +42211,10 @@ abstract class SignalingPullMessagesResponseApplicationJson_Ocs_Data
 abstract interface class $SignalingPullMessagesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<SignalingPullMessagesResponseApplicationJson_Ocs_Data> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingPullMessagesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingPullMessagesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class SignalingPullMessagesResponseApplicationJson_Ocs
@@ -38679,11 +42249,25 @@ abstract class SignalingPullMessagesResponseApplicationJson_Ocs
   /// Serializer for SignalingPullMessagesResponseApplicationJson_Ocs.
   static Serializer<SignalingPullMessagesResponseApplicationJson_Ocs> get serializer =>
       _$signalingPullMessagesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingPullMessagesResponseApplicationJson_OcsBuilder b) {
+    $SignalingPullMessagesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingPullMessagesResponseApplicationJson_OcsBuilder b) {
+    $SignalingPullMessagesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SignalingPullMessagesResponseApplicationJsonInterface {
   SignalingPullMessagesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingPullMessagesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingPullMessagesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class SignalingPullMessagesResponseApplicationJson
@@ -38717,6 +42301,16 @@ abstract class SignalingPullMessagesResponseApplicationJson
   /// Serializer for SignalingPullMessagesResponseApplicationJson.
   static Serializer<SignalingPullMessagesResponseApplicationJson> get serializer =>
       _$signalingPullMessagesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingPullMessagesResponseApplicationJsonBuilder b) {
+    $SignalingPullMessagesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingPullMessagesResponseApplicationJsonBuilder b) {
+    $SignalingPullMessagesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class SignalingSendMessagesApiVersion extends EnumClass {
@@ -38780,6 +42374,10 @@ class _$SignalingSendMessagesApiVersionSerializer implements PrimitiveSerializer
 abstract interface class $SignalingSendMessagesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingSendMessagesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingSendMessagesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class SignalingSendMessagesResponseApplicationJson_Ocs
@@ -38814,11 +42412,25 @@ abstract class SignalingSendMessagesResponseApplicationJson_Ocs
   /// Serializer for SignalingSendMessagesResponseApplicationJson_Ocs.
   static Serializer<SignalingSendMessagesResponseApplicationJson_Ocs> get serializer =>
       _$signalingSendMessagesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingSendMessagesResponseApplicationJson_OcsBuilder b) {
+    $SignalingSendMessagesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingSendMessagesResponseApplicationJson_OcsBuilder b) {
+    $SignalingSendMessagesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SignalingSendMessagesResponseApplicationJsonInterface {
   SignalingSendMessagesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingSendMessagesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingSendMessagesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class SignalingSendMessagesResponseApplicationJson
@@ -38852,6 +42464,16 @@ abstract class SignalingSendMessagesResponseApplicationJson
   /// Serializer for SignalingSendMessagesResponseApplicationJson.
   static Serializer<SignalingSendMessagesResponseApplicationJson> get serializer =>
       _$signalingSendMessagesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingSendMessagesResponseApplicationJsonBuilder b) {
+    $SignalingSendMessagesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingSendMessagesResponseApplicationJsonBuilder b) {
+    $SignalingSendMessagesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class SignalingGetWelcomeMessageApiVersion extends EnumClass {
@@ -38919,6 +42541,10 @@ class _$SignalingGetWelcomeMessageApiVersionSerializer
 abstract interface class $SignalingGetWelcomeMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, JsonObject> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class SignalingGetWelcomeMessageResponseApplicationJson_Ocs
@@ -38953,11 +42579,25 @@ abstract class SignalingGetWelcomeMessageResponseApplicationJson_Ocs
   /// Serializer for SignalingGetWelcomeMessageResponseApplicationJson_Ocs.
   static Serializer<SignalingGetWelcomeMessageResponseApplicationJson_Ocs> get serializer =>
       _$signalingGetWelcomeMessageResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder b) {
+    $SignalingGetWelcomeMessageResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder b) {
+    $SignalingGetWelcomeMessageResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SignalingGetWelcomeMessageResponseApplicationJsonInterface {
   SignalingGetWelcomeMessageResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class SignalingGetWelcomeMessageResponseApplicationJson
@@ -38992,12 +42632,26 @@ abstract class SignalingGetWelcomeMessageResponseApplicationJson
   /// Serializer for SignalingGetWelcomeMessageResponseApplicationJson.
   static Serializer<SignalingGetWelcomeMessageResponseApplicationJson> get serializer =>
       _$signalingGetWelcomeMessageResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingGetWelcomeMessageResponseApplicationJsonBuilder b) {
+    $SignalingGetWelcomeMessageResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingGetWelcomeMessageResponseApplicationJsonBuilder b) {
+    $SignalingGetWelcomeMessageResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TempAvatarPostAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TempAvatarPostAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TempAvatarPostAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TempAvatarPostAvatarResponseApplicationJson_Ocs
@@ -39031,11 +42685,25 @@ abstract class TempAvatarPostAvatarResponseApplicationJson_Ocs
   /// Serializer for TempAvatarPostAvatarResponseApplicationJson_Ocs.
   static Serializer<TempAvatarPostAvatarResponseApplicationJson_Ocs> get serializer =>
       _$tempAvatarPostAvatarResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TempAvatarPostAvatarResponseApplicationJson_OcsBuilder b) {
+    $TempAvatarPostAvatarResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TempAvatarPostAvatarResponseApplicationJson_OcsBuilder b) {
+    $TempAvatarPostAvatarResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TempAvatarPostAvatarResponseApplicationJsonInterface {
   TempAvatarPostAvatarResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TempAvatarPostAvatarResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TempAvatarPostAvatarResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TempAvatarPostAvatarResponseApplicationJson
@@ -39069,12 +42737,26 @@ abstract class TempAvatarPostAvatarResponseApplicationJson
   /// Serializer for TempAvatarPostAvatarResponseApplicationJson.
   static Serializer<TempAvatarPostAvatarResponseApplicationJson> get serializer =>
       _$tempAvatarPostAvatarResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TempAvatarPostAvatarResponseApplicationJsonBuilder b) {
+    $TempAvatarPostAvatarResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TempAvatarPostAvatarResponseApplicationJsonBuilder b) {
+    $TempAvatarPostAvatarResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TempAvatarDeleteAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TempAvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TempAvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class TempAvatarDeleteAvatarResponseApplicationJson_Ocs
@@ -39109,11 +42791,25 @@ abstract class TempAvatarDeleteAvatarResponseApplicationJson_Ocs
   /// Serializer for TempAvatarDeleteAvatarResponseApplicationJson_Ocs.
   static Serializer<TempAvatarDeleteAvatarResponseApplicationJson_Ocs> get serializer =>
       _$tempAvatarDeleteAvatarResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder b) {
+    $TempAvatarDeleteAvatarResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder b) {
+    $TempAvatarDeleteAvatarResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $TempAvatarDeleteAvatarResponseApplicationJsonInterface {
   TempAvatarDeleteAvatarResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TempAvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TempAvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class TempAvatarDeleteAvatarResponseApplicationJson
@@ -39147,11 +42843,25 @@ abstract class TempAvatarDeleteAvatarResponseApplicationJson
   /// Serializer for TempAvatarDeleteAvatarResponseApplicationJson.
   static Serializer<TempAvatarDeleteAvatarResponseApplicationJson> get serializer =>
       _$tempAvatarDeleteAvatarResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TempAvatarDeleteAvatarResponseApplicationJsonBuilder b) {
+    $TempAvatarDeleteAvatarResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TempAvatarDeleteAvatarResponseApplicationJsonBuilder b) {
+    $TempAvatarDeleteAvatarResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $BotWithDetailsAndSecretInterface implements $BotWithDetailsInterface {
   String get secret;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotWithDetailsAndSecretInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotWithDetailsAndSecretInterfaceBuilder b) {}
 }
 
 abstract class BotWithDetailsAndSecret
@@ -39180,6 +42890,16 @@ abstract class BotWithDetailsAndSecret
 
   /// Serializer for BotWithDetailsAndSecret.
   static Serializer<BotWithDetailsAndSecret> get serializer => _$botWithDetailsAndSecretSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotWithDetailsAndSecretBuilder b) {
+    $BotWithDetailsAndSecretInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotWithDetailsAndSecretBuilder b) {
+    $BotWithDetailsAndSecretInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -39197,6 +42917,10 @@ abstract interface class $FederationInviteInterface {
   String get remoteToken;
   @BuiltValueField(wireName: 'user_id')
   String get userId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($FederationInviteInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($FederationInviteInterfaceBuilder b) {}
 }
 
 abstract class FederationInvite
@@ -39224,12 +42948,26 @@ abstract class FederationInvite
 
   /// Serializer for FederationInvite.
   static Serializer<FederationInvite> get serializer => _$federationInviteSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(FederationInviteBuilder b) {
+    $FederationInviteInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(FederationInviteBuilder b) {
+    $FederationInviteInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PublicCapabilities0_Spreed_Config_AttachmentsInterface {
   bool get allowed;
   String? get folder;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilities0_Spreed_Config_AttachmentsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilities0_Spreed_Config_AttachmentsInterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities0_Spreed_Config_Attachments
@@ -39263,6 +43001,16 @@ abstract class PublicCapabilities0_Spreed_Config_Attachments
   /// Serializer for PublicCapabilities0_Spreed_Config_Attachments.
   static Serializer<PublicCapabilities0_Spreed_Config_Attachments> get serializer =>
       _$publicCapabilities0SpreedConfigAttachmentsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilities0_Spreed_Config_AttachmentsBuilder b) {
+    $PublicCapabilities0_Spreed_Config_AttachmentsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilities0_Spreed_Config_AttachmentsBuilder b) {
+    $PublicCapabilities0_Spreed_Config_AttachmentsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -39285,6 +43033,10 @@ abstract interface class $PublicCapabilities0_Spreed_Config_CallInterface {
   bool? get sipDialoutEnabled;
   @BuiltValueField(wireName: 'can-enable-sip')
   bool? get canEnableSip;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilities0_Spreed_Config_CallInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilities0_Spreed_Config_CallInterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities0_Spreed_Config_Call
@@ -39317,6 +43069,16 @@ abstract class PublicCapabilities0_Spreed_Config_Call
   /// Serializer for PublicCapabilities0_Spreed_Config_Call.
   static Serializer<PublicCapabilities0_Spreed_Config_Call> get serializer =>
       _$publicCapabilities0SpreedConfigCallSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilities0_Spreed_Config_CallBuilder b) {
+    $PublicCapabilities0_Spreed_Config_CallInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilities0_Spreed_Config_CallBuilder b) {
+    $PublicCapabilities0_Spreed_Config_CallInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -39330,6 +43092,10 @@ abstract interface class $PublicCapabilities0_Spreed_Config_ChatInterface {
   @BuiltValueField(wireName: 'typing-privacy')
   int get typingPrivacy;
   BuiltList<String>? get translations;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilities0_Spreed_Config_ChatInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilities0_Spreed_Config_ChatInterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities0_Spreed_Config_Chat
@@ -39362,12 +43128,26 @@ abstract class PublicCapabilities0_Spreed_Config_Chat
   /// Serializer for PublicCapabilities0_Spreed_Config_Chat.
   static Serializer<PublicCapabilities0_Spreed_Config_Chat> get serializer =>
       _$publicCapabilities0SpreedConfigChatSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilities0_Spreed_Config_ChatBuilder b) {
+    $PublicCapabilities0_Spreed_Config_ChatInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilities0_Spreed_Config_ChatBuilder b) {
+    $PublicCapabilities0_Spreed_Config_ChatInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PublicCapabilities0_Spreed_Config_ConversationsInterface {
   @BuiltValueField(wireName: 'can-create')
   bool get canCreate;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilities0_Spreed_Config_ConversationsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilities0_Spreed_Config_ConversationsInterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities0_Spreed_Config_Conversations
@@ -39401,12 +43181,26 @@ abstract class PublicCapabilities0_Spreed_Config_Conversations
   /// Serializer for PublicCapabilities0_Spreed_Config_Conversations.
   static Serializer<PublicCapabilities0_Spreed_Config_Conversations> get serializer =>
       _$publicCapabilities0SpreedConfigConversationsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilities0_Spreed_Config_ConversationsBuilder b) {
+    $PublicCapabilities0_Spreed_Config_ConversationsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilities0_Spreed_Config_ConversationsBuilder b) {
+    $PublicCapabilities0_Spreed_Config_ConversationsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PublicCapabilities0_Spreed_Config_PreviewsInterface {
   @BuiltValueField(wireName: 'max-gif-size')
   int get maxGifSize;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilities0_Spreed_Config_PreviewsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilities0_Spreed_Config_PreviewsInterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities0_Spreed_Config_Previews
@@ -39440,6 +43234,16 @@ abstract class PublicCapabilities0_Spreed_Config_Previews
   /// Serializer for PublicCapabilities0_Spreed_Config_Previews.
   static Serializer<PublicCapabilities0_Spreed_Config_Previews> get serializer =>
       _$publicCapabilities0SpreedConfigPreviewsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilities0_Spreed_Config_PreviewsBuilder b) {
+    $PublicCapabilities0_Spreed_Config_PreviewsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilities0_Spreed_Config_PreviewsBuilder b) {
+    $PublicCapabilities0_Spreed_Config_PreviewsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -39448,6 +43252,10 @@ abstract interface class $PublicCapabilities0_Spreed_Config_SignalingInterface {
   int get sessionPingLimit;
   @BuiltValueField(wireName: 'hello-v2-token-key')
   String? get helloV2TokenKey;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilities0_Spreed_Config_SignalingInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilities0_Spreed_Config_SignalingInterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities0_Spreed_Config_Signaling
@@ -39481,6 +43289,16 @@ abstract class PublicCapabilities0_Spreed_Config_Signaling
   /// Serializer for PublicCapabilities0_Spreed_Config_Signaling.
   static Serializer<PublicCapabilities0_Spreed_Config_Signaling> get serializer =>
       _$publicCapabilities0SpreedConfigSignalingSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilities0_Spreed_Config_SignalingBuilder b) {
+    $PublicCapabilities0_Spreed_Config_SignalingInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilities0_Spreed_Config_SignalingBuilder b) {
+    $PublicCapabilities0_Spreed_Config_SignalingInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -39491,6 +43309,10 @@ abstract interface class $PublicCapabilities0_Spreed_ConfigInterface {
   PublicCapabilities0_Spreed_Config_Conversations get conversations;
   PublicCapabilities0_Spreed_Config_Previews get previews;
   PublicCapabilities0_Spreed_Config_Signaling get signaling;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilities0_Spreed_ConfigInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilities0_Spreed_ConfigInterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities0_Spreed_Config
@@ -39522,6 +43344,16 @@ abstract class PublicCapabilities0_Spreed_Config
 
   /// Serializer for PublicCapabilities0_Spreed_Config.
   static Serializer<PublicCapabilities0_Spreed_Config> get serializer => _$publicCapabilities0SpreedConfigSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilities0_Spreed_ConfigBuilder b) {
+    $PublicCapabilities0_Spreed_ConfigInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilities0_Spreed_ConfigBuilder b) {
+    $PublicCapabilities0_Spreed_ConfigInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -39529,6 +43361,10 @@ abstract interface class $PublicCapabilities0_SpreedInterface {
   BuiltList<String> get features;
   PublicCapabilities0_Spreed_Config get config;
   String get version;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilities0_SpreedInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilities0_SpreedInterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities0_Spreed
@@ -39560,11 +43396,25 @@ abstract class PublicCapabilities0_Spreed
 
   /// Serializer for PublicCapabilities0_Spreed.
   static Serializer<PublicCapabilities0_Spreed> get serializer => _$publicCapabilities0SpreedSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilities0_SpreedBuilder b) {
+    $PublicCapabilities0_SpreedInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilities0_SpreedBuilder b) {
+    $PublicCapabilities0_SpreedInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PublicCapabilities0Interface {
   PublicCapabilities0_Spreed get spreed;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilities0InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilities0InterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities0
@@ -39593,6 +43443,16 @@ abstract class PublicCapabilities0
 
   /// Serializer for PublicCapabilities0.
   static Serializer<PublicCapabilities0> get serializer => _$publicCapabilities0Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilities0Builder b) {
+    $PublicCapabilities0Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilities0Builder b) {
+    $PublicCapabilities0Interface._validate(b);
+  }
 }
 
 typedef PublicCapabilities = ({BuiltList<Never>? builtListNever, PublicCapabilities0? publicCapabilities0});

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -16199,9 +16199,14 @@ abstract interface class $BotWithDetailsInterface implements $BotInterface {
   @BuiltValueField(wireName: 'url_hash')
   String get urlHash;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($BotWithDetailsInterfaceBuilder b) {}
+  static void _defaults($BotWithDetailsInterfaceBuilder b) {
+    $BotInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($BotWithDetailsInterfaceBuilder b) {}
+  static void _validate($BotWithDetailsInterfaceBuilder b) {
+    $BotInterface._validate(b);
+  }
 }
 
 abstract class BotWithDetails implements $BotWithDetailsInterface, Built<BotWithDetails, BotWithDetailsBuilder> {
@@ -21541,9 +21546,14 @@ class _$ChatReceiveMessagesApiVersionSerializer implements PrimitiveSerializer<C
 abstract interface class $ChatMessageWithParentInterface implements $ChatMessageInterface {
   ChatMessage? get parent;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($ChatMessageWithParentInterfaceBuilder b) {}
+  static void _defaults($ChatMessageWithParentInterfaceBuilder b) {
+    $ChatMessageInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($ChatMessageWithParentInterfaceBuilder b) {}
+  static void _validate($ChatMessageWithParentInterfaceBuilder b) {
+    $ChatMessageInterface._validate(b);
+  }
 }
 
 abstract class ChatMessageWithParent
@@ -25587,9 +25597,16 @@ abstract class MatterbridgeProcessState
 abstract interface class $MatterbridgeWithProcessStateInterface
     implements $MatterbridgeInterface, $MatterbridgeProcessStateInterface {
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($MatterbridgeWithProcessStateInterfaceBuilder b) {}
+  static void _defaults($MatterbridgeWithProcessStateInterfaceBuilder b) {
+    $MatterbridgeInterface._defaults(b);
+    $MatterbridgeProcessStateInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($MatterbridgeWithProcessStateInterfaceBuilder b) {}
+  static void _validate($MatterbridgeWithProcessStateInterfaceBuilder b) {
+    $MatterbridgeInterface._validate(b);
+    $MatterbridgeProcessStateInterface._validate(b);
+  }
 }
 
 abstract class MatterbridgeWithProcessState
@@ -42859,9 +42876,14 @@ abstract class TempAvatarDeleteAvatarResponseApplicationJson
 abstract interface class $BotWithDetailsAndSecretInterface implements $BotWithDetailsInterface {
   String get secret;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($BotWithDetailsAndSecretInterfaceBuilder b) {}
+  static void _defaults($BotWithDetailsAndSecretInterfaceBuilder b) {
+    $BotWithDetailsInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($BotWithDetailsAndSecretInterfaceBuilder b) {}
+  static void _validate($BotWithDetailsAndSecretInterfaceBuilder b) {
+    $BotWithDetailsInterface._validate(b);
+  }
 }
 
 abstract class BotWithDetailsAndSecret

--- a/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
@@ -22028,7 +22028,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -22058,6 +22060,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -22456,7 +22459,9 @@ class RichObjectParameterBuilder
   int? get height => _$this._height;
   set height(covariant int? height) => _$this._height = height;
 
-  RichObjectParameterBuilder();
+  RichObjectParameterBuilder() {
+    RichObjectParameter._defaults(this);
+  }
 
   RichObjectParameterBuilder get _$this {
     final $v = _$v;
@@ -22507,6 +22512,7 @@ class RichObjectParameterBuilder
   RichObjectParameter build() => _build();
 
   _$RichObjectParameter _build() {
+    RichObjectParameter._validate(this);
     final _$result = _$v ??
         _$RichObjectParameter._(
             type: BuiltValueNullFieldError.checkNotNull(type, r'RichObjectParameter', 'type'),
@@ -22806,7 +22812,9 @@ class ChatMessageBuilder implements Builder<ChatMessage, ChatMessageBuilder>, $C
   String? get token => _$this._token;
   set token(covariant String? token) => _$this._token = token;
 
-  ChatMessageBuilder();
+  ChatMessageBuilder() {
+    ChatMessage._defaults(this);
+  }
 
   ChatMessageBuilder get _$this {
     final $v = _$v;
@@ -22847,6 +22855,7 @@ class ChatMessageBuilder implements Builder<ChatMessage, ChatMessageBuilder>, $C
   ChatMessage build() => _build();
 
   _$ChatMessage _build() {
+    ChatMessage._validate(this);
     _$ChatMessage _$result;
     try {
       _$result = _$v ??
@@ -23681,7 +23690,9 @@ class RoomBuilder implements Builder<Room, RoomBuilder>, $RoomInterfaceBuilder {
   int? get unreadMessages => _$this._unreadMessages;
   set unreadMessages(covariant int? unreadMessages) => _$this._unreadMessages = unreadMessages;
 
-  RoomBuilder();
+  RoomBuilder() {
+    Room._defaults(this);
+  }
 
   RoomBuilder get _$this {
     final $v = _$v;
@@ -23901,7 +23912,9 @@ class AvatarUploadAvatarResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  AvatarUploadAvatarResponseApplicationJson_OcsBuilder();
+  AvatarUploadAvatarResponseApplicationJson_OcsBuilder() {
+    AvatarUploadAvatarResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AvatarUploadAvatarResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -23928,6 +23941,7 @@ class AvatarUploadAvatarResponseApplicationJson_OcsBuilder
   AvatarUploadAvatarResponseApplicationJson_Ocs build() => _build();
 
   _$AvatarUploadAvatarResponseApplicationJson_Ocs _build() {
+    AvatarUploadAvatarResponseApplicationJson_Ocs._validate(this);
     _$AvatarUploadAvatarResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$AvatarUploadAvatarResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -24007,7 +24021,9 @@ class AvatarUploadAvatarResponseApplicationJsonBuilder
       _$this._ocs ??= AvatarUploadAvatarResponseApplicationJson_OcsBuilder();
   set ocs(covariant AvatarUploadAvatarResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AvatarUploadAvatarResponseApplicationJsonBuilder();
+  AvatarUploadAvatarResponseApplicationJsonBuilder() {
+    AvatarUploadAvatarResponseApplicationJson._defaults(this);
+  }
 
   AvatarUploadAvatarResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -24033,6 +24049,7 @@ class AvatarUploadAvatarResponseApplicationJsonBuilder
   AvatarUploadAvatarResponseApplicationJson build() => _build();
 
   _$AvatarUploadAvatarResponseApplicationJson _build() {
+    AvatarUploadAvatarResponseApplicationJson._validate(this);
     _$AvatarUploadAvatarResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AvatarUploadAvatarResponseApplicationJson._(ocs: ocs.build());
@@ -24123,7 +24140,9 @@ class AvatarDeleteAvatarResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  AvatarDeleteAvatarResponseApplicationJson_OcsBuilder();
+  AvatarDeleteAvatarResponseApplicationJson_OcsBuilder() {
+    AvatarDeleteAvatarResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AvatarDeleteAvatarResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -24150,6 +24169,7 @@ class AvatarDeleteAvatarResponseApplicationJson_OcsBuilder
   AvatarDeleteAvatarResponseApplicationJson_Ocs build() => _build();
 
   _$AvatarDeleteAvatarResponseApplicationJson_Ocs _build() {
+    AvatarDeleteAvatarResponseApplicationJson_Ocs._validate(this);
     _$AvatarDeleteAvatarResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$AvatarDeleteAvatarResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -24229,7 +24249,9 @@ class AvatarDeleteAvatarResponseApplicationJsonBuilder
       _$this._ocs ??= AvatarDeleteAvatarResponseApplicationJson_OcsBuilder();
   set ocs(covariant AvatarDeleteAvatarResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AvatarDeleteAvatarResponseApplicationJsonBuilder();
+  AvatarDeleteAvatarResponseApplicationJsonBuilder() {
+    AvatarDeleteAvatarResponseApplicationJson._defaults(this);
+  }
 
   AvatarDeleteAvatarResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -24255,6 +24277,7 @@ class AvatarDeleteAvatarResponseApplicationJsonBuilder
   AvatarDeleteAvatarResponseApplicationJson build() => _build();
 
   _$AvatarDeleteAvatarResponseApplicationJson _build() {
+    AvatarDeleteAvatarResponseApplicationJson._validate(this);
     _$AvatarDeleteAvatarResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AvatarDeleteAvatarResponseApplicationJson._(ocs: ocs.build());
@@ -24345,7 +24368,9 @@ class AvatarEmojiAvatarResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  AvatarEmojiAvatarResponseApplicationJson_OcsBuilder();
+  AvatarEmojiAvatarResponseApplicationJson_OcsBuilder() {
+    AvatarEmojiAvatarResponseApplicationJson_Ocs._defaults(this);
+  }
 
   AvatarEmojiAvatarResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -24372,6 +24397,7 @@ class AvatarEmojiAvatarResponseApplicationJson_OcsBuilder
   AvatarEmojiAvatarResponseApplicationJson_Ocs build() => _build();
 
   _$AvatarEmojiAvatarResponseApplicationJson_Ocs _build() {
+    AvatarEmojiAvatarResponseApplicationJson_Ocs._validate(this);
     _$AvatarEmojiAvatarResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$AvatarEmojiAvatarResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -24451,7 +24477,9 @@ class AvatarEmojiAvatarResponseApplicationJsonBuilder
       _$this._ocs ??= AvatarEmojiAvatarResponseApplicationJson_OcsBuilder();
   set ocs(covariant AvatarEmojiAvatarResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  AvatarEmojiAvatarResponseApplicationJsonBuilder();
+  AvatarEmojiAvatarResponseApplicationJsonBuilder() {
+    AvatarEmojiAvatarResponseApplicationJson._defaults(this);
+  }
 
   AvatarEmojiAvatarResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -24477,6 +24505,7 @@ class AvatarEmojiAvatarResponseApplicationJsonBuilder
   AvatarEmojiAvatarResponseApplicationJson build() => _build();
 
   _$AvatarEmojiAvatarResponseApplicationJson _build() {
+    AvatarEmojiAvatarResponseApplicationJson._validate(this);
     _$AvatarEmojiAvatarResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$AvatarEmojiAvatarResponseApplicationJson._(ocs: ocs.build());
@@ -24567,7 +24596,9 @@ class BotSendMessageResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  BotSendMessageResponseApplicationJson_OcsBuilder();
+  BotSendMessageResponseApplicationJson_OcsBuilder() {
+    BotSendMessageResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BotSendMessageResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -24594,6 +24625,7 @@ class BotSendMessageResponseApplicationJson_OcsBuilder
   BotSendMessageResponseApplicationJson_Ocs build() => _build();
 
   _$BotSendMessageResponseApplicationJson_Ocs _build() {
+    BotSendMessageResponseApplicationJson_Ocs._validate(this);
     _$BotSendMessageResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -24673,7 +24705,9 @@ class BotSendMessageResponseApplicationJsonBuilder
       _$this._ocs ??= BotSendMessageResponseApplicationJson_OcsBuilder();
   set ocs(covariant BotSendMessageResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BotSendMessageResponseApplicationJsonBuilder();
+  BotSendMessageResponseApplicationJsonBuilder() {
+    BotSendMessageResponseApplicationJson._defaults(this);
+  }
 
   BotSendMessageResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -24699,6 +24733,7 @@ class BotSendMessageResponseApplicationJsonBuilder
   BotSendMessageResponseApplicationJson build() => _build();
 
   _$BotSendMessageResponseApplicationJson _build() {
+    BotSendMessageResponseApplicationJson._validate(this);
     _$BotSendMessageResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BotSendMessageResponseApplicationJson._(ocs: ocs.build());
@@ -24786,7 +24821,9 @@ class BotReactResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  BotReactResponseApplicationJson_OcsBuilder();
+  BotReactResponseApplicationJson_OcsBuilder() {
+    BotReactResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BotReactResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -24813,6 +24850,7 @@ class BotReactResponseApplicationJson_OcsBuilder
   BotReactResponseApplicationJson_Ocs build() => _build();
 
   _$BotReactResponseApplicationJson_Ocs _build() {
+    BotReactResponseApplicationJson_Ocs._validate(this);
     _$BotReactResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -24889,7 +24927,9 @@ class BotReactResponseApplicationJsonBuilder
   BotReactResponseApplicationJson_OcsBuilder get ocs => _$this._ocs ??= BotReactResponseApplicationJson_OcsBuilder();
   set ocs(covariant BotReactResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BotReactResponseApplicationJsonBuilder();
+  BotReactResponseApplicationJsonBuilder() {
+    BotReactResponseApplicationJson._defaults(this);
+  }
 
   BotReactResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -24915,6 +24955,7 @@ class BotReactResponseApplicationJsonBuilder
   BotReactResponseApplicationJson build() => _build();
 
   _$BotReactResponseApplicationJson _build() {
+    BotReactResponseApplicationJson._validate(this);
     _$BotReactResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BotReactResponseApplicationJson._(ocs: ocs.build());
@@ -25005,7 +25046,9 @@ class BotDeleteReactionResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  BotDeleteReactionResponseApplicationJson_OcsBuilder();
+  BotDeleteReactionResponseApplicationJson_OcsBuilder() {
+    BotDeleteReactionResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BotDeleteReactionResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -25032,6 +25075,7 @@ class BotDeleteReactionResponseApplicationJson_OcsBuilder
   BotDeleteReactionResponseApplicationJson_Ocs build() => _build();
 
   _$BotDeleteReactionResponseApplicationJson_Ocs _build() {
+    BotDeleteReactionResponseApplicationJson_Ocs._validate(this);
     _$BotDeleteReactionResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -25113,7 +25157,9 @@ class BotDeleteReactionResponseApplicationJsonBuilder
       _$this._ocs ??= BotDeleteReactionResponseApplicationJson_OcsBuilder();
   set ocs(covariant BotDeleteReactionResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BotDeleteReactionResponseApplicationJsonBuilder();
+  BotDeleteReactionResponseApplicationJsonBuilder() {
+    BotDeleteReactionResponseApplicationJson._defaults(this);
+  }
 
   BotDeleteReactionResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -25139,6 +25185,7 @@ class BotDeleteReactionResponseApplicationJsonBuilder
   BotDeleteReactionResponseApplicationJson build() => _build();
 
   _$BotDeleteReactionResponseApplicationJson _build() {
+    BotDeleteReactionResponseApplicationJson._validate(this);
     _$BotDeleteReactionResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BotDeleteReactionResponseApplicationJson._(ocs: ocs.build());
@@ -25248,7 +25295,9 @@ class BotBuilder implements Builder<Bot, BotBuilder>, $BotInterfaceBuilder {
   int? get state => _$this._state;
   set state(covariant int? state) => _$this._state = state;
 
-  BotBuilder();
+  BotBuilder() {
+    Bot._defaults(this);
+  }
 
   BotBuilder get _$this {
     final $v = _$v;
@@ -25277,6 +25326,7 @@ class BotBuilder implements Builder<Bot, BotBuilder>, $BotInterfaceBuilder {
   Bot build() => _build();
 
   _$Bot _build() {
+    Bot._validate(this);
     final _$result = _$v ??
         _$Bot._(
             description: description,
@@ -25360,7 +25410,9 @@ class BotListBotsResponseApplicationJson_OcsBuilder
   ListBuilder<Bot> get data => _$this._data ??= ListBuilder<Bot>();
   set data(covariant ListBuilder<Bot>? data) => _$this._data = data;
 
-  BotListBotsResponseApplicationJson_OcsBuilder();
+  BotListBotsResponseApplicationJson_OcsBuilder() {
+    BotListBotsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BotListBotsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -25387,6 +25439,7 @@ class BotListBotsResponseApplicationJson_OcsBuilder
   BotListBotsResponseApplicationJson_Ocs build() => _build();
 
   _$BotListBotsResponseApplicationJson_Ocs _build() {
+    BotListBotsResponseApplicationJson_Ocs._validate(this);
     _$BotListBotsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$BotListBotsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -25463,7 +25516,9 @@ class BotListBotsResponseApplicationJsonBuilder
       _$this._ocs ??= BotListBotsResponseApplicationJson_OcsBuilder();
   set ocs(covariant BotListBotsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BotListBotsResponseApplicationJsonBuilder();
+  BotListBotsResponseApplicationJsonBuilder() {
+    BotListBotsResponseApplicationJson._defaults(this);
+  }
 
   BotListBotsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -25489,6 +25544,7 @@ class BotListBotsResponseApplicationJsonBuilder
   BotListBotsResponseApplicationJson build() => _build();
 
   _$BotListBotsResponseApplicationJson _build() {
+    BotListBotsResponseApplicationJson._validate(this);
     _$BotListBotsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BotListBotsResponseApplicationJson._(ocs: ocs.build());
@@ -25578,7 +25634,9 @@ class BotEnableBotResponseApplicationJson_OcsBuilder
   BotBuilder get data => _$this._data ??= BotBuilder();
   set data(covariant BotBuilder? data) => _$this._data = data;
 
-  BotEnableBotResponseApplicationJson_OcsBuilder();
+  BotEnableBotResponseApplicationJson_OcsBuilder() {
+    BotEnableBotResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BotEnableBotResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -25605,6 +25663,7 @@ class BotEnableBotResponseApplicationJson_OcsBuilder
   BotEnableBotResponseApplicationJson_Ocs build() => _build();
 
   _$BotEnableBotResponseApplicationJson_Ocs _build() {
+    BotEnableBotResponseApplicationJson_Ocs._validate(this);
     _$BotEnableBotResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$BotEnableBotResponseApplicationJson_Ocs._(meta: meta.build(), data: _data?.build());
@@ -25681,7 +25740,9 @@ class BotEnableBotResponseApplicationJsonBuilder
       _$this._ocs ??= BotEnableBotResponseApplicationJson_OcsBuilder();
   set ocs(covariant BotEnableBotResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BotEnableBotResponseApplicationJsonBuilder();
+  BotEnableBotResponseApplicationJsonBuilder() {
+    BotEnableBotResponseApplicationJson._defaults(this);
+  }
 
   BotEnableBotResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -25707,6 +25768,7 @@ class BotEnableBotResponseApplicationJsonBuilder
   BotEnableBotResponseApplicationJson build() => _build();
 
   _$BotEnableBotResponseApplicationJson _build() {
+    BotEnableBotResponseApplicationJson._validate(this);
     _$BotEnableBotResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BotEnableBotResponseApplicationJson._(ocs: ocs.build());
@@ -25796,7 +25858,9 @@ class BotDisableBotResponseApplicationJson_OcsBuilder
   BotBuilder get data => _$this._data ??= BotBuilder();
   set data(covariant BotBuilder? data) => _$this._data = data;
 
-  BotDisableBotResponseApplicationJson_OcsBuilder();
+  BotDisableBotResponseApplicationJson_OcsBuilder() {
+    BotDisableBotResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BotDisableBotResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -25823,6 +25887,7 @@ class BotDisableBotResponseApplicationJson_OcsBuilder
   BotDisableBotResponseApplicationJson_Ocs build() => _build();
 
   _$BotDisableBotResponseApplicationJson_Ocs _build() {
+    BotDisableBotResponseApplicationJson_Ocs._validate(this);
     _$BotDisableBotResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$BotDisableBotResponseApplicationJson_Ocs._(meta: meta.build(), data: _data?.build());
@@ -25901,7 +25966,9 @@ class BotDisableBotResponseApplicationJsonBuilder
       _$this._ocs ??= BotDisableBotResponseApplicationJson_OcsBuilder();
   set ocs(covariant BotDisableBotResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BotDisableBotResponseApplicationJsonBuilder();
+  BotDisableBotResponseApplicationJsonBuilder() {
+    BotDisableBotResponseApplicationJson._defaults(this);
+  }
 
   BotDisableBotResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -25927,6 +25994,7 @@ class BotDisableBotResponseApplicationJsonBuilder
   BotDisableBotResponseApplicationJson build() => _build();
 
   _$BotDisableBotResponseApplicationJson _build() {
+    BotDisableBotResponseApplicationJson._validate(this);
     _$BotDisableBotResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BotDisableBotResponseApplicationJson._(ocs: ocs.build());
@@ -26126,7 +26194,9 @@ class BotWithDetailsBuilder implements Builder<BotWithDetails, BotWithDetailsBui
   int? get state => _$this._state;
   set state(covariant int? state) => _$this._state = state;
 
-  BotWithDetailsBuilder();
+  BotWithDetailsBuilder() {
+    BotWithDetails._defaults(this);
+  }
 
   BotWithDetailsBuilder get _$this {
     final $v = _$v;
@@ -26161,6 +26231,7 @@ class BotWithDetailsBuilder implements Builder<BotWithDetails, BotWithDetailsBui
   BotWithDetails build() => _build();
 
   _$BotWithDetails _build() {
+    BotWithDetails._validate(this);
     final _$result = _$v ??
         _$BotWithDetails._(
             errorCount: BuiltValueNullFieldError.checkNotNull(errorCount, r'BotWithDetails', 'errorCount'),
@@ -26251,7 +26322,9 @@ class BotAdminListBotsResponseApplicationJson_OcsBuilder
   ListBuilder<BotWithDetails> get data => _$this._data ??= ListBuilder<BotWithDetails>();
   set data(covariant ListBuilder<BotWithDetails>? data) => _$this._data = data;
 
-  BotAdminListBotsResponseApplicationJson_OcsBuilder();
+  BotAdminListBotsResponseApplicationJson_OcsBuilder() {
+    BotAdminListBotsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BotAdminListBotsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -26278,6 +26351,7 @@ class BotAdminListBotsResponseApplicationJson_OcsBuilder
   BotAdminListBotsResponseApplicationJson_Ocs build() => _build();
 
   _$BotAdminListBotsResponseApplicationJson_Ocs _build() {
+    BotAdminListBotsResponseApplicationJson_Ocs._validate(this);
     _$BotAdminListBotsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$BotAdminListBotsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -26357,7 +26431,9 @@ class BotAdminListBotsResponseApplicationJsonBuilder
       _$this._ocs ??= BotAdminListBotsResponseApplicationJson_OcsBuilder();
   set ocs(covariant BotAdminListBotsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BotAdminListBotsResponseApplicationJsonBuilder();
+  BotAdminListBotsResponseApplicationJsonBuilder() {
+    BotAdminListBotsResponseApplicationJson._defaults(this);
+  }
 
   BotAdminListBotsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -26383,6 +26459,7 @@ class BotAdminListBotsResponseApplicationJsonBuilder
   BotAdminListBotsResponseApplicationJson build() => _build();
 
   _$BotAdminListBotsResponseApplicationJson _build() {
+    BotAdminListBotsResponseApplicationJson._validate(this);
     _$BotAdminListBotsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BotAdminListBotsResponseApplicationJson._(ocs: ocs.build());
@@ -26480,7 +26557,9 @@ class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder
   ListBuilder<Room> get data => _$this._data ??= ListBuilder<Room>();
   set data(covariant ListBuilder<Room>? data) => _$this._data = data;
 
-  BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder();
+  BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder() {
+    BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -26507,6 +26586,7 @@ class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder
   BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs build() => _build();
 
   _$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs _build() {
+    BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs._validate(this);
     _$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -26591,7 +26671,9 @@ class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder
       _$this._ocs ??= BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder();
   set ocs(covariant BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder();
+  BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder() {
+    BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson._defaults(this);
+  }
 
   BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -26617,6 +26699,7 @@ class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder
   BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson build() => _build();
 
   _$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson _build() {
+    BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson._validate(this);
     _$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson._(ocs: ocs.build());
@@ -26712,7 +26795,9 @@ class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder();
+  BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder() {
+    BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -26739,6 +26824,7 @@ class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder
   BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs build() => _build();
 
   _$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs _build() {
+    BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs._validate(this);
     _$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -26823,7 +26909,9 @@ class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder
       _$this._ocs ??= BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder();
   set ocs(covariant BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder();
+  BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder() {
+    BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson._defaults(this);
+  }
 
   BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -26849,6 +26937,7 @@ class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder
   BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson build() => _build();
 
   _$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson _build() {
+    BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson._validate(this);
     _$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson._(ocs: ocs.build());
@@ -26945,7 +27034,9 @@ class BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder
   ListBuilder<Room> get data => _$this._data ??= ListBuilder<Room>();
   set data(covariant ListBuilder<Room>? data) => _$this._data = data;
 
-  BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder();
+  BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder() {
+    BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -26972,6 +27063,7 @@ class BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder
   BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs build() => _build();
 
   _$BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs _build() {
+    BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs._validate(this);
     _$BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -27056,7 +27148,9 @@ class BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder
       _$this._ocs ??= BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder();
   set ocs(covariant BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder();
+  BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder() {
+    BreakoutRoomBroadcastChatMessageResponseApplicationJson._defaults(this);
+  }
 
   BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -27082,6 +27176,7 @@ class BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder
   BreakoutRoomBroadcastChatMessageResponseApplicationJson build() => _build();
 
   _$BreakoutRoomBroadcastChatMessageResponseApplicationJson _build() {
+    BreakoutRoomBroadcastChatMessageResponseApplicationJson._validate(this);
     _$BreakoutRoomBroadcastChatMessageResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BreakoutRoomBroadcastChatMessageResponseApplicationJson._(ocs: ocs.build());
@@ -27175,7 +27270,9 @@ class BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder
   ListBuilder<Room> get data => _$this._data ??= ListBuilder<Room>();
   set data(covariant ListBuilder<Room>? data) => _$this._data = data;
 
-  BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder();
+  BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder() {
+    BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -27202,6 +27299,7 @@ class BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder
   BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs build() => _build();
 
   _$BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs _build() {
+    BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs._validate(this);
     _$BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -27286,7 +27384,9 @@ class BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder
       _$this._ocs ??= BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder();
   set ocs(covariant BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder();
+  BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder() {
+    BreakoutRoomApplyAttendeeMapResponseApplicationJson._defaults(this);
+  }
 
   BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -27312,6 +27412,7 @@ class BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder
   BreakoutRoomApplyAttendeeMapResponseApplicationJson build() => _build();
 
   _$BreakoutRoomApplyAttendeeMapResponseApplicationJson _build() {
+    BreakoutRoomApplyAttendeeMapResponseApplicationJson._validate(this);
     _$BreakoutRoomApplyAttendeeMapResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BreakoutRoomApplyAttendeeMapResponseApplicationJson._(ocs: ocs.build());
@@ -27407,7 +27508,9 @@ class BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder();
+  BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder() {
+    BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -27434,6 +27537,7 @@ class BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder
   BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs build() => _build();
 
   _$BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs _build() {
+    BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs._validate(this);
     _$BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -27518,7 +27622,9 @@ class BreakoutRoomRequestAssistanceResponseApplicationJsonBuilder
       _$this._ocs ??= BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder();
   set ocs(covariant BreakoutRoomRequestAssistanceResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BreakoutRoomRequestAssistanceResponseApplicationJsonBuilder();
+  BreakoutRoomRequestAssistanceResponseApplicationJsonBuilder() {
+    BreakoutRoomRequestAssistanceResponseApplicationJson._defaults(this);
+  }
 
   BreakoutRoomRequestAssistanceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -27544,6 +27650,7 @@ class BreakoutRoomRequestAssistanceResponseApplicationJsonBuilder
   BreakoutRoomRequestAssistanceResponseApplicationJson build() => _build();
 
   _$BreakoutRoomRequestAssistanceResponseApplicationJson _build() {
+    BreakoutRoomRequestAssistanceResponseApplicationJson._validate(this);
     _$BreakoutRoomRequestAssistanceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BreakoutRoomRequestAssistanceResponseApplicationJson._(ocs: ocs.build());
@@ -27642,7 +27749,9 @@ class BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder();
+  BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder() {
+    BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -27669,6 +27778,7 @@ class BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder
   BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs build() => _build();
 
   _$BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs _build() {
+    BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs._validate(this);
     _$BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -27754,7 +27864,9 @@ class BreakoutRoomResetRequestForAssistanceResponseApplicationJsonBuilder
       _$this._ocs ??= BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder();
   set ocs(covariant BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BreakoutRoomResetRequestForAssistanceResponseApplicationJsonBuilder();
+  BreakoutRoomResetRequestForAssistanceResponseApplicationJsonBuilder() {
+    BreakoutRoomResetRequestForAssistanceResponseApplicationJson._defaults(this);
+  }
 
   BreakoutRoomResetRequestForAssistanceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -27780,6 +27892,7 @@ class BreakoutRoomResetRequestForAssistanceResponseApplicationJsonBuilder
   BreakoutRoomResetRequestForAssistanceResponseApplicationJson build() => _build();
 
   _$BreakoutRoomResetRequestForAssistanceResponseApplicationJson _build() {
+    BreakoutRoomResetRequestForAssistanceResponseApplicationJson._validate(this);
     _$BreakoutRoomResetRequestForAssistanceResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BreakoutRoomResetRequestForAssistanceResponseApplicationJson._(ocs: ocs.build());
@@ -27875,7 +27988,9 @@ class BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder
   ListBuilder<Room> get data => _$this._data ??= ListBuilder<Room>();
   set data(covariant ListBuilder<Room>? data) => _$this._data = data;
 
-  BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder();
+  BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder() {
+    BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -27902,6 +28017,7 @@ class BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder
   BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs build() => _build();
 
   _$BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs _build() {
+    BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs._validate(this);
     _$BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -27986,7 +28102,9 @@ class BreakoutRoomStartBreakoutRoomsResponseApplicationJsonBuilder
       _$this._ocs ??= BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder();
   set ocs(covariant BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BreakoutRoomStartBreakoutRoomsResponseApplicationJsonBuilder();
+  BreakoutRoomStartBreakoutRoomsResponseApplicationJsonBuilder() {
+    BreakoutRoomStartBreakoutRoomsResponseApplicationJson._defaults(this);
+  }
 
   BreakoutRoomStartBreakoutRoomsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -28012,6 +28130,7 @@ class BreakoutRoomStartBreakoutRoomsResponseApplicationJsonBuilder
   BreakoutRoomStartBreakoutRoomsResponseApplicationJson build() => _build();
 
   _$BreakoutRoomStartBreakoutRoomsResponseApplicationJson _build() {
+    BreakoutRoomStartBreakoutRoomsResponseApplicationJson._validate(this);
     _$BreakoutRoomStartBreakoutRoomsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BreakoutRoomStartBreakoutRoomsResponseApplicationJson._(ocs: ocs.build());
@@ -28107,7 +28226,9 @@ class BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder
   ListBuilder<Room> get data => _$this._data ??= ListBuilder<Room>();
   set data(covariant ListBuilder<Room>? data) => _$this._data = data;
 
-  BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder();
+  BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder() {
+    BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -28134,6 +28255,7 @@ class BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder
   BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs build() => _build();
 
   _$BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs _build() {
+    BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs._validate(this);
     _$BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -28218,7 +28340,9 @@ class BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder
       _$this._ocs ??= BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder();
   set ocs(covariant BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder();
+  BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder() {
+    BreakoutRoomStopBreakoutRoomsResponseApplicationJson._defaults(this);
+  }
 
   BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -28244,6 +28368,7 @@ class BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder
   BreakoutRoomStopBreakoutRoomsResponseApplicationJson build() => _build();
 
   _$BreakoutRoomStopBreakoutRoomsResponseApplicationJson _build() {
+    BreakoutRoomStopBreakoutRoomsResponseApplicationJson._validate(this);
     _$BreakoutRoomStopBreakoutRoomsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BreakoutRoomStopBreakoutRoomsResponseApplicationJson._(ocs: ocs.build());
@@ -28339,7 +28464,9 @@ class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder();
+  BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder() {
+    BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -28366,6 +28493,7 @@ class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder
   BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs build() => _build();
 
   _$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs _build() {
+    BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs._validate(this);
     _$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -28450,7 +28578,9 @@ class BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder
       _$this._ocs ??= BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder();
+  BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder() {
+    BreakoutRoomSwitchBreakoutRoomResponseApplicationJson._defaults(this);
+  }
 
   BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -28476,6 +28606,7 @@ class BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder
   BreakoutRoomSwitchBreakoutRoomResponseApplicationJson build() => _build();
 
   _$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson _build() {
+    BreakoutRoomSwitchBreakoutRoomResponseApplicationJson._validate(this);
     _$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson._(ocs: ocs.build());
@@ -28620,7 +28751,9 @@ class CallPeerBuilder implements Builder<CallPeer, CallPeerBuilder>, $CallPeerIn
   String? get token => _$this._token;
   set token(covariant String? token) => _$this._token = token;
 
-  CallPeerBuilder();
+  CallPeerBuilder() {
+    CallPeer._defaults(this);
+  }
 
   CallPeerBuilder get _$this {
     final $v = _$v;
@@ -28651,6 +28784,7 @@ class CallPeerBuilder implements Builder<CallPeer, CallPeerBuilder>, $CallPeerIn
   CallPeer build() => _build();
 
   _$CallPeer _build() {
+    CallPeer._validate(this);
     final _$result = _$v ??
         _$CallPeer._(
             actorId: BuiltValueNullFieldError.checkNotNull(actorId, r'CallPeer', 'actorId'),
@@ -28736,7 +28870,9 @@ class CallGetPeersForCallResponseApplicationJson_OcsBuilder
   ListBuilder<CallPeer> get data => _$this._data ??= ListBuilder<CallPeer>();
   set data(covariant ListBuilder<CallPeer>? data) => _$this._data = data;
 
-  CallGetPeersForCallResponseApplicationJson_OcsBuilder();
+  CallGetPeersForCallResponseApplicationJson_OcsBuilder() {
+    CallGetPeersForCallResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CallGetPeersForCallResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -28763,6 +28899,7 @@ class CallGetPeersForCallResponseApplicationJson_OcsBuilder
   CallGetPeersForCallResponseApplicationJson_Ocs build() => _build();
 
   _$CallGetPeersForCallResponseApplicationJson_Ocs _build() {
+    CallGetPeersForCallResponseApplicationJson_Ocs._validate(this);
     _$CallGetPeersForCallResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$CallGetPeersForCallResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -28843,7 +28980,9 @@ class CallGetPeersForCallResponseApplicationJsonBuilder
       _$this._ocs ??= CallGetPeersForCallResponseApplicationJson_OcsBuilder();
   set ocs(covariant CallGetPeersForCallResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CallGetPeersForCallResponseApplicationJsonBuilder();
+  CallGetPeersForCallResponseApplicationJsonBuilder() {
+    CallGetPeersForCallResponseApplicationJson._defaults(this);
+  }
 
   CallGetPeersForCallResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -28869,6 +29008,7 @@ class CallGetPeersForCallResponseApplicationJsonBuilder
   CallGetPeersForCallResponseApplicationJson build() => _build();
 
   _$CallGetPeersForCallResponseApplicationJson _build() {
+    CallGetPeersForCallResponseApplicationJson._validate(this);
     _$CallGetPeersForCallResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CallGetPeersForCallResponseApplicationJson._(ocs: ocs.build());
@@ -28959,7 +29099,9 @@ class CallUpdateCallFlagsResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  CallUpdateCallFlagsResponseApplicationJson_OcsBuilder();
+  CallUpdateCallFlagsResponseApplicationJson_OcsBuilder() {
+    CallUpdateCallFlagsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CallUpdateCallFlagsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -28986,6 +29128,7 @@ class CallUpdateCallFlagsResponseApplicationJson_OcsBuilder
   CallUpdateCallFlagsResponseApplicationJson_Ocs build() => _build();
 
   _$CallUpdateCallFlagsResponseApplicationJson_Ocs _build() {
+    CallUpdateCallFlagsResponseApplicationJson_Ocs._validate(this);
     _$CallUpdateCallFlagsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -29068,7 +29211,9 @@ class CallUpdateCallFlagsResponseApplicationJsonBuilder
       _$this._ocs ??= CallUpdateCallFlagsResponseApplicationJson_OcsBuilder();
   set ocs(covariant CallUpdateCallFlagsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CallUpdateCallFlagsResponseApplicationJsonBuilder();
+  CallUpdateCallFlagsResponseApplicationJsonBuilder() {
+    CallUpdateCallFlagsResponseApplicationJson._defaults(this);
+  }
 
   CallUpdateCallFlagsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -29094,6 +29239,7 @@ class CallUpdateCallFlagsResponseApplicationJsonBuilder
   CallUpdateCallFlagsResponseApplicationJson build() => _build();
 
   _$CallUpdateCallFlagsResponseApplicationJson _build() {
+    CallUpdateCallFlagsResponseApplicationJson._validate(this);
     _$CallUpdateCallFlagsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CallUpdateCallFlagsResponseApplicationJson._(ocs: ocs.build());
@@ -29184,7 +29330,9 @@ class CallJoinCallResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  CallJoinCallResponseApplicationJson_OcsBuilder();
+  CallJoinCallResponseApplicationJson_OcsBuilder() {
+    CallJoinCallResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CallJoinCallResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -29211,6 +29359,7 @@ class CallJoinCallResponseApplicationJson_OcsBuilder
   CallJoinCallResponseApplicationJson_Ocs build() => _build();
 
   _$CallJoinCallResponseApplicationJson_Ocs _build() {
+    CallJoinCallResponseApplicationJson_Ocs._validate(this);
     _$CallJoinCallResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -29288,7 +29437,9 @@ class CallJoinCallResponseApplicationJsonBuilder
       _$this._ocs ??= CallJoinCallResponseApplicationJson_OcsBuilder();
   set ocs(covariant CallJoinCallResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CallJoinCallResponseApplicationJsonBuilder();
+  CallJoinCallResponseApplicationJsonBuilder() {
+    CallJoinCallResponseApplicationJson._defaults(this);
+  }
 
   CallJoinCallResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -29314,6 +29465,7 @@ class CallJoinCallResponseApplicationJsonBuilder
   CallJoinCallResponseApplicationJson build() => _build();
 
   _$CallJoinCallResponseApplicationJson _build() {
+    CallJoinCallResponseApplicationJson._validate(this);
     _$CallJoinCallResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CallJoinCallResponseApplicationJson._(ocs: ocs.build());
@@ -29404,7 +29556,9 @@ class CallLeaveCallResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  CallLeaveCallResponseApplicationJson_OcsBuilder();
+  CallLeaveCallResponseApplicationJson_OcsBuilder() {
+    CallLeaveCallResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CallLeaveCallResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -29431,6 +29585,7 @@ class CallLeaveCallResponseApplicationJson_OcsBuilder
   CallLeaveCallResponseApplicationJson_Ocs build() => _build();
 
   _$CallLeaveCallResponseApplicationJson_Ocs _build() {
+    CallLeaveCallResponseApplicationJson_Ocs._validate(this);
     _$CallLeaveCallResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -29510,7 +29665,9 @@ class CallLeaveCallResponseApplicationJsonBuilder
       _$this._ocs ??= CallLeaveCallResponseApplicationJson_OcsBuilder();
   set ocs(covariant CallLeaveCallResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CallLeaveCallResponseApplicationJsonBuilder();
+  CallLeaveCallResponseApplicationJsonBuilder() {
+    CallLeaveCallResponseApplicationJson._defaults(this);
+  }
 
   CallLeaveCallResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -29536,6 +29693,7 @@ class CallLeaveCallResponseApplicationJsonBuilder
   CallLeaveCallResponseApplicationJson build() => _build();
 
   _$CallLeaveCallResponseApplicationJson _build() {
+    CallLeaveCallResponseApplicationJson._validate(this);
     _$CallLeaveCallResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CallLeaveCallResponseApplicationJson._(ocs: ocs.build());
@@ -29626,7 +29784,9 @@ class CallRingAttendeeResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  CallRingAttendeeResponseApplicationJson_OcsBuilder();
+  CallRingAttendeeResponseApplicationJson_OcsBuilder() {
+    CallRingAttendeeResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CallRingAttendeeResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -29653,6 +29813,7 @@ class CallRingAttendeeResponseApplicationJson_OcsBuilder
   CallRingAttendeeResponseApplicationJson_Ocs build() => _build();
 
   _$CallRingAttendeeResponseApplicationJson_Ocs _build() {
+    CallRingAttendeeResponseApplicationJson_Ocs._validate(this);
     _$CallRingAttendeeResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -29734,7 +29895,9 @@ class CallRingAttendeeResponseApplicationJsonBuilder
       _$this._ocs ??= CallRingAttendeeResponseApplicationJson_OcsBuilder();
   set ocs(covariant CallRingAttendeeResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CallRingAttendeeResponseApplicationJsonBuilder();
+  CallRingAttendeeResponseApplicationJsonBuilder() {
+    CallRingAttendeeResponseApplicationJson._defaults(this);
+  }
 
   CallRingAttendeeResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -29760,6 +29923,7 @@ class CallRingAttendeeResponseApplicationJsonBuilder
   CallRingAttendeeResponseApplicationJson build() => _build();
 
   _$CallRingAttendeeResponseApplicationJson _build() {
+    CallRingAttendeeResponseApplicationJson._validate(this);
     _$CallRingAttendeeResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CallRingAttendeeResponseApplicationJson._(ocs: ocs.build());
@@ -29847,7 +30011,9 @@ class CallSipDialOutResponseApplicationJson_Ocs_DataBuilder
   String? get message => _$this._message;
   set message(covariant String? message) => _$this._message = message;
 
-  CallSipDialOutResponseApplicationJson_Ocs_DataBuilder();
+  CallSipDialOutResponseApplicationJson_Ocs_DataBuilder() {
+    CallSipDialOutResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   CallSipDialOutResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -29874,6 +30040,7 @@ class CallSipDialOutResponseApplicationJson_Ocs_DataBuilder
   CallSipDialOutResponseApplicationJson_Ocs_Data build() => _build();
 
   _$CallSipDialOutResponseApplicationJson_Ocs_Data _build() {
+    CallSipDialOutResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ?? _$CallSipDialOutResponseApplicationJson_Ocs_Data._(error: error, message: message);
     replace(_$result);
     return _$result;
@@ -29953,7 +30120,9 @@ class CallSipDialOutResponseApplicationJson_OcsBuilder
       _$this._data ??= CallSipDialOutResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant CallSipDialOutResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  CallSipDialOutResponseApplicationJson_OcsBuilder();
+  CallSipDialOutResponseApplicationJson_OcsBuilder() {
+    CallSipDialOutResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CallSipDialOutResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -29980,6 +30149,7 @@ class CallSipDialOutResponseApplicationJson_OcsBuilder
   CallSipDialOutResponseApplicationJson_Ocs build() => _build();
 
   _$CallSipDialOutResponseApplicationJson_Ocs _build() {
+    CallSipDialOutResponseApplicationJson_Ocs._validate(this);
     _$CallSipDialOutResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$CallSipDialOutResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -30058,7 +30228,9 @@ class CallSipDialOutResponseApplicationJsonBuilder
       _$this._ocs ??= CallSipDialOutResponseApplicationJson_OcsBuilder();
   set ocs(covariant CallSipDialOutResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CallSipDialOutResponseApplicationJsonBuilder();
+  CallSipDialOutResponseApplicationJsonBuilder() {
+    CallSipDialOutResponseApplicationJson._defaults(this);
+  }
 
   CallSipDialOutResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -30084,6 +30256,7 @@ class CallSipDialOutResponseApplicationJsonBuilder
   CallSipDialOutResponseApplicationJson build() => _build();
 
   _$CallSipDialOutResponseApplicationJson _build() {
+    CallSipDialOutResponseApplicationJson._validate(this);
     _$CallSipDialOutResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CallSipDialOutResponseApplicationJson._(ocs: ocs.build());
@@ -30164,7 +30337,9 @@ class CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder
   int? get expirationInDays => _$this._expirationInDays;
   set expirationInDays(covariant int? expirationInDays) => _$this._expirationInDays = expirationInDays;
 
-  CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder();
+  CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder() {
+    CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -30190,6 +30365,7 @@ class CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder
   CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data build() => _build();
 
   _$CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data _build() {
+    CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data._(expirationInDays: expirationInDays);
     replace(_$result);
@@ -30278,7 +30454,9 @@ class CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder
   set data(covariant CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
-  CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder();
+  CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder() {
+    CertificateGetCertificateExpirationResponseApplicationJson_Ocs._defaults(this);
+  }
 
   CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -30305,6 +30483,7 @@ class CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder
   CertificateGetCertificateExpirationResponseApplicationJson_Ocs build() => _build();
 
   _$CertificateGetCertificateExpirationResponseApplicationJson_Ocs _build() {
+    CertificateGetCertificateExpirationResponseApplicationJson_Ocs._validate(this);
     _$CertificateGetCertificateExpirationResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -30389,7 +30568,9 @@ class CertificateGetCertificateExpirationResponseApplicationJsonBuilder
       _$this._ocs ??= CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder();
   set ocs(covariant CertificateGetCertificateExpirationResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  CertificateGetCertificateExpirationResponseApplicationJsonBuilder();
+  CertificateGetCertificateExpirationResponseApplicationJsonBuilder() {
+    CertificateGetCertificateExpirationResponseApplicationJson._defaults(this);
+  }
 
   CertificateGetCertificateExpirationResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -30415,6 +30596,7 @@ class CertificateGetCertificateExpirationResponseApplicationJsonBuilder
   CertificateGetCertificateExpirationResponseApplicationJson build() => _build();
 
   _$CertificateGetCertificateExpirationResponseApplicationJson _build() {
+    CertificateGetCertificateExpirationResponseApplicationJson._validate(this);
     _$CertificateGetCertificateExpirationResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$CertificateGetCertificateExpirationResponseApplicationJson._(ocs: ocs.build());
@@ -30715,7 +30897,9 @@ class ChatMessageWithParentBuilder
   String? get token => _$this._token;
   set token(covariant String? token) => _$this._token = token;
 
-  ChatMessageWithParentBuilder();
+  ChatMessageWithParentBuilder() {
+    ChatMessageWithParent._defaults(this);
+  }
 
   ChatMessageWithParentBuilder get _$this {
     final $v = _$v;
@@ -30757,6 +30941,7 @@ class ChatMessageWithParentBuilder
   ChatMessageWithParent build() => _build();
 
   _$ChatMessageWithParent _build() {
+    ChatMessageWithParent._validate(this);
     _$ChatMessageWithParent _$result;
     try {
       _$result = _$v ??
@@ -30874,7 +31059,9 @@ class ChatReceiveMessagesResponseApplicationJson_OcsBuilder
   ListBuilder<ChatMessageWithParent> get data => _$this._data ??= ListBuilder<ChatMessageWithParent>();
   set data(covariant ListBuilder<ChatMessageWithParent>? data) => _$this._data = data;
 
-  ChatReceiveMessagesResponseApplicationJson_OcsBuilder();
+  ChatReceiveMessagesResponseApplicationJson_OcsBuilder() {
+    ChatReceiveMessagesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatReceiveMessagesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -30901,6 +31088,7 @@ class ChatReceiveMessagesResponseApplicationJson_OcsBuilder
   ChatReceiveMessagesResponseApplicationJson_Ocs build() => _build();
 
   _$ChatReceiveMessagesResponseApplicationJson_Ocs _build() {
+    ChatReceiveMessagesResponseApplicationJson_Ocs._validate(this);
     _$ChatReceiveMessagesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ChatReceiveMessagesResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -30981,7 +31169,9 @@ class ChatReceiveMessagesResponseApplicationJsonBuilder
       _$this._ocs ??= ChatReceiveMessagesResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatReceiveMessagesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatReceiveMessagesResponseApplicationJsonBuilder();
+  ChatReceiveMessagesResponseApplicationJsonBuilder() {
+    ChatReceiveMessagesResponseApplicationJson._defaults(this);
+  }
 
   ChatReceiveMessagesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -31007,6 +31197,7 @@ class ChatReceiveMessagesResponseApplicationJsonBuilder
   ChatReceiveMessagesResponseApplicationJson build() => _build();
 
   _$ChatReceiveMessagesResponseApplicationJson _build() {
+    ChatReceiveMessagesResponseApplicationJson._validate(this);
     _$ChatReceiveMessagesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatReceiveMessagesResponseApplicationJson._(ocs: ocs.build());
@@ -31093,7 +31284,9 @@ class ChatChatReceiveMessagesHeadersBuilder
   String? get xChatLastGiven => _$this._xChatLastGiven;
   set xChatLastGiven(covariant String? xChatLastGiven) => _$this._xChatLastGiven = xChatLastGiven;
 
-  ChatChatReceiveMessagesHeadersBuilder();
+  ChatChatReceiveMessagesHeadersBuilder() {
+    ChatChatReceiveMessagesHeaders._defaults(this);
+  }
 
   ChatChatReceiveMessagesHeadersBuilder get _$this {
     final $v = _$v;
@@ -31120,6 +31313,7 @@ class ChatChatReceiveMessagesHeadersBuilder
   ChatChatReceiveMessagesHeaders build() => _build();
 
   _$ChatChatReceiveMessagesHeaders _build() {
+    ChatChatReceiveMessagesHeaders._validate(this);
     final _$result = _$v ??
         _$ChatChatReceiveMessagesHeaders._(xChatLastCommonRead: xChatLastCommonRead, xChatLastGiven: xChatLastGiven);
     replace(_$result);
@@ -31198,7 +31392,9 @@ class ChatSendMessageResponseApplicationJson_OcsBuilder
   ChatMessageWithParentBuilder get data => _$this._data ??= ChatMessageWithParentBuilder();
   set data(covariant ChatMessageWithParentBuilder? data) => _$this._data = data;
 
-  ChatSendMessageResponseApplicationJson_OcsBuilder();
+  ChatSendMessageResponseApplicationJson_OcsBuilder() {
+    ChatSendMessageResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatSendMessageResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -31225,6 +31421,7 @@ class ChatSendMessageResponseApplicationJson_OcsBuilder
   ChatSendMessageResponseApplicationJson_Ocs build() => _build();
 
   _$ChatSendMessageResponseApplicationJson_Ocs _build() {
+    ChatSendMessageResponseApplicationJson_Ocs._validate(this);
     _$ChatSendMessageResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ChatSendMessageResponseApplicationJson_Ocs._(meta: meta.build(), data: _data?.build());
@@ -31304,7 +31501,9 @@ class ChatSendMessageResponseApplicationJsonBuilder
       _$this._ocs ??= ChatSendMessageResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatSendMessageResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatSendMessageResponseApplicationJsonBuilder();
+  ChatSendMessageResponseApplicationJsonBuilder() {
+    ChatSendMessageResponseApplicationJson._defaults(this);
+  }
 
   ChatSendMessageResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -31330,6 +31529,7 @@ class ChatSendMessageResponseApplicationJsonBuilder
   ChatSendMessageResponseApplicationJson build() => _build();
 
   _$ChatSendMessageResponseApplicationJson _build() {
+    ChatSendMessageResponseApplicationJson._validate(this);
     _$ChatSendMessageResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatSendMessageResponseApplicationJson._(ocs: ocs.build());
@@ -31402,7 +31602,9 @@ class ChatChatSendMessageHeadersBuilder
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  ChatChatSendMessageHeadersBuilder();
+  ChatChatSendMessageHeadersBuilder() {
+    ChatChatSendMessageHeaders._defaults(this);
+  }
 
   ChatChatSendMessageHeadersBuilder get _$this {
     final $v = _$v;
@@ -31428,6 +31630,7 @@ class ChatChatSendMessageHeadersBuilder
   ChatChatSendMessageHeaders build() => _build();
 
   _$ChatChatSendMessageHeaders _build() {
+    ChatChatSendMessageHeaders._validate(this);
     final _$result = _$v ?? _$ChatChatSendMessageHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
@@ -31506,7 +31709,9 @@ class ChatClearHistoryResponseApplicationJson_OcsBuilder
   ChatMessageBuilder get data => _$this._data ??= ChatMessageBuilder();
   set data(covariant ChatMessageBuilder? data) => _$this._data = data;
 
-  ChatClearHistoryResponseApplicationJson_OcsBuilder();
+  ChatClearHistoryResponseApplicationJson_OcsBuilder() {
+    ChatClearHistoryResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatClearHistoryResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -31533,6 +31738,7 @@ class ChatClearHistoryResponseApplicationJson_OcsBuilder
   ChatClearHistoryResponseApplicationJson_Ocs build() => _build();
 
   _$ChatClearHistoryResponseApplicationJson_Ocs _build() {
+    ChatClearHistoryResponseApplicationJson_Ocs._validate(this);
     _$ChatClearHistoryResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ChatClearHistoryResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -31612,7 +31818,9 @@ class ChatClearHistoryResponseApplicationJsonBuilder
       _$this._ocs ??= ChatClearHistoryResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatClearHistoryResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatClearHistoryResponseApplicationJsonBuilder();
+  ChatClearHistoryResponseApplicationJsonBuilder() {
+    ChatClearHistoryResponseApplicationJson._defaults(this);
+  }
 
   ChatClearHistoryResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -31638,6 +31846,7 @@ class ChatClearHistoryResponseApplicationJsonBuilder
   ChatClearHistoryResponseApplicationJson build() => _build();
 
   _$ChatClearHistoryResponseApplicationJson _build() {
+    ChatClearHistoryResponseApplicationJson._validate(this);
     _$ChatClearHistoryResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatClearHistoryResponseApplicationJson._(ocs: ocs.build());
@@ -31711,7 +31920,9 @@ class ChatChatClearHistoryHeadersBuilder
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  ChatChatClearHistoryHeadersBuilder();
+  ChatChatClearHistoryHeadersBuilder() {
+    ChatChatClearHistoryHeaders._defaults(this);
+  }
 
   ChatChatClearHistoryHeadersBuilder get _$this {
     final $v = _$v;
@@ -31737,6 +31948,7 @@ class ChatChatClearHistoryHeadersBuilder
   ChatChatClearHistoryHeaders build() => _build();
 
   _$ChatChatClearHistoryHeaders _build() {
+    ChatChatClearHistoryHeaders._validate(this);
     final _$result = _$v ?? _$ChatChatClearHistoryHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
@@ -31815,7 +32027,9 @@ class ChatDeleteMessageResponseApplicationJson_OcsBuilder
   ChatMessageWithParentBuilder get data => _$this._data ??= ChatMessageWithParentBuilder();
   set data(covariant ChatMessageWithParentBuilder? data) => _$this._data = data;
 
-  ChatDeleteMessageResponseApplicationJson_OcsBuilder();
+  ChatDeleteMessageResponseApplicationJson_OcsBuilder() {
+    ChatDeleteMessageResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatDeleteMessageResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -31842,6 +32056,7 @@ class ChatDeleteMessageResponseApplicationJson_OcsBuilder
   ChatDeleteMessageResponseApplicationJson_Ocs build() => _build();
 
   _$ChatDeleteMessageResponseApplicationJson_Ocs _build() {
+    ChatDeleteMessageResponseApplicationJson_Ocs._validate(this);
     _$ChatDeleteMessageResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ChatDeleteMessageResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -31921,7 +32136,9 @@ class ChatDeleteMessageResponseApplicationJsonBuilder
       _$this._ocs ??= ChatDeleteMessageResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatDeleteMessageResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatDeleteMessageResponseApplicationJsonBuilder();
+  ChatDeleteMessageResponseApplicationJsonBuilder() {
+    ChatDeleteMessageResponseApplicationJson._defaults(this);
+  }
 
   ChatDeleteMessageResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -31947,6 +32164,7 @@ class ChatDeleteMessageResponseApplicationJsonBuilder
   ChatDeleteMessageResponseApplicationJson build() => _build();
 
   _$ChatDeleteMessageResponseApplicationJson _build() {
+    ChatDeleteMessageResponseApplicationJson._validate(this);
     _$ChatDeleteMessageResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatDeleteMessageResponseApplicationJson._(ocs: ocs.build());
@@ -32020,7 +32238,9 @@ class ChatChatDeleteMessageHeadersBuilder
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  ChatChatDeleteMessageHeadersBuilder();
+  ChatChatDeleteMessageHeadersBuilder() {
+    ChatChatDeleteMessageHeaders._defaults(this);
+  }
 
   ChatChatDeleteMessageHeadersBuilder get _$this {
     final $v = _$v;
@@ -32046,6 +32266,7 @@ class ChatChatDeleteMessageHeadersBuilder
   ChatChatDeleteMessageHeaders build() => _build();
 
   _$ChatChatDeleteMessageHeaders _build() {
+    ChatChatDeleteMessageHeaders._validate(this);
     final _$result = _$v ?? _$ChatChatDeleteMessageHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
@@ -32125,7 +32346,9 @@ class ChatGetMessageContextResponseApplicationJson_OcsBuilder
   ListBuilder<ChatMessageWithParent> get data => _$this._data ??= ListBuilder<ChatMessageWithParent>();
   set data(covariant ListBuilder<ChatMessageWithParent>? data) => _$this._data = data;
 
-  ChatGetMessageContextResponseApplicationJson_OcsBuilder();
+  ChatGetMessageContextResponseApplicationJson_OcsBuilder() {
+    ChatGetMessageContextResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatGetMessageContextResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -32152,6 +32375,7 @@ class ChatGetMessageContextResponseApplicationJson_OcsBuilder
   ChatGetMessageContextResponseApplicationJson_Ocs build() => _build();
 
   _$ChatGetMessageContextResponseApplicationJson_Ocs _build() {
+    ChatGetMessageContextResponseApplicationJson_Ocs._validate(this);
     _$ChatGetMessageContextResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ChatGetMessageContextResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -32232,7 +32456,9 @@ class ChatGetMessageContextResponseApplicationJsonBuilder
       _$this._ocs ??= ChatGetMessageContextResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatGetMessageContextResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatGetMessageContextResponseApplicationJsonBuilder();
+  ChatGetMessageContextResponseApplicationJsonBuilder() {
+    ChatGetMessageContextResponseApplicationJson._defaults(this);
+  }
 
   ChatGetMessageContextResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -32258,6 +32484,7 @@ class ChatGetMessageContextResponseApplicationJsonBuilder
   ChatGetMessageContextResponseApplicationJson build() => _build();
 
   _$ChatGetMessageContextResponseApplicationJson _build() {
+    ChatGetMessageContextResponseApplicationJson._validate(this);
     _$ChatGetMessageContextResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatGetMessageContextResponseApplicationJson._(ocs: ocs.build());
@@ -32344,7 +32571,9 @@ class ChatChatGetMessageContextHeadersBuilder
   String? get xChatLastGiven => _$this._xChatLastGiven;
   set xChatLastGiven(covariant String? xChatLastGiven) => _$this._xChatLastGiven = xChatLastGiven;
 
-  ChatChatGetMessageContextHeadersBuilder();
+  ChatChatGetMessageContextHeadersBuilder() {
+    ChatChatGetMessageContextHeaders._defaults(this);
+  }
 
   ChatChatGetMessageContextHeadersBuilder get _$this {
     final $v = _$v;
@@ -32371,6 +32600,7 @@ class ChatChatGetMessageContextHeadersBuilder
   ChatChatGetMessageContextHeaders build() => _build();
 
   _$ChatChatGetMessageContextHeaders _build() {
+    ChatChatGetMessageContextHeaders._validate(this);
     final _$result = _$v ??
         _$ChatChatGetMessageContextHeaders._(xChatLastCommonRead: xChatLastCommonRead, xChatLastGiven: xChatLastGiven);
     replace(_$result);
@@ -32472,7 +32702,9 @@ class ChatReminderBuilder implements Builder<ChatReminder, ChatReminderBuilder>,
   String? get userId => _$this._userId;
   set userId(covariant String? userId) => _$this._userId = userId;
 
-  ChatReminderBuilder();
+  ChatReminderBuilder() {
+    ChatReminder._defaults(this);
+  }
 
   ChatReminderBuilder get _$this {
     final $v = _$v;
@@ -32501,6 +32733,7 @@ class ChatReminderBuilder implements Builder<ChatReminder, ChatReminderBuilder>,
   ChatReminder build() => _build();
 
   _$ChatReminder _build() {
+    ChatReminder._validate(this);
     final _$result = _$v ??
         _$ChatReminder._(
             messageId: BuiltValueNullFieldError.checkNotNull(messageId, r'ChatReminder', 'messageId'),
@@ -32584,7 +32817,9 @@ class ChatGetReminderResponseApplicationJson_OcsBuilder
   ChatReminderBuilder get data => _$this._data ??= ChatReminderBuilder();
   set data(covariant ChatReminderBuilder? data) => _$this._data = data;
 
-  ChatGetReminderResponseApplicationJson_OcsBuilder();
+  ChatGetReminderResponseApplicationJson_OcsBuilder() {
+    ChatGetReminderResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatGetReminderResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -32611,6 +32846,7 @@ class ChatGetReminderResponseApplicationJson_OcsBuilder
   ChatGetReminderResponseApplicationJson_Ocs build() => _build();
 
   _$ChatGetReminderResponseApplicationJson_Ocs _build() {
+    ChatGetReminderResponseApplicationJson_Ocs._validate(this);
     _$ChatGetReminderResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ChatGetReminderResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -32690,7 +32926,9 @@ class ChatGetReminderResponseApplicationJsonBuilder
       _$this._ocs ??= ChatGetReminderResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatGetReminderResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatGetReminderResponseApplicationJsonBuilder();
+  ChatGetReminderResponseApplicationJsonBuilder() {
+    ChatGetReminderResponseApplicationJson._defaults(this);
+  }
 
   ChatGetReminderResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -32716,6 +32954,7 @@ class ChatGetReminderResponseApplicationJsonBuilder
   ChatGetReminderResponseApplicationJson build() => _build();
 
   _$ChatGetReminderResponseApplicationJson _build() {
+    ChatGetReminderResponseApplicationJson._validate(this);
     _$ChatGetReminderResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatGetReminderResponseApplicationJson._(ocs: ocs.build());
@@ -32806,7 +33045,9 @@ class ChatSetReminderResponseApplicationJson_OcsBuilder
   ChatReminderBuilder get data => _$this._data ??= ChatReminderBuilder();
   set data(covariant ChatReminderBuilder? data) => _$this._data = data;
 
-  ChatSetReminderResponseApplicationJson_OcsBuilder();
+  ChatSetReminderResponseApplicationJson_OcsBuilder() {
+    ChatSetReminderResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatSetReminderResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -32833,6 +33074,7 @@ class ChatSetReminderResponseApplicationJson_OcsBuilder
   ChatSetReminderResponseApplicationJson_Ocs build() => _build();
 
   _$ChatSetReminderResponseApplicationJson_Ocs _build() {
+    ChatSetReminderResponseApplicationJson_Ocs._validate(this);
     _$ChatSetReminderResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ChatSetReminderResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -32912,7 +33154,9 @@ class ChatSetReminderResponseApplicationJsonBuilder
       _$this._ocs ??= ChatSetReminderResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatSetReminderResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatSetReminderResponseApplicationJsonBuilder();
+  ChatSetReminderResponseApplicationJsonBuilder() {
+    ChatSetReminderResponseApplicationJson._defaults(this);
+  }
 
   ChatSetReminderResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -32938,6 +33182,7 @@ class ChatSetReminderResponseApplicationJsonBuilder
   ChatSetReminderResponseApplicationJson build() => _build();
 
   _$ChatSetReminderResponseApplicationJson _build() {
+    ChatSetReminderResponseApplicationJson._validate(this);
     _$ChatSetReminderResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatSetReminderResponseApplicationJson._(ocs: ocs.build());
@@ -33028,7 +33273,9 @@ class ChatDeleteReminderResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ChatDeleteReminderResponseApplicationJson_OcsBuilder();
+  ChatDeleteReminderResponseApplicationJson_OcsBuilder() {
+    ChatDeleteReminderResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatDeleteReminderResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -33055,6 +33302,7 @@ class ChatDeleteReminderResponseApplicationJson_OcsBuilder
   ChatDeleteReminderResponseApplicationJson_Ocs build() => _build();
 
   _$ChatDeleteReminderResponseApplicationJson_Ocs _build() {
+    ChatDeleteReminderResponseApplicationJson_Ocs._validate(this);
     _$ChatDeleteReminderResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -33136,7 +33384,9 @@ class ChatDeleteReminderResponseApplicationJsonBuilder
       _$this._ocs ??= ChatDeleteReminderResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatDeleteReminderResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatDeleteReminderResponseApplicationJsonBuilder();
+  ChatDeleteReminderResponseApplicationJsonBuilder() {
+    ChatDeleteReminderResponseApplicationJson._defaults(this);
+  }
 
   ChatDeleteReminderResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -33162,6 +33412,7 @@ class ChatDeleteReminderResponseApplicationJsonBuilder
   ChatDeleteReminderResponseApplicationJson build() => _build();
 
   _$ChatDeleteReminderResponseApplicationJson _build() {
+    ChatDeleteReminderResponseApplicationJson._validate(this);
     _$ChatDeleteReminderResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatDeleteReminderResponseApplicationJson._(ocs: ocs.build());
@@ -33252,7 +33503,9 @@ class ChatSetReadMarkerResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ChatSetReadMarkerResponseApplicationJson_OcsBuilder();
+  ChatSetReadMarkerResponseApplicationJson_OcsBuilder() {
+    ChatSetReadMarkerResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatSetReadMarkerResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -33279,6 +33532,7 @@ class ChatSetReadMarkerResponseApplicationJson_OcsBuilder
   ChatSetReadMarkerResponseApplicationJson_Ocs build() => _build();
 
   _$ChatSetReadMarkerResponseApplicationJson_Ocs _build() {
+    ChatSetReadMarkerResponseApplicationJson_Ocs._validate(this);
     _$ChatSetReadMarkerResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -33360,7 +33614,9 @@ class ChatSetReadMarkerResponseApplicationJsonBuilder
       _$this._ocs ??= ChatSetReadMarkerResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatSetReadMarkerResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatSetReadMarkerResponseApplicationJsonBuilder();
+  ChatSetReadMarkerResponseApplicationJsonBuilder() {
+    ChatSetReadMarkerResponseApplicationJson._defaults(this);
+  }
 
   ChatSetReadMarkerResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -33386,6 +33642,7 @@ class ChatSetReadMarkerResponseApplicationJsonBuilder
   ChatSetReadMarkerResponseApplicationJson build() => _build();
 
   _$ChatSetReadMarkerResponseApplicationJson _build() {
+    ChatSetReadMarkerResponseApplicationJson._validate(this);
     _$ChatSetReadMarkerResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatSetReadMarkerResponseApplicationJson._(ocs: ocs.build());
@@ -33459,7 +33716,9 @@ class ChatChatSetReadMarkerHeadersBuilder
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  ChatChatSetReadMarkerHeadersBuilder();
+  ChatChatSetReadMarkerHeadersBuilder() {
+    ChatChatSetReadMarkerHeaders._defaults(this);
+  }
 
   ChatChatSetReadMarkerHeadersBuilder get _$this {
     final $v = _$v;
@@ -33485,6 +33744,7 @@ class ChatChatSetReadMarkerHeadersBuilder
   ChatChatSetReadMarkerHeaders build() => _build();
 
   _$ChatChatSetReadMarkerHeaders _build() {
+    ChatChatSetReadMarkerHeaders._validate(this);
     final _$result = _$v ?? _$ChatChatSetReadMarkerHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
@@ -33563,7 +33823,9 @@ class ChatMarkUnreadResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ChatMarkUnreadResponseApplicationJson_OcsBuilder();
+  ChatMarkUnreadResponseApplicationJson_OcsBuilder() {
+    ChatMarkUnreadResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatMarkUnreadResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -33590,6 +33852,7 @@ class ChatMarkUnreadResponseApplicationJson_OcsBuilder
   ChatMarkUnreadResponseApplicationJson_Ocs build() => _build();
 
   _$ChatMarkUnreadResponseApplicationJson_Ocs _build() {
+    ChatMarkUnreadResponseApplicationJson_Ocs._validate(this);
     _$ChatMarkUnreadResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -33669,7 +33932,9 @@ class ChatMarkUnreadResponseApplicationJsonBuilder
       _$this._ocs ??= ChatMarkUnreadResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatMarkUnreadResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatMarkUnreadResponseApplicationJsonBuilder();
+  ChatMarkUnreadResponseApplicationJsonBuilder() {
+    ChatMarkUnreadResponseApplicationJson._defaults(this);
+  }
 
   ChatMarkUnreadResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -33695,6 +33960,7 @@ class ChatMarkUnreadResponseApplicationJsonBuilder
   ChatMarkUnreadResponseApplicationJson build() => _build();
 
   _$ChatMarkUnreadResponseApplicationJson _build() {
+    ChatMarkUnreadResponseApplicationJson._validate(this);
     _$ChatMarkUnreadResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatMarkUnreadResponseApplicationJson._(ocs: ocs.build());
@@ -33767,7 +34033,9 @@ class ChatChatMarkUnreadHeadersBuilder
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  ChatChatMarkUnreadHeadersBuilder();
+  ChatChatMarkUnreadHeadersBuilder() {
+    ChatChatMarkUnreadHeaders._defaults(this);
+  }
 
   ChatChatMarkUnreadHeadersBuilder get _$this {
     final $v = _$v;
@@ -33793,6 +34061,7 @@ class ChatChatMarkUnreadHeadersBuilder
   ChatChatMarkUnreadHeaders build() => _build();
 
   _$ChatChatMarkUnreadHeaders _build() {
+    ChatChatMarkUnreadHeaders._validate(this);
     final _$result = _$v ?? _$ChatChatMarkUnreadHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
@@ -33937,7 +34206,9 @@ class ChatMentionSuggestionBuilder
   String? get statusMessage => _$this._statusMessage;
   set statusMessage(covariant String? statusMessage) => _$this._statusMessage = statusMessage;
 
-  ChatMentionSuggestionBuilder();
+  ChatMentionSuggestionBuilder() {
+    ChatMentionSuggestion._defaults(this);
+  }
 
   ChatMentionSuggestionBuilder get _$this {
     final $v = _$v;
@@ -33969,6 +34240,7 @@ class ChatMentionSuggestionBuilder
   ChatMentionSuggestion build() => _build();
 
   _$ChatMentionSuggestion _build() {
+    ChatMentionSuggestion._validate(this);
     final _$result = _$v ??
         _$ChatMentionSuggestion._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'ChatMentionSuggestion', 'id'),
@@ -34055,7 +34327,9 @@ class ChatMentionsResponseApplicationJson_OcsBuilder
   ListBuilder<ChatMentionSuggestion> get data => _$this._data ??= ListBuilder<ChatMentionSuggestion>();
   set data(covariant ListBuilder<ChatMentionSuggestion>? data) => _$this._data = data;
 
-  ChatMentionsResponseApplicationJson_OcsBuilder();
+  ChatMentionsResponseApplicationJson_OcsBuilder() {
+    ChatMentionsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatMentionsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -34082,6 +34356,7 @@ class ChatMentionsResponseApplicationJson_OcsBuilder
   ChatMentionsResponseApplicationJson_Ocs build() => _build();
 
   _$ChatMentionsResponseApplicationJson_Ocs _build() {
+    ChatMentionsResponseApplicationJson_Ocs._validate(this);
     _$ChatMentionsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ChatMentionsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -34158,7 +34433,9 @@ class ChatMentionsResponseApplicationJsonBuilder
       _$this._ocs ??= ChatMentionsResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatMentionsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatMentionsResponseApplicationJsonBuilder();
+  ChatMentionsResponseApplicationJsonBuilder() {
+    ChatMentionsResponseApplicationJson._defaults(this);
+  }
 
   ChatMentionsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -34184,6 +34461,7 @@ class ChatMentionsResponseApplicationJsonBuilder
   ChatMentionsResponseApplicationJson build() => _build();
 
   _$ChatMentionsResponseApplicationJson _build() {
+    ChatMentionsResponseApplicationJson._validate(this);
     _$ChatMentionsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatMentionsResponseApplicationJson._(ocs: ocs.build());
@@ -34276,7 +34554,9 @@ class ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder
   ListBuilder<ChatMessage> get data => _$this._data ??= ListBuilder<ChatMessage>();
   set data(covariant ListBuilder<ChatMessage>? data) => _$this._data = data;
 
-  ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder();
+  ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder() {
+    ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -34303,6 +34583,7 @@ class ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder
   ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs build() => _build();
 
   _$ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs _build() {
+    ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs._validate(this);
     _$ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -34386,7 +34667,9 @@ class ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder
       _$this._ocs ??= ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatGetObjectsSharedInRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder();
+  ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder() {
+    ChatGetObjectsSharedInRoomResponseApplicationJson._defaults(this);
+  }
 
   ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -34412,6 +34695,7 @@ class ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder
   ChatGetObjectsSharedInRoomResponseApplicationJson build() => _build();
 
   _$ChatGetObjectsSharedInRoomResponseApplicationJson _build() {
+    ChatGetObjectsSharedInRoomResponseApplicationJson._validate(this);
     _$ChatGetObjectsSharedInRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatGetObjectsSharedInRoomResponseApplicationJson._(ocs: ocs.build());
@@ -34488,7 +34772,9 @@ class ChatChatGetObjectsSharedInRoomHeadersBuilder
   String? get xChatLastGiven => _$this._xChatLastGiven;
   set xChatLastGiven(covariant String? xChatLastGiven) => _$this._xChatLastGiven = xChatLastGiven;
 
-  ChatChatGetObjectsSharedInRoomHeadersBuilder();
+  ChatChatGetObjectsSharedInRoomHeadersBuilder() {
+    ChatChatGetObjectsSharedInRoomHeaders._defaults(this);
+  }
 
   ChatChatGetObjectsSharedInRoomHeadersBuilder get _$this {
     final $v = _$v;
@@ -34514,6 +34800,7 @@ class ChatChatGetObjectsSharedInRoomHeadersBuilder
   ChatChatGetObjectsSharedInRoomHeaders build() => _build();
 
   _$ChatChatGetObjectsSharedInRoomHeaders _build() {
+    ChatChatGetObjectsSharedInRoomHeaders._validate(this);
     final _$result = _$v ?? _$ChatChatGetObjectsSharedInRoomHeaders._(xChatLastGiven: xChatLastGiven);
     replace(_$result);
     return _$result;
@@ -34592,7 +34879,9 @@ class ChatShareObjectToChatResponseApplicationJson_OcsBuilder
   ChatMessageWithParentBuilder get data => _$this._data ??= ChatMessageWithParentBuilder();
   set data(covariant ChatMessageWithParentBuilder? data) => _$this._data = data;
 
-  ChatShareObjectToChatResponseApplicationJson_OcsBuilder();
+  ChatShareObjectToChatResponseApplicationJson_OcsBuilder() {
+    ChatShareObjectToChatResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatShareObjectToChatResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -34619,6 +34908,7 @@ class ChatShareObjectToChatResponseApplicationJson_OcsBuilder
   ChatShareObjectToChatResponseApplicationJson_Ocs build() => _build();
 
   _$ChatShareObjectToChatResponseApplicationJson_Ocs _build() {
+    ChatShareObjectToChatResponseApplicationJson_Ocs._validate(this);
     _$ChatShareObjectToChatResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ChatShareObjectToChatResponseApplicationJson_Ocs._(meta: meta.build(), data: _data?.build());
@@ -34699,7 +34989,9 @@ class ChatShareObjectToChatResponseApplicationJsonBuilder
       _$this._ocs ??= ChatShareObjectToChatResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatShareObjectToChatResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatShareObjectToChatResponseApplicationJsonBuilder();
+  ChatShareObjectToChatResponseApplicationJsonBuilder() {
+    ChatShareObjectToChatResponseApplicationJson._defaults(this);
+  }
 
   ChatShareObjectToChatResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -34725,6 +35017,7 @@ class ChatShareObjectToChatResponseApplicationJsonBuilder
   ChatShareObjectToChatResponseApplicationJson build() => _build();
 
   _$ChatShareObjectToChatResponseApplicationJson _build() {
+    ChatShareObjectToChatResponseApplicationJson._validate(this);
     _$ChatShareObjectToChatResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatShareObjectToChatResponseApplicationJson._(ocs: ocs.build());
@@ -34798,7 +35091,9 @@ class ChatChatShareObjectToChatHeadersBuilder
   String? get xChatLastCommonRead => _$this._xChatLastCommonRead;
   set xChatLastCommonRead(covariant String? xChatLastCommonRead) => _$this._xChatLastCommonRead = xChatLastCommonRead;
 
-  ChatChatShareObjectToChatHeadersBuilder();
+  ChatChatShareObjectToChatHeadersBuilder() {
+    ChatChatShareObjectToChatHeaders._defaults(this);
+  }
 
   ChatChatShareObjectToChatHeadersBuilder get _$this {
     final $v = _$v;
@@ -34824,6 +35119,7 @@ class ChatChatShareObjectToChatHeadersBuilder
   ChatChatShareObjectToChatHeaders build() => _build();
 
   _$ChatChatShareObjectToChatHeaders _build() {
+    ChatChatShareObjectToChatHeaders._validate(this);
     final _$result = _$v ?? _$ChatChatShareObjectToChatHeaders._(xChatLastCommonRead: xChatLastCommonRead);
     replace(_$result);
     return _$result;
@@ -34909,7 +35205,9 @@ class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder
   MapBuilder<String, BuiltList<ChatMessage>> get data => _$this._data ??= MapBuilder<String, BuiltList<ChatMessage>>();
   set data(covariant MapBuilder<String, BuiltList<ChatMessage>>? data) => _$this._data = data;
 
-  ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder();
+  ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder() {
+    ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -34936,6 +35234,7 @@ class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder
   ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs build() => _build();
 
   _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs _build() {
+    ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs._validate(this);
     _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -35020,7 +35319,9 @@ class ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder
       _$this._ocs ??= ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder();
   set ocs(covariant ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder();
+  ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder() {
+    ChatGetObjectsSharedInRoomOverviewResponseApplicationJson._defaults(this);
+  }
 
   ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -35046,6 +35347,7 @@ class ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder
   ChatGetObjectsSharedInRoomOverviewResponseApplicationJson build() => _build();
 
   _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson _build() {
+    ChatGetObjectsSharedInRoomOverviewResponseApplicationJson._validate(this);
     _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson._(ocs: ocs.build());
@@ -35128,7 +35430,9 @@ class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder
   String? get token => _$this._token;
   set token(covariant String? token) => _$this._token = token;
 
-  FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder();
+  FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder() {
+    FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -35154,6 +35458,7 @@ class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder
   FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data build() => _build();
 
   _$FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data _build() {
+    FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data._(
             token: BuiltValueNullFieldError.checkNotNull(
@@ -35241,7 +35546,9 @@ class FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder
   set data(covariant FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
-  FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder();
+  FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder() {
+    FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs._defaults(this);
+  }
 
   FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -35268,6 +35575,7 @@ class FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder
   FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs build() => _build();
 
   _$FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs _build() {
+    FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs._validate(this);
     _$FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -35352,7 +35660,9 @@ class FilesIntegrationGetRoomByFileIdResponseApplicationJsonBuilder
       _$this._ocs ??= FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder();
   set ocs(covariant FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  FilesIntegrationGetRoomByFileIdResponseApplicationJsonBuilder();
+  FilesIntegrationGetRoomByFileIdResponseApplicationJsonBuilder() {
+    FilesIntegrationGetRoomByFileIdResponseApplicationJson._defaults(this);
+  }
 
   FilesIntegrationGetRoomByFileIdResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -35378,6 +35688,7 @@ class FilesIntegrationGetRoomByFileIdResponseApplicationJsonBuilder
   FilesIntegrationGetRoomByFileIdResponseApplicationJson build() => _build();
 
   _$FilesIntegrationGetRoomByFileIdResponseApplicationJson _build() {
+    FilesIntegrationGetRoomByFileIdResponseApplicationJson._validate(this);
     _$FilesIntegrationGetRoomByFileIdResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$FilesIntegrationGetRoomByFileIdResponseApplicationJson._(ocs: ocs.build());
@@ -35492,7 +35803,9 @@ class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder
   String? get userDisplayName => _$this._userDisplayName;
   set userDisplayName(covariant String? userDisplayName) => _$this._userDisplayName = userDisplayName;
 
-  FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder();
+  FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder() {
+    FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -35520,6 +35833,7 @@ class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder
   FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data build() => _build();
 
   _$FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data _build() {
+    FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data._(
             token: BuiltValueNullFieldError.checkNotNull(
@@ -35614,7 +35928,9 @@ class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder
   set data(covariant FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
-  FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder();
+  FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder() {
+    FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs._defaults(this);
+  }
 
   FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -35641,6 +35957,7 @@ class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder
   FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs build() => _build();
 
   _$FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs _build() {
+    FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs._validate(this);
     _$FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -35725,7 +36042,9 @@ class FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder
       _$this._ocs ??= FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder();
   set ocs(covariant FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder();
+  FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder() {
+    FilesIntegrationGetRoomByShareTokenResponseApplicationJson._defaults(this);
+  }
 
   FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -35751,6 +36070,7 @@ class FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder
   FilesIntegrationGetRoomByShareTokenResponseApplicationJson build() => _build();
 
   _$FilesIntegrationGetRoomByShareTokenResponseApplicationJson _build() {
+    FilesIntegrationGetRoomByShareTokenResponseApplicationJson._validate(this);
     _$FilesIntegrationGetRoomByShareTokenResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$FilesIntegrationGetRoomByShareTokenResponseApplicationJson._(ocs: ocs.build());
@@ -35842,7 +36162,9 @@ class GuestSetDisplayNameResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  GuestSetDisplayNameResponseApplicationJson_OcsBuilder();
+  GuestSetDisplayNameResponseApplicationJson_OcsBuilder() {
+    GuestSetDisplayNameResponseApplicationJson_Ocs._defaults(this);
+  }
 
   GuestSetDisplayNameResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -35869,6 +36191,7 @@ class GuestSetDisplayNameResponseApplicationJson_OcsBuilder
   GuestSetDisplayNameResponseApplicationJson_Ocs build() => _build();
 
   _$GuestSetDisplayNameResponseApplicationJson_Ocs _build() {
+    GuestSetDisplayNameResponseApplicationJson_Ocs._validate(this);
     _$GuestSetDisplayNameResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -35951,7 +36274,9 @@ class GuestSetDisplayNameResponseApplicationJsonBuilder
       _$this._ocs ??= GuestSetDisplayNameResponseApplicationJson_OcsBuilder();
   set ocs(covariant GuestSetDisplayNameResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  GuestSetDisplayNameResponseApplicationJsonBuilder();
+  GuestSetDisplayNameResponseApplicationJsonBuilder() {
+    GuestSetDisplayNameResponseApplicationJson._defaults(this);
+  }
 
   GuestSetDisplayNameResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -35977,6 +36302,7 @@ class GuestSetDisplayNameResponseApplicationJsonBuilder
   GuestSetDisplayNameResponseApplicationJson build() => _build();
 
   _$GuestSetDisplayNameResponseApplicationJson _build() {
+    GuestSetDisplayNameResponseApplicationJson._validate(this);
     _$GuestSetDisplayNameResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$GuestSetDisplayNameResponseApplicationJson._(ocs: ocs.build());
@@ -36074,7 +36400,9 @@ class HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder
   MapBuilder<String, JsonObject> get data => _$this._data ??= MapBuilder<String, JsonObject>();
   set data(covariant MapBuilder<String, JsonObject>? data) => _$this._data = data;
 
-  HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder();
+  HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder() {
+    HostedSignalingServerRequestTrialResponseApplicationJson_Ocs._defaults(this);
+  }
 
   HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -36101,6 +36429,7 @@ class HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder
   HostedSignalingServerRequestTrialResponseApplicationJson_Ocs build() => _build();
 
   _$HostedSignalingServerRequestTrialResponseApplicationJson_Ocs _build() {
+    HostedSignalingServerRequestTrialResponseApplicationJson_Ocs._validate(this);
     _$HostedSignalingServerRequestTrialResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -36185,7 +36514,9 @@ class HostedSignalingServerRequestTrialResponseApplicationJsonBuilder
       _$this._ocs ??= HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder();
   set ocs(covariant HostedSignalingServerRequestTrialResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  HostedSignalingServerRequestTrialResponseApplicationJsonBuilder();
+  HostedSignalingServerRequestTrialResponseApplicationJsonBuilder() {
+    HostedSignalingServerRequestTrialResponseApplicationJson._defaults(this);
+  }
 
   HostedSignalingServerRequestTrialResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -36211,6 +36542,7 @@ class HostedSignalingServerRequestTrialResponseApplicationJsonBuilder
   HostedSignalingServerRequestTrialResponseApplicationJson build() => _build();
 
   _$HostedSignalingServerRequestTrialResponseApplicationJson _build() {
+    HostedSignalingServerRequestTrialResponseApplicationJson._validate(this);
     _$HostedSignalingServerRequestTrialResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$HostedSignalingServerRequestTrialResponseApplicationJson._(ocs: ocs.build());
@@ -36309,7 +36641,9 @@ class HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder();
+  HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder() {
+    HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs._defaults(this);
+  }
 
   HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -36336,6 +36670,7 @@ class HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder
   HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs build() => _build();
 
   _$HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs _build() {
+    HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs._validate(this);
     _$HostedSignalingServerDeleteAccountResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -36421,7 +36756,9 @@ class HostedSignalingServerDeleteAccountResponseApplicationJsonBuilder
       _$this._ocs ??= HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder();
   set ocs(covariant HostedSignalingServerDeleteAccountResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  HostedSignalingServerDeleteAccountResponseApplicationJsonBuilder();
+  HostedSignalingServerDeleteAccountResponseApplicationJsonBuilder() {
+    HostedSignalingServerDeleteAccountResponseApplicationJson._defaults(this);
+  }
 
   HostedSignalingServerDeleteAccountResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -36447,6 +36784,7 @@ class HostedSignalingServerDeleteAccountResponseApplicationJsonBuilder
   HostedSignalingServerDeleteAccountResponseApplicationJson build() => _build();
 
   _$HostedSignalingServerDeleteAccountResponseApplicationJson _build() {
+    HostedSignalingServerDeleteAccountResponseApplicationJson._validate(this);
     _$HostedSignalingServerDeleteAccountResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$HostedSignalingServerDeleteAccountResponseApplicationJson._(ocs: ocs.build());
@@ -36543,7 +36881,9 @@ class MatterbridgeBuilder implements Builder<Matterbridge, MatterbridgeBuilder>,
   int? get pid => _$this._pid;
   set pid(covariant int? pid) => _$this._pid = pid;
 
-  MatterbridgeBuilder();
+  MatterbridgeBuilder() {
+    Matterbridge._defaults(this);
+  }
 
   MatterbridgeBuilder get _$this {
     final $v = _$v;
@@ -36571,6 +36911,7 @@ class MatterbridgeBuilder implements Builder<Matterbridge, MatterbridgeBuilder>,
   Matterbridge build() => _build();
 
   _$Matterbridge _build() {
+    Matterbridge._validate(this);
     _$Matterbridge _$result;
     try {
       _$result = _$v ??
@@ -36662,7 +37003,9 @@ class MatterbridgeProcessStateBuilder
   bool? get running => _$this._running;
   set running(covariant bool? running) => _$this._running = running;
 
-  MatterbridgeProcessStateBuilder();
+  MatterbridgeProcessStateBuilder() {
+    MatterbridgeProcessState._defaults(this);
+  }
 
   MatterbridgeProcessStateBuilder get _$this {
     final $v = _$v;
@@ -36689,6 +37032,7 @@ class MatterbridgeProcessStateBuilder
   MatterbridgeProcessState build() => _build();
 
   _$MatterbridgeProcessState _build() {
+    MatterbridgeProcessState._validate(this);
     final _$result = _$v ??
         _$MatterbridgeProcessState._(
             log: BuiltValueNullFieldError.checkNotNull(log, r'MatterbridgeProcessState', 'log'),
@@ -36811,7 +37155,9 @@ class MatterbridgeWithProcessStateBuilder
   bool? get running => _$this._running;
   set running(covariant bool? running) => _$this._running = running;
 
-  MatterbridgeWithProcessStateBuilder();
+  MatterbridgeWithProcessStateBuilder() {
+    MatterbridgeWithProcessState._defaults(this);
+  }
 
   MatterbridgeWithProcessStateBuilder get _$this {
     final $v = _$v;
@@ -36841,6 +37187,7 @@ class MatterbridgeWithProcessStateBuilder
   MatterbridgeWithProcessState build() => _build();
 
   _$MatterbridgeWithProcessState _build() {
+    MatterbridgeWithProcessState._validate(this);
     _$MatterbridgeWithProcessState _$result;
     try {
       _$result = _$v ??
@@ -36939,7 +37286,9 @@ class MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder
   MatterbridgeWithProcessStateBuilder get data => _$this._data ??= MatterbridgeWithProcessStateBuilder();
   set data(covariant MatterbridgeWithProcessStateBuilder? data) => _$this._data = data;
 
-  MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder();
+  MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder() {
+    MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -36966,6 +37315,7 @@ class MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder
   MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs build() => _build();
 
   _$MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs _build() {
+    MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs._validate(this);
     _$MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -37049,7 +37399,9 @@ class MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder
       _$this._ocs ??= MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder();
+  MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder() {
+    MatterbridgeGetBridgeOfRoomResponseApplicationJson._defaults(this);
+  }
 
   MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -37075,6 +37427,7 @@ class MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder
   MatterbridgeGetBridgeOfRoomResponseApplicationJson build() => _build();
 
   _$MatterbridgeGetBridgeOfRoomResponseApplicationJson _build() {
+    MatterbridgeGetBridgeOfRoomResponseApplicationJson._validate(this);
     _$MatterbridgeGetBridgeOfRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$MatterbridgeGetBridgeOfRoomResponseApplicationJson._(ocs: ocs.build());
@@ -37168,7 +37521,9 @@ class MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder
   MatterbridgeProcessStateBuilder get data => _$this._data ??= MatterbridgeProcessStateBuilder();
   set data(covariant MatterbridgeProcessStateBuilder? data) => _$this._data = data;
 
-  MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder();
+  MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder() {
+    MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -37195,6 +37550,7 @@ class MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder
   MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs build() => _build();
 
   _$MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs _build() {
+    MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs._validate(this);
     _$MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -37279,7 +37635,9 @@ class MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder
       _$this._ocs ??= MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder();
+  MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder() {
+    MatterbridgeEditBridgeOfRoomResponseApplicationJson._defaults(this);
+  }
 
   MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -37305,6 +37663,7 @@ class MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder
   MatterbridgeEditBridgeOfRoomResponseApplicationJson build() => _build();
 
   _$MatterbridgeEditBridgeOfRoomResponseApplicationJson _build() {
+    MatterbridgeEditBridgeOfRoomResponseApplicationJson._validate(this);
     _$MatterbridgeEditBridgeOfRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$MatterbridgeEditBridgeOfRoomResponseApplicationJson._(ocs: ocs.build());
@@ -37400,7 +37759,9 @@ class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder
   bool? get data => _$this._data;
   set data(covariant bool? data) => _$this._data = data;
 
-  MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder();
+  MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder() {
+    MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -37427,6 +37788,7 @@ class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder
   MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs build() => _build();
 
   _$MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs _build() {
+    MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs._validate(this);
     _$MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -37512,7 +37874,9 @@ class MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonBuilder
       _$this._ocs ??= MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonBuilder();
+  MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonBuilder() {
+    MatterbridgeDeleteBridgeOfRoomResponseApplicationJson._defaults(this);
+  }
 
   MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -37538,6 +37902,7 @@ class MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonBuilder
   MatterbridgeDeleteBridgeOfRoomResponseApplicationJson build() => _build();
 
   _$MatterbridgeDeleteBridgeOfRoomResponseApplicationJson _build() {
+    MatterbridgeDeleteBridgeOfRoomResponseApplicationJson._validate(this);
     _$MatterbridgeDeleteBridgeOfRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$MatterbridgeDeleteBridgeOfRoomResponseApplicationJson._(ocs: ocs.build());
@@ -37636,7 +38001,9 @@ class MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder
   MatterbridgeProcessStateBuilder get data => _$this._data ??= MatterbridgeProcessStateBuilder();
   set data(covariant MatterbridgeProcessStateBuilder? data) => _$this._data = data;
 
-  MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder();
+  MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder() {
+    MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs._defaults(this);
+  }
 
   MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -37663,6 +38030,7 @@ class MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder
   MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs build() => _build();
 
   _$MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs _build() {
+    MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs._validate(this);
     _$MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -37747,7 +38115,9 @@ class MatterbridgeGetBridgeProcessStateResponseApplicationJsonBuilder
       _$this._ocs ??= MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder();
   set ocs(covariant MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  MatterbridgeGetBridgeProcessStateResponseApplicationJsonBuilder();
+  MatterbridgeGetBridgeProcessStateResponseApplicationJsonBuilder() {
+    MatterbridgeGetBridgeProcessStateResponseApplicationJson._defaults(this);
+  }
 
   MatterbridgeGetBridgeProcessStateResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -37773,6 +38143,7 @@ class MatterbridgeGetBridgeProcessStateResponseApplicationJsonBuilder
   MatterbridgeGetBridgeProcessStateResponseApplicationJson build() => _build();
 
   _$MatterbridgeGetBridgeProcessStateResponseApplicationJson _build() {
+    MatterbridgeGetBridgeProcessStateResponseApplicationJson._validate(this);
     _$MatterbridgeGetBridgeProcessStateResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$MatterbridgeGetBridgeProcessStateResponseApplicationJson._(ocs: ocs.build());
@@ -37871,7 +38242,9 @@ class MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder
   bool? get data => _$this._data;
   set data(covariant bool? data) => _$this._data = data;
 
-  MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder();
+  MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder() {
+    MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -37898,6 +38271,7 @@ class MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder
   MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs build() => _build();
 
   _$MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs _build() {
+    MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs._validate(this);
     _$MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -37983,7 +38357,9 @@ class MatterbridgeSettingsStopAllBridgesResponseApplicationJsonBuilder
       _$this._ocs ??= MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder();
   set ocs(covariant MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  MatterbridgeSettingsStopAllBridgesResponseApplicationJsonBuilder();
+  MatterbridgeSettingsStopAllBridgesResponseApplicationJsonBuilder() {
+    MatterbridgeSettingsStopAllBridgesResponseApplicationJson._defaults(this);
+  }
 
   MatterbridgeSettingsStopAllBridgesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -38009,6 +38385,7 @@ class MatterbridgeSettingsStopAllBridgesResponseApplicationJsonBuilder
   MatterbridgeSettingsStopAllBridgesResponseApplicationJson build() => _build();
 
   _$MatterbridgeSettingsStopAllBridgesResponseApplicationJson _build() {
+    MatterbridgeSettingsStopAllBridgesResponseApplicationJson._validate(this);
     _$MatterbridgeSettingsStopAllBridgesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$MatterbridgeSettingsStopAllBridgesResponseApplicationJson._(ocs: ocs.build());
@@ -38095,7 +38472,9 @@ class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data
   String? get version => _$this._version;
   set version(covariant String? version) => _$this._version = version;
 
-  MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataBuilder();
+  MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataBuilder() {
+    MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -38122,6 +38501,7 @@ class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data
   MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data build() => _build();
 
   _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data _build() {
+    MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data._(
             version: BuiltValueNullFieldError.checkNotNull(
@@ -38213,7 +38593,9 @@ class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuild
   set data(covariant MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataBuilder? data) =>
       _$this._data = data;
 
-  MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuilder();
+  MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuilder() {
+    MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs._defaults(this);
+  }
 
   MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -38240,6 +38622,7 @@ class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuild
   MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs build() => _build();
 
   _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs _build() {
+    MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs._validate(this);
     _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -38329,7 +38712,9 @@ class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder
   set ocs(covariant MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsBuilder? ocs) =>
       _$this._ocs = ocs;
 
-  MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder();
+  MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder() {
+    MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson._defaults(this);
+  }
 
   MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -38355,6 +38740,7 @@ class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder
   MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson build() => _build();
 
   _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson _build() {
+    MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson._validate(this);
     _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson._(ocs: ocs.build());
@@ -38467,7 +38853,9 @@ class PollVoteBuilder implements Builder<PollVote, PollVoteBuilder>, $PollVoteIn
   int? get optionId => _$this._optionId;
   set optionId(covariant int? optionId) => _$this._optionId = optionId;
 
-  PollVoteBuilder();
+  PollVoteBuilder() {
+    PollVote._defaults(this);
+  }
 
   PollVoteBuilder get _$this {
     final $v = _$v;
@@ -38496,6 +38884,7 @@ class PollVoteBuilder implements Builder<PollVote, PollVoteBuilder>, $PollVoteIn
   PollVote build() => _build();
 
   _$PollVote _build() {
+    PollVote._validate(this);
     final _$result = _$v ??
         _$PollVote._(
             actorDisplayName: BuiltValueNullFieldError.checkNotNull(actorDisplayName, r'PollVote', 'actorDisplayName'),
@@ -38726,7 +39115,9 @@ class PollBuilder implements Builder<Poll, PollBuilder>, $PollInterfaceBuilder {
   MapBuilder<String, int> get votes => _$this._votes ??= MapBuilder<String, int>();
   set votes(covariant MapBuilder<String, int>? votes) => _$this._votes = votes;
 
-  PollBuilder();
+  PollBuilder() {
+    Poll._defaults(this);
+  }
 
   PollBuilder get _$this {
     final $v = _$v;
@@ -38764,6 +39155,7 @@ class PollBuilder implements Builder<Poll, PollBuilder>, $PollInterfaceBuilder {
   Poll build() => _build();
 
   _$Poll _build() {
+    Poll._validate(this);
     _$Poll _$result;
     try {
       _$result = _$v ??
@@ -38876,7 +39268,9 @@ class PollCreatePollResponseApplicationJson_OcsBuilder
   PollBuilder get data => _$this._data ??= PollBuilder();
   set data(covariant PollBuilder? data) => _$this._data = data;
 
-  PollCreatePollResponseApplicationJson_OcsBuilder();
+  PollCreatePollResponseApplicationJson_OcsBuilder() {
+    PollCreatePollResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PollCreatePollResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -38903,6 +39297,7 @@ class PollCreatePollResponseApplicationJson_OcsBuilder
   PollCreatePollResponseApplicationJson_Ocs build() => _build();
 
   _$PollCreatePollResponseApplicationJson_Ocs _build() {
+    PollCreatePollResponseApplicationJson_Ocs._validate(this);
     _$PollCreatePollResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$PollCreatePollResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -38981,7 +39376,9 @@ class PollCreatePollResponseApplicationJsonBuilder
       _$this._ocs ??= PollCreatePollResponseApplicationJson_OcsBuilder();
   set ocs(covariant PollCreatePollResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PollCreatePollResponseApplicationJsonBuilder();
+  PollCreatePollResponseApplicationJsonBuilder() {
+    PollCreatePollResponseApplicationJson._defaults(this);
+  }
 
   PollCreatePollResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -39007,6 +39404,7 @@ class PollCreatePollResponseApplicationJsonBuilder
   PollCreatePollResponseApplicationJson build() => _build();
 
   _$PollCreatePollResponseApplicationJson _build() {
+    PollCreatePollResponseApplicationJson._validate(this);
     _$PollCreatePollResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PollCreatePollResponseApplicationJson._(ocs: ocs.build());
@@ -39097,7 +39495,9 @@ class PollShowPollResponseApplicationJson_OcsBuilder
   PollBuilder get data => _$this._data ??= PollBuilder();
   set data(covariant PollBuilder? data) => _$this._data = data;
 
-  PollShowPollResponseApplicationJson_OcsBuilder();
+  PollShowPollResponseApplicationJson_OcsBuilder() {
+    PollShowPollResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PollShowPollResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -39124,6 +39524,7 @@ class PollShowPollResponseApplicationJson_OcsBuilder
   PollShowPollResponseApplicationJson_Ocs build() => _build();
 
   _$PollShowPollResponseApplicationJson_Ocs _build() {
+    PollShowPollResponseApplicationJson_Ocs._validate(this);
     _$PollShowPollResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$PollShowPollResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -39200,7 +39601,9 @@ class PollShowPollResponseApplicationJsonBuilder
       _$this._ocs ??= PollShowPollResponseApplicationJson_OcsBuilder();
   set ocs(covariant PollShowPollResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PollShowPollResponseApplicationJsonBuilder();
+  PollShowPollResponseApplicationJsonBuilder() {
+    PollShowPollResponseApplicationJson._defaults(this);
+  }
 
   PollShowPollResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -39226,6 +39629,7 @@ class PollShowPollResponseApplicationJsonBuilder
   PollShowPollResponseApplicationJson build() => _build();
 
   _$PollShowPollResponseApplicationJson _build() {
+    PollShowPollResponseApplicationJson._validate(this);
     _$PollShowPollResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PollShowPollResponseApplicationJson._(ocs: ocs.build());
@@ -39316,7 +39720,9 @@ class PollVotePollResponseApplicationJson_OcsBuilder
   PollBuilder get data => _$this._data ??= PollBuilder();
   set data(covariant PollBuilder? data) => _$this._data = data;
 
-  PollVotePollResponseApplicationJson_OcsBuilder();
+  PollVotePollResponseApplicationJson_OcsBuilder() {
+    PollVotePollResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PollVotePollResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -39343,6 +39749,7 @@ class PollVotePollResponseApplicationJson_OcsBuilder
   PollVotePollResponseApplicationJson_Ocs build() => _build();
 
   _$PollVotePollResponseApplicationJson_Ocs _build() {
+    PollVotePollResponseApplicationJson_Ocs._validate(this);
     _$PollVotePollResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$PollVotePollResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -39419,7 +39826,9 @@ class PollVotePollResponseApplicationJsonBuilder
       _$this._ocs ??= PollVotePollResponseApplicationJson_OcsBuilder();
   set ocs(covariant PollVotePollResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PollVotePollResponseApplicationJsonBuilder();
+  PollVotePollResponseApplicationJsonBuilder() {
+    PollVotePollResponseApplicationJson._defaults(this);
+  }
 
   PollVotePollResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -39445,6 +39854,7 @@ class PollVotePollResponseApplicationJsonBuilder
   PollVotePollResponseApplicationJson build() => _build();
 
   _$PollVotePollResponseApplicationJson _build() {
+    PollVotePollResponseApplicationJson._validate(this);
     _$PollVotePollResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PollVotePollResponseApplicationJson._(ocs: ocs.build());
@@ -39535,7 +39945,9 @@ class PollClosePollResponseApplicationJson_OcsBuilder
   PollBuilder get data => _$this._data ??= PollBuilder();
   set data(covariant PollBuilder? data) => _$this._data = data;
 
-  PollClosePollResponseApplicationJson_OcsBuilder();
+  PollClosePollResponseApplicationJson_OcsBuilder() {
+    PollClosePollResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PollClosePollResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -39562,6 +39974,7 @@ class PollClosePollResponseApplicationJson_OcsBuilder
   PollClosePollResponseApplicationJson_Ocs build() => _build();
 
   _$PollClosePollResponseApplicationJson_Ocs _build() {
+    PollClosePollResponseApplicationJson_Ocs._validate(this);
     _$PollClosePollResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$PollClosePollResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -39640,7 +40053,9 @@ class PollClosePollResponseApplicationJsonBuilder
       _$this._ocs ??= PollClosePollResponseApplicationJson_OcsBuilder();
   set ocs(covariant PollClosePollResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PollClosePollResponseApplicationJsonBuilder();
+  PollClosePollResponseApplicationJsonBuilder() {
+    PollClosePollResponseApplicationJson._defaults(this);
+  }
 
   PollClosePollResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -39666,6 +40081,7 @@ class PollClosePollResponseApplicationJsonBuilder
   PollClosePollResponseApplicationJson build() => _build();
 
   _$PollClosePollResponseApplicationJson _build() {
+    PollClosePollResponseApplicationJson._validate(this);
     _$PollClosePollResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PollClosePollResponseApplicationJson._(ocs: ocs.build());
@@ -39776,7 +40192,9 @@ class PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder
   String? get displayName => _$this._displayName;
   set displayName(covariant String? displayName) => _$this._displayName = displayName;
 
-  PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder();
+  PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder() {
+    PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -39804,6 +40222,7 @@ class PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder
   PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data build() => _build();
 
   _$PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data _build() {
+    PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data._(
             token: BuiltValueNullFieldError.checkNotNull(
@@ -39892,7 +40311,9 @@ class PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder
       _$this._data ??= PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder();
+  PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder() {
+    PublicShareAuthCreateRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -39919,6 +40340,7 @@ class PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder
   PublicShareAuthCreateRoomResponseApplicationJson_Ocs build() => _build();
 
   _$PublicShareAuthCreateRoomResponseApplicationJson_Ocs _build() {
+    PublicShareAuthCreateRoomResponseApplicationJson_Ocs._validate(this);
     _$PublicShareAuthCreateRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -40002,7 +40424,9 @@ class PublicShareAuthCreateRoomResponseApplicationJsonBuilder
       _$this._ocs ??= PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant PublicShareAuthCreateRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PublicShareAuthCreateRoomResponseApplicationJsonBuilder();
+  PublicShareAuthCreateRoomResponseApplicationJsonBuilder() {
+    PublicShareAuthCreateRoomResponseApplicationJson._defaults(this);
+  }
 
   PublicShareAuthCreateRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -40028,6 +40452,7 @@ class PublicShareAuthCreateRoomResponseApplicationJsonBuilder
   PublicShareAuthCreateRoomResponseApplicationJson build() => _build();
 
   _$PublicShareAuthCreateRoomResponseApplicationJson _build() {
+    PublicShareAuthCreateRoomResponseApplicationJson._validate(this);
     _$PublicShareAuthCreateRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PublicShareAuthCreateRoomResponseApplicationJson._(ocs: ocs.build());
@@ -40141,7 +40566,9 @@ class ReactionBuilder implements Builder<Reaction, ReactionBuilder>, $ReactionIn
   int? get timestamp => _$this._timestamp;
   set timestamp(covariant int? timestamp) => _$this._timestamp = timestamp;
 
-  ReactionBuilder();
+  ReactionBuilder() {
+    Reaction._defaults(this);
+  }
 
   ReactionBuilder get _$this {
     final $v = _$v;
@@ -40170,6 +40597,7 @@ class ReactionBuilder implements Builder<Reaction, ReactionBuilder>, $ReactionIn
   Reaction build() => _build();
 
   _$Reaction _build() {
+    Reaction._validate(this);
     final _$result = _$v ??
         _$Reaction._(
             actorDisplayName: BuiltValueNullFieldError.checkNotNull(actorDisplayName, r'Reaction', 'actorDisplayName'),
@@ -40254,7 +40682,9 @@ class ReactionGetReactionsResponseApplicationJson_OcsBuilder
   MapBuilder<String, BuiltList<Reaction>> get data => _$this._data ??= MapBuilder<String, BuiltList<Reaction>>();
   set data(covariant MapBuilder<String, BuiltList<Reaction>>? data) => _$this._data = data;
 
-  ReactionGetReactionsResponseApplicationJson_OcsBuilder();
+  ReactionGetReactionsResponseApplicationJson_OcsBuilder() {
+    ReactionGetReactionsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ReactionGetReactionsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -40281,6 +40711,7 @@ class ReactionGetReactionsResponseApplicationJson_OcsBuilder
   ReactionGetReactionsResponseApplicationJson_Ocs build() => _build();
 
   _$ReactionGetReactionsResponseApplicationJson_Ocs _build() {
+    ReactionGetReactionsResponseApplicationJson_Ocs._validate(this);
     _$ReactionGetReactionsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ReactionGetReactionsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -40361,7 +40792,9 @@ class ReactionGetReactionsResponseApplicationJsonBuilder
       _$this._ocs ??= ReactionGetReactionsResponseApplicationJson_OcsBuilder();
   set ocs(covariant ReactionGetReactionsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ReactionGetReactionsResponseApplicationJsonBuilder();
+  ReactionGetReactionsResponseApplicationJsonBuilder() {
+    ReactionGetReactionsResponseApplicationJson._defaults(this);
+  }
 
   ReactionGetReactionsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -40387,6 +40820,7 @@ class ReactionGetReactionsResponseApplicationJsonBuilder
   ReactionGetReactionsResponseApplicationJson build() => _build();
 
   _$ReactionGetReactionsResponseApplicationJson _build() {
+    ReactionGetReactionsResponseApplicationJson._validate(this);
     _$ReactionGetReactionsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ReactionGetReactionsResponseApplicationJson._(ocs: ocs.build());
@@ -40477,7 +40911,9 @@ class ReactionReactResponseApplicationJson_OcsBuilder
   MapBuilder<String, BuiltList<Reaction>> get data => _$this._data ??= MapBuilder<String, BuiltList<Reaction>>();
   set data(covariant MapBuilder<String, BuiltList<Reaction>>? data) => _$this._data = data;
 
-  ReactionReactResponseApplicationJson_OcsBuilder();
+  ReactionReactResponseApplicationJson_OcsBuilder() {
+    ReactionReactResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ReactionReactResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -40504,6 +40940,7 @@ class ReactionReactResponseApplicationJson_OcsBuilder
   ReactionReactResponseApplicationJson_Ocs build() => _build();
 
   _$ReactionReactResponseApplicationJson_Ocs _build() {
+    ReactionReactResponseApplicationJson_Ocs._validate(this);
     _$ReactionReactResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ReactionReactResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -40582,7 +41019,9 @@ class ReactionReactResponseApplicationJsonBuilder
       _$this._ocs ??= ReactionReactResponseApplicationJson_OcsBuilder();
   set ocs(covariant ReactionReactResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ReactionReactResponseApplicationJsonBuilder();
+  ReactionReactResponseApplicationJsonBuilder() {
+    ReactionReactResponseApplicationJson._defaults(this);
+  }
 
   ReactionReactResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -40608,6 +41047,7 @@ class ReactionReactResponseApplicationJsonBuilder
   ReactionReactResponseApplicationJson build() => _build();
 
   _$ReactionReactResponseApplicationJson _build() {
+    ReactionReactResponseApplicationJson._validate(this);
     _$ReactionReactResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ReactionReactResponseApplicationJson._(ocs: ocs.build());
@@ -40698,7 +41138,9 @@ class ReactionDeleteResponseApplicationJson_OcsBuilder
   MapBuilder<String, BuiltList<Reaction>> get data => _$this._data ??= MapBuilder<String, BuiltList<Reaction>>();
   set data(covariant MapBuilder<String, BuiltList<Reaction>>? data) => _$this._data = data;
 
-  ReactionDeleteResponseApplicationJson_OcsBuilder();
+  ReactionDeleteResponseApplicationJson_OcsBuilder() {
+    ReactionDeleteResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ReactionDeleteResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -40725,6 +41167,7 @@ class ReactionDeleteResponseApplicationJson_OcsBuilder
   ReactionDeleteResponseApplicationJson_Ocs build() => _build();
 
   _$ReactionDeleteResponseApplicationJson_Ocs _build() {
+    ReactionDeleteResponseApplicationJson_Ocs._validate(this);
     _$ReactionDeleteResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ReactionDeleteResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -40803,7 +41246,9 @@ class ReactionDeleteResponseApplicationJsonBuilder
       _$this._ocs ??= ReactionDeleteResponseApplicationJson_OcsBuilder();
   set ocs(covariant ReactionDeleteResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ReactionDeleteResponseApplicationJsonBuilder();
+  ReactionDeleteResponseApplicationJsonBuilder() {
+    ReactionDeleteResponseApplicationJson._defaults(this);
+  }
 
   ReactionDeleteResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -40829,6 +41274,7 @@ class ReactionDeleteResponseApplicationJsonBuilder
   ReactionDeleteResponseApplicationJson build() => _build();
 
   _$ReactionDeleteResponseApplicationJson _build() {
+    ReactionDeleteResponseApplicationJson._validate(this);
     _$ReactionDeleteResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ReactionDeleteResponseApplicationJson._(ocs: ocs.build());
@@ -40919,7 +41365,9 @@ class RecordingStartResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RecordingStartResponseApplicationJson_OcsBuilder();
+  RecordingStartResponseApplicationJson_OcsBuilder() {
+    RecordingStartResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RecordingStartResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -40946,6 +41394,7 @@ class RecordingStartResponseApplicationJson_OcsBuilder
   RecordingStartResponseApplicationJson_Ocs build() => _build();
 
   _$RecordingStartResponseApplicationJson_Ocs _build() {
+    RecordingStartResponseApplicationJson_Ocs._validate(this);
     _$RecordingStartResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -41025,7 +41474,9 @@ class RecordingStartResponseApplicationJsonBuilder
       _$this._ocs ??= RecordingStartResponseApplicationJson_OcsBuilder();
   set ocs(covariant RecordingStartResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RecordingStartResponseApplicationJsonBuilder();
+  RecordingStartResponseApplicationJsonBuilder() {
+    RecordingStartResponseApplicationJson._defaults(this);
+  }
 
   RecordingStartResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -41051,6 +41502,7 @@ class RecordingStartResponseApplicationJsonBuilder
   RecordingStartResponseApplicationJson build() => _build();
 
   _$RecordingStartResponseApplicationJson _build() {
+    RecordingStartResponseApplicationJson._validate(this);
     _$RecordingStartResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RecordingStartResponseApplicationJson._(ocs: ocs.build());
@@ -41141,7 +41593,9 @@ class RecordingStopResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RecordingStopResponseApplicationJson_OcsBuilder();
+  RecordingStopResponseApplicationJson_OcsBuilder() {
+    RecordingStopResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RecordingStopResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -41168,6 +41622,7 @@ class RecordingStopResponseApplicationJson_OcsBuilder
   RecordingStopResponseApplicationJson_Ocs build() => _build();
 
   _$RecordingStopResponseApplicationJson_Ocs _build() {
+    RecordingStopResponseApplicationJson_Ocs._validate(this);
     _$RecordingStopResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -41247,7 +41702,9 @@ class RecordingStopResponseApplicationJsonBuilder
       _$this._ocs ??= RecordingStopResponseApplicationJson_OcsBuilder();
   set ocs(covariant RecordingStopResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RecordingStopResponseApplicationJsonBuilder();
+  RecordingStopResponseApplicationJsonBuilder() {
+    RecordingStopResponseApplicationJson._defaults(this);
+  }
 
   RecordingStopResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -41273,6 +41730,7 @@ class RecordingStopResponseApplicationJsonBuilder
   RecordingStopResponseApplicationJson build() => _build();
 
   _$RecordingStopResponseApplicationJson _build() {
+    RecordingStopResponseApplicationJson._validate(this);
     _$RecordingStopResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RecordingStopResponseApplicationJson._(ocs: ocs.build());
@@ -41363,7 +41821,9 @@ class RecordingStoreResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RecordingStoreResponseApplicationJson_OcsBuilder();
+  RecordingStoreResponseApplicationJson_OcsBuilder() {
+    RecordingStoreResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RecordingStoreResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -41390,6 +41850,7 @@ class RecordingStoreResponseApplicationJson_OcsBuilder
   RecordingStoreResponseApplicationJson_Ocs build() => _build();
 
   _$RecordingStoreResponseApplicationJson_Ocs _build() {
+    RecordingStoreResponseApplicationJson_Ocs._validate(this);
     _$RecordingStoreResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -41469,7 +41930,9 @@ class RecordingStoreResponseApplicationJsonBuilder
       _$this._ocs ??= RecordingStoreResponseApplicationJson_OcsBuilder();
   set ocs(covariant RecordingStoreResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RecordingStoreResponseApplicationJsonBuilder();
+  RecordingStoreResponseApplicationJsonBuilder() {
+    RecordingStoreResponseApplicationJson._defaults(this);
+  }
 
   RecordingStoreResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -41495,6 +41958,7 @@ class RecordingStoreResponseApplicationJsonBuilder
   RecordingStoreResponseApplicationJson build() => _build();
 
   _$RecordingStoreResponseApplicationJson _build() {
+    RecordingStoreResponseApplicationJson._validate(this);
     _$RecordingStoreResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RecordingStoreResponseApplicationJson._(ocs: ocs.build());
@@ -41587,7 +42051,9 @@ class RecordingNotificationDismissResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RecordingNotificationDismissResponseApplicationJson_OcsBuilder();
+  RecordingNotificationDismissResponseApplicationJson_OcsBuilder() {
+    RecordingNotificationDismissResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RecordingNotificationDismissResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -41614,6 +42080,7 @@ class RecordingNotificationDismissResponseApplicationJson_OcsBuilder
   RecordingNotificationDismissResponseApplicationJson_Ocs build() => _build();
 
   _$RecordingNotificationDismissResponseApplicationJson_Ocs _build() {
+    RecordingNotificationDismissResponseApplicationJson_Ocs._validate(this);
     _$RecordingNotificationDismissResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -41699,7 +42166,9 @@ class RecordingNotificationDismissResponseApplicationJsonBuilder
       _$this._ocs ??= RecordingNotificationDismissResponseApplicationJson_OcsBuilder();
   set ocs(covariant RecordingNotificationDismissResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RecordingNotificationDismissResponseApplicationJsonBuilder();
+  RecordingNotificationDismissResponseApplicationJsonBuilder() {
+    RecordingNotificationDismissResponseApplicationJson._defaults(this);
+  }
 
   RecordingNotificationDismissResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -41725,6 +42194,7 @@ class RecordingNotificationDismissResponseApplicationJsonBuilder
   RecordingNotificationDismissResponseApplicationJson build() => _build();
 
   _$RecordingNotificationDismissResponseApplicationJson _build() {
+    RecordingNotificationDismissResponseApplicationJson._validate(this);
     _$RecordingNotificationDismissResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RecordingNotificationDismissResponseApplicationJson._(ocs: ocs.build());
@@ -41817,7 +42287,9 @@ class RecordingShareToChatResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RecordingShareToChatResponseApplicationJson_OcsBuilder();
+  RecordingShareToChatResponseApplicationJson_OcsBuilder() {
+    RecordingShareToChatResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RecordingShareToChatResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -41844,6 +42316,7 @@ class RecordingShareToChatResponseApplicationJson_OcsBuilder
   RecordingShareToChatResponseApplicationJson_Ocs build() => _build();
 
   _$RecordingShareToChatResponseApplicationJson_Ocs _build() {
+    RecordingShareToChatResponseApplicationJson_Ocs._validate(this);
     _$RecordingShareToChatResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -41926,7 +42399,9 @@ class RecordingShareToChatResponseApplicationJsonBuilder
       _$this._ocs ??= RecordingShareToChatResponseApplicationJson_OcsBuilder();
   set ocs(covariant RecordingShareToChatResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RecordingShareToChatResponseApplicationJsonBuilder();
+  RecordingShareToChatResponseApplicationJsonBuilder() {
+    RecordingShareToChatResponseApplicationJson._defaults(this);
+  }
 
   RecordingShareToChatResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -41952,6 +42427,7 @@ class RecordingShareToChatResponseApplicationJsonBuilder
   RecordingShareToChatResponseApplicationJson build() => _build();
 
   _$RecordingShareToChatResponseApplicationJson _build() {
+    RecordingShareToChatResponseApplicationJson._validate(this);
     _$RecordingShareToChatResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RecordingShareToChatResponseApplicationJson._(ocs: ocs.build());
@@ -42033,7 +42509,9 @@ class RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder
   double? get version => _$this._version;
   set version(covariant double? version) => _$this._version = version;
 
-  RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder();
+  RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder() {
+    RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -42059,6 +42537,7 @@ class RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder
   RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data build() => _build();
 
   _$RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data _build() {
+    RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data._(
             version: BuiltValueNullFieldError.checkNotNull(
@@ -42143,7 +42622,9 @@ class RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder
       _$this._data ??= RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder();
+  RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder() {
+    RecordingGetWelcomeMessageResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -42170,6 +42651,7 @@ class RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder
   RecordingGetWelcomeMessageResponseApplicationJson_Ocs build() => _build();
 
   _$RecordingGetWelcomeMessageResponseApplicationJson_Ocs _build() {
+    RecordingGetWelcomeMessageResponseApplicationJson_Ocs._validate(this);
     _$RecordingGetWelcomeMessageResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -42253,7 +42735,9 @@ class RecordingGetWelcomeMessageResponseApplicationJsonBuilder
       _$this._ocs ??= RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder();
   set ocs(covariant RecordingGetWelcomeMessageResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RecordingGetWelcomeMessageResponseApplicationJsonBuilder();
+  RecordingGetWelcomeMessageResponseApplicationJsonBuilder() {
+    RecordingGetWelcomeMessageResponseApplicationJson._defaults(this);
+  }
 
   RecordingGetWelcomeMessageResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -42279,6 +42763,7 @@ class RecordingGetWelcomeMessageResponseApplicationJsonBuilder
   RecordingGetWelcomeMessageResponseApplicationJson build() => _build();
 
   _$RecordingGetWelcomeMessageResponseApplicationJson _build() {
+    RecordingGetWelcomeMessageResponseApplicationJson._validate(this);
     _$RecordingGetWelcomeMessageResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RecordingGetWelcomeMessageResponseApplicationJson._(ocs: ocs.build());
@@ -42370,7 +42855,9 @@ class RoomGetRoomsResponseApplicationJson_OcsBuilder
   ListBuilder<Room> get data => _$this._data ??= ListBuilder<Room>();
   set data(covariant ListBuilder<Room>? data) => _$this._data = data;
 
-  RoomGetRoomsResponseApplicationJson_OcsBuilder();
+  RoomGetRoomsResponseApplicationJson_OcsBuilder() {
+    RoomGetRoomsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomGetRoomsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -42397,6 +42884,7 @@ class RoomGetRoomsResponseApplicationJson_OcsBuilder
   RoomGetRoomsResponseApplicationJson_Ocs build() => _build();
 
   _$RoomGetRoomsResponseApplicationJson_Ocs _build() {
+    RoomGetRoomsResponseApplicationJson_Ocs._validate(this);
     _$RoomGetRoomsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomGetRoomsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -42473,7 +42961,9 @@ class RoomGetRoomsResponseApplicationJsonBuilder
       _$this._ocs ??= RoomGetRoomsResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomGetRoomsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomGetRoomsResponseApplicationJsonBuilder();
+  RoomGetRoomsResponseApplicationJsonBuilder() {
+    RoomGetRoomsResponseApplicationJson._defaults(this);
+  }
 
   RoomGetRoomsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -42499,6 +42989,7 @@ class RoomGetRoomsResponseApplicationJsonBuilder
   RoomGetRoomsResponseApplicationJson build() => _build();
 
   _$RoomGetRoomsResponseApplicationJson _build() {
+    RoomGetRoomsResponseApplicationJson._validate(this);
     _$RoomGetRoomsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomGetRoomsResponseApplicationJson._(ocs: ocs.build());
@@ -42586,7 +43077,9 @@ class RoomRoomGetRoomsHeadersBuilder
   set xNextcloudTalkModifiedBefore(covariant String? xNextcloudTalkModifiedBefore) =>
       _$this._xNextcloudTalkModifiedBefore = xNextcloudTalkModifiedBefore;
 
-  RoomRoomGetRoomsHeadersBuilder();
+  RoomRoomGetRoomsHeadersBuilder() {
+    RoomRoomGetRoomsHeaders._defaults(this);
+  }
 
   RoomRoomGetRoomsHeadersBuilder get _$this {
     final $v = _$v;
@@ -42613,6 +43106,7 @@ class RoomRoomGetRoomsHeadersBuilder
   RoomRoomGetRoomsHeaders build() => _build();
 
   _$RoomRoomGetRoomsHeaders _build() {
+    RoomRoomGetRoomsHeaders._validate(this);
     final _$result = _$v ??
         _$RoomRoomGetRoomsHeaders._(
             xNextcloudTalkHash: xNextcloudTalkHash, xNextcloudTalkModifiedBefore: xNextcloudTalkModifiedBefore);
@@ -42693,7 +43187,9 @@ class RoomCreateRoomResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  RoomCreateRoomResponseApplicationJson_OcsBuilder();
+  RoomCreateRoomResponseApplicationJson_OcsBuilder() {
+    RoomCreateRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomCreateRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -42720,6 +43216,7 @@ class RoomCreateRoomResponseApplicationJson_OcsBuilder
   RoomCreateRoomResponseApplicationJson_Ocs build() => _build();
 
   _$RoomCreateRoomResponseApplicationJson_Ocs _build() {
+    RoomCreateRoomResponseApplicationJson_Ocs._validate(this);
     _$RoomCreateRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomCreateRoomResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -42798,7 +43295,9 @@ class RoomCreateRoomResponseApplicationJsonBuilder
       _$this._ocs ??= RoomCreateRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomCreateRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomCreateRoomResponseApplicationJsonBuilder();
+  RoomCreateRoomResponseApplicationJsonBuilder() {
+    RoomCreateRoomResponseApplicationJson._defaults(this);
+  }
 
   RoomCreateRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -42824,6 +43323,7 @@ class RoomCreateRoomResponseApplicationJsonBuilder
   RoomCreateRoomResponseApplicationJson build() => _build();
 
   _$RoomCreateRoomResponseApplicationJson _build() {
+    RoomCreateRoomResponseApplicationJson._validate(this);
     _$RoomCreateRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomCreateRoomResponseApplicationJson._(ocs: ocs.build());
@@ -42914,7 +43414,9 @@ class RoomGetListedRoomsResponseApplicationJson_OcsBuilder
   ListBuilder<Room> get data => _$this._data ??= ListBuilder<Room>();
   set data(covariant ListBuilder<Room>? data) => _$this._data = data;
 
-  RoomGetListedRoomsResponseApplicationJson_OcsBuilder();
+  RoomGetListedRoomsResponseApplicationJson_OcsBuilder() {
+    RoomGetListedRoomsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomGetListedRoomsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -42941,6 +43443,7 @@ class RoomGetListedRoomsResponseApplicationJson_OcsBuilder
   RoomGetListedRoomsResponseApplicationJson_Ocs build() => _build();
 
   _$RoomGetListedRoomsResponseApplicationJson_Ocs _build() {
+    RoomGetListedRoomsResponseApplicationJson_Ocs._validate(this);
     _$RoomGetListedRoomsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomGetListedRoomsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -43020,7 +43523,9 @@ class RoomGetListedRoomsResponseApplicationJsonBuilder
       _$this._ocs ??= RoomGetListedRoomsResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomGetListedRoomsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomGetListedRoomsResponseApplicationJsonBuilder();
+  RoomGetListedRoomsResponseApplicationJsonBuilder() {
+    RoomGetListedRoomsResponseApplicationJson._defaults(this);
+  }
 
   RoomGetListedRoomsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -43046,6 +43551,7 @@ class RoomGetListedRoomsResponseApplicationJsonBuilder
   RoomGetListedRoomsResponseApplicationJson build() => _build();
 
   _$RoomGetListedRoomsResponseApplicationJson _build() {
+    RoomGetListedRoomsResponseApplicationJson._validate(this);
     _$RoomGetListedRoomsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomGetListedRoomsResponseApplicationJson._(ocs: ocs.build());
@@ -43140,7 +43646,9 @@ class RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder();
+  RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder() {
+    RoomGetNoteToSelfConversationResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -43167,6 +43675,7 @@ class RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder
   RoomGetNoteToSelfConversationResponseApplicationJson_Ocs build() => _build();
 
   _$RoomGetNoteToSelfConversationResponseApplicationJson_Ocs _build() {
+    RoomGetNoteToSelfConversationResponseApplicationJson_Ocs._validate(this);
     _$RoomGetNoteToSelfConversationResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -43251,7 +43760,9 @@ class RoomGetNoteToSelfConversationResponseApplicationJsonBuilder
       _$this._ocs ??= RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomGetNoteToSelfConversationResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomGetNoteToSelfConversationResponseApplicationJsonBuilder();
+  RoomGetNoteToSelfConversationResponseApplicationJsonBuilder() {
+    RoomGetNoteToSelfConversationResponseApplicationJson._defaults(this);
+  }
 
   RoomGetNoteToSelfConversationResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -43277,6 +43788,7 @@ class RoomGetNoteToSelfConversationResponseApplicationJsonBuilder
   RoomGetNoteToSelfConversationResponseApplicationJson build() => _build();
 
   _$RoomGetNoteToSelfConversationResponseApplicationJson _build() {
+    RoomGetNoteToSelfConversationResponseApplicationJson._validate(this);
     _$RoomGetNoteToSelfConversationResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomGetNoteToSelfConversationResponseApplicationJson._(ocs: ocs.build());
@@ -43354,7 +43866,9 @@ class RoomRoomGetNoteToSelfConversationHeadersBuilder
   String? get xNextcloudTalkHash => _$this._xNextcloudTalkHash;
   set xNextcloudTalkHash(covariant String? xNextcloudTalkHash) => _$this._xNextcloudTalkHash = xNextcloudTalkHash;
 
-  RoomRoomGetNoteToSelfConversationHeadersBuilder();
+  RoomRoomGetNoteToSelfConversationHeadersBuilder() {
+    RoomRoomGetNoteToSelfConversationHeaders._defaults(this);
+  }
 
   RoomRoomGetNoteToSelfConversationHeadersBuilder get _$this {
     final $v = _$v;
@@ -43380,6 +43894,7 @@ class RoomRoomGetNoteToSelfConversationHeadersBuilder
   RoomRoomGetNoteToSelfConversationHeaders build() => _build();
 
   _$RoomRoomGetNoteToSelfConversationHeaders _build() {
+    RoomRoomGetNoteToSelfConversationHeaders._validate(this);
     final _$result = _$v ?? _$RoomRoomGetNoteToSelfConversationHeaders._(xNextcloudTalkHash: xNextcloudTalkHash);
     replace(_$result);
     return _$result;
@@ -43458,7 +43973,9 @@ class RoomGetSingleRoomResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  RoomGetSingleRoomResponseApplicationJson_OcsBuilder();
+  RoomGetSingleRoomResponseApplicationJson_OcsBuilder() {
+    RoomGetSingleRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomGetSingleRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -43485,6 +44002,7 @@ class RoomGetSingleRoomResponseApplicationJson_OcsBuilder
   RoomGetSingleRoomResponseApplicationJson_Ocs build() => _build();
 
   _$RoomGetSingleRoomResponseApplicationJson_Ocs _build() {
+    RoomGetSingleRoomResponseApplicationJson_Ocs._validate(this);
     _$RoomGetSingleRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomGetSingleRoomResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -43564,7 +44082,9 @@ class RoomGetSingleRoomResponseApplicationJsonBuilder
       _$this._ocs ??= RoomGetSingleRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomGetSingleRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomGetSingleRoomResponseApplicationJsonBuilder();
+  RoomGetSingleRoomResponseApplicationJsonBuilder() {
+    RoomGetSingleRoomResponseApplicationJson._defaults(this);
+  }
 
   RoomGetSingleRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -43590,6 +44110,7 @@ class RoomGetSingleRoomResponseApplicationJsonBuilder
   RoomGetSingleRoomResponseApplicationJson build() => _build();
 
   _$RoomGetSingleRoomResponseApplicationJson _build() {
+    RoomGetSingleRoomResponseApplicationJson._validate(this);
     _$RoomGetSingleRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomGetSingleRoomResponseApplicationJson._(ocs: ocs.build());
@@ -43662,7 +44183,9 @@ class RoomRoomGetSingleRoomHeadersBuilder
   String? get xNextcloudTalkHash => _$this._xNextcloudTalkHash;
   set xNextcloudTalkHash(covariant String? xNextcloudTalkHash) => _$this._xNextcloudTalkHash = xNextcloudTalkHash;
 
-  RoomRoomGetSingleRoomHeadersBuilder();
+  RoomRoomGetSingleRoomHeadersBuilder() {
+    RoomRoomGetSingleRoomHeaders._defaults(this);
+  }
 
   RoomRoomGetSingleRoomHeadersBuilder get _$this {
     final $v = _$v;
@@ -43688,6 +44211,7 @@ class RoomRoomGetSingleRoomHeadersBuilder
   RoomRoomGetSingleRoomHeaders build() => _build();
 
   _$RoomRoomGetSingleRoomHeaders _build() {
+    RoomRoomGetSingleRoomHeaders._validate(this);
     final _$result = _$v ?? _$RoomRoomGetSingleRoomHeaders._(xNextcloudTalkHash: xNextcloudTalkHash);
     replace(_$result);
     return _$result;
@@ -43766,7 +44290,9 @@ class RoomRenameRoomResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomRenameRoomResponseApplicationJson_OcsBuilder();
+  RoomRenameRoomResponseApplicationJson_OcsBuilder() {
+    RoomRenameRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomRenameRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -43793,6 +44319,7 @@ class RoomRenameRoomResponseApplicationJson_OcsBuilder
   RoomRenameRoomResponseApplicationJson_Ocs build() => _build();
 
   _$RoomRenameRoomResponseApplicationJson_Ocs _build() {
+    RoomRenameRoomResponseApplicationJson_Ocs._validate(this);
     _$RoomRenameRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -43872,7 +44399,9 @@ class RoomRenameRoomResponseApplicationJsonBuilder
       _$this._ocs ??= RoomRenameRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomRenameRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomRenameRoomResponseApplicationJsonBuilder();
+  RoomRenameRoomResponseApplicationJsonBuilder() {
+    RoomRenameRoomResponseApplicationJson._defaults(this);
+  }
 
   RoomRenameRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -43898,6 +44427,7 @@ class RoomRenameRoomResponseApplicationJsonBuilder
   RoomRenameRoomResponseApplicationJson build() => _build();
 
   _$RoomRenameRoomResponseApplicationJson _build() {
+    RoomRenameRoomResponseApplicationJson._validate(this);
     _$RoomRenameRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomRenameRoomResponseApplicationJson._(ocs: ocs.build());
@@ -43988,7 +44518,9 @@ class RoomDeleteRoomResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomDeleteRoomResponseApplicationJson_OcsBuilder();
+  RoomDeleteRoomResponseApplicationJson_OcsBuilder() {
+    RoomDeleteRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomDeleteRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -44015,6 +44547,7 @@ class RoomDeleteRoomResponseApplicationJson_OcsBuilder
   RoomDeleteRoomResponseApplicationJson_Ocs build() => _build();
 
   _$RoomDeleteRoomResponseApplicationJson_Ocs _build() {
+    RoomDeleteRoomResponseApplicationJson_Ocs._validate(this);
     _$RoomDeleteRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -44094,7 +44627,9 @@ class RoomDeleteRoomResponseApplicationJsonBuilder
       _$this._ocs ??= RoomDeleteRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomDeleteRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomDeleteRoomResponseApplicationJsonBuilder();
+  RoomDeleteRoomResponseApplicationJsonBuilder() {
+    RoomDeleteRoomResponseApplicationJson._defaults(this);
+  }
 
   RoomDeleteRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -44120,6 +44655,7 @@ class RoomDeleteRoomResponseApplicationJsonBuilder
   RoomDeleteRoomResponseApplicationJson build() => _build();
 
   _$RoomDeleteRoomResponseApplicationJson _build() {
+    RoomDeleteRoomResponseApplicationJson._validate(this);
     _$RoomDeleteRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomDeleteRoomResponseApplicationJson._(ocs: ocs.build());
@@ -44211,7 +44747,9 @@ class RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder
   ListBuilder<Room> get data => _$this._data ??= ListBuilder<Room>();
   set data(covariant ListBuilder<Room>? data) => _$this._data = data;
 
-  RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder();
+  RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder() {
+    RoomGetBreakoutRoomsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -44238,6 +44776,7 @@ class RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder
   RoomGetBreakoutRoomsResponseApplicationJson_Ocs build() => _build();
 
   _$RoomGetBreakoutRoomsResponseApplicationJson_Ocs _build() {
+    RoomGetBreakoutRoomsResponseApplicationJson_Ocs._validate(this);
     _$RoomGetBreakoutRoomsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomGetBreakoutRoomsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -44318,7 +44857,9 @@ class RoomGetBreakoutRoomsResponseApplicationJsonBuilder
       _$this._ocs ??= RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomGetBreakoutRoomsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomGetBreakoutRoomsResponseApplicationJsonBuilder();
+  RoomGetBreakoutRoomsResponseApplicationJsonBuilder() {
+    RoomGetBreakoutRoomsResponseApplicationJson._defaults(this);
+  }
 
   RoomGetBreakoutRoomsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -44344,6 +44885,7 @@ class RoomGetBreakoutRoomsResponseApplicationJsonBuilder
   RoomGetBreakoutRoomsResponseApplicationJson build() => _build();
 
   _$RoomGetBreakoutRoomsResponseApplicationJson _build() {
+    RoomGetBreakoutRoomsResponseApplicationJson._validate(this);
     _$RoomGetBreakoutRoomsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomGetBreakoutRoomsResponseApplicationJson._(ocs: ocs.build());
@@ -44434,7 +44976,9 @@ class RoomMakePublicResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomMakePublicResponseApplicationJson_OcsBuilder();
+  RoomMakePublicResponseApplicationJson_OcsBuilder() {
+    RoomMakePublicResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomMakePublicResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -44461,6 +45005,7 @@ class RoomMakePublicResponseApplicationJson_OcsBuilder
   RoomMakePublicResponseApplicationJson_Ocs build() => _build();
 
   _$RoomMakePublicResponseApplicationJson_Ocs _build() {
+    RoomMakePublicResponseApplicationJson_Ocs._validate(this);
     _$RoomMakePublicResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -44540,7 +45085,9 @@ class RoomMakePublicResponseApplicationJsonBuilder
       _$this._ocs ??= RoomMakePublicResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomMakePublicResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomMakePublicResponseApplicationJsonBuilder();
+  RoomMakePublicResponseApplicationJsonBuilder() {
+    RoomMakePublicResponseApplicationJson._defaults(this);
+  }
 
   RoomMakePublicResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -44566,6 +45113,7 @@ class RoomMakePublicResponseApplicationJsonBuilder
   RoomMakePublicResponseApplicationJson build() => _build();
 
   _$RoomMakePublicResponseApplicationJson _build() {
+    RoomMakePublicResponseApplicationJson._validate(this);
     _$RoomMakePublicResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomMakePublicResponseApplicationJson._(ocs: ocs.build());
@@ -44656,7 +45204,9 @@ class RoomMakePrivateResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomMakePrivateResponseApplicationJson_OcsBuilder();
+  RoomMakePrivateResponseApplicationJson_OcsBuilder() {
+    RoomMakePrivateResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomMakePrivateResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -44683,6 +45233,7 @@ class RoomMakePrivateResponseApplicationJson_OcsBuilder
   RoomMakePrivateResponseApplicationJson_Ocs build() => _build();
 
   _$RoomMakePrivateResponseApplicationJson_Ocs _build() {
+    RoomMakePrivateResponseApplicationJson_Ocs._validate(this);
     _$RoomMakePrivateResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -44763,7 +45314,9 @@ class RoomMakePrivateResponseApplicationJsonBuilder
       _$this._ocs ??= RoomMakePrivateResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomMakePrivateResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomMakePrivateResponseApplicationJsonBuilder();
+  RoomMakePrivateResponseApplicationJsonBuilder() {
+    RoomMakePrivateResponseApplicationJson._defaults(this);
+  }
 
   RoomMakePrivateResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -44789,6 +45342,7 @@ class RoomMakePrivateResponseApplicationJsonBuilder
   RoomMakePrivateResponseApplicationJson build() => _build();
 
   _$RoomMakePrivateResponseApplicationJson _build() {
+    RoomMakePrivateResponseApplicationJson._validate(this);
     _$RoomMakePrivateResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomMakePrivateResponseApplicationJson._(ocs: ocs.build());
@@ -44879,7 +45433,9 @@ class RoomSetDescriptionResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomSetDescriptionResponseApplicationJson_OcsBuilder();
+  RoomSetDescriptionResponseApplicationJson_OcsBuilder() {
+    RoomSetDescriptionResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetDescriptionResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -44906,6 +45462,7 @@ class RoomSetDescriptionResponseApplicationJson_OcsBuilder
   RoomSetDescriptionResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetDescriptionResponseApplicationJson_Ocs _build() {
+    RoomSetDescriptionResponseApplicationJson_Ocs._validate(this);
     _$RoomSetDescriptionResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -44987,7 +45544,9 @@ class RoomSetDescriptionResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetDescriptionResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetDescriptionResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetDescriptionResponseApplicationJsonBuilder();
+  RoomSetDescriptionResponseApplicationJsonBuilder() {
+    RoomSetDescriptionResponseApplicationJson._defaults(this);
+  }
 
   RoomSetDescriptionResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -45013,6 +45572,7 @@ class RoomSetDescriptionResponseApplicationJsonBuilder
   RoomSetDescriptionResponseApplicationJson build() => _build();
 
   _$RoomSetDescriptionResponseApplicationJson _build() {
+    RoomSetDescriptionResponseApplicationJson._validate(this);
     _$RoomSetDescriptionResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetDescriptionResponseApplicationJson._(ocs: ocs.build());
@@ -45103,7 +45663,9 @@ class RoomSetReadOnlyResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomSetReadOnlyResponseApplicationJson_OcsBuilder();
+  RoomSetReadOnlyResponseApplicationJson_OcsBuilder() {
+    RoomSetReadOnlyResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetReadOnlyResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -45130,6 +45692,7 @@ class RoomSetReadOnlyResponseApplicationJson_OcsBuilder
   RoomSetReadOnlyResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetReadOnlyResponseApplicationJson_Ocs _build() {
+    RoomSetReadOnlyResponseApplicationJson_Ocs._validate(this);
     _$RoomSetReadOnlyResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -45210,7 +45773,9 @@ class RoomSetReadOnlyResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetReadOnlyResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetReadOnlyResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetReadOnlyResponseApplicationJsonBuilder();
+  RoomSetReadOnlyResponseApplicationJsonBuilder() {
+    RoomSetReadOnlyResponseApplicationJson._defaults(this);
+  }
 
   RoomSetReadOnlyResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -45236,6 +45801,7 @@ class RoomSetReadOnlyResponseApplicationJsonBuilder
   RoomSetReadOnlyResponseApplicationJson build() => _build();
 
   _$RoomSetReadOnlyResponseApplicationJson _build() {
+    RoomSetReadOnlyResponseApplicationJson._validate(this);
     _$RoomSetReadOnlyResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetReadOnlyResponseApplicationJson._(ocs: ocs.build());
@@ -45326,7 +45892,9 @@ class RoomSetListableResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomSetListableResponseApplicationJson_OcsBuilder();
+  RoomSetListableResponseApplicationJson_OcsBuilder() {
+    RoomSetListableResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetListableResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -45353,6 +45921,7 @@ class RoomSetListableResponseApplicationJson_OcsBuilder
   RoomSetListableResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetListableResponseApplicationJson_Ocs _build() {
+    RoomSetListableResponseApplicationJson_Ocs._validate(this);
     _$RoomSetListableResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -45433,7 +46002,9 @@ class RoomSetListableResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetListableResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetListableResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetListableResponseApplicationJsonBuilder();
+  RoomSetListableResponseApplicationJsonBuilder() {
+    RoomSetListableResponseApplicationJson._defaults(this);
+  }
 
   RoomSetListableResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -45459,6 +46030,7 @@ class RoomSetListableResponseApplicationJsonBuilder
   RoomSetListableResponseApplicationJson build() => _build();
 
   _$RoomSetListableResponseApplicationJson _build() {
+    RoomSetListableResponseApplicationJson._validate(this);
     _$RoomSetListableResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetListableResponseApplicationJson._(ocs: ocs.build());
@@ -45549,7 +46121,9 @@ class RoomSetPasswordResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomSetPasswordResponseApplicationJson_OcsBuilder();
+  RoomSetPasswordResponseApplicationJson_OcsBuilder() {
+    RoomSetPasswordResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetPasswordResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -45576,6 +46150,7 @@ class RoomSetPasswordResponseApplicationJson_OcsBuilder
   RoomSetPasswordResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetPasswordResponseApplicationJson_Ocs _build() {
+    RoomSetPasswordResponseApplicationJson_Ocs._validate(this);
     _$RoomSetPasswordResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -45656,7 +46231,9 @@ class RoomSetPasswordResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetPasswordResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetPasswordResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetPasswordResponseApplicationJsonBuilder();
+  RoomSetPasswordResponseApplicationJsonBuilder() {
+    RoomSetPasswordResponseApplicationJson._defaults(this);
+  }
 
   RoomSetPasswordResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -45682,6 +46259,7 @@ class RoomSetPasswordResponseApplicationJsonBuilder
   RoomSetPasswordResponseApplicationJson build() => _build();
 
   _$RoomSetPasswordResponseApplicationJson _build() {
+    RoomSetPasswordResponseApplicationJson._validate(this);
     _$RoomSetPasswordResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetPasswordResponseApplicationJson._(ocs: ocs.build());
@@ -45772,7 +46350,9 @@ class RoomSetPermissionsResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  RoomSetPermissionsResponseApplicationJson_OcsBuilder();
+  RoomSetPermissionsResponseApplicationJson_OcsBuilder() {
+    RoomSetPermissionsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetPermissionsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -45799,6 +46379,7 @@ class RoomSetPermissionsResponseApplicationJson_OcsBuilder
   RoomSetPermissionsResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetPermissionsResponseApplicationJson_Ocs _build() {
+    RoomSetPermissionsResponseApplicationJson_Ocs._validate(this);
     _$RoomSetPermissionsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomSetPermissionsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -45878,7 +46459,9 @@ class RoomSetPermissionsResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetPermissionsResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetPermissionsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetPermissionsResponseApplicationJsonBuilder();
+  RoomSetPermissionsResponseApplicationJsonBuilder() {
+    RoomSetPermissionsResponseApplicationJson._defaults(this);
+  }
 
   RoomSetPermissionsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -45904,6 +46487,7 @@ class RoomSetPermissionsResponseApplicationJsonBuilder
   RoomSetPermissionsResponseApplicationJson build() => _build();
 
   _$RoomSetPermissionsResponseApplicationJson _build() {
+    RoomSetPermissionsResponseApplicationJson._validate(this);
     _$RoomSetPermissionsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetPermissionsResponseApplicationJson._(ocs: ocs.build());
@@ -46210,7 +46794,9 @@ class ParticipantBuilder implements Builder<Participant, ParticipantBuilder>, $P
   String? get callId => _$this._callId;
   set callId(covariant String? callId) => _$this._callId = callId;
 
-  ParticipantBuilder();
+  ParticipantBuilder() {
+    Participant._defaults(this);
+  }
 
   ParticipantBuilder get _$this {
     final $v = _$v;
@@ -46253,6 +46839,7 @@ class ParticipantBuilder implements Builder<Participant, ParticipantBuilder>, $P
   Participant build() => _build();
 
   _$Participant _build() {
+    Participant._validate(this);
     _$Participant _$result;
     try {
       _$result = _$v ??
@@ -46364,7 +46951,9 @@ class RoomGetParticipantsResponseApplicationJson_OcsBuilder
   ListBuilder<Participant> get data => _$this._data ??= ListBuilder<Participant>();
   set data(covariant ListBuilder<Participant>? data) => _$this._data = data;
 
-  RoomGetParticipantsResponseApplicationJson_OcsBuilder();
+  RoomGetParticipantsResponseApplicationJson_OcsBuilder() {
+    RoomGetParticipantsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomGetParticipantsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -46391,6 +46980,7 @@ class RoomGetParticipantsResponseApplicationJson_OcsBuilder
   RoomGetParticipantsResponseApplicationJson_Ocs build() => _build();
 
   _$RoomGetParticipantsResponseApplicationJson_Ocs _build() {
+    RoomGetParticipantsResponseApplicationJson_Ocs._validate(this);
     _$RoomGetParticipantsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomGetParticipantsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -46471,7 +47061,9 @@ class RoomGetParticipantsResponseApplicationJsonBuilder
       _$this._ocs ??= RoomGetParticipantsResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomGetParticipantsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomGetParticipantsResponseApplicationJsonBuilder();
+  RoomGetParticipantsResponseApplicationJsonBuilder() {
+    RoomGetParticipantsResponseApplicationJson._defaults(this);
+  }
 
   RoomGetParticipantsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -46497,6 +47089,7 @@ class RoomGetParticipantsResponseApplicationJsonBuilder
   RoomGetParticipantsResponseApplicationJson build() => _build();
 
   _$RoomGetParticipantsResponseApplicationJson _build() {
+    RoomGetParticipantsResponseApplicationJson._validate(this);
     _$RoomGetParticipantsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomGetParticipantsResponseApplicationJson._(ocs: ocs.build());
@@ -46571,7 +47164,9 @@ class RoomRoomGetParticipantsHeadersBuilder
   set xNextcloudHasUserStatuses(covariant HeaderBuilder<bool>? xNextcloudHasUserStatuses) =>
       _$this._xNextcloudHasUserStatuses = xNextcloudHasUserStatuses;
 
-  RoomRoomGetParticipantsHeadersBuilder();
+  RoomRoomGetParticipantsHeadersBuilder() {
+    RoomRoomGetParticipantsHeaders._defaults(this);
+  }
 
   RoomRoomGetParticipantsHeadersBuilder get _$this {
     final $v = _$v;
@@ -46597,6 +47192,7 @@ class RoomRoomGetParticipantsHeadersBuilder
   RoomRoomGetParticipantsHeaders build() => _build();
 
   _$RoomRoomGetParticipantsHeaders _build() {
+    RoomRoomGetParticipantsHeaders._validate(this);
     _$RoomRoomGetParticipantsHeaders _$result;
     try {
       _$result =
@@ -46678,7 +47274,9 @@ class RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Builder
   int? get type => _$this._type;
   set type(covariant int? type) => _$this._type = type;
 
-  RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Builder();
+  RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Builder() {
+    RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0._defaults(this);
+  }
 
   RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Builder get _$this {
     final $v = _$v;
@@ -46704,6 +47302,7 @@ class RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Builder
   RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0 build() => _build();
 
   _$RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0 _build() {
+    RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0._validate(this);
     final _$result = _$v ??
         _$RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0._(
             type: BuiltValueNullFieldError.checkNotNull(
@@ -46790,7 +47389,9 @@ class RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder
   RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data? get data => _$this._data;
   set data(covariant RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data? data) => _$this._data = data;
 
-  RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder();
+  RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder() {
+    RoomAddParticipantToRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -46902,7 +47503,9 @@ class RoomAddParticipantToRoomResponseApplicationJsonBuilder
       _$this._ocs ??= RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomAddParticipantToRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomAddParticipantToRoomResponseApplicationJsonBuilder();
+  RoomAddParticipantToRoomResponseApplicationJsonBuilder() {
+    RoomAddParticipantToRoomResponseApplicationJson._defaults(this);
+  }
 
   RoomAddParticipantToRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -46928,6 +47531,7 @@ class RoomAddParticipantToRoomResponseApplicationJsonBuilder
   RoomAddParticipantToRoomResponseApplicationJson build() => _build();
 
   _$RoomAddParticipantToRoomResponseApplicationJson _build() {
+    RoomAddParticipantToRoomResponseApplicationJson._validate(this);
     _$RoomAddParticipantToRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomAddParticipantToRoomResponseApplicationJson._(ocs: ocs.build());
@@ -47023,7 +47627,9 @@ class RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder
   ListBuilder<Participant> get data => _$this._data ??= ListBuilder<Participant>();
   set data(covariant ListBuilder<Participant>? data) => _$this._data = data;
 
-  RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder();
+  RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder() {
+    RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -47050,6 +47656,7 @@ class RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder
   RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs build() => _build();
 
   _$RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs _build() {
+    RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs._validate(this);
     _$RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -47134,7 +47741,9 @@ class RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder
       _$this._ocs ??= RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder();
+  RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder() {
+    RoomGetBreakoutRoomParticipantsResponseApplicationJson._defaults(this);
+  }
 
   RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -47160,6 +47769,7 @@ class RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder
   RoomGetBreakoutRoomParticipantsResponseApplicationJson build() => _build();
 
   _$RoomGetBreakoutRoomParticipantsResponseApplicationJson _build() {
+    RoomGetBreakoutRoomParticipantsResponseApplicationJson._validate(this);
     _$RoomGetBreakoutRoomParticipantsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomGetBreakoutRoomParticipantsResponseApplicationJson._(ocs: ocs.build());
@@ -47239,7 +47849,9 @@ class RoomRoomGetBreakoutRoomParticipantsHeadersBuilder
   set xNextcloudHasUserStatuses(covariant HeaderBuilder<bool>? xNextcloudHasUserStatuses) =>
       _$this._xNextcloudHasUserStatuses = xNextcloudHasUserStatuses;
 
-  RoomRoomGetBreakoutRoomParticipantsHeadersBuilder();
+  RoomRoomGetBreakoutRoomParticipantsHeadersBuilder() {
+    RoomRoomGetBreakoutRoomParticipantsHeaders._defaults(this);
+  }
 
   RoomRoomGetBreakoutRoomParticipantsHeadersBuilder get _$this {
     final $v = _$v;
@@ -47265,6 +47877,7 @@ class RoomRoomGetBreakoutRoomParticipantsHeadersBuilder
   RoomRoomGetBreakoutRoomParticipantsHeaders build() => _build();
 
   _$RoomRoomGetBreakoutRoomParticipantsHeaders _build() {
+    RoomRoomGetBreakoutRoomParticipantsHeaders._validate(this);
     _$RoomRoomGetBreakoutRoomParticipantsHeaders _$result;
     try {
       _$result = _$v ??
@@ -47358,7 +47971,9 @@ class RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder();
+  RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder() {
+    RoomRemoveSelfFromRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -47385,6 +48000,7 @@ class RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder
   RoomRemoveSelfFromRoomResponseApplicationJson_Ocs build() => _build();
 
   _$RoomRemoveSelfFromRoomResponseApplicationJson_Ocs _build() {
+    RoomRemoveSelfFromRoomResponseApplicationJson_Ocs._validate(this);
     _$RoomRemoveSelfFromRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -47467,7 +48083,9 @@ class RoomRemoveSelfFromRoomResponseApplicationJsonBuilder
       _$this._ocs ??= RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomRemoveSelfFromRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomRemoveSelfFromRoomResponseApplicationJsonBuilder();
+  RoomRemoveSelfFromRoomResponseApplicationJsonBuilder() {
+    RoomRemoveSelfFromRoomResponseApplicationJson._defaults(this);
+  }
 
   RoomRemoveSelfFromRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -47493,6 +48111,7 @@ class RoomRemoveSelfFromRoomResponseApplicationJsonBuilder
   RoomRemoveSelfFromRoomResponseApplicationJson build() => _build();
 
   _$RoomRemoveSelfFromRoomResponseApplicationJson _build() {
+    RoomRemoveSelfFromRoomResponseApplicationJson._validate(this);
     _$RoomRemoveSelfFromRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomRemoveSelfFromRoomResponseApplicationJson._(ocs: ocs.build());
@@ -47585,7 +48204,9 @@ class RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder();
+  RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder() {
+    RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -47612,6 +48233,7 @@ class RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder
   RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs build() => _build();
 
   _$RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs _build() {
+    RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs._validate(this);
     _$RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -47696,7 +48318,9 @@ class RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder
       _$this._ocs ??= RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder();
+  RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder() {
+    RoomRemoveAttendeeFromRoomResponseApplicationJson._defaults(this);
+  }
 
   RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -47722,6 +48346,7 @@ class RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder
   RoomRemoveAttendeeFromRoomResponseApplicationJson build() => _build();
 
   _$RoomRemoveAttendeeFromRoomResponseApplicationJson _build() {
+    RoomRemoveAttendeeFromRoomResponseApplicationJson._validate(this);
     _$RoomRemoveAttendeeFromRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomRemoveAttendeeFromRoomResponseApplicationJson._(ocs: ocs.build());
@@ -47815,7 +48440,9 @@ class RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder();
+  RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder() {
+    RoomSetAttendeePermissionsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -47842,6 +48469,7 @@ class RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder
   RoomSetAttendeePermissionsResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetAttendeePermissionsResponseApplicationJson_Ocs _build() {
+    RoomSetAttendeePermissionsResponseApplicationJson_Ocs._validate(this);
     _$RoomSetAttendeePermissionsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -47926,7 +48554,9 @@ class RoomSetAttendeePermissionsResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetAttendeePermissionsResponseApplicationJsonBuilder();
+  RoomSetAttendeePermissionsResponseApplicationJsonBuilder() {
+    RoomSetAttendeePermissionsResponseApplicationJson._defaults(this);
+  }
 
   RoomSetAttendeePermissionsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -47952,6 +48582,7 @@ class RoomSetAttendeePermissionsResponseApplicationJsonBuilder
   RoomSetAttendeePermissionsResponseApplicationJson build() => _build();
 
   _$RoomSetAttendeePermissionsResponseApplicationJson _build() {
+    RoomSetAttendeePermissionsResponseApplicationJson._validate(this);
     _$RoomSetAttendeePermissionsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetAttendeePermissionsResponseApplicationJson._(ocs: ocs.build());
@@ -48047,7 +48678,9 @@ class RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder();
+  RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder() {
+    RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -48074,6 +48707,7 @@ class RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder
   RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs _build() {
+    RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs._validate(this);
     _$RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -48158,7 +48792,9 @@ class RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder();
+  RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder() {
+    RoomSetAllAttendeesPermissionsResponseApplicationJson._defaults(this);
+  }
 
   RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -48184,6 +48820,7 @@ class RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder
   RoomSetAllAttendeesPermissionsResponseApplicationJson build() => _build();
 
   _$RoomSetAllAttendeesPermissionsResponseApplicationJson _build() {
+    RoomSetAllAttendeesPermissionsResponseApplicationJson._validate(this);
     _$RoomSetAllAttendeesPermissionsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetAllAttendeesPermissionsResponseApplicationJson._(ocs: ocs.build());
@@ -48275,7 +48912,9 @@ class RoomJoinRoomResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  RoomJoinRoomResponseApplicationJson_OcsBuilder();
+  RoomJoinRoomResponseApplicationJson_OcsBuilder() {
+    RoomJoinRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomJoinRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -48302,6 +48941,7 @@ class RoomJoinRoomResponseApplicationJson_OcsBuilder
   RoomJoinRoomResponseApplicationJson_Ocs build() => _build();
 
   _$RoomJoinRoomResponseApplicationJson_Ocs _build() {
+    RoomJoinRoomResponseApplicationJson_Ocs._validate(this);
     _$RoomJoinRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomJoinRoomResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -48378,7 +49018,9 @@ class RoomJoinRoomResponseApplicationJsonBuilder
       _$this._ocs ??= RoomJoinRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomJoinRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomJoinRoomResponseApplicationJsonBuilder();
+  RoomJoinRoomResponseApplicationJsonBuilder() {
+    RoomJoinRoomResponseApplicationJson._defaults(this);
+  }
 
   RoomJoinRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -48404,6 +49046,7 @@ class RoomJoinRoomResponseApplicationJsonBuilder
   RoomJoinRoomResponseApplicationJson build() => _build();
 
   _$RoomJoinRoomResponseApplicationJson _build() {
+    RoomJoinRoomResponseApplicationJson._validate(this);
     _$RoomJoinRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomJoinRoomResponseApplicationJson._(ocs: ocs.build());
@@ -48494,7 +49137,9 @@ class RoomLeaveRoomResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomLeaveRoomResponseApplicationJson_OcsBuilder();
+  RoomLeaveRoomResponseApplicationJson_OcsBuilder() {
+    RoomLeaveRoomResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomLeaveRoomResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -48521,6 +49166,7 @@ class RoomLeaveRoomResponseApplicationJson_OcsBuilder
   RoomLeaveRoomResponseApplicationJson_Ocs build() => _build();
 
   _$RoomLeaveRoomResponseApplicationJson_Ocs _build() {
+    RoomLeaveRoomResponseApplicationJson_Ocs._validate(this);
     _$RoomLeaveRoomResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -48600,7 +49246,9 @@ class RoomLeaveRoomResponseApplicationJsonBuilder
       _$this._ocs ??= RoomLeaveRoomResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomLeaveRoomResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomLeaveRoomResponseApplicationJsonBuilder();
+  RoomLeaveRoomResponseApplicationJsonBuilder() {
+    RoomLeaveRoomResponseApplicationJson._defaults(this);
+  }
 
   RoomLeaveRoomResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -48626,6 +49274,7 @@ class RoomLeaveRoomResponseApplicationJsonBuilder
   RoomLeaveRoomResponseApplicationJson build() => _build();
 
   _$RoomLeaveRoomResponseApplicationJson _build() {
+    RoomLeaveRoomResponseApplicationJson._validate(this);
     _$RoomLeaveRoomResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomLeaveRoomResponseApplicationJson._(ocs: ocs.build());
@@ -48717,7 +49366,9 @@ class RoomResendInvitationsResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomResendInvitationsResponseApplicationJson_OcsBuilder();
+  RoomResendInvitationsResponseApplicationJson_OcsBuilder() {
+    RoomResendInvitationsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomResendInvitationsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -48744,6 +49395,7 @@ class RoomResendInvitationsResponseApplicationJson_OcsBuilder
   RoomResendInvitationsResponseApplicationJson_Ocs build() => _build();
 
   _$RoomResendInvitationsResponseApplicationJson_Ocs _build() {
+    RoomResendInvitationsResponseApplicationJson_Ocs._validate(this);
     _$RoomResendInvitationsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -48826,7 +49478,9 @@ class RoomResendInvitationsResponseApplicationJsonBuilder
       _$this._ocs ??= RoomResendInvitationsResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomResendInvitationsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomResendInvitationsResponseApplicationJsonBuilder();
+  RoomResendInvitationsResponseApplicationJsonBuilder() {
+    RoomResendInvitationsResponseApplicationJson._defaults(this);
+  }
 
   RoomResendInvitationsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -48852,6 +49506,7 @@ class RoomResendInvitationsResponseApplicationJsonBuilder
   RoomResendInvitationsResponseApplicationJson build() => _build();
 
   _$RoomResendInvitationsResponseApplicationJson _build() {
+    RoomResendInvitationsResponseApplicationJson._validate(this);
     _$RoomResendInvitationsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomResendInvitationsResponseApplicationJson._(ocs: ocs.build());
@@ -48942,7 +49597,9 @@ class RoomSetSessionStateResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  RoomSetSessionStateResponseApplicationJson_OcsBuilder();
+  RoomSetSessionStateResponseApplicationJson_OcsBuilder() {
+    RoomSetSessionStateResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetSessionStateResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -48969,6 +49626,7 @@ class RoomSetSessionStateResponseApplicationJson_OcsBuilder
   RoomSetSessionStateResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetSessionStateResponseApplicationJson_Ocs _build() {
+    RoomSetSessionStateResponseApplicationJson_Ocs._validate(this);
     _$RoomSetSessionStateResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomSetSessionStateResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -49049,7 +49707,9 @@ class RoomSetSessionStateResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetSessionStateResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetSessionStateResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetSessionStateResponseApplicationJsonBuilder();
+  RoomSetSessionStateResponseApplicationJsonBuilder() {
+    RoomSetSessionStateResponseApplicationJson._defaults(this);
+  }
 
   RoomSetSessionStateResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -49075,6 +49735,7 @@ class RoomSetSessionStateResponseApplicationJsonBuilder
   RoomSetSessionStateResponseApplicationJson build() => _build();
 
   _$RoomSetSessionStateResponseApplicationJson _build() {
+    RoomSetSessionStateResponseApplicationJson._validate(this);
     _$RoomSetSessionStateResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetSessionStateResponseApplicationJson._(ocs: ocs.build());
@@ -49166,7 +49827,9 @@ class RoomPromoteModeratorResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomPromoteModeratorResponseApplicationJson_OcsBuilder();
+  RoomPromoteModeratorResponseApplicationJson_OcsBuilder() {
+    RoomPromoteModeratorResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomPromoteModeratorResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -49193,6 +49856,7 @@ class RoomPromoteModeratorResponseApplicationJson_OcsBuilder
   RoomPromoteModeratorResponseApplicationJson_Ocs build() => _build();
 
   _$RoomPromoteModeratorResponseApplicationJson_Ocs _build() {
+    RoomPromoteModeratorResponseApplicationJson_Ocs._validate(this);
     _$RoomPromoteModeratorResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -49275,7 +49939,9 @@ class RoomPromoteModeratorResponseApplicationJsonBuilder
       _$this._ocs ??= RoomPromoteModeratorResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomPromoteModeratorResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomPromoteModeratorResponseApplicationJsonBuilder();
+  RoomPromoteModeratorResponseApplicationJsonBuilder() {
+    RoomPromoteModeratorResponseApplicationJson._defaults(this);
+  }
 
   RoomPromoteModeratorResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -49301,6 +49967,7 @@ class RoomPromoteModeratorResponseApplicationJsonBuilder
   RoomPromoteModeratorResponseApplicationJson build() => _build();
 
   _$RoomPromoteModeratorResponseApplicationJson _build() {
+    RoomPromoteModeratorResponseApplicationJson._validate(this);
     _$RoomPromoteModeratorResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomPromoteModeratorResponseApplicationJson._(ocs: ocs.build());
@@ -49391,7 +50058,9 @@ class RoomDemoteModeratorResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomDemoteModeratorResponseApplicationJson_OcsBuilder();
+  RoomDemoteModeratorResponseApplicationJson_OcsBuilder() {
+    RoomDemoteModeratorResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomDemoteModeratorResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -49418,6 +50087,7 @@ class RoomDemoteModeratorResponseApplicationJson_OcsBuilder
   RoomDemoteModeratorResponseApplicationJson_Ocs build() => _build();
 
   _$RoomDemoteModeratorResponseApplicationJson_Ocs _build() {
+    RoomDemoteModeratorResponseApplicationJson_Ocs._validate(this);
     _$RoomDemoteModeratorResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -49500,7 +50170,9 @@ class RoomDemoteModeratorResponseApplicationJsonBuilder
       _$this._ocs ??= RoomDemoteModeratorResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomDemoteModeratorResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomDemoteModeratorResponseApplicationJsonBuilder();
+  RoomDemoteModeratorResponseApplicationJsonBuilder() {
+    RoomDemoteModeratorResponseApplicationJson._defaults(this);
+  }
 
   RoomDemoteModeratorResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -49526,6 +50198,7 @@ class RoomDemoteModeratorResponseApplicationJsonBuilder
   RoomDemoteModeratorResponseApplicationJson build() => _build();
 
   _$RoomDemoteModeratorResponseApplicationJson _build() {
+    RoomDemoteModeratorResponseApplicationJson._validate(this);
     _$RoomDemoteModeratorResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomDemoteModeratorResponseApplicationJson._(ocs: ocs.build());
@@ -49616,7 +50289,9 @@ class RoomAddToFavoritesResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomAddToFavoritesResponseApplicationJson_OcsBuilder();
+  RoomAddToFavoritesResponseApplicationJson_OcsBuilder() {
+    RoomAddToFavoritesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomAddToFavoritesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -49643,6 +50318,7 @@ class RoomAddToFavoritesResponseApplicationJson_OcsBuilder
   RoomAddToFavoritesResponseApplicationJson_Ocs build() => _build();
 
   _$RoomAddToFavoritesResponseApplicationJson_Ocs _build() {
+    RoomAddToFavoritesResponseApplicationJson_Ocs._validate(this);
     _$RoomAddToFavoritesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -49724,7 +50400,9 @@ class RoomAddToFavoritesResponseApplicationJsonBuilder
       _$this._ocs ??= RoomAddToFavoritesResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomAddToFavoritesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomAddToFavoritesResponseApplicationJsonBuilder();
+  RoomAddToFavoritesResponseApplicationJsonBuilder() {
+    RoomAddToFavoritesResponseApplicationJson._defaults(this);
+  }
 
   RoomAddToFavoritesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -49750,6 +50428,7 @@ class RoomAddToFavoritesResponseApplicationJsonBuilder
   RoomAddToFavoritesResponseApplicationJson build() => _build();
 
   _$RoomAddToFavoritesResponseApplicationJson _build() {
+    RoomAddToFavoritesResponseApplicationJson._validate(this);
     _$RoomAddToFavoritesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomAddToFavoritesResponseApplicationJson._(ocs: ocs.build());
@@ -49841,7 +50520,9 @@ class RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder();
+  RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder() {
+    RoomRemoveFromFavoritesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -49868,6 +50549,7 @@ class RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder
   RoomRemoveFromFavoritesResponseApplicationJson_Ocs build() => _build();
 
   _$RoomRemoveFromFavoritesResponseApplicationJson_Ocs _build() {
+    RoomRemoveFromFavoritesResponseApplicationJson_Ocs._validate(this);
     _$RoomRemoveFromFavoritesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -49950,7 +50632,9 @@ class RoomRemoveFromFavoritesResponseApplicationJsonBuilder
       _$this._ocs ??= RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomRemoveFromFavoritesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomRemoveFromFavoritesResponseApplicationJsonBuilder();
+  RoomRemoveFromFavoritesResponseApplicationJsonBuilder() {
+    RoomRemoveFromFavoritesResponseApplicationJson._defaults(this);
+  }
 
   RoomRemoveFromFavoritesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -49976,6 +50660,7 @@ class RoomRemoveFromFavoritesResponseApplicationJsonBuilder
   RoomRemoveFromFavoritesResponseApplicationJson build() => _build();
 
   _$RoomRemoveFromFavoritesResponseApplicationJson _build() {
+    RoomRemoveFromFavoritesResponseApplicationJson._validate(this);
     _$RoomRemoveFromFavoritesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomRemoveFromFavoritesResponseApplicationJson._(ocs: ocs.build());
@@ -50069,7 +50754,9 @@ class RoomSetNotificationLevelResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomSetNotificationLevelResponseApplicationJson_OcsBuilder();
+  RoomSetNotificationLevelResponseApplicationJson_OcsBuilder() {
+    RoomSetNotificationLevelResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetNotificationLevelResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -50096,6 +50783,7 @@ class RoomSetNotificationLevelResponseApplicationJson_OcsBuilder
   RoomSetNotificationLevelResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetNotificationLevelResponseApplicationJson_Ocs _build() {
+    RoomSetNotificationLevelResponseApplicationJson_Ocs._validate(this);
     _$RoomSetNotificationLevelResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -50180,7 +50868,9 @@ class RoomSetNotificationLevelResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetNotificationLevelResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetNotificationLevelResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetNotificationLevelResponseApplicationJsonBuilder();
+  RoomSetNotificationLevelResponseApplicationJsonBuilder() {
+    RoomSetNotificationLevelResponseApplicationJson._defaults(this);
+  }
 
   RoomSetNotificationLevelResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -50206,6 +50896,7 @@ class RoomSetNotificationLevelResponseApplicationJsonBuilder
   RoomSetNotificationLevelResponseApplicationJson build() => _build();
 
   _$RoomSetNotificationLevelResponseApplicationJson _build() {
+    RoomSetNotificationLevelResponseApplicationJson._validate(this);
     _$RoomSetNotificationLevelResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetNotificationLevelResponseApplicationJson._(ocs: ocs.build());
@@ -50299,7 +50990,9 @@ class RoomSetNotificationCallsResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomSetNotificationCallsResponseApplicationJson_OcsBuilder();
+  RoomSetNotificationCallsResponseApplicationJson_OcsBuilder() {
+    RoomSetNotificationCallsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetNotificationCallsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -50326,6 +51019,7 @@ class RoomSetNotificationCallsResponseApplicationJson_OcsBuilder
   RoomSetNotificationCallsResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetNotificationCallsResponseApplicationJson_Ocs _build() {
+    RoomSetNotificationCallsResponseApplicationJson_Ocs._validate(this);
     _$RoomSetNotificationCallsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -50410,7 +51104,9 @@ class RoomSetNotificationCallsResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetNotificationCallsResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetNotificationCallsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetNotificationCallsResponseApplicationJsonBuilder();
+  RoomSetNotificationCallsResponseApplicationJsonBuilder() {
+    RoomSetNotificationCallsResponseApplicationJson._defaults(this);
+  }
 
   RoomSetNotificationCallsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -50436,6 +51132,7 @@ class RoomSetNotificationCallsResponseApplicationJsonBuilder
   RoomSetNotificationCallsResponseApplicationJson build() => _build();
 
   _$RoomSetNotificationCallsResponseApplicationJson _build() {
+    RoomSetNotificationCallsResponseApplicationJson._validate(this);
     _$RoomSetNotificationCallsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetNotificationCallsResponseApplicationJson._(ocs: ocs.build());
@@ -50527,7 +51224,9 @@ class RoomSetLobbyResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  RoomSetLobbyResponseApplicationJson_OcsBuilder();
+  RoomSetLobbyResponseApplicationJson_OcsBuilder() {
+    RoomSetLobbyResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetLobbyResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -50554,6 +51253,7 @@ class RoomSetLobbyResponseApplicationJson_OcsBuilder
   RoomSetLobbyResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetLobbyResponseApplicationJson_Ocs _build() {
+    RoomSetLobbyResponseApplicationJson_Ocs._validate(this);
     _$RoomSetLobbyResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomSetLobbyResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -50630,7 +51330,9 @@ class RoomSetLobbyResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetLobbyResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetLobbyResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetLobbyResponseApplicationJsonBuilder();
+  RoomSetLobbyResponseApplicationJsonBuilder() {
+    RoomSetLobbyResponseApplicationJson._defaults(this);
+  }
 
   RoomSetLobbyResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -50656,6 +51358,7 @@ class RoomSetLobbyResponseApplicationJsonBuilder
   RoomSetLobbyResponseApplicationJson build() => _build();
 
   _$RoomSetLobbyResponseApplicationJson _build() {
+    RoomSetLobbyResponseApplicationJson._validate(this);
     _$RoomSetLobbyResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetLobbyResponseApplicationJson._(ocs: ocs.build());
@@ -50746,7 +51449,9 @@ class RoomSetsipEnabledResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  RoomSetsipEnabledResponseApplicationJson_OcsBuilder();
+  RoomSetsipEnabledResponseApplicationJson_OcsBuilder() {
+    RoomSetsipEnabledResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetsipEnabledResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -50773,6 +51478,7 @@ class RoomSetsipEnabledResponseApplicationJson_OcsBuilder
   RoomSetsipEnabledResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetsipEnabledResponseApplicationJson_Ocs _build() {
+    RoomSetsipEnabledResponseApplicationJson_Ocs._validate(this);
     _$RoomSetsipEnabledResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomSetsipEnabledResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -50852,7 +51558,9 @@ class RoomSetsipEnabledResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetsipEnabledResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetsipEnabledResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetsipEnabledResponseApplicationJsonBuilder();
+  RoomSetsipEnabledResponseApplicationJsonBuilder() {
+    RoomSetsipEnabledResponseApplicationJson._defaults(this);
+  }
 
   RoomSetsipEnabledResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -50878,6 +51586,7 @@ class RoomSetsipEnabledResponseApplicationJsonBuilder
   RoomSetsipEnabledResponseApplicationJson build() => _build();
 
   _$RoomSetsipEnabledResponseApplicationJson _build() {
+    RoomSetsipEnabledResponseApplicationJson._validate(this);
     _$RoomSetsipEnabledResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetsipEnabledResponseApplicationJson._(ocs: ocs.build());
@@ -50969,7 +51678,9 @@ class RoomSetRecordingConsentResponseApplicationJson_OcsBuilder
   RoomBuilder get data => _$this._data ??= RoomBuilder();
   set data(covariant RoomBuilder? data) => _$this._data = data;
 
-  RoomSetRecordingConsentResponseApplicationJson_OcsBuilder();
+  RoomSetRecordingConsentResponseApplicationJson_OcsBuilder() {
+    RoomSetRecordingConsentResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetRecordingConsentResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -50996,6 +51707,7 @@ class RoomSetRecordingConsentResponseApplicationJson_OcsBuilder
   RoomSetRecordingConsentResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetRecordingConsentResponseApplicationJson_Ocs _build() {
+    RoomSetRecordingConsentResponseApplicationJson_Ocs._validate(this);
     _$RoomSetRecordingConsentResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$RoomSetRecordingConsentResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -51076,7 +51788,9 @@ class RoomSetRecordingConsentResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetRecordingConsentResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetRecordingConsentResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetRecordingConsentResponseApplicationJsonBuilder();
+  RoomSetRecordingConsentResponseApplicationJsonBuilder() {
+    RoomSetRecordingConsentResponseApplicationJson._defaults(this);
+  }
 
   RoomSetRecordingConsentResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -51102,6 +51816,7 @@ class RoomSetRecordingConsentResponseApplicationJsonBuilder
   RoomSetRecordingConsentResponseApplicationJson build() => _build();
 
   _$RoomSetRecordingConsentResponseApplicationJson _build() {
+    RoomSetRecordingConsentResponseApplicationJson._validate(this);
     _$RoomSetRecordingConsentResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetRecordingConsentResponseApplicationJson._(ocs: ocs.build());
@@ -51195,7 +51910,9 @@ class RoomSetMessageExpirationResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  RoomSetMessageExpirationResponseApplicationJson_OcsBuilder();
+  RoomSetMessageExpirationResponseApplicationJson_OcsBuilder() {
+    RoomSetMessageExpirationResponseApplicationJson_Ocs._defaults(this);
+  }
 
   RoomSetMessageExpirationResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -51222,6 +51939,7 @@ class RoomSetMessageExpirationResponseApplicationJson_OcsBuilder
   RoomSetMessageExpirationResponseApplicationJson_Ocs build() => _build();
 
   _$RoomSetMessageExpirationResponseApplicationJson_Ocs _build() {
+    RoomSetMessageExpirationResponseApplicationJson_Ocs._validate(this);
     _$RoomSetMessageExpirationResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -51306,7 +52024,9 @@ class RoomSetMessageExpirationResponseApplicationJsonBuilder
       _$this._ocs ??= RoomSetMessageExpirationResponseApplicationJson_OcsBuilder();
   set ocs(covariant RoomSetMessageExpirationResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  RoomSetMessageExpirationResponseApplicationJsonBuilder();
+  RoomSetMessageExpirationResponseApplicationJsonBuilder() {
+    RoomSetMessageExpirationResponseApplicationJson._defaults(this);
+  }
 
   RoomSetMessageExpirationResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -51332,6 +52052,7 @@ class RoomSetMessageExpirationResponseApplicationJsonBuilder
   RoomSetMessageExpirationResponseApplicationJson build() => _build();
 
   _$RoomSetMessageExpirationResponseApplicationJson _build() {
+    RoomSetMessageExpirationResponseApplicationJson._validate(this);
     _$RoomSetMessageExpirationResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$RoomSetMessageExpirationResponseApplicationJson._(ocs: ocs.build());
@@ -51424,7 +52145,9 @@ class SettingsSetUserSettingResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  SettingsSetUserSettingResponseApplicationJson_OcsBuilder();
+  SettingsSetUserSettingResponseApplicationJson_OcsBuilder() {
+    SettingsSetUserSettingResponseApplicationJson_Ocs._defaults(this);
+  }
 
   SettingsSetUserSettingResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -51451,6 +52174,7 @@ class SettingsSetUserSettingResponseApplicationJson_OcsBuilder
   SettingsSetUserSettingResponseApplicationJson_Ocs build() => _build();
 
   _$SettingsSetUserSettingResponseApplicationJson_Ocs _build() {
+    SettingsSetUserSettingResponseApplicationJson_Ocs._validate(this);
     _$SettingsSetUserSettingResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -51533,7 +52257,9 @@ class SettingsSetUserSettingResponseApplicationJsonBuilder
       _$this._ocs ??= SettingsSetUserSettingResponseApplicationJson_OcsBuilder();
   set ocs(covariant SettingsSetUserSettingResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  SettingsSetUserSettingResponseApplicationJsonBuilder();
+  SettingsSetUserSettingResponseApplicationJsonBuilder() {
+    SettingsSetUserSettingResponseApplicationJson._defaults(this);
+  }
 
   SettingsSetUserSettingResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -51559,6 +52285,7 @@ class SettingsSetUserSettingResponseApplicationJsonBuilder
   SettingsSetUserSettingResponseApplicationJson build() => _build();
 
   _$SettingsSetUserSettingResponseApplicationJson _build() {
+    SettingsSetUserSettingResponseApplicationJson._validate(this);
     _$SettingsSetUserSettingResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$SettingsSetUserSettingResponseApplicationJson._(ocs: ocs.build());
@@ -51650,7 +52377,9 @@ class SettingsSetsipSettingsResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  SettingsSetsipSettingsResponseApplicationJson_OcsBuilder();
+  SettingsSetsipSettingsResponseApplicationJson_OcsBuilder() {
+    SettingsSetsipSettingsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   SettingsSetsipSettingsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -51677,6 +52406,7 @@ class SettingsSetsipSettingsResponseApplicationJson_OcsBuilder
   SettingsSetsipSettingsResponseApplicationJson_Ocs build() => _build();
 
   _$SettingsSetsipSettingsResponseApplicationJson_Ocs _build() {
+    SettingsSetsipSettingsResponseApplicationJson_Ocs._validate(this);
     _$SettingsSetsipSettingsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -51759,7 +52489,9 @@ class SettingsSetsipSettingsResponseApplicationJsonBuilder
       _$this._ocs ??= SettingsSetsipSettingsResponseApplicationJson_OcsBuilder();
   set ocs(covariant SettingsSetsipSettingsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  SettingsSetsipSettingsResponseApplicationJsonBuilder();
+  SettingsSetsipSettingsResponseApplicationJsonBuilder() {
+    SettingsSetsipSettingsResponseApplicationJson._defaults(this);
+  }
 
   SettingsSetsipSettingsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -51785,6 +52517,7 @@ class SettingsSetsipSettingsResponseApplicationJsonBuilder
   SettingsSetsipSettingsResponseApplicationJson build() => _build();
 
   _$SettingsSetsipSettingsResponseApplicationJson _build() {
+    SettingsSetsipSettingsResponseApplicationJson._validate(this);
     _$SettingsSetsipSettingsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$SettingsSetsipSettingsResponseApplicationJson._(ocs: ocs.build());
@@ -51873,7 +52606,9 @@ class SignalingSettings_HelloAuthParams_10Builder
   String? get ticket => _$this._ticket;
   set ticket(covariant String? ticket) => _$this._ticket = ticket;
 
-  SignalingSettings_HelloAuthParams_10Builder();
+  SignalingSettings_HelloAuthParams_10Builder() {
+    SignalingSettings_HelloAuthParams_10._defaults(this);
+  }
 
   SignalingSettings_HelloAuthParams_10Builder get _$this {
     final $v = _$v;
@@ -51900,6 +52635,7 @@ class SignalingSettings_HelloAuthParams_10Builder
   SignalingSettings_HelloAuthParams_10 build() => _build();
 
   _$SignalingSettings_HelloAuthParams_10 _build() {
+    SignalingSettings_HelloAuthParams_10._validate(this);
     final _$result = _$v ??
         _$SignalingSettings_HelloAuthParams_10._(
             userid: userid,
@@ -51966,7 +52702,9 @@ class SignalingSettings_HelloAuthParams_20Builder
   String? get token => _$this._token;
   set token(covariant String? token) => _$this._token = token;
 
-  SignalingSettings_HelloAuthParams_20Builder();
+  SignalingSettings_HelloAuthParams_20Builder() {
+    SignalingSettings_HelloAuthParams_20._defaults(this);
+  }
 
   SignalingSettings_HelloAuthParams_20Builder get _$this {
     final $v = _$v;
@@ -51992,6 +52730,7 @@ class SignalingSettings_HelloAuthParams_20Builder
   SignalingSettings_HelloAuthParams_20 build() => _build();
 
   _$SignalingSettings_HelloAuthParams_20 _build() {
+    SignalingSettings_HelloAuthParams_20._validate(this);
     final _$result = _$v ??
         _$SignalingSettings_HelloAuthParams_20._(
             token: BuiltValueNullFieldError.checkNotNull(token, r'SignalingSettings_HelloAuthParams_20', 'token'));
@@ -52069,7 +52808,9 @@ class SignalingSettings_HelloAuthParamsBuilder
   SignalingSettings_HelloAuthParams_20Builder get $20 => _$this._$20 ??= SignalingSettings_HelloAuthParams_20Builder();
   set $20(covariant SignalingSettings_HelloAuthParams_20Builder? $20) => _$this._$20 = $20;
 
-  SignalingSettings_HelloAuthParamsBuilder();
+  SignalingSettings_HelloAuthParamsBuilder() {
+    SignalingSettings_HelloAuthParams._defaults(this);
+  }
 
   SignalingSettings_HelloAuthParamsBuilder get _$this {
     final $v = _$v;
@@ -52096,6 +52837,7 @@ class SignalingSettings_HelloAuthParamsBuilder
   SignalingSettings_HelloAuthParams build() => _build();
 
   _$SignalingSettings_HelloAuthParams _build() {
+    SignalingSettings_HelloAuthParams._validate(this);
     _$SignalingSettings_HelloAuthParams _$result;
     try {
       _$result = _$v ?? _$SignalingSettings_HelloAuthParams._($10: $10.build(), $20: $20.build());
@@ -52171,7 +52913,9 @@ class SignalingSettings_StunserversBuilder
   ListBuilder<String> get urls => _$this._urls ??= ListBuilder<String>();
   set urls(covariant ListBuilder<String>? urls) => _$this._urls = urls;
 
-  SignalingSettings_StunserversBuilder();
+  SignalingSettings_StunserversBuilder() {
+    SignalingSettings_Stunservers._defaults(this);
+  }
 
   SignalingSettings_StunserversBuilder get _$this {
     final $v = _$v;
@@ -52197,6 +52941,7 @@ class SignalingSettings_StunserversBuilder
   SignalingSettings_Stunservers build() => _build();
 
   _$SignalingSettings_Stunservers _build() {
+    SignalingSettings_Stunservers._validate(this);
     _$SignalingSettings_Stunservers _$result;
     try {
       _$result = _$v ?? _$SignalingSettings_Stunservers._(urls: urls.build());
@@ -52300,7 +53045,9 @@ class SignalingSettings_TurnserversBuilder
   JsonObject? get credential => _$this._credential;
   set credential(covariant JsonObject? credential) => _$this._credential = credential;
 
-  SignalingSettings_TurnserversBuilder();
+  SignalingSettings_TurnserversBuilder() {
+    SignalingSettings_Turnservers._defaults(this);
+  }
 
   SignalingSettings_TurnserversBuilder get _$this {
     final $v = _$v;
@@ -52328,6 +53075,7 @@ class SignalingSettings_TurnserversBuilder
   SignalingSettings_Turnservers build() => _build();
 
   _$SignalingSettings_Turnservers _build() {
+    SignalingSettings_Turnservers._validate(this);
     _$SignalingSettings_Turnservers _$result;
     try {
       _$result = _$v ??
@@ -52525,7 +53273,9 @@ class SignalingSettingsBuilder
   String? get userId => _$this._userId;
   set userId(covariant String? userId) => _$this._userId = userId;
 
-  SignalingSettingsBuilder();
+  SignalingSettingsBuilder() {
+    SignalingSettings._defaults(this);
+  }
 
   SignalingSettingsBuilder get _$this {
     final $v = _$v;
@@ -52559,6 +53309,7 @@ class SignalingSettingsBuilder
   SignalingSettings build() => _build();
 
   _$SignalingSettings _build() {
+    SignalingSettings._validate(this);
     _$SignalingSettings _$result;
     try {
       _$result = _$v ??
@@ -52668,7 +53419,9 @@ class SignalingGetSettingsResponseApplicationJson_OcsBuilder
   SignalingSettingsBuilder get data => _$this._data ??= SignalingSettingsBuilder();
   set data(covariant SignalingSettingsBuilder? data) => _$this._data = data;
 
-  SignalingGetSettingsResponseApplicationJson_OcsBuilder();
+  SignalingGetSettingsResponseApplicationJson_OcsBuilder() {
+    SignalingGetSettingsResponseApplicationJson_Ocs._defaults(this);
+  }
 
   SignalingGetSettingsResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -52695,6 +53448,7 @@ class SignalingGetSettingsResponseApplicationJson_OcsBuilder
   SignalingGetSettingsResponseApplicationJson_Ocs build() => _build();
 
   _$SignalingGetSettingsResponseApplicationJson_Ocs _build() {
+    SignalingGetSettingsResponseApplicationJson_Ocs._validate(this);
     _$SignalingGetSettingsResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$SignalingGetSettingsResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -52775,7 +53529,9 @@ class SignalingGetSettingsResponseApplicationJsonBuilder
       _$this._ocs ??= SignalingGetSettingsResponseApplicationJson_OcsBuilder();
   set ocs(covariant SignalingGetSettingsResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  SignalingGetSettingsResponseApplicationJsonBuilder();
+  SignalingGetSettingsResponseApplicationJsonBuilder() {
+    SignalingGetSettingsResponseApplicationJson._defaults(this);
+  }
 
   SignalingGetSettingsResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -52801,6 +53557,7 @@ class SignalingGetSettingsResponseApplicationJsonBuilder
   SignalingGetSettingsResponseApplicationJson build() => _build();
 
   _$SignalingGetSettingsResponseApplicationJson _build() {
+    SignalingGetSettingsResponseApplicationJson._validate(this);
     _$SignalingGetSettingsResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$SignalingGetSettingsResponseApplicationJson._(ocs: ocs.build());
@@ -52947,7 +53704,9 @@ class SignalingSessionBuilder
   String? get userId => _$this._userId;
   set userId(covariant String? userId) => _$this._userId = userId;
 
-  SignalingSessionBuilder();
+  SignalingSessionBuilder() {
+    SignalingSession._defaults(this);
+  }
 
   SignalingSessionBuilder get _$this {
     final $v = _$v;
@@ -52978,6 +53737,7 @@ class SignalingSessionBuilder
   SignalingSession build() => _build();
 
   _$SignalingSession _build() {
+    SignalingSession._validate(this);
     final _$result = _$v ??
         _$SignalingSession._(
             inCall: BuiltValueNullFieldError.checkNotNull(inCall, r'SignalingSession', 'inCall'),
@@ -53069,7 +53829,9 @@ class SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder
   SignalingPullMessagesResponseApplicationJson_Ocs_Data_Data? get data => _$this._data;
   set data(covariant SignalingPullMessagesResponseApplicationJson_Ocs_Data_Data? data) => _$this._data = data;
 
-  SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder();
+  SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder() {
+    SignalingPullMessagesResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   SignalingPullMessagesResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -53182,7 +53944,9 @@ class SignalingPullMessagesResponseApplicationJson_OcsBuilder
       _$this._data ??= ListBuilder<SignalingPullMessagesResponseApplicationJson_Ocs_Data>();
   set data(covariant ListBuilder<SignalingPullMessagesResponseApplicationJson_Ocs_Data>? data) => _$this._data = data;
 
-  SignalingPullMessagesResponseApplicationJson_OcsBuilder();
+  SignalingPullMessagesResponseApplicationJson_OcsBuilder() {
+    SignalingPullMessagesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   SignalingPullMessagesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -53209,6 +53973,7 @@ class SignalingPullMessagesResponseApplicationJson_OcsBuilder
   SignalingPullMessagesResponseApplicationJson_Ocs build() => _build();
 
   _$SignalingPullMessagesResponseApplicationJson_Ocs _build() {
+    SignalingPullMessagesResponseApplicationJson_Ocs._validate(this);
     _$SignalingPullMessagesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$SignalingPullMessagesResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -53289,7 +54054,9 @@ class SignalingPullMessagesResponseApplicationJsonBuilder
       _$this._ocs ??= SignalingPullMessagesResponseApplicationJson_OcsBuilder();
   set ocs(covariant SignalingPullMessagesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  SignalingPullMessagesResponseApplicationJsonBuilder();
+  SignalingPullMessagesResponseApplicationJsonBuilder() {
+    SignalingPullMessagesResponseApplicationJson._defaults(this);
+  }
 
   SignalingPullMessagesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -53315,6 +54082,7 @@ class SignalingPullMessagesResponseApplicationJsonBuilder
   SignalingPullMessagesResponseApplicationJson build() => _build();
 
   _$SignalingPullMessagesResponseApplicationJson _build() {
+    SignalingPullMessagesResponseApplicationJson._validate(this);
     _$SignalingPullMessagesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$SignalingPullMessagesResponseApplicationJson._(ocs: ocs.build());
@@ -53406,7 +54174,9 @@ class SignalingSendMessagesResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  SignalingSendMessagesResponseApplicationJson_OcsBuilder();
+  SignalingSendMessagesResponseApplicationJson_OcsBuilder() {
+    SignalingSendMessagesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   SignalingSendMessagesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -53433,6 +54203,7 @@ class SignalingSendMessagesResponseApplicationJson_OcsBuilder
   SignalingSendMessagesResponseApplicationJson_Ocs build() => _build();
 
   _$SignalingSendMessagesResponseApplicationJson_Ocs _build() {
+    SignalingSendMessagesResponseApplicationJson_Ocs._validate(this);
     _$SignalingSendMessagesResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -53515,7 +54286,9 @@ class SignalingSendMessagesResponseApplicationJsonBuilder
       _$this._ocs ??= SignalingSendMessagesResponseApplicationJson_OcsBuilder();
   set ocs(covariant SignalingSendMessagesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  SignalingSendMessagesResponseApplicationJsonBuilder();
+  SignalingSendMessagesResponseApplicationJsonBuilder() {
+    SignalingSendMessagesResponseApplicationJson._defaults(this);
+  }
 
   SignalingSendMessagesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -53541,6 +54314,7 @@ class SignalingSendMessagesResponseApplicationJsonBuilder
   SignalingSendMessagesResponseApplicationJson build() => _build();
 
   _$SignalingSendMessagesResponseApplicationJson _build() {
+    SignalingSendMessagesResponseApplicationJson._validate(this);
     _$SignalingSendMessagesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$SignalingSendMessagesResponseApplicationJson._(ocs: ocs.build());
@@ -53633,7 +54407,9 @@ class SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder
   MapBuilder<String, JsonObject> get data => _$this._data ??= MapBuilder<String, JsonObject>();
   set data(covariant MapBuilder<String, JsonObject>? data) => _$this._data = data;
 
-  SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder();
+  SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder() {
+    SignalingGetWelcomeMessageResponseApplicationJson_Ocs._defaults(this);
+  }
 
   SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -53660,6 +54436,7 @@ class SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder
   SignalingGetWelcomeMessageResponseApplicationJson_Ocs build() => _build();
 
   _$SignalingGetWelcomeMessageResponseApplicationJson_Ocs _build() {
+    SignalingGetWelcomeMessageResponseApplicationJson_Ocs._validate(this);
     _$SignalingGetWelcomeMessageResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -53743,7 +54520,9 @@ class SignalingGetWelcomeMessageResponseApplicationJsonBuilder
       _$this._ocs ??= SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder();
   set ocs(covariant SignalingGetWelcomeMessageResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  SignalingGetWelcomeMessageResponseApplicationJsonBuilder();
+  SignalingGetWelcomeMessageResponseApplicationJsonBuilder() {
+    SignalingGetWelcomeMessageResponseApplicationJson._defaults(this);
+  }
 
   SignalingGetWelcomeMessageResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -53769,6 +54548,7 @@ class SignalingGetWelcomeMessageResponseApplicationJsonBuilder
   SignalingGetWelcomeMessageResponseApplicationJson build() => _build();
 
   _$SignalingGetWelcomeMessageResponseApplicationJson _build() {
+    SignalingGetWelcomeMessageResponseApplicationJson._validate(this);
     _$SignalingGetWelcomeMessageResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$SignalingGetWelcomeMessageResponseApplicationJson._(ocs: ocs.build());
@@ -53861,7 +54641,9 @@ class TempAvatarPostAvatarResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  TempAvatarPostAvatarResponseApplicationJson_OcsBuilder();
+  TempAvatarPostAvatarResponseApplicationJson_OcsBuilder() {
+    TempAvatarPostAvatarResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TempAvatarPostAvatarResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -53888,6 +54670,7 @@ class TempAvatarPostAvatarResponseApplicationJson_OcsBuilder
   TempAvatarPostAvatarResponseApplicationJson_Ocs build() => _build();
 
   _$TempAvatarPostAvatarResponseApplicationJson_Ocs _build() {
+    TempAvatarPostAvatarResponseApplicationJson_Ocs._validate(this);
     _$TempAvatarPostAvatarResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -53970,7 +54753,9 @@ class TempAvatarPostAvatarResponseApplicationJsonBuilder
       _$this._ocs ??= TempAvatarPostAvatarResponseApplicationJson_OcsBuilder();
   set ocs(covariant TempAvatarPostAvatarResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TempAvatarPostAvatarResponseApplicationJsonBuilder();
+  TempAvatarPostAvatarResponseApplicationJsonBuilder() {
+    TempAvatarPostAvatarResponseApplicationJson._defaults(this);
+  }
 
   TempAvatarPostAvatarResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -53996,6 +54781,7 @@ class TempAvatarPostAvatarResponseApplicationJsonBuilder
   TempAvatarPostAvatarResponseApplicationJson build() => _build();
 
   _$TempAvatarPostAvatarResponseApplicationJson _build() {
+    TempAvatarPostAvatarResponseApplicationJson._validate(this);
     _$TempAvatarPostAvatarResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TempAvatarPostAvatarResponseApplicationJson._(ocs: ocs.build());
@@ -54087,7 +54873,9 @@ class TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder();
+  TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder() {
+    TempAvatarDeleteAvatarResponseApplicationJson_Ocs._defaults(this);
+  }
 
   TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -54114,6 +54902,7 @@ class TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder
   TempAvatarDeleteAvatarResponseApplicationJson_Ocs build() => _build();
 
   _$TempAvatarDeleteAvatarResponseApplicationJson_Ocs _build() {
+    TempAvatarDeleteAvatarResponseApplicationJson_Ocs._validate(this);
     _$TempAvatarDeleteAvatarResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -54196,7 +54985,9 @@ class TempAvatarDeleteAvatarResponseApplicationJsonBuilder
       _$this._ocs ??= TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder();
   set ocs(covariant TempAvatarDeleteAvatarResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  TempAvatarDeleteAvatarResponseApplicationJsonBuilder();
+  TempAvatarDeleteAvatarResponseApplicationJsonBuilder() {
+    TempAvatarDeleteAvatarResponseApplicationJson._defaults(this);
+  }
 
   TempAvatarDeleteAvatarResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -54222,6 +55013,7 @@ class TempAvatarDeleteAvatarResponseApplicationJsonBuilder
   TempAvatarDeleteAvatarResponseApplicationJson build() => _build();
 
   _$TempAvatarDeleteAvatarResponseApplicationJson _build() {
+    TempAvatarDeleteAvatarResponseApplicationJson._validate(this);
     _$TempAvatarDeleteAvatarResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$TempAvatarDeleteAvatarResponseApplicationJson._(ocs: ocs.build());
@@ -54439,7 +55231,9 @@ class BotWithDetailsAndSecretBuilder
   int? get state => _$this._state;
   set state(covariant int? state) => _$this._state = state;
 
-  BotWithDetailsAndSecretBuilder();
+  BotWithDetailsAndSecretBuilder() {
+    BotWithDetailsAndSecret._defaults(this);
+  }
 
   BotWithDetailsAndSecretBuilder get _$this {
     final $v = _$v;
@@ -54475,6 +55269,7 @@ class BotWithDetailsAndSecretBuilder
   BotWithDetailsAndSecret build() => _build();
 
   _$BotWithDetailsAndSecret _build() {
+    BotWithDetailsAndSecret._validate(this);
     final _$result = _$v ??
         _$BotWithDetailsAndSecret._(
             secret: BuiltValueNullFieldError.checkNotNull(secret, r'BotWithDetailsAndSecret', 'secret'),
@@ -54636,7 +55431,9 @@ class FederationInviteBuilder
   String? get userId => _$this._userId;
   set userId(covariant String? userId) => _$this._userId = userId;
 
-  FederationInviteBuilder();
+  FederationInviteBuilder() {
+    FederationInvite._defaults(this);
+  }
 
   FederationInviteBuilder get _$this {
     final $v = _$v;
@@ -54668,6 +55465,7 @@ class FederationInviteBuilder
   FederationInvite build() => _build();
 
   _$FederationInvite _build() {
+    FederationInvite._validate(this);
     final _$result = _$v ??
         _$FederationInvite._(
             accessToken: BuiltValueNullFieldError.checkNotNull(accessToken, r'FederationInvite', 'accessToken'),
@@ -54755,7 +55553,9 @@ class PublicCapabilities0_Spreed_Config_AttachmentsBuilder
   String? get folder => _$this._folder;
   set folder(covariant String? folder) => _$this._folder = folder;
 
-  PublicCapabilities0_Spreed_Config_AttachmentsBuilder();
+  PublicCapabilities0_Spreed_Config_AttachmentsBuilder() {
+    PublicCapabilities0_Spreed_Config_Attachments._defaults(this);
+  }
 
   PublicCapabilities0_Spreed_Config_AttachmentsBuilder get _$this {
     final $v = _$v;
@@ -54782,6 +55582,7 @@ class PublicCapabilities0_Spreed_Config_AttachmentsBuilder
   PublicCapabilities0_Spreed_Config_Attachments build() => _build();
 
   _$PublicCapabilities0_Spreed_Config_Attachments _build() {
+    PublicCapabilities0_Spreed_Config_Attachments._validate(this);
     final _$result = _$v ??
         _$PublicCapabilities0_Spreed_Config_Attachments._(
             allowed: BuiltValueNullFieldError.checkNotNull(
@@ -54982,7 +55783,9 @@ class PublicCapabilities0_Spreed_Config_CallBuilder
   bool? get canEnableSip => _$this._canEnableSip;
   set canEnableSip(covariant bool? canEnableSip) => _$this._canEnableSip = canEnableSip;
 
-  PublicCapabilities0_Spreed_Config_CallBuilder();
+  PublicCapabilities0_Spreed_Config_CallBuilder() {
+    PublicCapabilities0_Spreed_Config_Call._defaults(this);
+  }
 
   PublicCapabilities0_Spreed_Config_CallBuilder get _$this {
     final $v = _$v;
@@ -55017,6 +55820,7 @@ class PublicCapabilities0_Spreed_Config_CallBuilder
   PublicCapabilities0_Spreed_Config_Call build() => _build();
 
   _$PublicCapabilities0_Spreed_Config_Call _build() {
+    PublicCapabilities0_Spreed_Config_Call._validate(this);
     _$PublicCapabilities0_Spreed_Config_Call _$result;
     try {
       _$result = _$v ??
@@ -55170,7 +55974,9 @@ class PublicCapabilities0_Spreed_Config_ChatBuilder
   ListBuilder<String> get translations => _$this._translations ??= ListBuilder<String>();
   set translations(covariant ListBuilder<String>? translations) => _$this._translations = translations;
 
-  PublicCapabilities0_Spreed_Config_ChatBuilder();
+  PublicCapabilities0_Spreed_Config_ChatBuilder() {
+    PublicCapabilities0_Spreed_Config_Chat._defaults(this);
+  }
 
   PublicCapabilities0_Spreed_Config_ChatBuilder get _$this {
     final $v = _$v;
@@ -55200,6 +56006,7 @@ class PublicCapabilities0_Spreed_Config_ChatBuilder
   PublicCapabilities0_Spreed_Config_Chat build() => _build();
 
   _$PublicCapabilities0_Spreed_Config_Chat _build() {
+    PublicCapabilities0_Spreed_Config_Chat._validate(this);
     _$PublicCapabilities0_Spreed_Config_Chat _$result;
     try {
       _$result = _$v ??
@@ -55288,7 +56095,9 @@ class PublicCapabilities0_Spreed_Config_ConversationsBuilder
   bool? get canCreate => _$this._canCreate;
   set canCreate(covariant bool? canCreate) => _$this._canCreate = canCreate;
 
-  PublicCapabilities0_Spreed_Config_ConversationsBuilder();
+  PublicCapabilities0_Spreed_Config_ConversationsBuilder() {
+    PublicCapabilities0_Spreed_Config_Conversations._defaults(this);
+  }
 
   PublicCapabilities0_Spreed_Config_ConversationsBuilder get _$this {
     final $v = _$v;
@@ -55314,6 +56123,7 @@ class PublicCapabilities0_Spreed_Config_ConversationsBuilder
   PublicCapabilities0_Spreed_Config_Conversations build() => _build();
 
   _$PublicCapabilities0_Spreed_Config_Conversations _build() {
+    PublicCapabilities0_Spreed_Config_Conversations._validate(this);
     final _$result = _$v ??
         _$PublicCapabilities0_Spreed_Config_Conversations._(
             canCreate: BuiltValueNullFieldError.checkNotNull(
@@ -55382,7 +56192,9 @@ class PublicCapabilities0_Spreed_Config_PreviewsBuilder
   int? get maxGifSize => _$this._maxGifSize;
   set maxGifSize(covariant int? maxGifSize) => _$this._maxGifSize = maxGifSize;
 
-  PublicCapabilities0_Spreed_Config_PreviewsBuilder();
+  PublicCapabilities0_Spreed_Config_PreviewsBuilder() {
+    PublicCapabilities0_Spreed_Config_Previews._defaults(this);
+  }
 
   PublicCapabilities0_Spreed_Config_PreviewsBuilder get _$this {
     final $v = _$v;
@@ -55408,6 +56220,7 @@ class PublicCapabilities0_Spreed_Config_PreviewsBuilder
   PublicCapabilities0_Spreed_Config_Previews build() => _build();
 
   _$PublicCapabilities0_Spreed_Config_Previews _build() {
+    PublicCapabilities0_Spreed_Config_Previews._validate(this);
     final _$result = _$v ??
         _$PublicCapabilities0_Spreed_Config_Previews._(
             maxGifSize: BuiltValueNullFieldError.checkNotNull(
@@ -55491,7 +56304,9 @@ class PublicCapabilities0_Spreed_Config_SignalingBuilder
   String? get helloV2TokenKey => _$this._helloV2TokenKey;
   set helloV2TokenKey(covariant String? helloV2TokenKey) => _$this._helloV2TokenKey = helloV2TokenKey;
 
-  PublicCapabilities0_Spreed_Config_SignalingBuilder();
+  PublicCapabilities0_Spreed_Config_SignalingBuilder() {
+    PublicCapabilities0_Spreed_Config_Signaling._defaults(this);
+  }
 
   PublicCapabilities0_Spreed_Config_SignalingBuilder get _$this {
     final $v = _$v;
@@ -55518,6 +56333,7 @@ class PublicCapabilities0_Spreed_Config_SignalingBuilder
   PublicCapabilities0_Spreed_Config_Signaling build() => _build();
 
   _$PublicCapabilities0_Spreed_Config_Signaling _build() {
+    PublicCapabilities0_Spreed_Config_Signaling._validate(this);
     final _$result = _$v ??
         _$PublicCapabilities0_Spreed_Config_Signaling._(
             sessionPingLimit: BuiltValueNullFieldError.checkNotNull(
@@ -55667,7 +56483,9 @@ class PublicCapabilities0_Spreed_ConfigBuilder
   set signaling(covariant PublicCapabilities0_Spreed_Config_SignalingBuilder? signaling) =>
       _$this._signaling = signaling;
 
-  PublicCapabilities0_Spreed_ConfigBuilder();
+  PublicCapabilities0_Spreed_ConfigBuilder() {
+    PublicCapabilities0_Spreed_Config._defaults(this);
+  }
 
   PublicCapabilities0_Spreed_ConfigBuilder get _$this {
     final $v = _$v;
@@ -55698,6 +56516,7 @@ class PublicCapabilities0_Spreed_ConfigBuilder
   PublicCapabilities0_Spreed_Config build() => _build();
 
   _$PublicCapabilities0_Spreed_Config _build() {
+    PublicCapabilities0_Spreed_Config._validate(this);
     _$PublicCapabilities0_Spreed_Config _$result;
     try {
       _$result = _$v ??
@@ -55817,7 +56636,9 @@ class PublicCapabilities0_SpreedBuilder
   String? get version => _$this._version;
   set version(covariant String? version) => _$this._version = version;
 
-  PublicCapabilities0_SpreedBuilder();
+  PublicCapabilities0_SpreedBuilder() {
+    PublicCapabilities0_Spreed._defaults(this);
+  }
 
   PublicCapabilities0_SpreedBuilder get _$this {
     final $v = _$v;
@@ -55845,6 +56666,7 @@ class PublicCapabilities0_SpreedBuilder
   PublicCapabilities0_Spreed build() => _build();
 
   _$PublicCapabilities0_Spreed _build() {
+    PublicCapabilities0_Spreed._validate(this);
     _$PublicCapabilities0_Spreed _$result;
     try {
       _$result = _$v ??
@@ -55922,7 +56744,9 @@ class PublicCapabilities0Builder
   PublicCapabilities0_SpreedBuilder get spreed => _$this._spreed ??= PublicCapabilities0_SpreedBuilder();
   set spreed(covariant PublicCapabilities0_SpreedBuilder? spreed) => _$this._spreed = spreed;
 
-  PublicCapabilities0Builder();
+  PublicCapabilities0Builder() {
+    PublicCapabilities0._defaults(this);
+  }
 
   PublicCapabilities0Builder get _$this {
     final $v = _$v;
@@ -55948,6 +56772,7 @@ class PublicCapabilities0Builder
   PublicCapabilities0 build() => _build();
 
   _$PublicCapabilities0 _build() {
+    PublicCapabilities0._validate(this);
     _$PublicCapabilities0 _$result;
     try {
       _$result = _$v ?? _$PublicCapabilities0._(spreed: spreed.build());

--- a/packages/nextcloud/lib/src/api/systemtags.openapi.dart
+++ b/packages/nextcloud/lib/src/api/systemtags.openapi.dart
@@ -85,6 +85,10 @@ class _$Capabilities_Systemtags_EnabledSerializer implements PrimitiveSerializer
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities_SystemtagsInterface {
   Capabilities_Systemtags_Enabled get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_SystemtagsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_SystemtagsInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_Systemtags
@@ -113,11 +117,25 @@ abstract class Capabilities_Systemtags
 
   /// Serializer for Capabilities_Systemtags.
   static Serializer<Capabilities_Systemtags> get serializer => _$capabilitiesSystemtagsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_SystemtagsBuilder b) {
+    $Capabilities_SystemtagsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_SystemtagsBuilder b) {
+    $Capabilities_SystemtagsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   Capabilities_Systemtags get systemtags;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -144,6 +162,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/systemtags.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/systemtags.openapi.g.dart
@@ -159,7 +159,9 @@ class Capabilities_SystemtagsBuilder
   Capabilities_Systemtags_Enabled? get enabled => _$this._enabled;
   set enabled(covariant Capabilities_Systemtags_Enabled? enabled) => _$this._enabled = enabled;
 
-  Capabilities_SystemtagsBuilder();
+  Capabilities_SystemtagsBuilder() {
+    Capabilities_Systemtags._defaults(this);
+  }
 
   Capabilities_SystemtagsBuilder get _$this {
     final $v = _$v;
@@ -185,6 +187,7 @@ class Capabilities_SystemtagsBuilder
   Capabilities_Systemtags build() => _build();
 
   _$Capabilities_Systemtags _build() {
+    Capabilities_Systemtags._validate(this);
     final _$result = _$v ??
         _$Capabilities_Systemtags._(
             enabled: BuiltValueNullFieldError.checkNotNull(enabled, r'Capabilities_Systemtags', 'enabled'));
@@ -244,7 +247,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities_SystemtagsBuilder get systemtags => _$this._systemtags ??= Capabilities_SystemtagsBuilder();
   set systemtags(covariant Capabilities_SystemtagsBuilder? systemtags) => _$this._systemtags = systemtags;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -270,6 +275,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(systemtags: systemtags.build());

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -1079,6 +1079,16 @@ abstract interface class $ThemingGetManifestResponseApplicationJson_IconsInterfa
   String get src;
   String get type;
   String get sizes;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ThemingGetManifestResponseApplicationJson_IconsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ThemingGetManifestResponseApplicationJson_IconsInterfaceBuilder b) {
+    _i5.checkMinLength(
+      b.src,
+      1,
+      'src',
+    );
+  }
 }
 
 abstract class ThemingGetManifestResponseApplicationJson_Icons
@@ -1113,13 +1123,14 @@ abstract class ThemingGetManifestResponseApplicationJson_Icons
   static Serializer<ThemingGetManifestResponseApplicationJson_Icons> get serializer =>
       _$themingGetManifestResponseApplicationJsonIconsSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ThemingGetManifestResponseApplicationJson_IconsBuilder b) {
+    $ThemingGetManifestResponseApplicationJson_IconsInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(ThemingGetManifestResponseApplicationJson_IconsBuilder b) {
-    _i5.checkMinLength(
-      b.src,
-      1,
-      'src',
-    );
+    $ThemingGetManifestResponseApplicationJson_IconsInterface._validate(b);
   }
 }
 
@@ -1137,6 +1148,10 @@ abstract interface class $ThemingGetManifestResponseApplicationJsonInterface {
   String get description;
   BuiltList<ThemingGetManifestResponseApplicationJson_Icons> get icons;
   String get display;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ThemingGetManifestResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ThemingGetManifestResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ThemingGetManifestResponseApplicationJson
@@ -1170,6 +1185,16 @@ abstract class ThemingGetManifestResponseApplicationJson
   /// Serializer for ThemingGetManifestResponseApplicationJson.
   static Serializer<ThemingGetManifestResponseApplicationJson> get serializer =>
       _$themingGetManifestResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ThemingGetManifestResponseApplicationJsonBuilder b) {
+    $ThemingGetManifestResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ThemingGetManifestResponseApplicationJsonBuilder b) {
+    $ThemingGetManifestResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1179,6 +1204,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -1205,12 +1234,26 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserThemeEnableThemeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserThemeEnableThemeResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserThemeEnableThemeResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UserThemeEnableThemeResponseApplicationJson_Ocs
@@ -1244,11 +1287,25 @@ abstract class UserThemeEnableThemeResponseApplicationJson_Ocs
   /// Serializer for UserThemeEnableThemeResponseApplicationJson_Ocs.
   static Serializer<UserThemeEnableThemeResponseApplicationJson_Ocs> get serializer =>
       _$userThemeEnableThemeResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserThemeEnableThemeResponseApplicationJson_OcsBuilder b) {
+    $UserThemeEnableThemeResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserThemeEnableThemeResponseApplicationJson_OcsBuilder b) {
+    $UserThemeEnableThemeResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserThemeEnableThemeResponseApplicationJsonInterface {
   UserThemeEnableThemeResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserThemeEnableThemeResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserThemeEnableThemeResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UserThemeEnableThemeResponseApplicationJson
@@ -1282,12 +1339,26 @@ abstract class UserThemeEnableThemeResponseApplicationJson
   /// Serializer for UserThemeEnableThemeResponseApplicationJson.
   static Serializer<UserThemeEnableThemeResponseApplicationJson> get serializer =>
       _$userThemeEnableThemeResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserThemeEnableThemeResponseApplicationJsonBuilder b) {
+    $UserThemeEnableThemeResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserThemeEnableThemeResponseApplicationJsonBuilder b) {
+    $UserThemeEnableThemeResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserThemeDisableThemeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserThemeDisableThemeResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserThemeDisableThemeResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UserThemeDisableThemeResponseApplicationJson_Ocs
@@ -1322,11 +1393,25 @@ abstract class UserThemeDisableThemeResponseApplicationJson_Ocs
   /// Serializer for UserThemeDisableThemeResponseApplicationJson_Ocs.
   static Serializer<UserThemeDisableThemeResponseApplicationJson_Ocs> get serializer =>
       _$userThemeDisableThemeResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserThemeDisableThemeResponseApplicationJson_OcsBuilder b) {
+    $UserThemeDisableThemeResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserThemeDisableThemeResponseApplicationJson_OcsBuilder b) {
+    $UserThemeDisableThemeResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserThemeDisableThemeResponseApplicationJsonInterface {
   UserThemeDisableThemeResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserThemeDisableThemeResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserThemeDisableThemeResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UserThemeDisableThemeResponseApplicationJson
@@ -1360,6 +1445,16 @@ abstract class UserThemeDisableThemeResponseApplicationJson
   /// Serializer for UserThemeDisableThemeResponseApplicationJson.
   static Serializer<UserThemeDisableThemeResponseApplicationJson> get serializer =>
       _$userThemeDisableThemeResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserThemeDisableThemeResponseApplicationJsonBuilder b) {
+    $UserThemeDisableThemeResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserThemeDisableThemeResponseApplicationJsonBuilder b) {
+    $UserThemeDisableThemeResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1384,6 +1479,10 @@ abstract interface class $PublicCapabilities_ThemingInterface {
   bool get backgroundDefault;
   String get logoheader;
   String get favicon;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilities_ThemingInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilities_ThemingInterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities_Theming
@@ -1415,11 +1514,25 @@ abstract class PublicCapabilities_Theming
 
   /// Serializer for PublicCapabilities_Theming.
   static Serializer<PublicCapabilities_Theming> get serializer => _$publicCapabilitiesThemingSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilities_ThemingBuilder b) {
+    $PublicCapabilities_ThemingInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilities_ThemingBuilder b) {
+    $PublicCapabilities_ThemingInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PublicCapabilitiesInterface {
   PublicCapabilities_Theming get theming;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicCapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicCapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class PublicCapabilities
@@ -1448,6 +1561,16 @@ abstract class PublicCapabilities
 
   /// Serializer for PublicCapabilities.
   static Serializer<PublicCapabilities> get serializer => _$publicCapabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicCapabilitiesBuilder b) {
+    $PublicCapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicCapabilitiesBuilder b) {
+    $PublicCapabilitiesInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/theming.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.g.dart
@@ -702,7 +702,9 @@ class ThemingGetManifestResponseApplicationJson_IconsBuilder
   String? get sizes => _$this._sizes;
   set sizes(covariant String? sizes) => _$this._sizes = sizes;
 
-  ThemingGetManifestResponseApplicationJson_IconsBuilder();
+  ThemingGetManifestResponseApplicationJson_IconsBuilder() {
+    ThemingGetManifestResponseApplicationJson_Icons._defaults(this);
+  }
 
   ThemingGetManifestResponseApplicationJson_IconsBuilder get _$this {
     final $v = _$v;
@@ -906,7 +908,9 @@ class ThemingGetManifestResponseApplicationJsonBuilder
   String? get display => _$this._display;
   set display(covariant String? display) => _$this._display = display;
 
-  ThemingGetManifestResponseApplicationJsonBuilder();
+  ThemingGetManifestResponseApplicationJsonBuilder() {
+    ThemingGetManifestResponseApplicationJson._defaults(this);
+  }
 
   ThemingGetManifestResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -939,6 +943,7 @@ class ThemingGetManifestResponseApplicationJsonBuilder
   ThemingGetManifestResponseApplicationJson build() => _build();
 
   _$ThemingGetManifestResponseApplicationJson _build() {
+    ThemingGetManifestResponseApplicationJson._validate(this);
     _$ThemingGetManifestResponseApplicationJson _$result;
     try {
       _$result = _$v ??
@@ -1075,7 +1080,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -1105,6 +1112,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -1190,7 +1198,9 @@ class UserThemeEnableThemeResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UserThemeEnableThemeResponseApplicationJson_OcsBuilder();
+  UserThemeEnableThemeResponseApplicationJson_OcsBuilder() {
+    UserThemeEnableThemeResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UserThemeEnableThemeResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1217,6 +1227,7 @@ class UserThemeEnableThemeResponseApplicationJson_OcsBuilder
   UserThemeEnableThemeResponseApplicationJson_Ocs build() => _build();
 
   _$UserThemeEnableThemeResponseApplicationJson_Ocs _build() {
+    UserThemeEnableThemeResponseApplicationJson_Ocs._validate(this);
     _$UserThemeEnableThemeResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -1299,7 +1310,9 @@ class UserThemeEnableThemeResponseApplicationJsonBuilder
       _$this._ocs ??= UserThemeEnableThemeResponseApplicationJson_OcsBuilder();
   set ocs(covariant UserThemeEnableThemeResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UserThemeEnableThemeResponseApplicationJsonBuilder();
+  UserThemeEnableThemeResponseApplicationJsonBuilder() {
+    UserThemeEnableThemeResponseApplicationJson._defaults(this);
+  }
 
   UserThemeEnableThemeResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1325,6 +1338,7 @@ class UserThemeEnableThemeResponseApplicationJsonBuilder
   UserThemeEnableThemeResponseApplicationJson build() => _build();
 
   _$UserThemeEnableThemeResponseApplicationJson _build() {
+    UserThemeEnableThemeResponseApplicationJson._validate(this);
     _$UserThemeEnableThemeResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UserThemeEnableThemeResponseApplicationJson._(ocs: ocs.build());
@@ -1416,7 +1430,9 @@ class UserThemeDisableThemeResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UserThemeDisableThemeResponseApplicationJson_OcsBuilder();
+  UserThemeDisableThemeResponseApplicationJson_OcsBuilder() {
+    UserThemeDisableThemeResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UserThemeDisableThemeResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1443,6 +1459,7 @@ class UserThemeDisableThemeResponseApplicationJson_OcsBuilder
   UserThemeDisableThemeResponseApplicationJson_Ocs build() => _build();
 
   _$UserThemeDisableThemeResponseApplicationJson_Ocs _build() {
+    UserThemeDisableThemeResponseApplicationJson_Ocs._validate(this);
     _$UserThemeDisableThemeResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -1525,7 +1542,9 @@ class UserThemeDisableThemeResponseApplicationJsonBuilder
       _$this._ocs ??= UserThemeDisableThemeResponseApplicationJson_OcsBuilder();
   set ocs(covariant UserThemeDisableThemeResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UserThemeDisableThemeResponseApplicationJsonBuilder();
+  UserThemeDisableThemeResponseApplicationJsonBuilder() {
+    UserThemeDisableThemeResponseApplicationJson._defaults(this);
+  }
 
   UserThemeDisableThemeResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1551,6 +1570,7 @@ class UserThemeDisableThemeResponseApplicationJsonBuilder
   UserThemeDisableThemeResponseApplicationJson build() => _build();
 
   _$UserThemeDisableThemeResponseApplicationJson _build() {
+    UserThemeDisableThemeResponseApplicationJson._validate(this);
     _$UserThemeDisableThemeResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UserThemeDisableThemeResponseApplicationJson._(ocs: ocs.build());
@@ -1811,7 +1831,9 @@ class PublicCapabilities_ThemingBuilder
   String? get favicon => _$this._favicon;
   set favicon(covariant String? favicon) => _$this._favicon = favicon;
 
-  PublicCapabilities_ThemingBuilder();
+  PublicCapabilities_ThemingBuilder() {
+    PublicCapabilities_Theming._defaults(this);
+  }
 
   PublicCapabilities_ThemingBuilder get _$this {
     final $v = _$v;
@@ -1850,6 +1872,7 @@ class PublicCapabilities_ThemingBuilder
   PublicCapabilities_Theming build() => _build();
 
   _$PublicCapabilities_Theming _build() {
+    PublicCapabilities_Theming._validate(this);
     final _$result = _$v ??
         _$PublicCapabilities_Theming._(
             name: BuiltValueNullFieldError.checkNotNull(name, r'PublicCapabilities_Theming', 'name'),
@@ -1929,7 +1952,9 @@ class PublicCapabilitiesBuilder
   PublicCapabilities_ThemingBuilder get theming => _$this._theming ??= PublicCapabilities_ThemingBuilder();
   set theming(covariant PublicCapabilities_ThemingBuilder? theming) => _$this._theming = theming;
 
-  PublicCapabilitiesBuilder();
+  PublicCapabilitiesBuilder() {
+    PublicCapabilities._defaults(this);
+  }
 
   PublicCapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -1955,6 +1980,7 @@ class PublicCapabilitiesBuilder
   PublicCapabilities build() => _build();
 
   _$PublicCapabilities _build() {
+    PublicCapabilities._validate(this);
     _$PublicCapabilities _$result;
     try {
       _$result = _$v ?? _$PublicCapabilities._(theming: theming.build());

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
@@ -226,6 +226,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -252,12 +256,26 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $AppInterface {
   String get appId;
   String get appName;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppInterfaceBuilder b) {}
 }
 
 abstract class App implements $AppInterface, Built<App, AppBuilder> {
@@ -284,12 +302,26 @@ abstract class App implements $AppInterface, Built<App, AppBuilder> {
 
   /// Serializer for App.
   static Serializer<App> get serializer => _$appSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppBuilder b) {
+    $AppInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppBuilder b) {
+    $AppInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiGetAppListResponseApplicationJson_Ocs_DataInterface {
   BuiltList<App> get missing;
   BuiltList<App> get available;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGetAppListResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGetAppListResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class ApiGetAppListResponseApplicationJson_Ocs_Data
@@ -323,12 +355,26 @@ abstract class ApiGetAppListResponseApplicationJson_Ocs_Data
   /// Serializer for ApiGetAppListResponseApplicationJson_Ocs_Data.
   static Serializer<ApiGetAppListResponseApplicationJson_Ocs_Data> get serializer =>
       _$apiGetAppListResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGetAppListResponseApplicationJson_Ocs_DataBuilder b) {
+    $ApiGetAppListResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGetAppListResponseApplicationJson_Ocs_DataBuilder b) {
+    $ApiGetAppListResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiGetAppListResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ApiGetAppListResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGetAppListResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGetAppListResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ApiGetAppListResponseApplicationJson_Ocs
@@ -362,11 +408,25 @@ abstract class ApiGetAppListResponseApplicationJson_Ocs
   /// Serializer for ApiGetAppListResponseApplicationJson_Ocs.
   static Serializer<ApiGetAppListResponseApplicationJson_Ocs> get serializer =>
       _$apiGetAppListResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGetAppListResponseApplicationJson_OcsBuilder b) {
+    $ApiGetAppListResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGetAppListResponseApplicationJson_OcsBuilder b) {
+    $ApiGetAppListResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ApiGetAppListResponseApplicationJsonInterface {
   ApiGetAppListResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGetAppListResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGetAppListResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ApiGetAppListResponseApplicationJson
@@ -399,6 +459,16 @@ abstract class ApiGetAppListResponseApplicationJson
   /// Serializer for ApiGetAppListResponseApplicationJson.
   static Serializer<ApiGetAppListResponseApplicationJson> get serializer =>
       _$apiGetAppListResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGetAppListResponseApplicationJsonBuilder b) {
+    $ApiGetAppListResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGetAppListResponseApplicationJsonBuilder b) {
+    $ApiGetAppListResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.g.dart
@@ -385,7 +385,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -415,6 +417,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -491,7 +494,9 @@ class AppBuilder implements Builder<App, AppBuilder>, $AppInterfaceBuilder {
   String? get appName => _$this._appName;
   set appName(covariant String? appName) => _$this._appName = appName;
 
-  AppBuilder();
+  AppBuilder() {
+    App._defaults(this);
+  }
 
   AppBuilder get _$this {
     final $v = _$v;
@@ -518,6 +523,7 @@ class AppBuilder implements Builder<App, AppBuilder>, $AppInterfaceBuilder {
   App build() => _build();
 
   _$App _build() {
+    App._validate(this);
     final _$result = _$v ??
         _$App._(
             appId: BuiltValueNullFieldError.checkNotNull(appId, r'App', 'appId'),
@@ -601,7 +607,9 @@ class ApiGetAppListResponseApplicationJson_Ocs_DataBuilder
   ListBuilder<App> get available => _$this._available ??= ListBuilder<App>();
   set available(covariant ListBuilder<App>? available) => _$this._available = available;
 
-  ApiGetAppListResponseApplicationJson_Ocs_DataBuilder();
+  ApiGetAppListResponseApplicationJson_Ocs_DataBuilder() {
+    ApiGetAppListResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   ApiGetAppListResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -628,6 +636,7 @@ class ApiGetAppListResponseApplicationJson_Ocs_DataBuilder
   ApiGetAppListResponseApplicationJson_Ocs_Data build() => _build();
 
   _$ApiGetAppListResponseApplicationJson_Ocs_Data _build() {
+    ApiGetAppListResponseApplicationJson_Ocs_Data._validate(this);
     _$ApiGetAppListResponseApplicationJson_Ocs_Data _$result;
     try {
       _$result = _$v ??
@@ -722,7 +731,9 @@ class ApiGetAppListResponseApplicationJson_OcsBuilder
       _$this._data ??= ApiGetAppListResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant ApiGetAppListResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  ApiGetAppListResponseApplicationJson_OcsBuilder();
+  ApiGetAppListResponseApplicationJson_OcsBuilder() {
+    ApiGetAppListResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ApiGetAppListResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -749,6 +760,7 @@ class ApiGetAppListResponseApplicationJson_OcsBuilder
   ApiGetAppListResponseApplicationJson_Ocs build() => _build();
 
   _$ApiGetAppListResponseApplicationJson_Ocs _build() {
+    ApiGetAppListResponseApplicationJson_Ocs._validate(this);
     _$ApiGetAppListResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ApiGetAppListResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -827,7 +839,9 @@ class ApiGetAppListResponseApplicationJsonBuilder
       _$this._ocs ??= ApiGetAppListResponseApplicationJson_OcsBuilder();
   set ocs(covariant ApiGetAppListResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ApiGetAppListResponseApplicationJsonBuilder();
+  ApiGetAppListResponseApplicationJsonBuilder() {
+    ApiGetAppListResponseApplicationJson._defaults(this);
+  }
 
   ApiGetAppListResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -853,6 +867,7 @@ class ApiGetAppListResponseApplicationJsonBuilder
   ApiGetAppListResponseApplicationJson build() => _build();
 
   _$ApiGetAppListResponseApplicationJson _build() {
+    ApiGetAppListResponseApplicationJson._validate(this);
     _$ApiGetAppListResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ApiGetAppListResponseApplicationJson._(ocs: ocs.build());

--- a/packages/nextcloud/lib/src/api/uppush.openapi.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.dart
@@ -882,6 +882,10 @@ class $Client extends _i1.DynamiteClient {
 @BuiltValue(instantiable: false)
 abstract interface class $CheckResponseApplicationJsonInterface {
   bool get success;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CheckResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CheckResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CheckResponseApplicationJson
@@ -913,11 +917,25 @@ abstract class CheckResponseApplicationJson
 
   /// Serializer for CheckResponseApplicationJson.
   static Serializer<CheckResponseApplicationJson> get serializer => _$checkResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CheckResponseApplicationJsonBuilder b) {
+    $CheckResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CheckResponseApplicationJsonBuilder b) {
+    $CheckResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SetKeepaliveResponseApplicationJsonInterface {
   bool get success;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SetKeepaliveResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SetKeepaliveResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class SetKeepaliveResponseApplicationJson
@@ -950,12 +968,26 @@ abstract class SetKeepaliveResponseApplicationJson
   /// Serializer for SetKeepaliveResponseApplicationJson.
   static Serializer<SetKeepaliveResponseApplicationJson> get serializer =>
       _$setKeepaliveResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SetKeepaliveResponseApplicationJsonBuilder b) {
+    $SetKeepaliveResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SetKeepaliveResponseApplicationJsonBuilder b) {
+    $SetKeepaliveResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CreateDeviceResponseApplicationJsonInterface {
   bool get success;
   String get deviceId;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CreateDeviceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CreateDeviceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CreateDeviceResponseApplicationJson
@@ -988,11 +1020,25 @@ abstract class CreateDeviceResponseApplicationJson
   /// Serializer for CreateDeviceResponseApplicationJson.
   static Serializer<CreateDeviceResponseApplicationJson> get serializer =>
       _$createDeviceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CreateDeviceResponseApplicationJsonBuilder b) {
+    $CreateDeviceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CreateDeviceResponseApplicationJsonBuilder b) {
+    $CreateDeviceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SyncDeviceResponseApplicationJsonInterface {
   bool get success;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SyncDeviceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SyncDeviceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class SyncDeviceResponseApplicationJson
@@ -1024,11 +1070,25 @@ abstract class SyncDeviceResponseApplicationJson
 
   /// Serializer for SyncDeviceResponseApplicationJson.
   static Serializer<SyncDeviceResponseApplicationJson> get serializer => _$syncDeviceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SyncDeviceResponseApplicationJsonBuilder b) {
+    $SyncDeviceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SyncDeviceResponseApplicationJsonBuilder b) {
+    $SyncDeviceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DeleteDeviceResponseApplicationJsonInterface {
   bool get success;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DeleteDeviceResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DeleteDeviceResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DeleteDeviceResponseApplicationJson
@@ -1061,12 +1121,26 @@ abstract class DeleteDeviceResponseApplicationJson
   /// Serializer for DeleteDeviceResponseApplicationJson.
   static Serializer<DeleteDeviceResponseApplicationJson> get serializer =>
       _$deleteDeviceResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DeleteDeviceResponseApplicationJsonBuilder b) {
+    $DeleteDeviceResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DeleteDeviceResponseApplicationJsonBuilder b) {
+    $DeleteDeviceResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CreateAppResponseApplicationJsonInterface {
   bool get success;
   String get token;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CreateAppResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CreateAppResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class CreateAppResponseApplicationJson
@@ -1098,11 +1172,25 @@ abstract class CreateAppResponseApplicationJson
 
   /// Serializer for CreateAppResponseApplicationJson.
   static Serializer<CreateAppResponseApplicationJson> get serializer => _$createAppResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CreateAppResponseApplicationJsonBuilder b) {
+    $CreateAppResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CreateAppResponseApplicationJsonBuilder b) {
+    $CreateAppResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $DeleteAppResponseApplicationJsonInterface {
   bool get success;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DeleteAppResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DeleteAppResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class DeleteAppResponseApplicationJson
@@ -1134,11 +1222,25 @@ abstract class DeleteAppResponseApplicationJson
 
   /// Serializer for DeleteAppResponseApplicationJson.
   static Serializer<DeleteAppResponseApplicationJson> get serializer => _$deleteAppResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DeleteAppResponseApplicationJsonBuilder b) {
+    $DeleteAppResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DeleteAppResponseApplicationJsonBuilder b) {
+    $DeleteAppResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterface {
   int get version;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder b) {}
 }
 
 abstract class UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush
@@ -1173,11 +1275,25 @@ abstract class UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush
   /// Serializer for UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush.
   static Serializer<UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush> get serializer =>
       _$unifiedpushDiscoveryResponseApplicationJsonUnifiedpushSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder b) {
+    $UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder b) {
+    $UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UnifiedpushDiscoveryResponseApplicationJsonInterface {
   UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush get unifiedpush;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedpushDiscoveryResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedpushDiscoveryResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UnifiedpushDiscoveryResponseApplicationJson
@@ -1211,11 +1327,25 @@ abstract class UnifiedpushDiscoveryResponseApplicationJson
   /// Serializer for UnifiedpushDiscoveryResponseApplicationJson.
   static Serializer<UnifiedpushDiscoveryResponseApplicationJson> get serializer =>
       _$unifiedpushDiscoveryResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedpushDiscoveryResponseApplicationJsonBuilder b) {
+    $UnifiedpushDiscoveryResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UnifiedpushDiscoveryResponseApplicationJsonBuilder b) {
+    $UnifiedpushDiscoveryResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PushResponseApplicationJsonInterface {
   bool get success;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PushResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PushResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PushResponseApplicationJson
@@ -1247,11 +1377,25 @@ abstract class PushResponseApplicationJson
 
   /// Serializer for PushResponseApplicationJson.
   static Serializer<PushResponseApplicationJson> get serializer => _$pushResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PushResponseApplicationJsonBuilder b) {
+    $PushResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PushResponseApplicationJsonBuilder b) {
+    $PushResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterface {
   String get gateway;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder b) {}
 }
 
 abstract class GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush
@@ -1286,11 +1430,25 @@ abstract class GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush
   /// Serializer for GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush.
   static Serializer<GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush> get serializer =>
       _$gatewayMatrixDiscoveryResponseApplicationJsonUnifiedpushSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder b) {
+    $GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder b) {
+    $GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GatewayMatrixDiscoveryResponseApplicationJsonInterface {
   GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush get unifiedpush;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GatewayMatrixDiscoveryResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GatewayMatrixDiscoveryResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class GatewayMatrixDiscoveryResponseApplicationJson
@@ -1324,11 +1482,25 @@ abstract class GatewayMatrixDiscoveryResponseApplicationJson
   /// Serializer for GatewayMatrixDiscoveryResponseApplicationJson.
   static Serializer<GatewayMatrixDiscoveryResponseApplicationJson> get serializer =>
       _$gatewayMatrixDiscoveryResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GatewayMatrixDiscoveryResponseApplicationJsonBuilder b) {
+    $GatewayMatrixDiscoveryResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GatewayMatrixDiscoveryResponseApplicationJsonBuilder b) {
+    $GatewayMatrixDiscoveryResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $GatewayMatrixResponseApplicationJsonInterface {
   BuiltList<String> get rejected;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GatewayMatrixResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GatewayMatrixResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class GatewayMatrixResponseApplicationJson
@@ -1361,6 +1533,16 @@ abstract class GatewayMatrixResponseApplicationJson
   /// Serializer for GatewayMatrixResponseApplicationJson.
   static Serializer<GatewayMatrixResponseApplicationJson> get serializer =>
       _$gatewayMatrixResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GatewayMatrixResponseApplicationJsonBuilder b) {
+    $GatewayMatrixResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GatewayMatrixResponseApplicationJsonBuilder b) {
+    $GatewayMatrixResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/uppush.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.g.dart
@@ -623,7 +623,9 @@ class CheckResponseApplicationJsonBuilder
   bool? get success => _$this._success;
   set success(covariant bool? success) => _$this._success = success;
 
-  CheckResponseApplicationJsonBuilder();
+  CheckResponseApplicationJsonBuilder() {
+    CheckResponseApplicationJson._defaults(this);
+  }
 
   CheckResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -649,6 +651,7 @@ class CheckResponseApplicationJsonBuilder
   CheckResponseApplicationJson build() => _build();
 
   _$CheckResponseApplicationJson _build() {
+    CheckResponseApplicationJson._validate(this);
     final _$result = _$v ??
         _$CheckResponseApplicationJson._(
             success: BuiltValueNullFieldError.checkNotNull(success, r'CheckResponseApplicationJson', 'success'));
@@ -712,7 +715,9 @@ class SetKeepaliveResponseApplicationJsonBuilder
   bool? get success => _$this._success;
   set success(covariant bool? success) => _$this._success = success;
 
-  SetKeepaliveResponseApplicationJsonBuilder();
+  SetKeepaliveResponseApplicationJsonBuilder() {
+    SetKeepaliveResponseApplicationJson._defaults(this);
+  }
 
   SetKeepaliveResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -738,6 +743,7 @@ class SetKeepaliveResponseApplicationJsonBuilder
   SetKeepaliveResponseApplicationJson build() => _build();
 
   _$SetKeepaliveResponseApplicationJson _build() {
+    SetKeepaliveResponseApplicationJson._validate(this);
     final _$result = _$v ??
         _$SetKeepaliveResponseApplicationJson._(
             success: BuiltValueNullFieldError.checkNotNull(success, r'SetKeepaliveResponseApplicationJson', 'success'));
@@ -815,7 +821,9 @@ class CreateDeviceResponseApplicationJsonBuilder
   String? get deviceId => _$this._deviceId;
   set deviceId(covariant String? deviceId) => _$this._deviceId = deviceId;
 
-  CreateDeviceResponseApplicationJsonBuilder();
+  CreateDeviceResponseApplicationJsonBuilder() {
+    CreateDeviceResponseApplicationJson._defaults(this);
+  }
 
   CreateDeviceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -842,6 +850,7 @@ class CreateDeviceResponseApplicationJsonBuilder
   CreateDeviceResponseApplicationJson build() => _build();
 
   _$CreateDeviceResponseApplicationJson _build() {
+    CreateDeviceResponseApplicationJson._validate(this);
     final _$result = _$v ??
         _$CreateDeviceResponseApplicationJson._(
             success: BuiltValueNullFieldError.checkNotNull(success, r'CreateDeviceResponseApplicationJson', 'success'),
@@ -907,7 +916,9 @@ class SyncDeviceResponseApplicationJsonBuilder
   bool? get success => _$this._success;
   set success(covariant bool? success) => _$this._success = success;
 
-  SyncDeviceResponseApplicationJsonBuilder();
+  SyncDeviceResponseApplicationJsonBuilder() {
+    SyncDeviceResponseApplicationJson._defaults(this);
+  }
 
   SyncDeviceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -933,6 +944,7 @@ class SyncDeviceResponseApplicationJsonBuilder
   SyncDeviceResponseApplicationJson build() => _build();
 
   _$SyncDeviceResponseApplicationJson _build() {
+    SyncDeviceResponseApplicationJson._validate(this);
     final _$result = _$v ??
         _$SyncDeviceResponseApplicationJson._(
             success: BuiltValueNullFieldError.checkNotNull(success, r'SyncDeviceResponseApplicationJson', 'success'));
@@ -996,7 +1008,9 @@ class DeleteDeviceResponseApplicationJsonBuilder
   bool? get success => _$this._success;
   set success(covariant bool? success) => _$this._success = success;
 
-  DeleteDeviceResponseApplicationJsonBuilder();
+  DeleteDeviceResponseApplicationJsonBuilder() {
+    DeleteDeviceResponseApplicationJson._defaults(this);
+  }
 
   DeleteDeviceResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1022,6 +1036,7 @@ class DeleteDeviceResponseApplicationJsonBuilder
   DeleteDeviceResponseApplicationJson build() => _build();
 
   _$DeleteDeviceResponseApplicationJson _build() {
+    DeleteDeviceResponseApplicationJson._validate(this);
     final _$result = _$v ??
         _$DeleteDeviceResponseApplicationJson._(
             success: BuiltValueNullFieldError.checkNotNull(success, r'DeleteDeviceResponseApplicationJson', 'success'));
@@ -1099,7 +1114,9 @@ class CreateAppResponseApplicationJsonBuilder
   String? get token => _$this._token;
   set token(covariant String? token) => _$this._token = token;
 
-  CreateAppResponseApplicationJsonBuilder();
+  CreateAppResponseApplicationJsonBuilder() {
+    CreateAppResponseApplicationJson._defaults(this);
+  }
 
   CreateAppResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1126,6 +1143,7 @@ class CreateAppResponseApplicationJsonBuilder
   CreateAppResponseApplicationJson build() => _build();
 
   _$CreateAppResponseApplicationJson _build() {
+    CreateAppResponseApplicationJson._validate(this);
     final _$result = _$v ??
         _$CreateAppResponseApplicationJson._(
             success: BuiltValueNullFieldError.checkNotNull(success, r'CreateAppResponseApplicationJson', 'success'),
@@ -1190,7 +1208,9 @@ class DeleteAppResponseApplicationJsonBuilder
   bool? get success => _$this._success;
   set success(covariant bool? success) => _$this._success = success;
 
-  DeleteAppResponseApplicationJsonBuilder();
+  DeleteAppResponseApplicationJsonBuilder() {
+    DeleteAppResponseApplicationJson._defaults(this);
+  }
 
   DeleteAppResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1216,6 +1236,7 @@ class DeleteAppResponseApplicationJsonBuilder
   DeleteAppResponseApplicationJson build() => _build();
 
   _$DeleteAppResponseApplicationJson _build() {
+    DeleteAppResponseApplicationJson._validate(this);
     final _$result = _$v ??
         _$DeleteAppResponseApplicationJson._(
             success: BuiltValueNullFieldError.checkNotNull(success, r'DeleteAppResponseApplicationJson', 'success'));
@@ -1287,7 +1308,9 @@ class UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder
   int? get version => _$this._version;
   set version(covariant int? version) => _$this._version = version;
 
-  UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder();
+  UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder() {
+    UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush._defaults(this);
+  }
 
   UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder get _$this {
     final $v = _$v;
@@ -1313,6 +1336,7 @@ class UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder
   UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush build() => _build();
 
   _$UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush _build() {
+    UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush._validate(this);
     final _$result = _$v ??
         _$UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush._(
             version: BuiltValueNullFieldError.checkNotNull(
@@ -1384,7 +1408,9 @@ class UnifiedpushDiscoveryResponseApplicationJsonBuilder
   set unifiedpush(covariant UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushBuilder? unifiedpush) =>
       _$this._unifiedpush = unifiedpush;
 
-  UnifiedpushDiscoveryResponseApplicationJsonBuilder();
+  UnifiedpushDiscoveryResponseApplicationJsonBuilder() {
+    UnifiedpushDiscoveryResponseApplicationJson._defaults(this);
+  }
 
   UnifiedpushDiscoveryResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1410,6 +1436,7 @@ class UnifiedpushDiscoveryResponseApplicationJsonBuilder
   UnifiedpushDiscoveryResponseApplicationJson build() => _build();
 
   _$UnifiedpushDiscoveryResponseApplicationJson _build() {
+    UnifiedpushDiscoveryResponseApplicationJson._validate(this);
     _$UnifiedpushDiscoveryResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UnifiedpushDiscoveryResponseApplicationJson._(unifiedpush: unifiedpush.build());
@@ -1483,7 +1510,9 @@ class PushResponseApplicationJsonBuilder
   bool? get success => _$this._success;
   set success(covariant bool? success) => _$this._success = success;
 
-  PushResponseApplicationJsonBuilder();
+  PushResponseApplicationJsonBuilder() {
+    PushResponseApplicationJson._defaults(this);
+  }
 
   PushResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1509,6 +1538,7 @@ class PushResponseApplicationJsonBuilder
   PushResponseApplicationJson build() => _build();
 
   _$PushResponseApplicationJson _build() {
+    PushResponseApplicationJson._validate(this);
     final _$result = _$v ??
         _$PushResponseApplicationJson._(
             success: BuiltValueNullFieldError.checkNotNull(success, r'PushResponseApplicationJson', 'success'));
@@ -1580,7 +1610,9 @@ class GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder
   String? get gateway => _$this._gateway;
   set gateway(covariant String? gateway) => _$this._gateway = gateway;
 
-  GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder();
+  GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder() {
+    GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush._defaults(this);
+  }
 
   GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder get _$this {
     final $v = _$v;
@@ -1606,6 +1638,7 @@ class GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder
   GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush build() => _build();
 
   _$GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush _build() {
+    GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush._validate(this);
     final _$result = _$v ??
         _$GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush._(
             gateway: BuiltValueNullFieldError.checkNotNull(
@@ -1677,7 +1710,9 @@ class GatewayMatrixDiscoveryResponseApplicationJsonBuilder
   set unifiedpush(covariant GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushBuilder? unifiedpush) =>
       _$this._unifiedpush = unifiedpush;
 
-  GatewayMatrixDiscoveryResponseApplicationJsonBuilder();
+  GatewayMatrixDiscoveryResponseApplicationJsonBuilder() {
+    GatewayMatrixDiscoveryResponseApplicationJson._defaults(this);
+  }
 
   GatewayMatrixDiscoveryResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1703,6 +1738,7 @@ class GatewayMatrixDiscoveryResponseApplicationJsonBuilder
   GatewayMatrixDiscoveryResponseApplicationJson build() => _build();
 
   _$GatewayMatrixDiscoveryResponseApplicationJson _build() {
+    GatewayMatrixDiscoveryResponseApplicationJson._validate(this);
     _$GatewayMatrixDiscoveryResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$GatewayMatrixDiscoveryResponseApplicationJson._(unifiedpush: unifiedpush.build());
@@ -1778,7 +1814,9 @@ class GatewayMatrixResponseApplicationJsonBuilder
   ListBuilder<String> get rejected => _$this._rejected ??= ListBuilder<String>();
   set rejected(covariant ListBuilder<String>? rejected) => _$this._rejected = rejected;
 
-  GatewayMatrixResponseApplicationJsonBuilder();
+  GatewayMatrixResponseApplicationJsonBuilder() {
+    GatewayMatrixResponseApplicationJson._defaults(this);
+  }
 
   GatewayMatrixResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1804,6 +1842,7 @@ class GatewayMatrixResponseApplicationJsonBuilder
   GatewayMatrixResponseApplicationJson build() => _build();
 
   _$GatewayMatrixResponseApplicationJson _build() {
+    GatewayMatrixResponseApplicationJson._validate(this);
     _$GatewayMatrixResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$GatewayMatrixResponseApplicationJson._(rejected: rejected.build());

--- a/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
@@ -470,6 +470,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -496,11 +500,25 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ConfigapiCreateResponseApplicationJson_Ocs_DataInterface {
   String get configID;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiCreateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiCreateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
 }
 
 abstract class ConfigapiCreateResponseApplicationJson_Ocs_Data
@@ -534,12 +552,26 @@ abstract class ConfigapiCreateResponseApplicationJson_Ocs_Data
   /// Serializer for ConfigapiCreateResponseApplicationJson_Ocs_Data.
   static Serializer<ConfigapiCreateResponseApplicationJson_Ocs_Data> get serializer =>
       _$configapiCreateResponseApplicationJsonOcsDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiCreateResponseApplicationJson_Ocs_DataBuilder b) {
+    $ConfigapiCreateResponseApplicationJson_Ocs_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiCreateResponseApplicationJson_Ocs_DataBuilder b) {
+    $ConfigapiCreateResponseApplicationJson_Ocs_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ConfigapiCreateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ConfigapiCreateResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ConfigapiCreateResponseApplicationJson_Ocs
@@ -573,11 +605,25 @@ abstract class ConfigapiCreateResponseApplicationJson_Ocs
   /// Serializer for ConfigapiCreateResponseApplicationJson_Ocs.
   static Serializer<ConfigapiCreateResponseApplicationJson_Ocs> get serializer =>
       _$configapiCreateResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiCreateResponseApplicationJson_OcsBuilder b) {
+    $ConfigapiCreateResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiCreateResponseApplicationJson_OcsBuilder b) {
+    $ConfigapiCreateResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ConfigapiCreateResponseApplicationJsonInterface {
   ConfigapiCreateResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiCreateResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiCreateResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ConfigapiCreateResponseApplicationJson
@@ -610,6 +656,16 @@ abstract class ConfigapiCreateResponseApplicationJson
   /// Serializer for ConfigapiCreateResponseApplicationJson.
   static Serializer<ConfigapiCreateResponseApplicationJson> get serializer =>
       _$configapiCreateResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiCreateResponseApplicationJsonBuilder b) {
+    $ConfigapiCreateResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiCreateResponseApplicationJsonBuilder b) {
+    $ConfigapiCreateResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ConfigapiShowShowPassword extends EnumClass {
@@ -679,6 +735,10 @@ class _$ConfigapiShowShowPasswordSerializer implements PrimitiveSerializer<Confi
 abstract interface class $ConfigapiShowResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, JsonObject> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiShowResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiShowResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ConfigapiShowResponseApplicationJson_Ocs
@@ -712,11 +772,25 @@ abstract class ConfigapiShowResponseApplicationJson_Ocs
   /// Serializer for ConfigapiShowResponseApplicationJson_Ocs.
   static Serializer<ConfigapiShowResponseApplicationJson_Ocs> get serializer =>
       _$configapiShowResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiShowResponseApplicationJson_OcsBuilder b) {
+    $ConfigapiShowResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiShowResponseApplicationJson_OcsBuilder b) {
+    $ConfigapiShowResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ConfigapiShowResponseApplicationJsonInterface {
   ConfigapiShowResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiShowResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiShowResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ConfigapiShowResponseApplicationJson
@@ -749,12 +823,26 @@ abstract class ConfigapiShowResponseApplicationJson
   /// Serializer for ConfigapiShowResponseApplicationJson.
   static Serializer<ConfigapiShowResponseApplicationJson> get serializer =>
       _$configapiShowResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiShowResponseApplicationJsonBuilder b) {
+    $ConfigapiShowResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiShowResponseApplicationJsonBuilder b) {
+    $ConfigapiShowResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ConfigapiModifyResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiModifyResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiModifyResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ConfigapiModifyResponseApplicationJson_Ocs
@@ -788,11 +876,25 @@ abstract class ConfigapiModifyResponseApplicationJson_Ocs
   /// Serializer for ConfigapiModifyResponseApplicationJson_Ocs.
   static Serializer<ConfigapiModifyResponseApplicationJson_Ocs> get serializer =>
       _$configapiModifyResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiModifyResponseApplicationJson_OcsBuilder b) {
+    $ConfigapiModifyResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiModifyResponseApplicationJson_OcsBuilder b) {
+    $ConfigapiModifyResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ConfigapiModifyResponseApplicationJsonInterface {
   ConfigapiModifyResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiModifyResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiModifyResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ConfigapiModifyResponseApplicationJson
@@ -825,12 +927,26 @@ abstract class ConfigapiModifyResponseApplicationJson
   /// Serializer for ConfigapiModifyResponseApplicationJson.
   static Serializer<ConfigapiModifyResponseApplicationJson> get serializer =>
       _$configapiModifyResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiModifyResponseApplicationJsonBuilder b) {
+    $ConfigapiModifyResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiModifyResponseApplicationJsonBuilder b) {
+    $ConfigapiModifyResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ConfigapiDeleteResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiDeleteResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiDeleteResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class ConfigapiDeleteResponseApplicationJson_Ocs
@@ -864,11 +980,25 @@ abstract class ConfigapiDeleteResponseApplicationJson_Ocs
   /// Serializer for ConfigapiDeleteResponseApplicationJson_Ocs.
   static Serializer<ConfigapiDeleteResponseApplicationJson_Ocs> get serializer =>
       _$configapiDeleteResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiDeleteResponseApplicationJson_OcsBuilder b) {
+    $ConfigapiDeleteResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiDeleteResponseApplicationJson_OcsBuilder b) {
+    $ConfigapiDeleteResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ConfigapiDeleteResponseApplicationJsonInterface {
   ConfigapiDeleteResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiDeleteResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiDeleteResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class ConfigapiDeleteResponseApplicationJson
@@ -901,6 +1031,16 @@ abstract class ConfigapiDeleteResponseApplicationJson
   /// Serializer for ConfigapiDeleteResponseApplicationJson.
   static Serializer<ConfigapiDeleteResponseApplicationJson> get serializer =>
       _$configapiDeleteResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiDeleteResponseApplicationJsonBuilder b) {
+    $ConfigapiDeleteResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiDeleteResponseApplicationJsonBuilder b) {
+    $ConfigapiDeleteResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start

--- a/packages/nextcloud/lib/src/api/user_ldap.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/user_ldap.openapi.g.dart
@@ -618,7 +618,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -648,6 +650,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -720,7 +723,9 @@ class ConfigapiCreateResponseApplicationJson_Ocs_DataBuilder
   String? get configID => _$this._configID;
   set configID(covariant String? configID) => _$this._configID = configID;
 
-  ConfigapiCreateResponseApplicationJson_Ocs_DataBuilder();
+  ConfigapiCreateResponseApplicationJson_Ocs_DataBuilder() {
+    ConfigapiCreateResponseApplicationJson_Ocs_Data._defaults(this);
+  }
 
   ConfigapiCreateResponseApplicationJson_Ocs_DataBuilder get _$this {
     final $v = _$v;
@@ -746,6 +751,7 @@ class ConfigapiCreateResponseApplicationJson_Ocs_DataBuilder
   ConfigapiCreateResponseApplicationJson_Ocs_Data build() => _build();
 
   _$ConfigapiCreateResponseApplicationJson_Ocs_Data _build() {
+    ConfigapiCreateResponseApplicationJson_Ocs_Data._validate(this);
     final _$result = _$v ??
         _$ConfigapiCreateResponseApplicationJson_Ocs_Data._(
             configID: BuiltValueNullFieldError.checkNotNull(
@@ -828,7 +834,9 @@ class ConfigapiCreateResponseApplicationJson_OcsBuilder
       _$this._data ??= ConfigapiCreateResponseApplicationJson_Ocs_DataBuilder();
   set data(covariant ConfigapiCreateResponseApplicationJson_Ocs_DataBuilder? data) => _$this._data = data;
 
-  ConfigapiCreateResponseApplicationJson_OcsBuilder();
+  ConfigapiCreateResponseApplicationJson_OcsBuilder() {
+    ConfigapiCreateResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ConfigapiCreateResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -855,6 +863,7 @@ class ConfigapiCreateResponseApplicationJson_OcsBuilder
   ConfigapiCreateResponseApplicationJson_Ocs build() => _build();
 
   _$ConfigapiCreateResponseApplicationJson_Ocs _build() {
+    ConfigapiCreateResponseApplicationJson_Ocs._validate(this);
     _$ConfigapiCreateResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ConfigapiCreateResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -934,7 +943,9 @@ class ConfigapiCreateResponseApplicationJsonBuilder
       _$this._ocs ??= ConfigapiCreateResponseApplicationJson_OcsBuilder();
   set ocs(covariant ConfigapiCreateResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ConfigapiCreateResponseApplicationJsonBuilder();
+  ConfigapiCreateResponseApplicationJsonBuilder() {
+    ConfigapiCreateResponseApplicationJson._defaults(this);
+  }
 
   ConfigapiCreateResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -960,6 +971,7 @@ class ConfigapiCreateResponseApplicationJsonBuilder
   ConfigapiCreateResponseApplicationJson build() => _build();
 
   _$ConfigapiCreateResponseApplicationJson _build() {
+    ConfigapiCreateResponseApplicationJson._validate(this);
     _$ConfigapiCreateResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ConfigapiCreateResponseApplicationJson._(ocs: ocs.build());
@@ -1050,7 +1062,9 @@ class ConfigapiShowResponseApplicationJson_OcsBuilder
   MapBuilder<String, JsonObject> get data => _$this._data ??= MapBuilder<String, JsonObject>();
   set data(covariant MapBuilder<String, JsonObject>? data) => _$this._data = data;
 
-  ConfigapiShowResponseApplicationJson_OcsBuilder();
+  ConfigapiShowResponseApplicationJson_OcsBuilder() {
+    ConfigapiShowResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ConfigapiShowResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1077,6 +1091,7 @@ class ConfigapiShowResponseApplicationJson_OcsBuilder
   ConfigapiShowResponseApplicationJson_Ocs build() => _build();
 
   _$ConfigapiShowResponseApplicationJson_Ocs _build() {
+    ConfigapiShowResponseApplicationJson_Ocs._validate(this);
     _$ConfigapiShowResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$ConfigapiShowResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -1155,7 +1170,9 @@ class ConfigapiShowResponseApplicationJsonBuilder
       _$this._ocs ??= ConfigapiShowResponseApplicationJson_OcsBuilder();
   set ocs(covariant ConfigapiShowResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ConfigapiShowResponseApplicationJsonBuilder();
+  ConfigapiShowResponseApplicationJsonBuilder() {
+    ConfigapiShowResponseApplicationJson._defaults(this);
+  }
 
   ConfigapiShowResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1181,6 +1198,7 @@ class ConfigapiShowResponseApplicationJsonBuilder
   ConfigapiShowResponseApplicationJson build() => _build();
 
   _$ConfigapiShowResponseApplicationJson _build() {
+    ConfigapiShowResponseApplicationJson._validate(this);
     _$ConfigapiShowResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ConfigapiShowResponseApplicationJson._(ocs: ocs.build());
@@ -1271,7 +1289,9 @@ class ConfigapiModifyResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ConfigapiModifyResponseApplicationJson_OcsBuilder();
+  ConfigapiModifyResponseApplicationJson_OcsBuilder() {
+    ConfigapiModifyResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ConfigapiModifyResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1298,6 +1318,7 @@ class ConfigapiModifyResponseApplicationJson_OcsBuilder
   ConfigapiModifyResponseApplicationJson_Ocs build() => _build();
 
   _$ConfigapiModifyResponseApplicationJson_Ocs _build() {
+    ConfigapiModifyResponseApplicationJson_Ocs._validate(this);
     _$ConfigapiModifyResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -1378,7 +1399,9 @@ class ConfigapiModifyResponseApplicationJsonBuilder
       _$this._ocs ??= ConfigapiModifyResponseApplicationJson_OcsBuilder();
   set ocs(covariant ConfigapiModifyResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ConfigapiModifyResponseApplicationJsonBuilder();
+  ConfigapiModifyResponseApplicationJsonBuilder() {
+    ConfigapiModifyResponseApplicationJson._defaults(this);
+  }
 
   ConfigapiModifyResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1404,6 +1427,7 @@ class ConfigapiModifyResponseApplicationJsonBuilder
   ConfigapiModifyResponseApplicationJson build() => _build();
 
   _$ConfigapiModifyResponseApplicationJson _build() {
+    ConfigapiModifyResponseApplicationJson._validate(this);
     _$ConfigapiModifyResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ConfigapiModifyResponseApplicationJson._(ocs: ocs.build());
@@ -1494,7 +1518,9 @@ class ConfigapiDeleteResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  ConfigapiDeleteResponseApplicationJson_OcsBuilder();
+  ConfigapiDeleteResponseApplicationJson_OcsBuilder() {
+    ConfigapiDeleteResponseApplicationJson_Ocs._defaults(this);
+  }
 
   ConfigapiDeleteResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -1521,6 +1547,7 @@ class ConfigapiDeleteResponseApplicationJson_OcsBuilder
   ConfigapiDeleteResponseApplicationJson_Ocs build() => _build();
 
   _$ConfigapiDeleteResponseApplicationJson_Ocs _build() {
+    ConfigapiDeleteResponseApplicationJson_Ocs._validate(this);
     _$ConfigapiDeleteResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -1601,7 +1628,9 @@ class ConfigapiDeleteResponseApplicationJsonBuilder
       _$this._ocs ??= ConfigapiDeleteResponseApplicationJson_OcsBuilder();
   set ocs(covariant ConfigapiDeleteResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  ConfigapiDeleteResponseApplicationJsonBuilder();
+  ConfigapiDeleteResponseApplicationJsonBuilder() {
+    ConfigapiDeleteResponseApplicationJson._defaults(this);
+  }
 
   ConfigapiDeleteResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -1627,6 +1656,7 @@ class ConfigapiDeleteResponseApplicationJsonBuilder
   ConfigapiDeleteResponseApplicationJson build() => _build();
 
   _$ConfigapiDeleteResponseApplicationJson _build() {
+    ConfigapiDeleteResponseApplicationJson._validate(this);
     _$ConfigapiDeleteResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$ConfigapiDeleteResponseApplicationJson._(ocs: ocs.build());

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -1041,6 +1041,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -1067,6 +1071,16 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 class $Type extends EnumClass {
@@ -1157,6 +1171,10 @@ abstract interface class $PublicInterface {
   String? get icon;
   int? get clearAt;
   $Type get status;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicInterfaceBuilder b) {}
 }
 
 abstract class Public implements $PublicInterface, Built<Public, PublicBuilder> {
@@ -1183,6 +1201,16 @@ abstract class Public implements $PublicInterface, Built<Public, PublicBuilder> 
 
   /// Serializer for Public.
   static Serializer<Public> get serializer => _$publicSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicBuilder b) {
+    $PublicInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicBuilder b) {
+    $PublicInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1190,6 +1218,10 @@ abstract interface class $PrivateInterface implements $PublicInterface {
   String? get messageId;
   bool get messageIsPredefined;
   bool get statusIsUserDefined;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PrivateInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PrivateInterfaceBuilder b) {}
 }
 
 abstract class Private implements $PrivateInterface, Built<Private, PrivateBuilder> {
@@ -1216,12 +1248,26 @@ abstract class Private implements $PrivateInterface, Built<Private, PrivateBuild
 
   /// Serializer for Private.
   static Serializer<Private> get serializer => _$privateSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PrivateBuilder b) {
+    $PrivateInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PrivateBuilder b) {
+    $PrivateInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $HeartbeatHeartbeatResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HeartbeatHeartbeatResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HeartbeatHeartbeatResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class HeartbeatHeartbeatResponseApplicationJson_Ocs
@@ -1255,11 +1301,25 @@ abstract class HeartbeatHeartbeatResponseApplicationJson_Ocs
   /// Serializer for HeartbeatHeartbeatResponseApplicationJson_Ocs.
   static Serializer<HeartbeatHeartbeatResponseApplicationJson_Ocs> get serializer =>
       _$heartbeatHeartbeatResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HeartbeatHeartbeatResponseApplicationJson_OcsBuilder b) {
+    $HeartbeatHeartbeatResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HeartbeatHeartbeatResponseApplicationJson_OcsBuilder b) {
+    $HeartbeatHeartbeatResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $HeartbeatHeartbeatResponseApplicationJsonInterface {
   HeartbeatHeartbeatResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HeartbeatHeartbeatResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HeartbeatHeartbeatResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class HeartbeatHeartbeatResponseApplicationJson
@@ -1293,6 +1353,16 @@ abstract class HeartbeatHeartbeatResponseApplicationJson
   /// Serializer for HeartbeatHeartbeatResponseApplicationJson.
   static Serializer<HeartbeatHeartbeatResponseApplicationJson> get serializer =>
       _$heartbeatHeartbeatResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HeartbeatHeartbeatResponseApplicationJsonBuilder b) {
+    $HeartbeatHeartbeatResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HeartbeatHeartbeatResponseApplicationJsonBuilder b) {
+    $HeartbeatHeartbeatResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 class ClearAt_Type extends EnumClass {
@@ -1424,6 +1494,12 @@ typedef ClearAt_Time = ({ClearAtTimeType? clearAtTimeType, int? $int});
 abstract interface class $ClearAtInterface {
   ClearAt_Type get type;
   ClearAt_Time get time;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ClearAtInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ClearAtInterfaceBuilder b) {
+    b.time?.validateOneOf();
+  }
 }
 
 abstract class ClearAt implements $ClearAtInterface, Built<ClearAt, ClearAtBuilder> {
@@ -1451,9 +1527,14 @@ abstract class ClearAt implements $ClearAtInterface, Built<ClearAt, ClearAtBuild
   /// Serializer for ClearAt.
   static Serializer<ClearAt> get serializer => _$clearAtSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ClearAtBuilder b) {
+    $ClearAtInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(ClearAtBuilder b) {
-    b.time?.validateOneOf();
+    $ClearAtInterface._validate(b);
   }
 }
 
@@ -1464,6 +1545,10 @@ abstract interface class $PredefinedInterface {
   String get message;
   ClearAt? get clearAt;
   bool? get visible;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PredefinedInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PredefinedInterfaceBuilder b) {}
 }
 
 abstract class Predefined implements $PredefinedInterface, Built<Predefined, PredefinedBuilder> {
@@ -1490,12 +1575,26 @@ abstract class Predefined implements $PredefinedInterface, Built<Predefined, Pre
 
   /// Serializer for Predefined.
   static Serializer<Predefined> get serializer => _$predefinedSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PredefinedBuilder b) {
+    $PredefinedInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PredefinedBuilder b) {
+    $PredefinedInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PredefinedStatusFindAllResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Predefined> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PredefinedStatusFindAllResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PredefinedStatusFindAllResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class PredefinedStatusFindAllResponseApplicationJson_Ocs
@@ -1530,11 +1629,25 @@ abstract class PredefinedStatusFindAllResponseApplicationJson_Ocs
   /// Serializer for PredefinedStatusFindAllResponseApplicationJson_Ocs.
   static Serializer<PredefinedStatusFindAllResponseApplicationJson_Ocs> get serializer =>
       _$predefinedStatusFindAllResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PredefinedStatusFindAllResponseApplicationJson_OcsBuilder b) {
+    $PredefinedStatusFindAllResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PredefinedStatusFindAllResponseApplicationJson_OcsBuilder b) {
+    $PredefinedStatusFindAllResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $PredefinedStatusFindAllResponseApplicationJsonInterface {
   PredefinedStatusFindAllResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PredefinedStatusFindAllResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PredefinedStatusFindAllResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class PredefinedStatusFindAllResponseApplicationJson
@@ -1568,12 +1681,26 @@ abstract class PredefinedStatusFindAllResponseApplicationJson
   /// Serializer for PredefinedStatusFindAllResponseApplicationJson.
   static Serializer<PredefinedStatusFindAllResponseApplicationJson> get serializer =>
       _$predefinedStatusFindAllResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PredefinedStatusFindAllResponseApplicationJsonBuilder b) {
+    $PredefinedStatusFindAllResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PredefinedStatusFindAllResponseApplicationJsonBuilder b) {
+    $PredefinedStatusFindAllResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $StatusesFindAllResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Public> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($StatusesFindAllResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($StatusesFindAllResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class StatusesFindAllResponseApplicationJson_Ocs
@@ -1607,11 +1734,25 @@ abstract class StatusesFindAllResponseApplicationJson_Ocs
   /// Serializer for StatusesFindAllResponseApplicationJson_Ocs.
   static Serializer<StatusesFindAllResponseApplicationJson_Ocs> get serializer =>
       _$statusesFindAllResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(StatusesFindAllResponseApplicationJson_OcsBuilder b) {
+    $StatusesFindAllResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(StatusesFindAllResponseApplicationJson_OcsBuilder b) {
+    $StatusesFindAllResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $StatusesFindAllResponseApplicationJsonInterface {
   StatusesFindAllResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($StatusesFindAllResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($StatusesFindAllResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class StatusesFindAllResponseApplicationJson
@@ -1644,12 +1785,26 @@ abstract class StatusesFindAllResponseApplicationJson
   /// Serializer for StatusesFindAllResponseApplicationJson.
   static Serializer<StatusesFindAllResponseApplicationJson> get serializer =>
       _$statusesFindAllResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(StatusesFindAllResponseApplicationJsonBuilder b) {
+    $StatusesFindAllResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(StatusesFindAllResponseApplicationJsonBuilder b) {
+    $StatusesFindAllResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $StatusesFindResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Public get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($StatusesFindResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($StatusesFindResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class StatusesFindResponseApplicationJson_Ocs
@@ -1682,11 +1837,25 @@ abstract class StatusesFindResponseApplicationJson_Ocs
   /// Serializer for StatusesFindResponseApplicationJson_Ocs.
   static Serializer<StatusesFindResponseApplicationJson_Ocs> get serializer =>
       _$statusesFindResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(StatusesFindResponseApplicationJson_OcsBuilder b) {
+    $StatusesFindResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(StatusesFindResponseApplicationJson_OcsBuilder b) {
+    $StatusesFindResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $StatusesFindResponseApplicationJsonInterface {
   StatusesFindResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($StatusesFindResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($StatusesFindResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class StatusesFindResponseApplicationJson
@@ -1719,12 +1888,26 @@ abstract class StatusesFindResponseApplicationJson
   /// Serializer for StatusesFindResponseApplicationJson.
   static Serializer<StatusesFindResponseApplicationJson> get serializer =>
       _$statusesFindResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(StatusesFindResponseApplicationJsonBuilder b) {
+    $StatusesFindResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(StatusesFindResponseApplicationJsonBuilder b) {
+    $StatusesFindResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusGetStatusResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusGetStatusResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusGetStatusResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UserStatusGetStatusResponseApplicationJson_Ocs
@@ -1758,11 +1941,25 @@ abstract class UserStatusGetStatusResponseApplicationJson_Ocs
   /// Serializer for UserStatusGetStatusResponseApplicationJson_Ocs.
   static Serializer<UserStatusGetStatusResponseApplicationJson_Ocs> get serializer =>
       _$userStatusGetStatusResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusGetStatusResponseApplicationJson_OcsBuilder b) {
+    $UserStatusGetStatusResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusGetStatusResponseApplicationJson_OcsBuilder b) {
+    $UserStatusGetStatusResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusGetStatusResponseApplicationJsonInterface {
   UserStatusGetStatusResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusGetStatusResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusGetStatusResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UserStatusGetStatusResponseApplicationJson
@@ -1796,12 +1993,26 @@ abstract class UserStatusGetStatusResponseApplicationJson
   /// Serializer for UserStatusGetStatusResponseApplicationJson.
   static Serializer<UserStatusGetStatusResponseApplicationJson> get serializer =>
       _$userStatusGetStatusResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusGetStatusResponseApplicationJsonBuilder b) {
+    $UserStatusGetStatusResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusGetStatusResponseApplicationJsonBuilder b) {
+    $UserStatusGetStatusResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusSetStatusResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusSetStatusResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusSetStatusResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UserStatusSetStatusResponseApplicationJson_Ocs
@@ -1835,11 +2046,25 @@ abstract class UserStatusSetStatusResponseApplicationJson_Ocs
   /// Serializer for UserStatusSetStatusResponseApplicationJson_Ocs.
   static Serializer<UserStatusSetStatusResponseApplicationJson_Ocs> get serializer =>
       _$userStatusSetStatusResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusSetStatusResponseApplicationJson_OcsBuilder b) {
+    $UserStatusSetStatusResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusSetStatusResponseApplicationJson_OcsBuilder b) {
+    $UserStatusSetStatusResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusSetStatusResponseApplicationJsonInterface {
   UserStatusSetStatusResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusSetStatusResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusSetStatusResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UserStatusSetStatusResponseApplicationJson
@@ -1873,12 +2098,26 @@ abstract class UserStatusSetStatusResponseApplicationJson
   /// Serializer for UserStatusSetStatusResponseApplicationJson.
   static Serializer<UserStatusSetStatusResponseApplicationJson> get serializer =>
       _$userStatusSetStatusResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusSetStatusResponseApplicationJsonBuilder b) {
+    $UserStatusSetStatusResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusSetStatusResponseApplicationJsonBuilder b) {
+    $UserStatusSetStatusResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UserStatusSetPredefinedMessageResponseApplicationJson_Ocs
@@ -1913,11 +2152,25 @@ abstract class UserStatusSetPredefinedMessageResponseApplicationJson_Ocs
   /// Serializer for UserStatusSetPredefinedMessageResponseApplicationJson_Ocs.
   static Serializer<UserStatusSetPredefinedMessageResponseApplicationJson_Ocs> get serializer =>
       _$userStatusSetPredefinedMessageResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder b) {
+    $UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder b) {
+    $UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusSetPredefinedMessageResponseApplicationJsonInterface {
   UserStatusSetPredefinedMessageResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusSetPredefinedMessageResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusSetPredefinedMessageResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UserStatusSetPredefinedMessageResponseApplicationJson
@@ -1952,12 +2205,26 @@ abstract class UserStatusSetPredefinedMessageResponseApplicationJson
   /// Serializer for UserStatusSetPredefinedMessageResponseApplicationJson.
   static Serializer<UserStatusSetPredefinedMessageResponseApplicationJson> get serializer =>
       _$userStatusSetPredefinedMessageResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusSetPredefinedMessageResponseApplicationJsonBuilder b) {
+    $UserStatusSetPredefinedMessageResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusSetPredefinedMessageResponseApplicationJsonBuilder b) {
+    $UserStatusSetPredefinedMessageResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusSetCustomMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusSetCustomMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusSetCustomMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UserStatusSetCustomMessageResponseApplicationJson_Ocs
@@ -1992,11 +2259,25 @@ abstract class UserStatusSetCustomMessageResponseApplicationJson_Ocs
   /// Serializer for UserStatusSetCustomMessageResponseApplicationJson_Ocs.
   static Serializer<UserStatusSetCustomMessageResponseApplicationJson_Ocs> get serializer =>
       _$userStatusSetCustomMessageResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder b) {
+    $UserStatusSetCustomMessageResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder b) {
+    $UserStatusSetCustomMessageResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusSetCustomMessageResponseApplicationJsonInterface {
   UserStatusSetCustomMessageResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusSetCustomMessageResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusSetCustomMessageResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UserStatusSetCustomMessageResponseApplicationJson
@@ -2031,12 +2312,26 @@ abstract class UserStatusSetCustomMessageResponseApplicationJson
   /// Serializer for UserStatusSetCustomMessageResponseApplicationJson.
   static Serializer<UserStatusSetCustomMessageResponseApplicationJson> get serializer =>
       _$userStatusSetCustomMessageResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusSetCustomMessageResponseApplicationJsonBuilder b) {
+    $UserStatusSetCustomMessageResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusSetCustomMessageResponseApplicationJsonBuilder b) {
+    $UserStatusSetCustomMessageResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusClearMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusClearMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusClearMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class UserStatusClearMessageResponseApplicationJson_Ocs
@@ -2071,11 +2366,25 @@ abstract class UserStatusClearMessageResponseApplicationJson_Ocs
   /// Serializer for UserStatusClearMessageResponseApplicationJson_Ocs.
   static Serializer<UserStatusClearMessageResponseApplicationJson_Ocs> get serializer =>
       _$userStatusClearMessageResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusClearMessageResponseApplicationJson_OcsBuilder b) {
+    $UserStatusClearMessageResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusClearMessageResponseApplicationJson_OcsBuilder b) {
+    $UserStatusClearMessageResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusClearMessageResponseApplicationJsonInterface {
   UserStatusClearMessageResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusClearMessageResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusClearMessageResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UserStatusClearMessageResponseApplicationJson
@@ -2109,6 +2418,16 @@ abstract class UserStatusClearMessageResponseApplicationJson
   /// Serializer for UserStatusClearMessageResponseApplicationJson.
   static Serializer<UserStatusClearMessageResponseApplicationJson> get serializer =>
       _$userStatusClearMessageResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusClearMessageResponseApplicationJsonBuilder b) {
+    $UserStatusClearMessageResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusClearMessageResponseApplicationJsonBuilder b) {
+    $UserStatusClearMessageResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 typedef UserStatusRevertStatusResponseApplicationJson_Ocs_Data = ({BuiltList<Never>? builtListNever, Private? private});
@@ -2117,6 +2436,12 @@ typedef UserStatusRevertStatusResponseApplicationJson_Ocs_Data = ({BuiltList<Nev
 abstract interface class $UserStatusRevertStatusResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UserStatusRevertStatusResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusRevertStatusResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusRevertStatusResponseApplicationJson_OcsInterfaceBuilder b) {
+    b.data?.validateOneOf();
+  }
 }
 
 abstract class UserStatusRevertStatusResponseApplicationJson_Ocs
@@ -2152,15 +2477,24 @@ abstract class UserStatusRevertStatusResponseApplicationJson_Ocs
   static Serializer<UserStatusRevertStatusResponseApplicationJson_Ocs> get serializer =>
       _$userStatusRevertStatusResponseApplicationJsonOcsSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusRevertStatusResponseApplicationJson_OcsBuilder b) {
+    $UserStatusRevertStatusResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UserStatusRevertStatusResponseApplicationJson_OcsBuilder b) {
-    b.data?.validateOneOf();
+    $UserStatusRevertStatusResponseApplicationJson_OcsInterface._validate(b);
   }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $UserStatusRevertStatusResponseApplicationJsonInterface {
   UserStatusRevertStatusResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusRevertStatusResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusRevertStatusResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class UserStatusRevertStatusResponseApplicationJson
@@ -2194,6 +2528,16 @@ abstract class UserStatusRevertStatusResponseApplicationJson
   /// Serializer for UserStatusRevertStatusResponseApplicationJson.
   static Serializer<UserStatusRevertStatusResponseApplicationJson> get serializer =>
       _$userStatusRevertStatusResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusRevertStatusResponseApplicationJsonBuilder b) {
+    $UserStatusRevertStatusResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusRevertStatusResponseApplicationJsonBuilder b) {
+    $UserStatusRevertStatusResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -2202,6 +2546,10 @@ abstract interface class $Capabilities_UserStatusInterface {
   bool get restore;
   @BuiltValueField(wireName: 'supports_emoji')
   bool get supportsEmoji;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_UserStatusInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_UserStatusInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_UserStatus
@@ -2230,12 +2578,26 @@ abstract class Capabilities_UserStatus
 
   /// Serializer for Capabilities_UserStatus.
   static Serializer<Capabilities_UserStatus> get serializer => _$capabilitiesUserStatusSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_UserStatusBuilder b) {
+    $Capabilities_UserStatusInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_UserStatusBuilder b) {
+    $Capabilities_UserStatusInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   @BuiltValueField(wireName: 'user_status')
   Capabilities_UserStatus get userStatus;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -2262,6 +2624,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 /// Serialization extension for `ClearAt_Time`.

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -1219,9 +1219,14 @@ abstract interface class $PrivateInterface implements $PublicInterface {
   bool get messageIsPredefined;
   bool get statusIsUserDefined;
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($PrivateInterfaceBuilder b) {}
+  static void _defaults($PrivateInterfaceBuilder b) {
+    $PublicInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($PrivateInterfaceBuilder b) {}
+  static void _validate($PrivateInterfaceBuilder b) {
+    $PublicInterface._validate(b);
+  }
 }
 
 abstract class Private implements $PrivateInterface, Built<Private, PrivateBuilder> {

--- a/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
@@ -1578,7 +1578,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -1608,6 +1610,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -1722,7 +1725,9 @@ class PublicBuilder implements Builder<Public, PublicBuilder>, $PublicInterfaceB
   $Type? get status => _$this._status;
   set status(covariant $Type? status) => _$this._status = status;
 
-  PublicBuilder();
+  PublicBuilder() {
+    Public._defaults(this);
+  }
 
   PublicBuilder get _$this {
     final $v = _$v;
@@ -1752,6 +1757,7 @@ class PublicBuilder implements Builder<Public, PublicBuilder>, $PublicInterfaceB
   Public build() => _build();
 
   _$Public _build() {
+    Public._validate(this);
     final _$result = _$v ??
         _$Public._(
             userId: BuiltValueNullFieldError.checkNotNull(userId, r'Public', 'userId'),
@@ -1913,7 +1919,9 @@ class PrivateBuilder implements Builder<Private, PrivateBuilder>, $PrivateInterf
   $Type? get status => _$this._status;
   set status(covariant $Type? status) => _$this._status = status;
 
-  PrivateBuilder();
+  PrivateBuilder() {
+    Private._defaults(this);
+  }
 
   PrivateBuilder get _$this {
     final $v = _$v;
@@ -1946,6 +1954,7 @@ class PrivateBuilder implements Builder<Private, PrivateBuilder>, $PrivateInterf
   Private build() => _build();
 
   _$Private _build() {
+    Private._validate(this);
     final _$result = _$v ??
         _$Private._(
             messageId: messageId,
@@ -2035,7 +2044,9 @@ class HeartbeatHeartbeatResponseApplicationJson_OcsBuilder
   PrivateBuilder get data => _$this._data ??= PrivateBuilder();
   set data(covariant PrivateBuilder? data) => _$this._data = data;
 
-  HeartbeatHeartbeatResponseApplicationJson_OcsBuilder();
+  HeartbeatHeartbeatResponseApplicationJson_OcsBuilder() {
+    HeartbeatHeartbeatResponseApplicationJson_Ocs._defaults(this);
+  }
 
   HeartbeatHeartbeatResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2062,6 +2073,7 @@ class HeartbeatHeartbeatResponseApplicationJson_OcsBuilder
   HeartbeatHeartbeatResponseApplicationJson_Ocs build() => _build();
 
   _$HeartbeatHeartbeatResponseApplicationJson_Ocs _build() {
+    HeartbeatHeartbeatResponseApplicationJson_Ocs._validate(this);
     _$HeartbeatHeartbeatResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$HeartbeatHeartbeatResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -2141,7 +2153,9 @@ class HeartbeatHeartbeatResponseApplicationJsonBuilder
       _$this._ocs ??= HeartbeatHeartbeatResponseApplicationJson_OcsBuilder();
   set ocs(covariant HeartbeatHeartbeatResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  HeartbeatHeartbeatResponseApplicationJsonBuilder();
+  HeartbeatHeartbeatResponseApplicationJsonBuilder() {
+    HeartbeatHeartbeatResponseApplicationJson._defaults(this);
+  }
 
   HeartbeatHeartbeatResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -2167,6 +2181,7 @@ class HeartbeatHeartbeatResponseApplicationJsonBuilder
   HeartbeatHeartbeatResponseApplicationJson build() => _build();
 
   _$HeartbeatHeartbeatResponseApplicationJson _build() {
+    HeartbeatHeartbeatResponseApplicationJson._validate(this);
     _$HeartbeatHeartbeatResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$HeartbeatHeartbeatResponseApplicationJson._(ocs: ocs.build());
@@ -2250,7 +2265,9 @@ class ClearAtBuilder implements Builder<ClearAt, ClearAtBuilder>, $ClearAtInterf
   ClearAt_Time? get time => _$this._time;
   set time(covariant ClearAt_Time? time) => _$this._time = time;
 
-  ClearAtBuilder();
+  ClearAtBuilder() {
+    ClearAt._defaults(this);
+  }
 
   ClearAtBuilder get _$this {
     final $v = _$v;
@@ -2391,7 +2408,9 @@ class PredefinedBuilder implements Builder<Predefined, PredefinedBuilder>, $Pred
   bool? get visible => _$this._visible;
   set visible(covariant bool? visible) => _$this._visible = visible;
 
-  PredefinedBuilder();
+  PredefinedBuilder() {
+    Predefined._defaults(this);
+  }
 
   PredefinedBuilder get _$this {
     final $v = _$v;
@@ -2421,6 +2440,7 @@ class PredefinedBuilder implements Builder<Predefined, PredefinedBuilder>, $Pred
   Predefined build() => _build();
 
   _$Predefined _build() {
+    Predefined._validate(this);
     _$Predefined _$result;
     try {
       _$result = _$v ??
@@ -2518,7 +2538,9 @@ class PredefinedStatusFindAllResponseApplicationJson_OcsBuilder
   ListBuilder<Predefined> get data => _$this._data ??= ListBuilder<Predefined>();
   set data(covariant ListBuilder<Predefined>? data) => _$this._data = data;
 
-  PredefinedStatusFindAllResponseApplicationJson_OcsBuilder();
+  PredefinedStatusFindAllResponseApplicationJson_OcsBuilder() {
+    PredefinedStatusFindAllResponseApplicationJson_Ocs._defaults(this);
+  }
 
   PredefinedStatusFindAllResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2545,6 +2567,7 @@ class PredefinedStatusFindAllResponseApplicationJson_OcsBuilder
   PredefinedStatusFindAllResponseApplicationJson_Ocs build() => _build();
 
   _$PredefinedStatusFindAllResponseApplicationJson_Ocs _build() {
+    PredefinedStatusFindAllResponseApplicationJson_Ocs._validate(this);
     _$PredefinedStatusFindAllResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$PredefinedStatusFindAllResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -2625,7 +2648,9 @@ class PredefinedStatusFindAllResponseApplicationJsonBuilder
       _$this._ocs ??= PredefinedStatusFindAllResponseApplicationJson_OcsBuilder();
   set ocs(covariant PredefinedStatusFindAllResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  PredefinedStatusFindAllResponseApplicationJsonBuilder();
+  PredefinedStatusFindAllResponseApplicationJsonBuilder() {
+    PredefinedStatusFindAllResponseApplicationJson._defaults(this);
+  }
 
   PredefinedStatusFindAllResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -2651,6 +2676,7 @@ class PredefinedStatusFindAllResponseApplicationJsonBuilder
   PredefinedStatusFindAllResponseApplicationJson build() => _build();
 
   _$PredefinedStatusFindAllResponseApplicationJson _build() {
+    PredefinedStatusFindAllResponseApplicationJson._validate(this);
     _$PredefinedStatusFindAllResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$PredefinedStatusFindAllResponseApplicationJson._(ocs: ocs.build());
@@ -2742,7 +2768,9 @@ class StatusesFindAllResponseApplicationJson_OcsBuilder
   ListBuilder<Public> get data => _$this._data ??= ListBuilder<Public>();
   set data(covariant ListBuilder<Public>? data) => _$this._data = data;
 
-  StatusesFindAllResponseApplicationJson_OcsBuilder();
+  StatusesFindAllResponseApplicationJson_OcsBuilder() {
+    StatusesFindAllResponseApplicationJson_Ocs._defaults(this);
+  }
 
   StatusesFindAllResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2769,6 +2797,7 @@ class StatusesFindAllResponseApplicationJson_OcsBuilder
   StatusesFindAllResponseApplicationJson_Ocs build() => _build();
 
   _$StatusesFindAllResponseApplicationJson_Ocs _build() {
+    StatusesFindAllResponseApplicationJson_Ocs._validate(this);
     _$StatusesFindAllResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$StatusesFindAllResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -2848,7 +2877,9 @@ class StatusesFindAllResponseApplicationJsonBuilder
       _$this._ocs ??= StatusesFindAllResponseApplicationJson_OcsBuilder();
   set ocs(covariant StatusesFindAllResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  StatusesFindAllResponseApplicationJsonBuilder();
+  StatusesFindAllResponseApplicationJsonBuilder() {
+    StatusesFindAllResponseApplicationJson._defaults(this);
+  }
 
   StatusesFindAllResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -2874,6 +2905,7 @@ class StatusesFindAllResponseApplicationJsonBuilder
   StatusesFindAllResponseApplicationJson build() => _build();
 
   _$StatusesFindAllResponseApplicationJson _build() {
+    StatusesFindAllResponseApplicationJson._validate(this);
     _$StatusesFindAllResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$StatusesFindAllResponseApplicationJson._(ocs: ocs.build());
@@ -2964,7 +2996,9 @@ class StatusesFindResponseApplicationJson_OcsBuilder
   PublicBuilder get data => _$this._data ??= PublicBuilder();
   set data(covariant PublicBuilder? data) => _$this._data = data;
 
-  StatusesFindResponseApplicationJson_OcsBuilder();
+  StatusesFindResponseApplicationJson_OcsBuilder() {
+    StatusesFindResponseApplicationJson_Ocs._defaults(this);
+  }
 
   StatusesFindResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2991,6 +3025,7 @@ class StatusesFindResponseApplicationJson_OcsBuilder
   StatusesFindResponseApplicationJson_Ocs build() => _build();
 
   _$StatusesFindResponseApplicationJson_Ocs _build() {
+    StatusesFindResponseApplicationJson_Ocs._validate(this);
     _$StatusesFindResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$StatusesFindResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -3067,7 +3102,9 @@ class StatusesFindResponseApplicationJsonBuilder
       _$this._ocs ??= StatusesFindResponseApplicationJson_OcsBuilder();
   set ocs(covariant StatusesFindResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  StatusesFindResponseApplicationJsonBuilder();
+  StatusesFindResponseApplicationJsonBuilder() {
+    StatusesFindResponseApplicationJson._defaults(this);
+  }
 
   StatusesFindResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3093,6 +3130,7 @@ class StatusesFindResponseApplicationJsonBuilder
   StatusesFindResponseApplicationJson build() => _build();
 
   _$StatusesFindResponseApplicationJson _build() {
+    StatusesFindResponseApplicationJson._validate(this);
     _$StatusesFindResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$StatusesFindResponseApplicationJson._(ocs: ocs.build());
@@ -3183,7 +3221,9 @@ class UserStatusGetStatusResponseApplicationJson_OcsBuilder
   PrivateBuilder get data => _$this._data ??= PrivateBuilder();
   set data(covariant PrivateBuilder? data) => _$this._data = data;
 
-  UserStatusGetStatusResponseApplicationJson_OcsBuilder();
+  UserStatusGetStatusResponseApplicationJson_OcsBuilder() {
+    UserStatusGetStatusResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UserStatusGetStatusResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3210,6 +3250,7 @@ class UserStatusGetStatusResponseApplicationJson_OcsBuilder
   UserStatusGetStatusResponseApplicationJson_Ocs build() => _build();
 
   _$UserStatusGetStatusResponseApplicationJson_Ocs _build() {
+    UserStatusGetStatusResponseApplicationJson_Ocs._validate(this);
     _$UserStatusGetStatusResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$UserStatusGetStatusResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -3290,7 +3331,9 @@ class UserStatusGetStatusResponseApplicationJsonBuilder
       _$this._ocs ??= UserStatusGetStatusResponseApplicationJson_OcsBuilder();
   set ocs(covariant UserStatusGetStatusResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UserStatusGetStatusResponseApplicationJsonBuilder();
+  UserStatusGetStatusResponseApplicationJsonBuilder() {
+    UserStatusGetStatusResponseApplicationJson._defaults(this);
+  }
 
   UserStatusGetStatusResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3316,6 +3359,7 @@ class UserStatusGetStatusResponseApplicationJsonBuilder
   UserStatusGetStatusResponseApplicationJson build() => _build();
 
   _$UserStatusGetStatusResponseApplicationJson _build() {
+    UserStatusGetStatusResponseApplicationJson._validate(this);
     _$UserStatusGetStatusResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UserStatusGetStatusResponseApplicationJson._(ocs: ocs.build());
@@ -3406,7 +3450,9 @@ class UserStatusSetStatusResponseApplicationJson_OcsBuilder
   PrivateBuilder get data => _$this._data ??= PrivateBuilder();
   set data(covariant PrivateBuilder? data) => _$this._data = data;
 
-  UserStatusSetStatusResponseApplicationJson_OcsBuilder();
+  UserStatusSetStatusResponseApplicationJson_OcsBuilder() {
+    UserStatusSetStatusResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UserStatusSetStatusResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3433,6 +3479,7 @@ class UserStatusSetStatusResponseApplicationJson_OcsBuilder
   UserStatusSetStatusResponseApplicationJson_Ocs build() => _build();
 
   _$UserStatusSetStatusResponseApplicationJson_Ocs _build() {
+    UserStatusSetStatusResponseApplicationJson_Ocs._validate(this);
     _$UserStatusSetStatusResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$UserStatusSetStatusResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -3513,7 +3560,9 @@ class UserStatusSetStatusResponseApplicationJsonBuilder
       _$this._ocs ??= UserStatusSetStatusResponseApplicationJson_OcsBuilder();
   set ocs(covariant UserStatusSetStatusResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UserStatusSetStatusResponseApplicationJsonBuilder();
+  UserStatusSetStatusResponseApplicationJsonBuilder() {
+    UserStatusSetStatusResponseApplicationJson._defaults(this);
+  }
 
   UserStatusSetStatusResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3539,6 +3588,7 @@ class UserStatusSetStatusResponseApplicationJsonBuilder
   UserStatusSetStatusResponseApplicationJson build() => _build();
 
   _$UserStatusSetStatusResponseApplicationJson _build() {
+    UserStatusSetStatusResponseApplicationJson._validate(this);
     _$UserStatusSetStatusResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UserStatusSetStatusResponseApplicationJson._(ocs: ocs.build());
@@ -3633,7 +3683,9 @@ class UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder
   PrivateBuilder get data => _$this._data ??= PrivateBuilder();
   set data(covariant PrivateBuilder? data) => _$this._data = data;
 
-  UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder();
+  UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder() {
+    UserStatusSetPredefinedMessageResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3660,6 +3712,7 @@ class UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder
   UserStatusSetPredefinedMessageResponseApplicationJson_Ocs build() => _build();
 
   _$UserStatusSetPredefinedMessageResponseApplicationJson_Ocs _build() {
+    UserStatusSetPredefinedMessageResponseApplicationJson_Ocs._validate(this);
     _$UserStatusSetPredefinedMessageResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -3744,7 +3797,9 @@ class UserStatusSetPredefinedMessageResponseApplicationJsonBuilder
       _$this._ocs ??= UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder();
   set ocs(covariant UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UserStatusSetPredefinedMessageResponseApplicationJsonBuilder();
+  UserStatusSetPredefinedMessageResponseApplicationJsonBuilder() {
+    UserStatusSetPredefinedMessageResponseApplicationJson._defaults(this);
+  }
 
   UserStatusSetPredefinedMessageResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3770,6 +3825,7 @@ class UserStatusSetPredefinedMessageResponseApplicationJsonBuilder
   UserStatusSetPredefinedMessageResponseApplicationJson build() => _build();
 
   _$UserStatusSetPredefinedMessageResponseApplicationJson _build() {
+    UserStatusSetPredefinedMessageResponseApplicationJson._validate(this);
     _$UserStatusSetPredefinedMessageResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UserStatusSetPredefinedMessageResponseApplicationJson._(ocs: ocs.build());
@@ -3863,7 +3919,9 @@ class UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder
   PrivateBuilder get data => _$this._data ??= PrivateBuilder();
   set data(covariant PrivateBuilder? data) => _$this._data = data;
 
-  UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder();
+  UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder() {
+    UserStatusSetCustomMessageResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3890,6 +3948,7 @@ class UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder
   UserStatusSetCustomMessageResponseApplicationJson_Ocs build() => _build();
 
   _$UserStatusSetCustomMessageResponseApplicationJson_Ocs _build() {
+    UserStatusSetCustomMessageResponseApplicationJson_Ocs._validate(this);
     _$UserStatusSetCustomMessageResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -3973,7 +4032,9 @@ class UserStatusSetCustomMessageResponseApplicationJsonBuilder
       _$this._ocs ??= UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder();
   set ocs(covariant UserStatusSetCustomMessageResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UserStatusSetCustomMessageResponseApplicationJsonBuilder();
+  UserStatusSetCustomMessageResponseApplicationJsonBuilder() {
+    UserStatusSetCustomMessageResponseApplicationJson._defaults(this);
+  }
 
   UserStatusSetCustomMessageResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3999,6 +4060,7 @@ class UserStatusSetCustomMessageResponseApplicationJsonBuilder
   UserStatusSetCustomMessageResponseApplicationJson build() => _build();
 
   _$UserStatusSetCustomMessageResponseApplicationJson _build() {
+    UserStatusSetCustomMessageResponseApplicationJson._validate(this);
     _$UserStatusSetCustomMessageResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UserStatusSetCustomMessageResponseApplicationJson._(ocs: ocs.build());
@@ -4091,7 +4153,9 @@ class UserStatusClearMessageResponseApplicationJson_OcsBuilder
   JsonObject? get data => _$this._data;
   set data(covariant JsonObject? data) => _$this._data = data;
 
-  UserStatusClearMessageResponseApplicationJson_OcsBuilder();
+  UserStatusClearMessageResponseApplicationJson_OcsBuilder() {
+    UserStatusClearMessageResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UserStatusClearMessageResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -4118,6 +4182,7 @@ class UserStatusClearMessageResponseApplicationJson_OcsBuilder
   UserStatusClearMessageResponseApplicationJson_Ocs build() => _build();
 
   _$UserStatusClearMessageResponseApplicationJson_Ocs _build() {
+    UserStatusClearMessageResponseApplicationJson_Ocs._validate(this);
     _$UserStatusClearMessageResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ??
@@ -4200,7 +4265,9 @@ class UserStatusClearMessageResponseApplicationJsonBuilder
       _$this._ocs ??= UserStatusClearMessageResponseApplicationJson_OcsBuilder();
   set ocs(covariant UserStatusClearMessageResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UserStatusClearMessageResponseApplicationJsonBuilder();
+  UserStatusClearMessageResponseApplicationJsonBuilder() {
+    UserStatusClearMessageResponseApplicationJson._defaults(this);
+  }
 
   UserStatusClearMessageResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -4226,6 +4293,7 @@ class UserStatusClearMessageResponseApplicationJsonBuilder
   UserStatusClearMessageResponseApplicationJson build() => _build();
 
   _$UserStatusClearMessageResponseApplicationJson _build() {
+    UserStatusClearMessageResponseApplicationJson._validate(this);
     _$UserStatusClearMessageResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UserStatusClearMessageResponseApplicationJson._(ocs: ocs.build());
@@ -4320,7 +4388,9 @@ class UserStatusRevertStatusResponseApplicationJson_OcsBuilder
   UserStatusRevertStatusResponseApplicationJson_Ocs_Data? get data => _$this._data;
   set data(covariant UserStatusRevertStatusResponseApplicationJson_Ocs_Data? data) => _$this._data = data;
 
-  UserStatusRevertStatusResponseApplicationJson_OcsBuilder();
+  UserStatusRevertStatusResponseApplicationJson_OcsBuilder() {
+    UserStatusRevertStatusResponseApplicationJson_Ocs._defaults(this);
+  }
 
   UserStatusRevertStatusResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -4430,7 +4500,9 @@ class UserStatusRevertStatusResponseApplicationJsonBuilder
       _$this._ocs ??= UserStatusRevertStatusResponseApplicationJson_OcsBuilder();
   set ocs(covariant UserStatusRevertStatusResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  UserStatusRevertStatusResponseApplicationJsonBuilder();
+  UserStatusRevertStatusResponseApplicationJsonBuilder() {
+    UserStatusRevertStatusResponseApplicationJson._defaults(this);
+  }
 
   UserStatusRevertStatusResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -4456,6 +4528,7 @@ class UserStatusRevertStatusResponseApplicationJsonBuilder
   UserStatusRevertStatusResponseApplicationJson build() => _build();
 
   _$UserStatusRevertStatusResponseApplicationJson _build() {
+    UserStatusRevertStatusResponseApplicationJson._validate(this);
     _$UserStatusRevertStatusResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$UserStatusRevertStatusResponseApplicationJson._(ocs: ocs.build());
@@ -4558,7 +4631,9 @@ class Capabilities_UserStatusBuilder
   bool? get supportsEmoji => _$this._supportsEmoji;
   set supportsEmoji(covariant bool? supportsEmoji) => _$this._supportsEmoji = supportsEmoji;
 
-  Capabilities_UserStatusBuilder();
+  Capabilities_UserStatusBuilder() {
+    Capabilities_UserStatus._defaults(this);
+  }
 
   Capabilities_UserStatusBuilder get _$this {
     final $v = _$v;
@@ -4586,6 +4661,7 @@ class Capabilities_UserStatusBuilder
   Capabilities_UserStatus build() => _build();
 
   _$Capabilities_UserStatus _build() {
+    Capabilities_UserStatus._validate(this);
     final _$result = _$v ??
         _$Capabilities_UserStatus._(
             enabled: BuiltValueNullFieldError.checkNotNull(enabled, r'Capabilities_UserStatus', 'enabled'),
@@ -4648,7 +4724,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities_UserStatusBuilder get userStatus => _$this._userStatus ??= Capabilities_UserStatusBuilder();
   set userStatus(covariant Capabilities_UserStatusBuilder? userStatus) => _$this._userStatus = userStatus;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -4674,6 +4752,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(userStatus: userStatus.build());

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -935,9 +935,16 @@ abstract class Location implements $LocationInterface, Built<Location, LocationB
 @BuiltValue(instantiable: false)
 abstract interface class $LocationWithSuccessInterface implements $LocationInterface, $SuccessInterface {
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($LocationWithSuccessInterfaceBuilder b) {}
+  static void _defaults($LocationWithSuccessInterfaceBuilder b) {
+    $LocationInterface._defaults(b);
+    $SuccessInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($LocationWithSuccessInterfaceBuilder b) {}
+  static void _validate($LocationWithSuccessInterfaceBuilder b) {
+    $LocationInterface._validate(b);
+    $SuccessInterface._validate(b);
+  }
 }
 
 abstract class LocationWithSuccess
@@ -1133,9 +1140,16 @@ abstract class Mode implements $ModeInterface, Built<Mode, ModeBuilder> {
 @BuiltValue(instantiable: false)
 abstract interface class $LocationWithModeInterface implements $LocationInterface, $ModeInterface {
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($LocationWithModeInterfaceBuilder b) {}
+  static void _defaults($LocationWithModeInterfaceBuilder b) {
+    $LocationInterface._defaults(b);
+    $ModeInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($LocationWithModeInterfaceBuilder b) {}
+  static void _validate($LocationWithModeInterfaceBuilder b) {
+    $LocationInterface._validate(b);
+    $ModeInterface._validate(b);
+  }
 }
 
 abstract class LocationWithMode

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -693,6 +693,10 @@ abstract interface class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OCSMetaInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OCSMetaInterfaceBuilder b) {}
 }
 
 abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuilder> {
@@ -719,11 +723,25 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 
   /// Serializer for OCSMeta.
   static Serializer<OCSMeta> get serializer => _$oCSMetaSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OCSMetaBuilder b) {
+    $OCSMetaInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OCSMetaBuilder b) {
+    $OCSMetaInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $SuccessInterface {
   bool get success;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SuccessInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SuccessInterfaceBuilder b) {}
 }
 
 abstract class Success implements $SuccessInterface, Built<Success, SuccessBuilder> {
@@ -750,12 +768,26 @@ abstract class Success implements $SuccessInterface, Built<Success, SuccessBuild
 
   /// Serializer for Success.
   static Serializer<Success> get serializer => _$successSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SuccessBuilder b) {
+    $SuccessInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SuccessBuilder b) {
+    $SuccessInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusSetModeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Success get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusSetModeResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusSetModeResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusSetModeResponseApplicationJson_Ocs
@@ -789,11 +821,25 @@ abstract class WeatherStatusSetModeResponseApplicationJson_Ocs
   /// Serializer for WeatherStatusSetModeResponseApplicationJson_Ocs.
   static Serializer<WeatherStatusSetModeResponseApplicationJson_Ocs> get serializer =>
       _$weatherStatusSetModeResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusSetModeResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusSetModeResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusSetModeResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusSetModeResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusSetModeResponseApplicationJsonInterface {
   WeatherStatusSetModeResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusSetModeResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusSetModeResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusSetModeResponseApplicationJson
@@ -827,6 +873,16 @@ abstract class WeatherStatusSetModeResponseApplicationJson
   /// Serializer for WeatherStatusSetModeResponseApplicationJson.
   static Serializer<WeatherStatusSetModeResponseApplicationJson> get serializer =>
       _$weatherStatusSetModeResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusSetModeResponseApplicationJsonBuilder b) {
+    $WeatherStatusSetModeResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusSetModeResponseApplicationJsonBuilder b) {
+    $WeatherStatusSetModeResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -834,6 +890,10 @@ abstract interface class $LocationInterface {
   String? get lat;
   String? get lon;
   String? get address;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($LocationInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($LocationInterfaceBuilder b) {}
 }
 
 abstract class Location implements $LocationInterface, Built<Location, LocationBuilder> {
@@ -860,10 +920,25 @@ abstract class Location implements $LocationInterface, Built<Location, LocationB
 
   /// Serializer for Location.
   static Serializer<Location> get serializer => _$locationSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(LocationBuilder b) {
+    $LocationInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(LocationBuilder b) {
+    $LocationInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $LocationWithSuccessInterface implements $LocationInterface, $SuccessInterface {}
+abstract interface class $LocationWithSuccessInterface implements $LocationInterface, $SuccessInterface {
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($LocationWithSuccessInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($LocationWithSuccessInterfaceBuilder b) {}
+}
 
 abstract class LocationWithSuccess
     implements $LocationWithSuccessInterface, Built<LocationWithSuccess, LocationWithSuccessBuilder> {
@@ -891,12 +966,26 @@ abstract class LocationWithSuccess
 
   /// Serializer for LocationWithSuccess.
   static Serializer<LocationWithSuccess> get serializer => _$locationWithSuccessSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(LocationWithSuccessBuilder b) {
+    $LocationWithSuccessInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(LocationWithSuccessBuilder b) {
+    $LocationWithSuccessInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   LocationWithSuccess get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs
@@ -931,11 +1020,25 @@ abstract class WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs
   /// Serializer for WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs.
   static Serializer<WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs> get serializer =>
       _$weatherStatusUsePersonalAddressResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusUsePersonalAddressResponseApplicationJsonInterface {
   WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusUsePersonalAddressResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusUsePersonalAddressResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusUsePersonalAddressResponseApplicationJson
@@ -970,11 +1073,25 @@ abstract class WeatherStatusUsePersonalAddressResponseApplicationJson
   /// Serializer for WeatherStatusUsePersonalAddressResponseApplicationJson.
   static Serializer<WeatherStatusUsePersonalAddressResponseApplicationJson> get serializer =>
       _$weatherStatusUsePersonalAddressResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusUsePersonalAddressResponseApplicationJsonBuilder b) {
+    $WeatherStatusUsePersonalAddressResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusUsePersonalAddressResponseApplicationJsonBuilder b) {
+    $WeatherStatusUsePersonalAddressResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ModeInterface {
   int get mode;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ModeInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ModeInterfaceBuilder b) {}
 }
 
 abstract class Mode implements $ModeInterface, Built<Mode, ModeBuilder> {
@@ -1001,10 +1118,25 @@ abstract class Mode implements $ModeInterface, Built<Mode, ModeBuilder> {
 
   /// Serializer for Mode.
   static Serializer<Mode> get serializer => _$modeSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ModeBuilder b) {
+    $ModeInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ModeBuilder b) {
+    $ModeInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
-abstract interface class $LocationWithModeInterface implements $LocationInterface, $ModeInterface {}
+abstract interface class $LocationWithModeInterface implements $LocationInterface, $ModeInterface {
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($LocationWithModeInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($LocationWithModeInterfaceBuilder b) {}
+}
 
 abstract class LocationWithMode
     implements $LocationWithModeInterface, Built<LocationWithMode, LocationWithModeBuilder> {
@@ -1031,12 +1163,26 @@ abstract class LocationWithMode
 
   /// Serializer for LocationWithMode.
   static Serializer<LocationWithMode> get serializer => _$locationWithModeSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(LocationWithModeBuilder b) {
+    $LocationWithModeInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(LocationWithModeBuilder b) {
+    $LocationWithModeInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusGetLocationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   LocationWithMode get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusGetLocationResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusGetLocationResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusGetLocationResponseApplicationJson_Ocs
@@ -1071,11 +1217,25 @@ abstract class WeatherStatusGetLocationResponseApplicationJson_Ocs
   /// Serializer for WeatherStatusGetLocationResponseApplicationJson_Ocs.
   static Serializer<WeatherStatusGetLocationResponseApplicationJson_Ocs> get serializer =>
       _$weatherStatusGetLocationResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusGetLocationResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusGetLocationResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusGetLocationResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusGetLocationResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusGetLocationResponseApplicationJsonInterface {
   WeatherStatusGetLocationResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusGetLocationResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusGetLocationResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusGetLocationResponseApplicationJson
@@ -1109,12 +1269,26 @@ abstract class WeatherStatusGetLocationResponseApplicationJson
   /// Serializer for WeatherStatusGetLocationResponseApplicationJson.
   static Serializer<WeatherStatusGetLocationResponseApplicationJson> get serializer =>
       _$weatherStatusGetLocationResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusGetLocationResponseApplicationJsonBuilder b) {
+    $WeatherStatusGetLocationResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusGetLocationResponseApplicationJsonBuilder b) {
+    $WeatherStatusGetLocationResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusSetLocationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   LocationWithSuccess get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusSetLocationResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusSetLocationResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusSetLocationResponseApplicationJson_Ocs
@@ -1149,11 +1323,25 @@ abstract class WeatherStatusSetLocationResponseApplicationJson_Ocs
   /// Serializer for WeatherStatusSetLocationResponseApplicationJson_Ocs.
   static Serializer<WeatherStatusSetLocationResponseApplicationJson_Ocs> get serializer =>
       _$weatherStatusSetLocationResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusSetLocationResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusSetLocationResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusSetLocationResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusSetLocationResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusSetLocationResponseApplicationJsonInterface {
   WeatherStatusSetLocationResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusSetLocationResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusSetLocationResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusSetLocationResponseApplicationJson
@@ -1187,6 +1375,16 @@ abstract class WeatherStatusSetLocationResponseApplicationJson
   /// Serializer for WeatherStatusSetLocationResponseApplicationJson.
   static Serializer<WeatherStatusSetLocationResponseApplicationJson> get serializer =>
       _$weatherStatusSetLocationResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusSetLocationResponseApplicationJsonBuilder b) {
+    $WeatherStatusSetLocationResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusSetLocationResponseApplicationJsonBuilder b) {
+    $WeatherStatusSetLocationResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1203,6 +1401,10 @@ abstract interface class $Forecast_Data_Instant_DetailsInterface {
   num get windFromDirection;
   @BuiltValueField(wireName: 'wind_speed')
   num get windSpeed;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_Instant_DetailsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_Instant_DetailsInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Instant_Details
@@ -1234,11 +1436,25 @@ abstract class Forecast_Data_Instant_Details
 
   /// Serializer for Forecast_Data_Instant_Details.
   static Serializer<Forecast_Data_Instant_Details> get serializer => _$forecastDataInstantDetailsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_Instant_DetailsBuilder b) {
+    $Forecast_Data_Instant_DetailsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_Instant_DetailsBuilder b) {
+    $Forecast_Data_Instant_DetailsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Forecast_Data_InstantInterface {
   Forecast_Data_Instant_Details get details;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_InstantInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_InstantInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Instant
@@ -1267,12 +1483,26 @@ abstract class Forecast_Data_Instant
 
   /// Serializer for Forecast_Data_Instant.
   static Serializer<Forecast_Data_Instant> get serializer => _$forecastDataInstantSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_InstantBuilder b) {
+    $Forecast_Data_InstantInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_InstantBuilder b) {
+    $Forecast_Data_InstantInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Forecast_Data_Next12Hours_SummaryInterface {
   @BuiltValueField(wireName: 'symbol_code')
   String get symbolCode;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_Next12Hours_SummaryInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_Next12Hours_SummaryInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Next12Hours_Summary
@@ -1304,12 +1534,26 @@ abstract class Forecast_Data_Next12Hours_Summary
 
   /// Serializer for Forecast_Data_Next12Hours_Summary.
   static Serializer<Forecast_Data_Next12Hours_Summary> get serializer => _$forecastDataNext12HoursSummarySerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_Next12Hours_SummaryBuilder b) {
+    $Forecast_Data_Next12Hours_SummaryInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_Next12Hours_SummaryBuilder b) {
+    $Forecast_Data_Next12Hours_SummaryInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Forecast_Data_Next12Hours_DetailsInterface {
   @BuiltValueField(wireName: 'precipitation_amount')
   num? get precipitationAmount;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_Next12Hours_DetailsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_Next12Hours_DetailsInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Next12Hours_Details
@@ -1341,12 +1585,26 @@ abstract class Forecast_Data_Next12Hours_Details
 
   /// Serializer for Forecast_Data_Next12Hours_Details.
   static Serializer<Forecast_Data_Next12Hours_Details> get serializer => _$forecastDataNext12HoursDetailsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_Next12Hours_DetailsBuilder b) {
+    $Forecast_Data_Next12Hours_DetailsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_Next12Hours_DetailsBuilder b) {
+    $Forecast_Data_Next12Hours_DetailsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Forecast_Data_Next12HoursInterface {
   Forecast_Data_Next12Hours_Summary get summary;
   Forecast_Data_Next12Hours_Details get details;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_Next12HoursInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_Next12HoursInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Next12Hours
@@ -1375,12 +1633,26 @@ abstract class Forecast_Data_Next12Hours
 
   /// Serializer for Forecast_Data_Next12Hours.
   static Serializer<Forecast_Data_Next12Hours> get serializer => _$forecastDataNext12HoursSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_Next12HoursBuilder b) {
+    $Forecast_Data_Next12HoursInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_Next12HoursBuilder b) {
+    $Forecast_Data_Next12HoursInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Forecast_Data_Next1Hours_SummaryInterface {
   @BuiltValueField(wireName: 'symbol_code')
   String get symbolCode;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_Next1Hours_SummaryInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_Next1Hours_SummaryInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Next1Hours_Summary
@@ -1412,12 +1684,26 @@ abstract class Forecast_Data_Next1Hours_Summary
 
   /// Serializer for Forecast_Data_Next1Hours_Summary.
   static Serializer<Forecast_Data_Next1Hours_Summary> get serializer => _$forecastDataNext1HoursSummarySerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_Next1Hours_SummaryBuilder b) {
+    $Forecast_Data_Next1Hours_SummaryInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_Next1Hours_SummaryBuilder b) {
+    $Forecast_Data_Next1Hours_SummaryInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Forecast_Data_Next1Hours_DetailsInterface {
   @BuiltValueField(wireName: 'precipitation_amount')
   num? get precipitationAmount;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_Next1Hours_DetailsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_Next1Hours_DetailsInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Next1Hours_Details
@@ -1449,12 +1735,26 @@ abstract class Forecast_Data_Next1Hours_Details
 
   /// Serializer for Forecast_Data_Next1Hours_Details.
   static Serializer<Forecast_Data_Next1Hours_Details> get serializer => _$forecastDataNext1HoursDetailsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_Next1Hours_DetailsBuilder b) {
+    $Forecast_Data_Next1Hours_DetailsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_Next1Hours_DetailsBuilder b) {
+    $Forecast_Data_Next1Hours_DetailsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Forecast_Data_Next1HoursInterface {
   Forecast_Data_Next1Hours_Summary get summary;
   Forecast_Data_Next1Hours_Details get details;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_Next1HoursInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_Next1HoursInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Next1Hours
@@ -1483,12 +1783,26 @@ abstract class Forecast_Data_Next1Hours
 
   /// Serializer for Forecast_Data_Next1Hours.
   static Serializer<Forecast_Data_Next1Hours> get serializer => _$forecastDataNext1HoursSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_Next1HoursBuilder b) {
+    $Forecast_Data_Next1HoursInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_Next1HoursBuilder b) {
+    $Forecast_Data_Next1HoursInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Forecast_Data_Next6Hours_SummaryInterface {
   @BuiltValueField(wireName: 'symbol_code')
   String get symbolCode;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_Next6Hours_SummaryInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_Next6Hours_SummaryInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Next6Hours_Summary
@@ -1520,12 +1834,26 @@ abstract class Forecast_Data_Next6Hours_Summary
 
   /// Serializer for Forecast_Data_Next6Hours_Summary.
   static Serializer<Forecast_Data_Next6Hours_Summary> get serializer => _$forecastDataNext6HoursSummarySerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_Next6Hours_SummaryBuilder b) {
+    $Forecast_Data_Next6Hours_SummaryInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_Next6Hours_SummaryBuilder b) {
+    $Forecast_Data_Next6Hours_SummaryInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Forecast_Data_Next6Hours_DetailsInterface {
   @BuiltValueField(wireName: 'precipitation_amount')
   num? get precipitationAmount;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_Next6Hours_DetailsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_Next6Hours_DetailsInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Next6Hours_Details
@@ -1557,12 +1885,26 @@ abstract class Forecast_Data_Next6Hours_Details
 
   /// Serializer for Forecast_Data_Next6Hours_Details.
   static Serializer<Forecast_Data_Next6Hours_Details> get serializer => _$forecastDataNext6HoursDetailsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_Next6Hours_DetailsBuilder b) {
+    $Forecast_Data_Next6Hours_DetailsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_Next6Hours_DetailsBuilder b) {
+    $Forecast_Data_Next6Hours_DetailsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Forecast_Data_Next6HoursInterface {
   Forecast_Data_Next6Hours_Summary get summary;
   Forecast_Data_Next6Hours_Details get details;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_Data_Next6HoursInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_Data_Next6HoursInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data_Next6Hours
@@ -1591,6 +1933,16 @@ abstract class Forecast_Data_Next6Hours
 
   /// Serializer for Forecast_Data_Next6Hours.
   static Serializer<Forecast_Data_Next6Hours> get serializer => _$forecastDataNext6HoursSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_Data_Next6HoursBuilder b) {
+    $Forecast_Data_Next6HoursInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_Data_Next6HoursBuilder b) {
+    $Forecast_Data_Next6HoursInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1602,6 +1954,10 @@ abstract interface class $Forecast_DataInterface {
   Forecast_Data_Next1Hours get next1Hours;
   @BuiltValueField(wireName: 'next_6_hours')
   Forecast_Data_Next6Hours get next6Hours;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Forecast_DataInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Forecast_DataInterfaceBuilder b) {}
 }
 
 abstract class Forecast_Data implements $Forecast_DataInterface, Built<Forecast_Data, Forecast_DataBuilder> {
@@ -1628,12 +1984,26 @@ abstract class Forecast_Data implements $Forecast_DataInterface, Built<Forecast_
 
   /// Serializer for Forecast_Data.
   static Serializer<Forecast_Data> get serializer => _$forecastDataSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Forecast_DataBuilder b) {
+    $Forecast_DataInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Forecast_DataBuilder b) {
+    $Forecast_DataInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $ForecastInterface {
   String get time;
   Forecast_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ForecastInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ForecastInterfaceBuilder b) {}
 }
 
 abstract class Forecast implements $ForecastInterface, Built<Forecast, ForecastBuilder> {
@@ -1660,11 +2030,25 @@ abstract class Forecast implements $ForecastInterface, Built<Forecast, ForecastB
 
   /// Serializer for Forecast.
   static Serializer<Forecast> get serializer => _$forecastSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ForecastBuilder b) {
+    $ForecastInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ForecastBuilder b) {
+    $ForecastInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Interface {
   String get error;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1InterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1InterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1
@@ -1699,6 +2083,16 @@ abstract class WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1
   /// Serializer for WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1.
   static Serializer<WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1> get serializer =>
       _$weatherStatusGetForecastResponseApplicationJsonOcsData1Serializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Builder b) {
+    $WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Interface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Builder b) {
+    $WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Interface._validate(b);
+  }
 }
 
 typedef WeatherStatusGetForecastResponseApplicationJson_Ocs_Data = ({
@@ -1710,6 +2104,12 @@ typedef WeatherStatusGetForecastResponseApplicationJson_Ocs_Data = ({
 abstract interface class $WeatherStatusGetForecastResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   WeatherStatusGetForecastResponseApplicationJson_Ocs_Data get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusGetForecastResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusGetForecastResponseApplicationJson_OcsInterfaceBuilder b) {
+    b.data?.validateOneOf();
+  }
 }
 
 abstract class WeatherStatusGetForecastResponseApplicationJson_Ocs
@@ -1745,15 +2145,24 @@ abstract class WeatherStatusGetForecastResponseApplicationJson_Ocs
   static Serializer<WeatherStatusGetForecastResponseApplicationJson_Ocs> get serializer =>
       _$weatherStatusGetForecastResponseApplicationJsonOcsSerializer;
 
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusGetForecastResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusGetForecastResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(WeatherStatusGetForecastResponseApplicationJson_OcsBuilder b) {
-    b.data?.validateOneOf();
+    $WeatherStatusGetForecastResponseApplicationJson_OcsInterface._validate(b);
   }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusGetForecastResponseApplicationJsonInterface {
   WeatherStatusGetForecastResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusGetForecastResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusGetForecastResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusGetForecastResponseApplicationJson
@@ -1787,12 +2196,26 @@ abstract class WeatherStatusGetForecastResponseApplicationJson
   /// Serializer for WeatherStatusGetForecastResponseApplicationJson.
   static Serializer<WeatherStatusGetForecastResponseApplicationJson> get serializer =>
       _$weatherStatusGetForecastResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusGetForecastResponseApplicationJsonBuilder b) {
+    $WeatherStatusGetForecastResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusGetForecastResponseApplicationJsonBuilder b) {
+    $WeatherStatusGetForecastResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusGetFavoritesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<String> get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusGetFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusGetFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusGetFavoritesResponseApplicationJson_Ocs
@@ -1827,11 +2250,25 @@ abstract class WeatherStatusGetFavoritesResponseApplicationJson_Ocs
   /// Serializer for WeatherStatusGetFavoritesResponseApplicationJson_Ocs.
   static Serializer<WeatherStatusGetFavoritesResponseApplicationJson_Ocs> get serializer =>
       _$weatherStatusGetFavoritesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusGetFavoritesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusGetFavoritesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusGetFavoritesResponseApplicationJsonInterface {
   WeatherStatusGetFavoritesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusGetFavoritesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusGetFavoritesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusGetFavoritesResponseApplicationJson
@@ -1866,12 +2303,26 @@ abstract class WeatherStatusGetFavoritesResponseApplicationJson
   /// Serializer for WeatherStatusGetFavoritesResponseApplicationJson.
   static Serializer<WeatherStatusGetFavoritesResponseApplicationJson> get serializer =>
       _$weatherStatusGetFavoritesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusGetFavoritesResponseApplicationJsonBuilder b) {
+    $WeatherStatusGetFavoritesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusGetFavoritesResponseApplicationJsonBuilder b) {
+    $WeatherStatusGetFavoritesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusSetFavoritesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Success get data;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusSetFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusSetFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusSetFavoritesResponseApplicationJson_Ocs
@@ -1906,11 +2357,25 @@ abstract class WeatherStatusSetFavoritesResponseApplicationJson_Ocs
   /// Serializer for WeatherStatusSetFavoritesResponseApplicationJson_Ocs.
   static Serializer<WeatherStatusSetFavoritesResponseApplicationJson_Ocs> get serializer =>
       _$weatherStatusSetFavoritesResponseApplicationJsonOcsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusSetFavoritesResponseApplicationJson_OcsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder b) {
+    $WeatherStatusSetFavoritesResponseApplicationJson_OcsInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $WeatherStatusSetFavoritesResponseApplicationJsonInterface {
   WeatherStatusSetFavoritesResponseApplicationJson_Ocs get ocs;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusSetFavoritesResponseApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusSetFavoritesResponseApplicationJsonInterfaceBuilder b) {}
 }
 
 abstract class WeatherStatusSetFavoritesResponseApplicationJson
@@ -1945,11 +2410,25 @@ abstract class WeatherStatusSetFavoritesResponseApplicationJson
   /// Serializer for WeatherStatusSetFavoritesResponseApplicationJson.
   static Serializer<WeatherStatusSetFavoritesResponseApplicationJson> get serializer =>
       _$weatherStatusSetFavoritesResponseApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusSetFavoritesResponseApplicationJsonBuilder b) {
+    $WeatherStatusSetFavoritesResponseApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusSetFavoritesResponseApplicationJsonBuilder b) {
+    $WeatherStatusSetFavoritesResponseApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $Capabilities_WeatherStatusInterface {
   bool get enabled;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($Capabilities_WeatherStatusInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($Capabilities_WeatherStatusInterfaceBuilder b) {}
 }
 
 abstract class Capabilities_WeatherStatus
@@ -1981,12 +2460,26 @@ abstract class Capabilities_WeatherStatus
 
   /// Serializer for Capabilities_WeatherStatus.
   static Serializer<Capabilities_WeatherStatus> get serializer => _$capabilitiesWeatherStatusSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(Capabilities_WeatherStatusBuilder b) {
+    $Capabilities_WeatherStatusInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(Capabilities_WeatherStatusBuilder b) {
+    $Capabilities_WeatherStatusInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
 abstract interface class $CapabilitiesInterface {
   @BuiltValueField(wireName: 'weather_status')
   Capabilities_WeatherStatus get weatherStatus;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CapabilitiesInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CapabilitiesInterfaceBuilder b) {}
 }
 
 abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilities, CapabilitiesBuilder> {
@@ -2013,6 +2506,16 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 
   /// Serializer for Capabilities.
   static Serializer<Capabilities> get serializer => _$capabilitiesSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CapabilitiesBuilder b) {
+    $CapabilitiesInterface._validate(b);
+  }
 }
 
 /// Serialization extension for `WeatherStatusGetForecastResponseApplicationJson_Ocs_Data`.

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.g.dart
@@ -1865,7 +1865,9 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   String? get itemsperpage => _$this._itemsperpage;
   set itemsperpage(covariant String? itemsperpage) => _$this._itemsperpage = itemsperpage;
 
-  OCSMetaBuilder();
+  OCSMetaBuilder() {
+    OCSMeta._defaults(this);
+  }
 
   OCSMetaBuilder get _$this {
     final $v = _$v;
@@ -1895,6 +1897,7 @@ class OCSMetaBuilder implements Builder<OCSMeta, OCSMetaBuilder>, $OCSMetaInterf
   OCSMeta build() => _build();
 
   _$OCSMeta _build() {
+    OCSMeta._validate(this);
     final _$result = _$v ??
         _$OCSMeta._(
             status: BuiltValueNullFieldError.checkNotNull(status, r'OCSMeta', 'status'),
@@ -1957,7 +1960,9 @@ class SuccessBuilder implements Builder<Success, SuccessBuilder>, $SuccessInterf
   bool? get success => _$this._success;
   set success(covariant bool? success) => _$this._success = success;
 
-  SuccessBuilder();
+  SuccessBuilder() {
+    Success._defaults(this);
+  }
 
   SuccessBuilder get _$this {
     final $v = _$v;
@@ -1983,6 +1988,7 @@ class SuccessBuilder implements Builder<Success, SuccessBuilder>, $SuccessInterf
   Success build() => _build();
 
   _$Success _build() {
+    Success._validate(this);
     final _$result = _$v ?? _$Success._(success: BuiltValueNullFieldError.checkNotNull(success, r'Success', 'success'));
     replace(_$result);
     return _$result;
@@ -2062,7 +2068,9 @@ class WeatherStatusSetModeResponseApplicationJson_OcsBuilder
   SuccessBuilder get data => _$this._data ??= SuccessBuilder();
   set data(covariant SuccessBuilder? data) => _$this._data = data;
 
-  WeatherStatusSetModeResponseApplicationJson_OcsBuilder();
+  WeatherStatusSetModeResponseApplicationJson_OcsBuilder() {
+    WeatherStatusSetModeResponseApplicationJson_Ocs._defaults(this);
+  }
 
   WeatherStatusSetModeResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2089,6 +2097,7 @@ class WeatherStatusSetModeResponseApplicationJson_OcsBuilder
   WeatherStatusSetModeResponseApplicationJson_Ocs build() => _build();
 
   _$WeatherStatusSetModeResponseApplicationJson_Ocs _build() {
+    WeatherStatusSetModeResponseApplicationJson_Ocs._validate(this);
     _$WeatherStatusSetModeResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$WeatherStatusSetModeResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -2169,7 +2178,9 @@ class WeatherStatusSetModeResponseApplicationJsonBuilder
       _$this._ocs ??= WeatherStatusSetModeResponseApplicationJson_OcsBuilder();
   set ocs(covariant WeatherStatusSetModeResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  WeatherStatusSetModeResponseApplicationJsonBuilder();
+  WeatherStatusSetModeResponseApplicationJsonBuilder() {
+    WeatherStatusSetModeResponseApplicationJson._defaults(this);
+  }
 
   WeatherStatusSetModeResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -2195,6 +2206,7 @@ class WeatherStatusSetModeResponseApplicationJsonBuilder
   WeatherStatusSetModeResponseApplicationJson build() => _build();
 
   _$WeatherStatusSetModeResponseApplicationJson _build() {
+    WeatherStatusSetModeResponseApplicationJson._validate(this);
     _$WeatherStatusSetModeResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$WeatherStatusSetModeResponseApplicationJson._(ocs: ocs.build());
@@ -2285,7 +2297,9 @@ class LocationBuilder implements Builder<Location, LocationBuilder>, $LocationIn
   String? get address => _$this._address;
   set address(covariant String? address) => _$this._address = address;
 
-  LocationBuilder();
+  LocationBuilder() {
+    Location._defaults(this);
+  }
 
   LocationBuilder get _$this {
     final $v = _$v;
@@ -2313,6 +2327,7 @@ class LocationBuilder implements Builder<Location, LocationBuilder>, $LocationIn
   Location build() => _build();
 
   _$Location _build() {
+    Location._validate(this);
     final _$result = _$v ?? _$Location._(lat: lat, lon: lon, address: address);
     replace(_$result);
     return _$result;
@@ -2412,7 +2427,9 @@ class LocationWithSuccessBuilder
   bool? get success => _$this._success;
   set success(covariant bool? success) => _$this._success = success;
 
-  LocationWithSuccessBuilder();
+  LocationWithSuccessBuilder() {
+    LocationWithSuccess._defaults(this);
+  }
 
   LocationWithSuccessBuilder get _$this {
     final $v = _$v;
@@ -2441,6 +2458,7 @@ class LocationWithSuccessBuilder
   LocationWithSuccess build() => _build();
 
   _$LocationWithSuccess _build() {
+    LocationWithSuccess._validate(this);
     final _$result = _$v ??
         _$LocationWithSuccess._(
             lat: lat,
@@ -2528,7 +2546,9 @@ class WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder
   LocationWithSuccessBuilder get data => _$this._data ??= LocationWithSuccessBuilder();
   set data(covariant LocationWithSuccessBuilder? data) => _$this._data = data;
 
-  WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder();
+  WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder() {
+    WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs._defaults(this);
+  }
 
   WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2555,6 +2575,7 @@ class WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder
   WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs build() => _build();
 
   _$WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs _build() {
+    WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs._validate(this);
     _$WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -2639,7 +2660,9 @@ class WeatherStatusUsePersonalAddressResponseApplicationJsonBuilder
       _$this._ocs ??= WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder();
   set ocs(covariant WeatherStatusUsePersonalAddressResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  WeatherStatusUsePersonalAddressResponseApplicationJsonBuilder();
+  WeatherStatusUsePersonalAddressResponseApplicationJsonBuilder() {
+    WeatherStatusUsePersonalAddressResponseApplicationJson._defaults(this);
+  }
 
   WeatherStatusUsePersonalAddressResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -2665,6 +2688,7 @@ class WeatherStatusUsePersonalAddressResponseApplicationJsonBuilder
   WeatherStatusUsePersonalAddressResponseApplicationJson build() => _build();
 
   _$WeatherStatusUsePersonalAddressResponseApplicationJson _build() {
+    WeatherStatusUsePersonalAddressResponseApplicationJson._validate(this);
     _$WeatherStatusUsePersonalAddressResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$WeatherStatusUsePersonalAddressResponseApplicationJson._(ocs: ocs.build());
@@ -2734,7 +2758,9 @@ class ModeBuilder implements Builder<Mode, ModeBuilder>, $ModeInterfaceBuilder {
   int? get mode => _$this._mode;
   set mode(covariant int? mode) => _$this._mode = mode;
 
-  ModeBuilder();
+  ModeBuilder() {
+    Mode._defaults(this);
+  }
 
   ModeBuilder get _$this {
     final $v = _$v;
@@ -2760,6 +2786,7 @@ class ModeBuilder implements Builder<Mode, ModeBuilder>, $ModeInterfaceBuilder {
   Mode build() => _build();
 
   _$Mode _build() {
+    Mode._validate(this);
     final _$result = _$v ?? _$Mode._(mode: BuiltValueNullFieldError.checkNotNull(mode, r'Mode', 'mode'));
     replace(_$result);
     return _$result;
@@ -2857,7 +2884,9 @@ class LocationWithModeBuilder
   int? get mode => _$this._mode;
   set mode(covariant int? mode) => _$this._mode = mode;
 
-  LocationWithModeBuilder();
+  LocationWithModeBuilder() {
+    LocationWithMode._defaults(this);
+  }
 
   LocationWithModeBuilder get _$this {
     final $v = _$v;
@@ -2886,6 +2915,7 @@ class LocationWithModeBuilder
   LocationWithMode build() => _build();
 
   _$LocationWithMode _build() {
+    LocationWithMode._validate(this);
     final _$result = _$v ??
         _$LocationWithMode._(
             lat: lat,
@@ -2971,7 +3001,9 @@ class WeatherStatusGetLocationResponseApplicationJson_OcsBuilder
   LocationWithModeBuilder get data => _$this._data ??= LocationWithModeBuilder();
   set data(covariant LocationWithModeBuilder? data) => _$this._data = data;
 
-  WeatherStatusGetLocationResponseApplicationJson_OcsBuilder();
+  WeatherStatusGetLocationResponseApplicationJson_OcsBuilder() {
+    WeatherStatusGetLocationResponseApplicationJson_Ocs._defaults(this);
+  }
 
   WeatherStatusGetLocationResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -2998,6 +3030,7 @@ class WeatherStatusGetLocationResponseApplicationJson_OcsBuilder
   WeatherStatusGetLocationResponseApplicationJson_Ocs build() => _build();
 
   _$WeatherStatusGetLocationResponseApplicationJson_Ocs _build() {
+    WeatherStatusGetLocationResponseApplicationJson_Ocs._validate(this);
     _$WeatherStatusGetLocationResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$WeatherStatusGetLocationResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -3080,7 +3113,9 @@ class WeatherStatusGetLocationResponseApplicationJsonBuilder
       _$this._ocs ??= WeatherStatusGetLocationResponseApplicationJson_OcsBuilder();
   set ocs(covariant WeatherStatusGetLocationResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  WeatherStatusGetLocationResponseApplicationJsonBuilder();
+  WeatherStatusGetLocationResponseApplicationJsonBuilder() {
+    WeatherStatusGetLocationResponseApplicationJson._defaults(this);
+  }
 
   WeatherStatusGetLocationResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3106,6 +3141,7 @@ class WeatherStatusGetLocationResponseApplicationJsonBuilder
   WeatherStatusGetLocationResponseApplicationJson build() => _build();
 
   _$WeatherStatusGetLocationResponseApplicationJson _build() {
+    WeatherStatusGetLocationResponseApplicationJson._validate(this);
     _$WeatherStatusGetLocationResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$WeatherStatusGetLocationResponseApplicationJson._(ocs: ocs.build());
@@ -3199,7 +3235,9 @@ class WeatherStatusSetLocationResponseApplicationJson_OcsBuilder
   LocationWithSuccessBuilder get data => _$this._data ??= LocationWithSuccessBuilder();
   set data(covariant LocationWithSuccessBuilder? data) => _$this._data = data;
 
-  WeatherStatusSetLocationResponseApplicationJson_OcsBuilder();
+  WeatherStatusSetLocationResponseApplicationJson_OcsBuilder() {
+    WeatherStatusSetLocationResponseApplicationJson_Ocs._defaults(this);
+  }
 
   WeatherStatusSetLocationResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -3226,6 +3264,7 @@ class WeatherStatusSetLocationResponseApplicationJson_OcsBuilder
   WeatherStatusSetLocationResponseApplicationJson_Ocs build() => _build();
 
   _$WeatherStatusSetLocationResponseApplicationJson_Ocs _build() {
+    WeatherStatusSetLocationResponseApplicationJson_Ocs._validate(this);
     _$WeatherStatusSetLocationResponseApplicationJson_Ocs _$result;
     try {
       _$result = _$v ?? _$WeatherStatusSetLocationResponseApplicationJson_Ocs._(meta: meta.build(), data: data.build());
@@ -3308,7 +3347,9 @@ class WeatherStatusSetLocationResponseApplicationJsonBuilder
       _$this._ocs ??= WeatherStatusSetLocationResponseApplicationJson_OcsBuilder();
   set ocs(covariant WeatherStatusSetLocationResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  WeatherStatusSetLocationResponseApplicationJsonBuilder();
+  WeatherStatusSetLocationResponseApplicationJsonBuilder() {
+    WeatherStatusSetLocationResponseApplicationJson._defaults(this);
+  }
 
   WeatherStatusSetLocationResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -3334,6 +3375,7 @@ class WeatherStatusSetLocationResponseApplicationJsonBuilder
   WeatherStatusSetLocationResponseApplicationJson build() => _build();
 
   _$WeatherStatusSetLocationResponseApplicationJson _build() {
+    WeatherStatusSetLocationResponseApplicationJson._validate(this);
     _$WeatherStatusSetLocationResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$WeatherStatusSetLocationResponseApplicationJson._(ocs: ocs.build());
@@ -3485,7 +3527,9 @@ class Forecast_Data_Instant_DetailsBuilder
   num? get windSpeed => _$this._windSpeed;
   set windSpeed(covariant num? windSpeed) => _$this._windSpeed = windSpeed;
 
-  Forecast_Data_Instant_DetailsBuilder();
+  Forecast_Data_Instant_DetailsBuilder() {
+    Forecast_Data_Instant_Details._defaults(this);
+  }
 
   Forecast_Data_Instant_DetailsBuilder get _$this {
     final $v = _$v;
@@ -3516,6 +3560,7 @@ class Forecast_Data_Instant_DetailsBuilder
   Forecast_Data_Instant_Details build() => _build();
 
   _$Forecast_Data_Instant_Details _build() {
+    Forecast_Data_Instant_Details._validate(this);
     final _$result = _$v ??
         _$Forecast_Data_Instant_Details._(
             airPressureAtSeaLevel: BuiltValueNullFieldError.checkNotNull(
@@ -3587,7 +3632,9 @@ class Forecast_Data_InstantBuilder
   Forecast_Data_Instant_DetailsBuilder get details => _$this._details ??= Forecast_Data_Instant_DetailsBuilder();
   set details(covariant Forecast_Data_Instant_DetailsBuilder? details) => _$this._details = details;
 
-  Forecast_Data_InstantBuilder();
+  Forecast_Data_InstantBuilder() {
+    Forecast_Data_Instant._defaults(this);
+  }
 
   Forecast_Data_InstantBuilder get _$this {
     final $v = _$v;
@@ -3613,6 +3660,7 @@ class Forecast_Data_InstantBuilder
   Forecast_Data_Instant build() => _build();
 
   _$Forecast_Data_Instant _build() {
+    Forecast_Data_Instant._validate(this);
     _$Forecast_Data_Instant _$result;
     try {
       _$result = _$v ?? _$Forecast_Data_Instant._(details: details.build());
@@ -3687,7 +3735,9 @@ class Forecast_Data_Next12Hours_SummaryBuilder
   String? get symbolCode => _$this._symbolCode;
   set symbolCode(covariant String? symbolCode) => _$this._symbolCode = symbolCode;
 
-  Forecast_Data_Next12Hours_SummaryBuilder();
+  Forecast_Data_Next12Hours_SummaryBuilder() {
+    Forecast_Data_Next12Hours_Summary._defaults(this);
+  }
 
   Forecast_Data_Next12Hours_SummaryBuilder get _$this {
     final $v = _$v;
@@ -3713,6 +3763,7 @@ class Forecast_Data_Next12Hours_SummaryBuilder
   Forecast_Data_Next12Hours_Summary build() => _build();
 
   _$Forecast_Data_Next12Hours_Summary _build() {
+    Forecast_Data_Next12Hours_Summary._validate(this);
     final _$result = _$v ??
         _$Forecast_Data_Next12Hours_Summary._(
             symbolCode:
@@ -3777,7 +3828,9 @@ class Forecast_Data_Next12Hours_DetailsBuilder
   num? get precipitationAmount => _$this._precipitationAmount;
   set precipitationAmount(covariant num? precipitationAmount) => _$this._precipitationAmount = precipitationAmount;
 
-  Forecast_Data_Next12Hours_DetailsBuilder();
+  Forecast_Data_Next12Hours_DetailsBuilder() {
+    Forecast_Data_Next12Hours_Details._defaults(this);
+  }
 
   Forecast_Data_Next12Hours_DetailsBuilder get _$this {
     final $v = _$v;
@@ -3803,6 +3856,7 @@ class Forecast_Data_Next12Hours_DetailsBuilder
   Forecast_Data_Next12Hours_Details build() => _build();
 
   _$Forecast_Data_Next12Hours_Details _build() {
+    Forecast_Data_Next12Hours_Details._validate(this);
     final _$result = _$v ?? _$Forecast_Data_Next12Hours_Details._(precipitationAmount: precipitationAmount);
     replace(_$result);
     return _$result;
@@ -3880,7 +3934,9 @@ class Forecast_Data_Next12HoursBuilder
       _$this._details ??= Forecast_Data_Next12Hours_DetailsBuilder();
   set details(covariant Forecast_Data_Next12Hours_DetailsBuilder? details) => _$this._details = details;
 
-  Forecast_Data_Next12HoursBuilder();
+  Forecast_Data_Next12HoursBuilder() {
+    Forecast_Data_Next12Hours._defaults(this);
+  }
 
   Forecast_Data_Next12HoursBuilder get _$this {
     final $v = _$v;
@@ -3907,6 +3963,7 @@ class Forecast_Data_Next12HoursBuilder
   Forecast_Data_Next12Hours build() => _build();
 
   _$Forecast_Data_Next12Hours _build() {
+    Forecast_Data_Next12Hours._validate(this);
     _$Forecast_Data_Next12Hours _$result;
     try {
       _$result = _$v ?? _$Forecast_Data_Next12Hours._(summary: summary.build(), details: details.build());
@@ -3982,7 +4039,9 @@ class Forecast_Data_Next1Hours_SummaryBuilder
   String? get symbolCode => _$this._symbolCode;
   set symbolCode(covariant String? symbolCode) => _$this._symbolCode = symbolCode;
 
-  Forecast_Data_Next1Hours_SummaryBuilder();
+  Forecast_Data_Next1Hours_SummaryBuilder() {
+    Forecast_Data_Next1Hours_Summary._defaults(this);
+  }
 
   Forecast_Data_Next1Hours_SummaryBuilder get _$this {
     final $v = _$v;
@@ -4008,6 +4067,7 @@ class Forecast_Data_Next1Hours_SummaryBuilder
   Forecast_Data_Next1Hours_Summary build() => _build();
 
   _$Forecast_Data_Next1Hours_Summary _build() {
+    Forecast_Data_Next1Hours_Summary._validate(this);
     final _$result = _$v ??
         _$Forecast_Data_Next1Hours_Summary._(
             symbolCode:
@@ -4072,7 +4132,9 @@ class Forecast_Data_Next1Hours_DetailsBuilder
   num? get precipitationAmount => _$this._precipitationAmount;
   set precipitationAmount(covariant num? precipitationAmount) => _$this._precipitationAmount = precipitationAmount;
 
-  Forecast_Data_Next1Hours_DetailsBuilder();
+  Forecast_Data_Next1Hours_DetailsBuilder() {
+    Forecast_Data_Next1Hours_Details._defaults(this);
+  }
 
   Forecast_Data_Next1Hours_DetailsBuilder get _$this {
     final $v = _$v;
@@ -4098,6 +4160,7 @@ class Forecast_Data_Next1Hours_DetailsBuilder
   Forecast_Data_Next1Hours_Details build() => _build();
 
   _$Forecast_Data_Next1Hours_Details _build() {
+    Forecast_Data_Next1Hours_Details._validate(this);
     final _$result = _$v ?? _$Forecast_Data_Next1Hours_Details._(precipitationAmount: precipitationAmount);
     replace(_$result);
     return _$result;
@@ -4173,7 +4236,9 @@ class Forecast_Data_Next1HoursBuilder
   Forecast_Data_Next1Hours_DetailsBuilder get details => _$this._details ??= Forecast_Data_Next1Hours_DetailsBuilder();
   set details(covariant Forecast_Data_Next1Hours_DetailsBuilder? details) => _$this._details = details;
 
-  Forecast_Data_Next1HoursBuilder();
+  Forecast_Data_Next1HoursBuilder() {
+    Forecast_Data_Next1Hours._defaults(this);
+  }
 
   Forecast_Data_Next1HoursBuilder get _$this {
     final $v = _$v;
@@ -4200,6 +4265,7 @@ class Forecast_Data_Next1HoursBuilder
   Forecast_Data_Next1Hours build() => _build();
 
   _$Forecast_Data_Next1Hours _build() {
+    Forecast_Data_Next1Hours._validate(this);
     _$Forecast_Data_Next1Hours _$result;
     try {
       _$result = _$v ?? _$Forecast_Data_Next1Hours._(summary: summary.build(), details: details.build());
@@ -4275,7 +4341,9 @@ class Forecast_Data_Next6Hours_SummaryBuilder
   String? get symbolCode => _$this._symbolCode;
   set symbolCode(covariant String? symbolCode) => _$this._symbolCode = symbolCode;
 
-  Forecast_Data_Next6Hours_SummaryBuilder();
+  Forecast_Data_Next6Hours_SummaryBuilder() {
+    Forecast_Data_Next6Hours_Summary._defaults(this);
+  }
 
   Forecast_Data_Next6Hours_SummaryBuilder get _$this {
     final $v = _$v;
@@ -4301,6 +4369,7 @@ class Forecast_Data_Next6Hours_SummaryBuilder
   Forecast_Data_Next6Hours_Summary build() => _build();
 
   _$Forecast_Data_Next6Hours_Summary _build() {
+    Forecast_Data_Next6Hours_Summary._validate(this);
     final _$result = _$v ??
         _$Forecast_Data_Next6Hours_Summary._(
             symbolCode:
@@ -4365,7 +4434,9 @@ class Forecast_Data_Next6Hours_DetailsBuilder
   num? get precipitationAmount => _$this._precipitationAmount;
   set precipitationAmount(covariant num? precipitationAmount) => _$this._precipitationAmount = precipitationAmount;
 
-  Forecast_Data_Next6Hours_DetailsBuilder();
+  Forecast_Data_Next6Hours_DetailsBuilder() {
+    Forecast_Data_Next6Hours_Details._defaults(this);
+  }
 
   Forecast_Data_Next6Hours_DetailsBuilder get _$this {
     final $v = _$v;
@@ -4391,6 +4462,7 @@ class Forecast_Data_Next6Hours_DetailsBuilder
   Forecast_Data_Next6Hours_Details build() => _build();
 
   _$Forecast_Data_Next6Hours_Details _build() {
+    Forecast_Data_Next6Hours_Details._validate(this);
     final _$result = _$v ?? _$Forecast_Data_Next6Hours_Details._(precipitationAmount: precipitationAmount);
     replace(_$result);
     return _$result;
@@ -4466,7 +4538,9 @@ class Forecast_Data_Next6HoursBuilder
   Forecast_Data_Next6Hours_DetailsBuilder get details => _$this._details ??= Forecast_Data_Next6Hours_DetailsBuilder();
   set details(covariant Forecast_Data_Next6Hours_DetailsBuilder? details) => _$this._details = details;
 
-  Forecast_Data_Next6HoursBuilder();
+  Forecast_Data_Next6HoursBuilder() {
+    Forecast_Data_Next6Hours._defaults(this);
+  }
 
   Forecast_Data_Next6HoursBuilder get _$this {
     final $v = _$v;
@@ -4493,6 +4567,7 @@ class Forecast_Data_Next6HoursBuilder
   Forecast_Data_Next6Hours build() => _build();
 
   _$Forecast_Data_Next6Hours _build() {
+    Forecast_Data_Next6Hours._validate(this);
     _$Forecast_Data_Next6Hours _$result;
     try {
       _$result = _$v ?? _$Forecast_Data_Next6Hours._(summary: summary.build(), details: details.build());
@@ -4608,7 +4683,9 @@ class Forecast_DataBuilder implements Builder<Forecast_Data, Forecast_DataBuilde
   Forecast_Data_Next6HoursBuilder get next6Hours => _$this._next6Hours ??= Forecast_Data_Next6HoursBuilder();
   set next6Hours(covariant Forecast_Data_Next6HoursBuilder? next6Hours) => _$this._next6Hours = next6Hours;
 
-  Forecast_DataBuilder();
+  Forecast_DataBuilder() {
+    Forecast_Data._defaults(this);
+  }
 
   Forecast_DataBuilder get _$this {
     final $v = _$v;
@@ -4637,6 +4714,7 @@ class Forecast_DataBuilder implements Builder<Forecast_Data, Forecast_DataBuilde
   Forecast_Data build() => _build();
 
   _$Forecast_Data _build() {
+    Forecast_Data._validate(this);
     _$Forecast_Data _$result;
     try {
       _$result = _$v ??
@@ -4730,7 +4808,9 @@ class ForecastBuilder implements Builder<Forecast, ForecastBuilder>, $ForecastIn
   Forecast_DataBuilder get data => _$this._data ??= Forecast_DataBuilder();
   set data(covariant Forecast_DataBuilder? data) => _$this._data = data;
 
-  ForecastBuilder();
+  ForecastBuilder() {
+    Forecast._defaults(this);
+  }
 
   ForecastBuilder get _$this {
     final $v = _$v;
@@ -4757,6 +4837,7 @@ class ForecastBuilder implements Builder<Forecast, ForecastBuilder>, $ForecastIn
   Forecast build() => _build();
 
   _$Forecast _build() {
+    Forecast._validate(this);
     _$Forecast _$result;
     try {
       _$result = _$v ??
@@ -4838,7 +4919,9 @@ class WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Builder
   String? get error => _$this._error;
   set error(covariant String? error) => _$this._error = error;
 
-  WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Builder();
+  WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Builder() {
+    WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1._defaults(this);
+  }
 
   WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Builder get _$this {
     final $v = _$v;
@@ -4864,6 +4947,7 @@ class WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Builder
   WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1 build() => _build();
 
   _$WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1 _build() {
+    WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1._validate(this);
     final _$result = _$v ??
         _$WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1._(
             error: BuiltValueNullFieldError.checkNotNull(
@@ -4950,7 +5034,9 @@ class WeatherStatusGetForecastResponseApplicationJson_OcsBuilder
   WeatherStatusGetForecastResponseApplicationJson_Ocs_Data? get data => _$this._data;
   set data(covariant WeatherStatusGetForecastResponseApplicationJson_Ocs_Data? data) => _$this._data = data;
 
-  WeatherStatusGetForecastResponseApplicationJson_OcsBuilder();
+  WeatherStatusGetForecastResponseApplicationJson_OcsBuilder() {
+    WeatherStatusGetForecastResponseApplicationJson_Ocs._defaults(this);
+  }
 
   WeatherStatusGetForecastResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -5062,7 +5148,9 @@ class WeatherStatusGetForecastResponseApplicationJsonBuilder
       _$this._ocs ??= WeatherStatusGetForecastResponseApplicationJson_OcsBuilder();
   set ocs(covariant WeatherStatusGetForecastResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  WeatherStatusGetForecastResponseApplicationJsonBuilder();
+  WeatherStatusGetForecastResponseApplicationJsonBuilder() {
+    WeatherStatusGetForecastResponseApplicationJson._defaults(this);
+  }
 
   WeatherStatusGetForecastResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -5088,6 +5176,7 @@ class WeatherStatusGetForecastResponseApplicationJsonBuilder
   WeatherStatusGetForecastResponseApplicationJson build() => _build();
 
   _$WeatherStatusGetForecastResponseApplicationJson _build() {
+    WeatherStatusGetForecastResponseApplicationJson._validate(this);
     _$WeatherStatusGetForecastResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$WeatherStatusGetForecastResponseApplicationJson._(ocs: ocs.build());
@@ -5181,7 +5270,9 @@ class WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder
   ListBuilder<String> get data => _$this._data ??= ListBuilder<String>();
   set data(covariant ListBuilder<String>? data) => _$this._data = data;
 
-  WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder();
+  WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder() {
+    WeatherStatusGetFavoritesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -5208,6 +5299,7 @@ class WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder
   WeatherStatusGetFavoritesResponseApplicationJson_Ocs build() => _build();
 
   _$WeatherStatusGetFavoritesResponseApplicationJson_Ocs _build() {
+    WeatherStatusGetFavoritesResponseApplicationJson_Ocs._validate(this);
     _$WeatherStatusGetFavoritesResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -5291,7 +5383,9 @@ class WeatherStatusGetFavoritesResponseApplicationJsonBuilder
       _$this._ocs ??= WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder();
   set ocs(covariant WeatherStatusGetFavoritesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  WeatherStatusGetFavoritesResponseApplicationJsonBuilder();
+  WeatherStatusGetFavoritesResponseApplicationJsonBuilder() {
+    WeatherStatusGetFavoritesResponseApplicationJson._defaults(this);
+  }
 
   WeatherStatusGetFavoritesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -5317,6 +5411,7 @@ class WeatherStatusGetFavoritesResponseApplicationJsonBuilder
   WeatherStatusGetFavoritesResponseApplicationJson build() => _build();
 
   _$WeatherStatusGetFavoritesResponseApplicationJson _build() {
+    WeatherStatusGetFavoritesResponseApplicationJson._validate(this);
     _$WeatherStatusGetFavoritesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$WeatherStatusGetFavoritesResponseApplicationJson._(ocs: ocs.build());
@@ -5410,7 +5505,9 @@ class WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder
   SuccessBuilder get data => _$this._data ??= SuccessBuilder();
   set data(covariant SuccessBuilder? data) => _$this._data = data;
 
-  WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder();
+  WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder() {
+    WeatherStatusSetFavoritesResponseApplicationJson_Ocs._defaults(this);
+  }
 
   WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder get _$this {
     final $v = _$v;
@@ -5437,6 +5534,7 @@ class WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder
   WeatherStatusSetFavoritesResponseApplicationJson_Ocs build() => _build();
 
   _$WeatherStatusSetFavoritesResponseApplicationJson_Ocs _build() {
+    WeatherStatusSetFavoritesResponseApplicationJson_Ocs._validate(this);
     _$WeatherStatusSetFavoritesResponseApplicationJson_Ocs _$result;
     try {
       _$result =
@@ -5520,7 +5618,9 @@ class WeatherStatusSetFavoritesResponseApplicationJsonBuilder
       _$this._ocs ??= WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder();
   set ocs(covariant WeatherStatusSetFavoritesResponseApplicationJson_OcsBuilder? ocs) => _$this._ocs = ocs;
 
-  WeatherStatusSetFavoritesResponseApplicationJsonBuilder();
+  WeatherStatusSetFavoritesResponseApplicationJsonBuilder() {
+    WeatherStatusSetFavoritesResponseApplicationJson._defaults(this);
+  }
 
   WeatherStatusSetFavoritesResponseApplicationJsonBuilder get _$this {
     final $v = _$v;
@@ -5546,6 +5646,7 @@ class WeatherStatusSetFavoritesResponseApplicationJsonBuilder
   WeatherStatusSetFavoritesResponseApplicationJson build() => _build();
 
   _$WeatherStatusSetFavoritesResponseApplicationJson _build() {
+    WeatherStatusSetFavoritesResponseApplicationJson._validate(this);
     _$WeatherStatusSetFavoritesResponseApplicationJson _$result;
     try {
       _$result = _$v ?? _$WeatherStatusSetFavoritesResponseApplicationJson._(ocs: ocs.build());
@@ -5620,7 +5721,9 @@ class Capabilities_WeatherStatusBuilder
   bool? get enabled => _$this._enabled;
   set enabled(covariant bool? enabled) => _$this._enabled = enabled;
 
-  Capabilities_WeatherStatusBuilder();
+  Capabilities_WeatherStatusBuilder() {
+    Capabilities_WeatherStatus._defaults(this);
+  }
 
   Capabilities_WeatherStatusBuilder get _$this {
     final $v = _$v;
@@ -5646,6 +5749,7 @@ class Capabilities_WeatherStatusBuilder
   Capabilities_WeatherStatus build() => _build();
 
   _$Capabilities_WeatherStatus _build() {
+    Capabilities_WeatherStatus._validate(this);
     final _$result = _$v ??
         _$Capabilities_WeatherStatus._(
             enabled: BuiltValueNullFieldError.checkNotNull(enabled, r'Capabilities_WeatherStatus', 'enabled'));
@@ -5706,7 +5810,9 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   set weatherStatus(covariant Capabilities_WeatherStatusBuilder? weatherStatus) =>
       _$this._weatherStatus = weatherStatus;
 
-  CapabilitiesBuilder();
+  CapabilitiesBuilder() {
+    Capabilities._defaults(this);
+  }
 
   CapabilitiesBuilder get _$this {
     final $v = _$v;
@@ -5732,6 +5838,7 @@ class CapabilitiesBuilder implements Builder<Capabilities, CapabilitiesBuilder>,
   Capabilities build() => _build();
 
   _$Capabilities _build() {
+    Capabilities._validate(this);
     _$Capabilities _$result;
     try {
       _$result = _$v ?? _$Capabilities._(weatherStatus: weatherStatus.build());


### PR DESCRIPTION
fixes: #1905

With further refactors we may be able to remove the generation of the empty methods but for now this is the easiest we can do to fix this issue.