### PR TITLE
fix(nextcloud)!: Require content-length for all WebDAV put requests

### DIFF
--- a/packages/neon/neon_files/lib/src/utils/task.dart
+++ b/packages/neon/neon_files/lib/src/utils/task.dart
@@ -128,7 +128,7 @@ class FilesUploadTaskMemory extends FilesTaskMemory implements FilesUploadTask {
   }
 
   @override
-  final int? size;
+  final int size;
 
   @override
   final tz.TZDateTime? lastModified;
@@ -136,6 +136,7 @@ class FilesUploadTaskMemory extends FilesTaskMemory implements FilesUploadTask {
   Future<void> execute(NextcloudClient client) async {
     await client.webdav.putStream(
       _stream.stream,
+      size,
       uri,
       lastModified: lastModified,
       onProgress: progressController.add,

--- a/packages/nextcloud/lib/src/webdav/client.dart
+++ b/packages/nextcloud/lib/src/webdav/client.dart
@@ -109,9 +109,9 @@ class WebDavClient {
 
     _addUploadHeaders(
       request,
+      localData.length,
       lastModified: lastModified,
       created: created,
-      contentLength: localData.length,
     );
     _addBaseHeaders(request);
     return request;
@@ -146,10 +146,10 @@ class WebDavClient {
   ///   * [putStream] for a complete operation executing this request.
   http.BaseRequest putStream_Request(
     Stream<List<int>> localData,
+    int contentLength,
     PathUri path, {
     DateTime? lastModified,
     DateTime? created,
-    int? contentLength,
     void Function(double progress)? onProgress,
   }) {
     final request = http.StreamedRequest('PUT', _constructUri(path));
@@ -157,12 +157,12 @@ class WebDavClient {
     _addBaseHeaders(request);
     _addUploadHeaders(
       request,
+      contentLength,
       lastModified: lastModified,
       created: created,
-      contentLength: contentLength,
     );
 
-    if (contentLength != null && onProgress != null) {
+    if (onProgress != null) {
       var uploaded = 0;
 
       unawaited(
@@ -192,18 +192,18 @@ class WebDavClient {
   ///   * [putStream_Request] for the request sent by this method.
   Future<http.StreamedResponse> putStream(
     Stream<List<int>> localData,
+    int contentLength,
     PathUri path, {
     DateTime? lastModified,
     DateTime? created,
-    int? contentLength,
     void Function(double progress)? onProgress,
   }) {
     final request = putStream_Request(
       localData,
+      contentLength,
       path,
       lastModified: lastModified,
       created: created,
-      contentLength: contentLength,
       onProgress: onProgress,
     );
 
@@ -226,10 +226,10 @@ class WebDavClient {
     // No need to set them here.
     return putStream_Request(
       file.openRead(),
+      fileStat.size,
       path,
       lastModified: lastModified,
       created: created,
-      contentLength: fileStat.size,
       onProgress: onProgress,
     );
   }
@@ -570,10 +570,10 @@ class WebDavClient {
   }
 
   static void _addUploadHeaders(
-    http.BaseRequest request, {
+    http.BaseRequest request,
+    int contentLength, {
     DateTime? lastModified,
     DateTime? created,
-    int? contentLength,
   }) {
     if (lastModified != null) {
       request.headers['X-OC-Mtime'] = lastModified.secondsSinceEpoch.toString();
@@ -581,9 +581,7 @@ class WebDavClient {
     if (created != null) {
       request.headers['X-OC-CTime'] = created.secondsSinceEpoch.toString();
     }
-    if (contentLength != null) {
-      request.headers['content-length'] = contentLength.toString();
-    }
+    request.headers['content-length'] = contentLength.toString();
   }
 
   void _addCopyHeaders(http.BaseRequest request, {required PathUri destinationPath, required bool overwrite}) {

--- a/packages/nextcloud/test/webdav_test.dart
+++ b/packages/nextcloud/test/webdav_test.dart
@@ -518,8 +518,8 @@ void main() {
 
         await client.webdav.putStream(
           source.openRead(),
+          source.lengthSync(),
           PathUri.parse('upload_stream.png'),
-          contentLength: source.lengthSync(),
           onProgress: progressValues.add,
         );
         final stream = client.webdav.getStream(


### PR DESCRIPTION
Some specific setups do not like it when the content-length header is not present. The consumer of the package should always know the size of the data they are trying to upload, so enforcing the content-length is no problem.
For reference: https://github.com/saber-notes/saber/issues/945 https://github.com/saber-notes/saber/issues/1232