### PR TITLE
docs(nextcloud): Clarify why setting Content-Length for WebDAV PUT requests is important

### DIFF
--- a/packages/neon/neon_files/lib/src/utils/task.dart
+++ b/packages/neon/neon_files/lib/src/utils/task.dart
@@ -128,7 +128,7 @@ class FilesUploadTaskMemory extends FilesTaskMemory implements FilesUploadTask {
   }
 
   @override
-  final int? size;
+  final int size;
 
   @override
   final tz.TZDateTime? lastModified;
@@ -138,6 +138,7 @@ class FilesUploadTaskMemory extends FilesTaskMemory implements FilesUploadTask {
       _stream.stream,
       uri,
       lastModified: lastModified,
+      contentLength: size,
       onProgress: progressController.add,
     );
     await progressController.close();

--- a/packages/nextcloud/lib/src/webdav/client.dart
+++ b/packages/nextcloud/lib/src/webdav/client.dart
@@ -142,6 +142,9 @@ class WebDavClient {
 
   /// Request to put a new file at [path] with [localData] as content.
   ///
+  /// Setting [contentLength] is important because some web servers will consider the file to be empty otherwise.
+  /// It will be required in the next major release.
+  ///
   /// See:
   ///   * [putStream] for a complete operation executing this request.
   http.BaseRequest putStream_Request(
@@ -187,6 +190,9 @@ class WebDavClient {
   /// [created] sets the date when the file was created on the server.
   /// [contentLength] sets the length of the [localData] that is uploaded.
   /// [onProgress] can be used to watch the upload progress. Possible values range from 0.0 to 1.0. [contentLength] needs to be set for it to work.
+  /// Setting [contentLength] is important because some web servers will consider the file to be empty otherwise.
+  /// It will be required in the next major release.
+  ///
   /// See:
   ///   * http://www.webdav.org/specs/rfc2518.html#METHOD_PUT for more information.
   ///   * [putStream_Request] for the request sent by this method.


### PR DESCRIPTION
Replaces https://github.com/nextcloud/neon/pull/1987
For reference: https://github.com/saber-notes/saber/issues/945 https://github.com/saber-notes/saber/issues/1232