### PR TITLE
fix(neon_dashboard): Only allow single lines in items

### DIFF
--- a/packages/neon/neon_dashboard/lib/src/widgets/widget_item.dart
+++ b/packages/neon/neon_dashboard/lib/src/widgets/widget_item.dart
@@ -62,10 +62,12 @@ class DashboardWidgetItem extends StatelessWidget {
       title: Text(
         item.title,
         overflow: TextOverflow.ellipsis,
+        maxLines: 1,
       ),
       subtitle: Text(
         item.subtitle,
         overflow: TextOverflow.ellipsis,
+        maxLines: 1,
       ),
       leading: leading,
       onTap: item.link.isNotEmpty ? () => context.go(item.link) : null,


### PR DESCRIPTION
This can happen for example with formatted Talk messages that have more than one line which is used as the subtitle. Did the same for the title to prevent the same problem there if it would ever happen.