### PR TITLE
feat(dynamite)!: add `Built` interface to the generated interfaces

### DIFF
--- a/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
+++ b/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
@@ -318,6 +318,15 @@ class $Client extends _i1.DynamiteClient {
 sealed class $NewPetInterface {
   String get name;
   String? get tag;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NewPetInterfaceBuilder].
+  $NewPetInterface rebuild(void Function($NewPetInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$NewPetInterfaceBuilder].
+  $NewPetInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NewPetInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -363,6 +372,17 @@ abstract class NewPet implements $NewPetInterface, Built<NewPet, NewPetBuilder> 
 @BuiltValue(instantiable: false)
 sealed class $PetInterface implements $NewPetInterface {
   int get id;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PetInterfaceBuilder].
+  @override
+  $PetInterface rebuild(void Function($PetInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PetInterfaceBuilder].
+  @override
+  $PetInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PetInterfaceBuilder b) {
     $NewPetInterface._defaults(b);
@@ -414,6 +434,15 @@ abstract class Pet implements $PetInterface, Built<Pet, PetBuilder> {
 sealed class $ErrorInterface {
   int get code;
   String get message;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ErrorInterfaceBuilder].
+  $ErrorInterface rebuild(void Function($ErrorInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ErrorInterfaceBuilder].
+  $ErrorInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ErrorInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_interface.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_interface.dart
@@ -77,6 +77,37 @@ Spec buildInterface(
       );
     }
 
+    final builderName = '${className}Builder';
+
+    b.methods.add(
+      Method((b) {
+        b
+          ..docs.add('''
+/// Rebuilds the instance.
+///
+/// The result is the same as this instance but with [updates] applied.
+/// [updates] is a function that takes a builder [$builderName].''')
+          ..returns = refer(className)
+          ..name = 'rebuild'
+          ..requiredParameters.add(
+            Parameter((b) {
+              b
+                ..name = 'updates'
+                ..type = refer('void Function($builderName)');
+            }),
+          );
+      }),
+    );
+
+    b.methods.add(
+      Method((b) {
+        b
+          ..docs.add('/// Converts the instance to a builder [$builderName].')
+          ..returns = refer(builderName)
+          ..name = 'toBuilder';
+      }),
+    );
+
     b.methods.add(
       Method((b) {
         b
@@ -92,7 +123,7 @@ Spec buildInterface(
             Parameter(
               (b) => b
                 ..name = 'b'
-                ..type = refer('${className}Builder'),
+                ..type = refer(builderName),
             ),
           );
         if (defaults.isNotEmpty) {
@@ -118,7 +149,7 @@ Spec buildInterface(
             Parameter(
               (b) => b
                 ..name = 'b'
-                ..type = refer('${className}Builder'),
+                ..type = refer(builderName),
             ),
           )
           ..body = validators.build();

--- a/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/all_of.openapi.dart
@@ -25,6 +25,15 @@ sealed class $ObjectAllOfInterface {
   String get attribute1AllOf;
   @BuiltValueField(wireName: 'attribute2-allOf')
   String get attribute2AllOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ObjectAllOfInterfaceBuilder].
+  $ObjectAllOfInterface rebuild(void Function($ObjectAllOfInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ObjectAllOfInterfaceBuilder].
+  $ObjectAllOfInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ObjectAllOfInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -67,6 +76,15 @@ abstract class ObjectAllOf implements $ObjectAllOfInterface, Built<ObjectAllOf, 
 sealed class $OneObjectAllOfInterface {
   @BuiltValueField(wireName: 'attribute-allOf')
   String get attributeAllOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OneObjectAllOfInterfaceBuilder].
+  $OneObjectAllOfInterface rebuild(void Function($OneObjectAllOfInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OneObjectAllOfInterfaceBuilder].
+  $OneObjectAllOfInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OneObjectAllOfInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -111,6 +129,15 @@ sealed class $PrimitiveAllOfInterface {
   int get $int;
   @BuiltValueField(wireName: 'String')
   String get string;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PrimitiveAllOfInterfaceBuilder].
+  $PrimitiveAllOfInterface rebuild(void Function($PrimitiveAllOfInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PrimitiveAllOfInterfaceBuilder].
+  $PrimitiveAllOfInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PrimitiveAllOfInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -155,6 +182,15 @@ sealed class $MixedAllOfInterface {
   String get string;
   @BuiltValueField(wireName: 'attribute-allOf')
   String get attributeAllOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MixedAllOfInterfaceBuilder].
+  $MixedAllOfInterface rebuild(void Function($MixedAllOfInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$MixedAllOfInterfaceBuilder].
+  $MixedAllOfInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MixedAllOfInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -197,6 +233,15 @@ abstract class MixedAllOf implements $MixedAllOfInterface, Built<MixedAllOf, Mix
 sealed class $OneValueAllOfInterface {
   @BuiltValueField(wireName: 'String')
   String get string;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OneValueAllOfInterfaceBuilder].
+  $OneValueAllOfInterface rebuild(void Function($OneValueAllOfInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OneValueAllOfInterfaceBuilder].
+  $OneValueAllOfInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OneValueAllOfInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -242,6 +287,15 @@ sealed class $SuperObjectInterface {
   )! as String;
 
   String get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SuperObjectInterfaceBuilder].
+  $SuperObjectInterface rebuild(void Function($SuperObjectInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SuperObjectInterfaceBuilder].
+  $SuperObjectInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SuperObjectInterfaceBuilder b) {
     b.value = _$value;
@@ -291,6 +345,16 @@ abstract class SuperObject implements $SuperObjectInterface, Built<SuperObject, 
 
 @BuiltValue(instantiable: false)
 sealed class $SubObjectInterface implements $SuperObjectInterface {
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SubObjectInterfaceBuilder].
+  @override
+  $SubObjectInterface rebuild(void Function($SubObjectInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SubObjectInterfaceBuilder].
+  @override
+  $SubObjectInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SubObjectInterfaceBuilder b) {
     $SuperObjectInterface._defaults(b);

--- a/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/any_of.openapi.dart
@@ -34,6 +34,15 @@ typedef AnyOfIntDoubleNum = num;
 sealed class $ObjectAnyOf0Interface {
   @BuiltValueField(wireName: 'attribute1-anyOf')
   String get attribute1AnyOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ObjectAnyOf0InterfaceBuilder].
+  $ObjectAnyOf0Interface rebuild(void Function($ObjectAnyOf0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ObjectAnyOf0InterfaceBuilder].
+  $ObjectAnyOf0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ObjectAnyOf0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -74,6 +83,15 @@ abstract class ObjectAnyOf0 implements $ObjectAnyOf0Interface, Built<ObjectAnyOf
 sealed class $ObjectAnyOf1Interface {
   @BuiltValueField(wireName: 'attribute2-anyOf')
   String get attribute2AnyOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ObjectAnyOf1InterfaceBuilder].
+  $ObjectAnyOf1Interface rebuild(void Function($ObjectAnyOf1InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ObjectAnyOf1InterfaceBuilder].
+  $ObjectAnyOf1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ObjectAnyOf1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -117,6 +135,15 @@ typedef ObjectAnyOf = ({ObjectAnyOf0? objectAnyOf0, ObjectAnyOf1? objectAnyOf1})
 sealed class $MixedAnyOf1Interface {
   @BuiltValueField(wireName: 'attribute-anyOf')
   String get attributeAnyOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MixedAnyOf1InterfaceBuilder].
+  $MixedAnyOf1Interface rebuild(void Function($MixedAnyOf1InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$MixedAnyOf1InterfaceBuilder].
+  $MixedAnyOf1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MixedAnyOf1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -160,6 +187,15 @@ typedef MixedAnyOf = ({MixedAnyOf1? mixedAnyOf1, String? string});
 sealed class $OneObjectAnyOf0Interface {
   @BuiltValueField(wireName: 'attribute-anyOf')
   String get attributeAnyOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OneObjectAnyOf0InterfaceBuilder].
+  $OneObjectAnyOf0Interface rebuild(void Function($OneObjectAnyOf0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OneObjectAnyOf0InterfaceBuilder].
+  $OneObjectAnyOf0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OneObjectAnyOf0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/dynamite/dynamite_end_to_end_test/lib/deprecation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/deprecation.openapi.dart
@@ -118,6 +118,15 @@ sealed class $Object2Interface {
   @Deprecated('')
   String get name;
   String? get tag;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Object2InterfaceBuilder].
+  $Object2Interface rebuild(void Function($Object2InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Object2InterfaceBuilder].
+  $Object2InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Object2InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -161,6 +170,17 @@ abstract class Object2 implements $Object2Interface, Built<Object2, Object2Build
 @BuiltValue(instantiable: false)
 sealed class $Object1Interface implements $Object2Interface {
   int get id;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Object1InterfaceBuilder].
+  @override
+  $Object1Interface rebuild(void Function($Object1InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Object1InterfaceBuilder].
+  @override
+  $Object1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Object1InterfaceBuilder b) {
     $Object2Interface._defaults(b);

--- a/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
@@ -398,6 +398,15 @@ sealed class $Object2Interface {
 
   /// The tag of an Object2 object.
   String? get tag;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Object2InterfaceBuilder].
+  $Object2Interface rebuild(void Function($Object2InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Object2InterfaceBuilder].
+  $Object2InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Object2InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -442,6 +451,17 @@ abstract class Object2 implements $Object2Interface, Built<Object2, Object2Build
 sealed class $Object1Interface implements $Object2Interface {
   /// The uuid in an UUIDv4 format.
   int get id;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Object1InterfaceBuilder].
+  @override
+  $Object1Interface rebuild(void Function($Object1InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Object1InterfaceBuilder].
+  @override
+  $Object1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Object1InterfaceBuilder b) {
     $Object2Interface._defaults(b);

--- a/packages/dynamite/dynamite_end_to_end_test/lib/enum.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/enum.openapi.dart
@@ -349,6 +349,15 @@ sealed class $WrappedEnumInterface {
   @BuiltValueField(wireName: 'String')
   WrappedEnum_String get string;
   WrappedEnum_Integer get integer;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WrappedEnumInterfaceBuilder].
+  $WrappedEnumInterface rebuild(void Function($WrappedEnumInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$WrappedEnumInterfaceBuilder].
+  $WrappedEnumInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WrappedEnumInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -388,6 +397,15 @@ abstract class WrappedEnum implements $WrappedEnumInterface, Built<WrappedEnum, 
 @BuiltValue(instantiable: false)
 sealed class $EnumReferenceInterface {
   EnumString get string;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EnumReferenceInterfaceBuilder].
+  $EnumReferenceInterface rebuild(void Function($EnumReferenceInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$EnumReferenceInterfaceBuilder].
+  $EnumReferenceInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EnumReferenceInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
@@ -176,6 +176,15 @@ class $Client extends _i1.DynamiteClient {
 sealed class $GetHeadersInterface {
   @BuiltValueField(wireName: 'my-header')
   String? get myHeader;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GetHeadersInterfaceBuilder].
+  $GetHeadersInterface rebuild(void Function($GetHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$GetHeadersInterfaceBuilder].
+  $GetHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GetHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -216,6 +225,17 @@ abstract class GetHeaders implements $GetHeadersInterface, Built<GetHeaders, Get
 sealed class $WithContentOperationIdHeadersInterface {
   @BuiltValueField(wireName: 'my-header')
   String? get myHeader;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WithContentOperationIdHeadersInterfaceBuilder].
+  $WithContentOperationIdHeadersInterface rebuild(
+    void Function($WithContentOperationIdHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WithContentOperationIdHeadersInterfaceBuilder].
+  $WithContentOperationIdHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WithContentOperationIdHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -261,6 +281,15 @@ abstract class WithContentOperationIdHeaders
 sealed class $GetWithContentHeadersInterface {
   @BuiltValueField(wireName: 'my-header')
   String? get myHeader;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GetWithContentHeadersInterfaceBuilder].
+  $GetWithContentHeadersInterface rebuild(void Function($GetWithContentHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$GetWithContentHeadersInterfaceBuilder].
+  $GetWithContentHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GetWithContentHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/dynamite/dynamite_end_to_end_test/lib/interfaces.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/interfaces.openapi.dart
@@ -20,6 +20,15 @@ part 'interfaces.openapi.g.dart';
 @BuiltValue(instantiable: false)
 sealed class $BaseInterface {
   String? get attribute;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseInterfaceBuilder].
+  $BaseInterface rebuild(void Function($BaseInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseInterfaceBuilder].
+  $BaseInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -59,6 +68,15 @@ abstract class Base implements $BaseInterface, Built<Base, BaseBuilder> {
 @BuiltValue(instantiable: false)
 sealed class $BaseInterfaceInterface {
   String? get attribute;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseInterfaceInterfaceBuilder].
+  $BaseInterfaceInterface rebuild(void Function($BaseInterfaceInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseInterfaceInterfaceBuilder].
+  $BaseInterfaceInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseInterfaceInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/nested_ofs.openapi.dart
@@ -24,6 +24,15 @@ sealed class $BaseAllOfInterface {
   String get string;
   @BuiltValueField(wireName: 'attribute-allOf')
   String get attributeAllOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseAllOfInterfaceBuilder].
+  $BaseAllOfInterface rebuild(void Function($BaseAllOfInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseAllOfInterfaceBuilder].
+  $BaseAllOfInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseAllOfInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -64,6 +73,15 @@ abstract class BaseAllOf implements $BaseAllOfInterface, Built<BaseAllOf, BaseAl
 sealed class $BaseOneOf1Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
   String get attributeOneOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseOneOf1InterfaceBuilder].
+  $BaseOneOf1Interface rebuild(void Function($BaseOneOf1InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseOneOf1InterfaceBuilder].
+  $BaseOneOf1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseOneOf1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -106,6 +124,15 @@ typedef BaseOneOf = ({BaseOneOf1? baseOneOf1, double? $double});
 sealed class $BaseAnyOf1Interface {
   @BuiltValueField(wireName: 'attribute-anyOf')
   String get attributeAnyOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseAnyOf1InterfaceBuilder].
+  $BaseAnyOf1Interface rebuild(void Function($BaseAnyOf1InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseAnyOf1InterfaceBuilder].
+  $BaseAnyOf1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseAnyOf1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -152,6 +179,17 @@ sealed class $BaseNestedAllOfInterface implements $BaseAllOfInterface {
   BaseAnyOf get baseAnyOf;
   @BuiltValueField(wireName: 'attribute-nested-allOf')
   String get attributeNestedAllOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseNestedAllOfInterfaceBuilder].
+  @override
+  $BaseNestedAllOfInterface rebuild(void Function($BaseNestedAllOfInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseNestedAllOfInterfaceBuilder].
+  @override
+  $BaseNestedAllOfInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseNestedAllOfInterfaceBuilder b) {
     $BaseAllOfInterface._defaults(b);
@@ -199,6 +237,15 @@ abstract class BaseNestedAllOf implements $BaseNestedAllOfInterface, Built<BaseN
 sealed class $BaseNestedOneOf3Interface {
   @BuiltValueField(wireName: 'attribute-nested-oneOf')
   String get attributeNestedOneOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseNestedOneOf3InterfaceBuilder].
+  $BaseNestedOneOf3Interface rebuild(void Function($BaseNestedOneOf3InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseNestedOneOf3InterfaceBuilder].
+  $BaseNestedOneOf3InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseNestedOneOf3InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -248,6 +295,15 @@ typedef BaseNestedOneOf = ({
 sealed class $BaseNestedAnyOf3Interface {
   @BuiltValueField(wireName: 'attribute-nested-anyOf')
   String get attributeNestedAnyOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseNestedAnyOf3InterfaceBuilder].
+  $BaseNestedAnyOf3Interface rebuild(void Function($BaseNestedAnyOf3InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseNestedAnyOf3InterfaceBuilder].
+  $BaseNestedAnyOf3InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseNestedAnyOf3InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/one_of.openapi.dart
@@ -36,6 +36,15 @@ typedef OneOfIntDoubleNum = num;
 sealed class $ObjectOneOf0Interface {
   @BuiltValueField(wireName: 'attribute1-oneOf')
   String get attribute1OneOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ObjectOneOf0InterfaceBuilder].
+  $ObjectOneOf0Interface rebuild(void Function($ObjectOneOf0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ObjectOneOf0InterfaceBuilder].
+  $ObjectOneOf0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ObjectOneOf0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -76,6 +85,15 @@ abstract class ObjectOneOf0 implements $ObjectOneOf0Interface, Built<ObjectOneOf
 sealed class $ObjectOneOf1Interface {
   @BuiltValueField(wireName: 'attribute2-oneOf')
   String get attribute2OneOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ObjectOneOf1InterfaceBuilder].
+  $ObjectOneOf1Interface rebuild(void Function($ObjectOneOf1InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ObjectOneOf1InterfaceBuilder].
+  $ObjectOneOf1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ObjectOneOf1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -119,6 +137,15 @@ typedef ObjectOneOf = ({ObjectOneOf0? objectOneOf0, ObjectOneOf1? objectOneOf1})
 sealed class $MixedOneOf1Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
   String get attributeOneOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MixedOneOf1InterfaceBuilder].
+  $MixedOneOf1Interface rebuild(void Function($MixedOneOf1InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$MixedOneOf1InterfaceBuilder].
+  $MixedOneOf1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MixedOneOf1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -162,6 +189,15 @@ typedef MixedOneOf = ({MixedOneOf1? mixedOneOf1, String? string});
 sealed class $OneObjectOneOf0Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
   String get attributeOneOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OneObjectOneOf0InterfaceBuilder].
+  $OneObjectOneOf0Interface rebuild(void Function($OneObjectOneOf0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OneObjectOneOf0InterfaceBuilder].
+  $OneObjectOneOf0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OneObjectOneOf0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -205,6 +241,15 @@ typedef OneOfIntDoubleOther = ({num? $num, String? string});
 sealed class $OneOfUnspecifiedArray0Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
   String get attributeOneOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OneOfUnspecifiedArray0InterfaceBuilder].
+  $OneOfUnspecifiedArray0Interface rebuild(void Function($OneOfUnspecifiedArray0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OneOfUnspecifiedArray0InterfaceBuilder].
+  $OneOfUnspecifiedArray0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OneOfUnspecifiedArray0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -252,6 +297,15 @@ typedef OneOfUnspecifiedArray = ({
 sealed class $OneOfStringArray0Interface {
   @BuiltValueField(wireName: 'attribute-oneOf')
   String get attributeOneOf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OneOfStringArray0InterfaceBuilder].
+  $OneOfStringArray0Interface rebuild(void Function($OneOfStringArray0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OneOfStringArray0InterfaceBuilder].
+  $OneOfStringArray0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OneOfStringArray0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/dynamite/dynamite_end_to_end_test/lib/pattern_check.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/pattern_check.openapi.dart
@@ -45,6 +45,15 @@ sealed class $TestObjectInterface {
   num? get exclusiveMinimum;
   @BuiltValueField(wireName: 'number-multiple-checks')
   num? get numberMultipleChecks;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TestObjectInterfaceBuilder].
+  $TestObjectInterface rebuild(void Function($TestObjectInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$TestObjectInterfaceBuilder].
+  $TestObjectInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TestObjectInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -163,6 +172,15 @@ abstract class TestObject implements $TestObjectInterface, Built<TestObject, Tes
 @BuiltValue(instantiable: false)
 sealed class $TestObjectUnspecifiedInterface {
   JsonObject? get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TestObjectUnspecifiedInterfaceBuilder].
+  $TestObjectUnspecifiedInterface rebuild(void Function($TestObjectUnspecifiedInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$TestObjectUnspecifiedInterfaceBuilder].
+  $TestObjectUnspecifiedInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TestObjectUnspecifiedInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/some_of.openapi.dart
@@ -35,6 +35,15 @@ sealed class $OneValueSomeOfInObjectInterface {
   num get intDouble;
   @BuiltValueField(wireName: 'IntDoubleString')
   OneValueSomeOfInObject_IntDoubleString? get intDoubleString;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OneValueSomeOfInObjectInterfaceBuilder].
+  $OneValueSomeOfInObjectInterface rebuild(void Function($OneValueSomeOfInObjectInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OneValueSomeOfInObjectInterfaceBuilder].
+  $OneValueSomeOfInObjectInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OneValueSomeOfInObjectInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/type_defs.openapi.dart
@@ -28,6 +28,15 @@ typedef RedirectEmptyType = dynamic;
 @BuiltValue(instantiable: false)
 sealed class $BaseInterface {
   String? get attribute;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseInterfaceBuilder].
+  $BaseInterface rebuild(void Function($BaseInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseInterfaceBuilder].
+  $BaseInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -69,6 +78,15 @@ sealed class $NestedRedirectInterface {
   Base? get redirect;
   int? get redirectBaseType;
   JsonObject? get redirectEmptyType;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NestedRedirectInterfaceBuilder].
+  $NestedRedirectInterface rebuild(void Function($NestedRedirectInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$NestedRedirectInterfaceBuilder].
+  $NestedRedirectInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NestedRedirectInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.dart
@@ -51,6 +51,15 @@ sealed class $BaseInterface {
   BuiltList<Never>? get listNever;
   @BuiltValueField(wireName: 'list-string')
   BuiltList<String>? get listString;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseInterfaceBuilder].
+  $BaseInterface rebuild(void Function($BaseInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseInterfaceBuilder].
+  $BaseInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -188,6 +197,15 @@ sealed class $DefaultsInterface {
   JsonObject get objectArray;
   @BuiltValueField(wireName: 'object-bool')
   JsonObject get objectBool;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DefaultsInterfaceBuilder].
+  $DefaultsInterface rebuild(void Function($DefaultsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$DefaultsInterfaceBuilder].
+  $DefaultsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DefaultsInterfaceBuilder b) {
     b.$bool = _$$bool;
@@ -273,6 +291,15 @@ sealed class $AdditionalPropertiesInterface {
   BuiltMap<String, BuiltList<Never>>? get listNever;
   @BuiltValueField(wireName: 'list-string')
   BuiltMap<String, BuiltList<String>>? get listString;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AdditionalPropertiesInterfaceBuilder].
+  $AdditionalPropertiesInterface rebuild(void Function($AdditionalPropertiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$AdditionalPropertiesInterfaceBuilder].
+  $AdditionalPropertiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AdditionalPropertiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/comments.openapi.dart
+++ b/packages/nextcloud/lib/src/api/comments.openapi.dart
@@ -27,6 +27,15 @@ part 'comments.openapi.g.dart';
 @BuiltValue(instantiable: false)
 sealed class $Capabilities_FilesInterface {
   bool get comments;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesInterfaceBuilder].
+  $Capabilities_FilesInterface rebuild(void Function($Capabilities_FilesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_FilesInterfaceBuilder].
+  $Capabilities_FilesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -74,6 +83,15 @@ abstract class Capabilities_Files
 @BuiltValue(instantiable: false)
 sealed class $CapabilitiesInterface {
   Capabilities_Files get files;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -5648,6 +5648,15 @@ sealed class $StatusInterface {
   String get edition;
   String get productname;
   bool get extendedSupport;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$StatusInterfaceBuilder].
+  $StatusInterface rebuild(void Function($StatusInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$StatusInterfaceBuilder].
+  $StatusInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($StatusInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5697,6 +5706,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5742,6 +5760,17 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 @BuiltValue(instantiable: false)
 sealed class $AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterface {
   String get apppassword;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordGetAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5796,6 +5825,17 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data
 sealed class $AppPasswordGetAppPasswordResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppPasswordGetAppPasswordResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordGetAppPasswordResponseApplicationJson_OcsInterfaceBuilder].
+  $AppPasswordGetAppPasswordResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppPasswordGetAppPasswordResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordGetAppPasswordResponseApplicationJson_OcsInterfaceBuilder].
+  $AppPasswordGetAppPasswordResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordGetAppPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5849,6 +5889,17 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppPasswordGetAppPasswordResponseApplicationJsonInterface {
   AppPasswordGetAppPasswordResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordGetAppPasswordResponseApplicationJsonInterfaceBuilder].
+  $AppPasswordGetAppPasswordResponseApplicationJsonInterface rebuild(
+    void Function($AppPasswordGetAppPasswordResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordGetAppPasswordResponseApplicationJsonInterfaceBuilder].
+  $AppPasswordGetAppPasswordResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordGetAppPasswordResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5903,6 +5954,17 @@ abstract class AppPasswordGetAppPasswordResponseApplicationJson
 sealed class $AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterfaceBuilder].
+  $AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterfaceBuilder].
+  $AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordDeleteAppPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5956,6 +6018,17 @@ abstract class AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppPasswordDeleteAppPasswordResponseApplicationJsonInterface {
   AppPasswordDeleteAppPasswordResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordDeleteAppPasswordResponseApplicationJsonInterfaceBuilder].
+  $AppPasswordDeleteAppPasswordResponseApplicationJsonInterface rebuild(
+    void Function($AppPasswordDeleteAppPasswordResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordDeleteAppPasswordResponseApplicationJsonInterfaceBuilder].
+  $AppPasswordDeleteAppPasswordResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordDeleteAppPasswordResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6009,6 +6082,17 @@ abstract class AppPasswordDeleteAppPasswordResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterface {
   String get apppassword;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6063,6 +6147,17 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data
 sealed class $AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterfaceBuilder].
+  $AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterfaceBuilder].
+  $AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordRotateAppPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6116,6 +6211,17 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppPasswordRotateAppPasswordResponseApplicationJsonInterface {
   AppPasswordRotateAppPasswordResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordRotateAppPasswordResponseApplicationJsonInterfaceBuilder].
+  $AppPasswordRotateAppPasswordResponseApplicationJsonInterface rebuild(
+    void Function($AppPasswordRotateAppPasswordResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordRotateAppPasswordResponseApplicationJsonInterfaceBuilder].
+  $AppPasswordRotateAppPasswordResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordRotateAppPasswordResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6169,6 +6275,17 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterface {
   int get lastLogin;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6223,6 +6340,17 @@ abstract class AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_Data
 sealed class $AppPasswordConfirmUserPasswordResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordConfirmUserPasswordResponseApplicationJson_OcsInterfaceBuilder].
+  $AppPasswordConfirmUserPasswordResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppPasswordConfirmUserPasswordResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordConfirmUserPasswordResponseApplicationJson_OcsInterfaceBuilder].
+  $AppPasswordConfirmUserPasswordResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordConfirmUserPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6276,6 +6404,17 @@ abstract class AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppPasswordConfirmUserPasswordResponseApplicationJsonInterface {
   AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordConfirmUserPasswordResponseApplicationJsonInterfaceBuilder].
+  $AppPasswordConfirmUserPasswordResponseApplicationJsonInterface rebuild(
+    void Function($AppPasswordConfirmUserPasswordResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordConfirmUserPasswordResponseApplicationJsonInterfaceBuilder].
+  $AppPasswordConfirmUserPasswordResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppPasswordConfirmUserPasswordResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6332,6 +6471,15 @@ sealed class $AutocompleteResult_Status0Interface {
   String? get message;
   String? get icon;
   int? get clearAt;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AutocompleteResult_Status0InterfaceBuilder].
+  $AutocompleteResult_Status0Interface rebuild(void Function($AutocompleteResult_Status0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$AutocompleteResult_Status0InterfaceBuilder].
+  $AutocompleteResult_Status0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AutocompleteResult_Status0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6390,6 +6538,15 @@ sealed class $AutocompleteResultInterface {
   AutocompleteResult_Status get status;
   String get subline;
   String get shareWithDisplayNameUnique;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AutocompleteResultInterfaceBuilder].
+  $AutocompleteResultInterface rebuild(void Function($AutocompleteResultInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$AutocompleteResultInterfaceBuilder].
+  $AutocompleteResultInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AutocompleteResultInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6440,6 +6597,17 @@ abstract class AutocompleteResult
 sealed class $AutoCompleteGetResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<AutocompleteResult> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AutoCompleteGetResponseApplicationJson_OcsInterfaceBuilder].
+  $AutoCompleteGetResponseApplicationJson_OcsInterface rebuild(
+    void Function($AutoCompleteGetResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AutoCompleteGetResponseApplicationJson_OcsInterfaceBuilder].
+  $AutoCompleteGetResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AutoCompleteGetResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6492,6 +6660,17 @@ abstract class AutoCompleteGetResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AutoCompleteGetResponseApplicationJsonInterface {
   AutoCompleteGetResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AutoCompleteGetResponseApplicationJsonInterfaceBuilder].
+  $AutoCompleteGetResponseApplicationJsonInterface rebuild(
+    void Function($AutoCompleteGetResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AutoCompleteGetResponseApplicationJsonInterfaceBuilder].
+  $AutoCompleteGetResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AutoCompleteGetResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6544,6 +6723,17 @@ abstract class AutoCompleteGetResponseApplicationJson
 sealed class $AvatarAvatarGetAvatarDarkHeadersInterface {
   @BuiltValueField(wireName: 'x-nc-iscustomavatar')
   Header<int?>? get xNcIscustomavatar;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder].
+  $AvatarAvatarGetAvatarDarkHeadersInterface rebuild(
+    void Function($AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder].
+  $AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6595,6 +6785,15 @@ abstract class AvatarAvatarGetAvatarDarkHeaders
 sealed class $AvatarAvatarGetAvatarHeadersInterface {
   @BuiltValueField(wireName: 'x-nc-iscustomavatar')
   Header<int?>? get xNcIscustomavatar;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarAvatarGetAvatarHeadersInterfaceBuilder].
+  $AvatarAvatarGetAvatarHeadersInterface rebuild(void Function($AvatarAvatarGetAvatarHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$AvatarAvatarGetAvatarHeadersInterfaceBuilder].
+  $AvatarAvatarGetAvatarHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AvatarAvatarGetAvatarHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6647,6 +6846,15 @@ sealed class $LoginFlowV2CredentialsInterface {
   String get server;
   String get loginName;
   String get appPassword;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$LoginFlowV2CredentialsInterfaceBuilder].
+  $LoginFlowV2CredentialsInterface rebuild(void Function($LoginFlowV2CredentialsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$LoginFlowV2CredentialsInterfaceBuilder].
+  $LoginFlowV2CredentialsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($LoginFlowV2CredentialsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6695,6 +6903,15 @@ abstract class LoginFlowV2Credentials
 sealed class $LoginFlowV2_PollInterface {
   String get token;
   String get endpoint;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$LoginFlowV2_PollInterfaceBuilder].
+  $LoginFlowV2_PollInterface rebuild(void Function($LoginFlowV2_PollInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$LoginFlowV2_PollInterfaceBuilder].
+  $LoginFlowV2_PollInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($LoginFlowV2_PollInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6742,6 +6959,15 @@ abstract class LoginFlowV2_Poll
 sealed class $LoginFlowV2Interface {
   LoginFlowV2_Poll get poll;
   String get login;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$LoginFlowV2InterfaceBuilder].
+  $LoginFlowV2Interface rebuild(void Function($LoginFlowV2InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$LoginFlowV2InterfaceBuilder].
+  $LoginFlowV2InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($LoginFlowV2InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6791,6 +7017,15 @@ sealed class $OpenGraphObjectInterface {
   String? get description;
   String? get thumb;
   String get link;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OpenGraphObjectInterfaceBuilder].
+  $OpenGraphObjectInterface rebuild(void Function($OpenGraphObjectInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OpenGraphObjectInterfaceBuilder].
+  $OpenGraphObjectInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OpenGraphObjectInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6839,6 +7074,15 @@ sealed class $ResourceInterface {
   BuiltMap<String, JsonObject> get richObject;
   OpenGraphObject get openGraphObject;
   bool get accessible;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ResourceInterfaceBuilder].
+  $ResourceInterface rebuild(void Function($ResourceInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ResourceInterfaceBuilder].
+  $ResourceInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ResourceInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6886,6 +7130,15 @@ sealed class $CollectionInterface {
   int get id;
   String get name;
   BuiltList<Resource> get resources;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollectionInterfaceBuilder].
+  $CollectionInterface rebuild(void Function($CollectionInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CollectionInterfaceBuilder].
+  $CollectionInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollectionInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6932,6 +7185,17 @@ abstract class Collection implements $CollectionInterface, Built<Collection, Col
 sealed class $CollaborationResourcesListCollectionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesListCollectionResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesListCollectionResponseApplicationJson_OcsInterface rebuild(
+    void Function($CollaborationResourcesListCollectionResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesListCollectionResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesListCollectionResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesListCollectionResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6985,6 +7249,17 @@ abstract class CollaborationResourcesListCollectionResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CollaborationResourcesListCollectionResponseApplicationJsonInterface {
   CollaborationResourcesListCollectionResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesListCollectionResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesListCollectionResponseApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesListCollectionResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesListCollectionResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesListCollectionResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesListCollectionResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7039,6 +7314,17 @@ abstract class CollaborationResourcesListCollectionResponseApplicationJson
 sealed class $CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterface rebuild(
+    void Function($CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7092,6 +7378,17 @@ abstract class CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CollaborationResourcesRenameCollectionResponseApplicationJsonInterface {
   CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesRenameCollectionResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesRenameCollectionResponseApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesRenameCollectionResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesRenameCollectionResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesRenameCollectionResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesRenameCollectionResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7146,6 +7443,17 @@ abstract class CollaborationResourcesRenameCollectionResponseApplicationJson
 sealed class $CollaborationResourcesAddResourceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesAddResourceResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesAddResourceResponseApplicationJson_OcsInterface rebuild(
+    void Function($CollaborationResourcesAddResourceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesAddResourceResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesAddResourceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesAddResourceResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7199,6 +7507,17 @@ abstract class CollaborationResourcesAddResourceResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CollaborationResourcesAddResourceResponseApplicationJsonInterface {
   CollaborationResourcesAddResourceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesAddResourceResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesAddResourceResponseApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesAddResourceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesAddResourceResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesAddResourceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesAddResourceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7253,6 +7572,17 @@ abstract class CollaborationResourcesAddResourceResponseApplicationJson
 sealed class $CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterface rebuild(
+    void Function($CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesRemoveResourceResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7306,6 +7636,17 @@ abstract class CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CollaborationResourcesRemoveResourceResponseApplicationJsonInterface {
   CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesRemoveResourceResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesRemoveResourceResponseApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesRemoveResourceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesRemoveResourceResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesRemoveResourceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesRemoveResourceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7360,6 +7701,17 @@ abstract class CollaborationResourcesRemoveResourceResponseApplicationJson
 sealed class $CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Collection> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterface rebuild(
+    void Function($CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesSearchCollectionsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7413,6 +7765,17 @@ abstract class CollaborationResourcesSearchCollectionsResponseApplicationJson_Oc
 @BuiltValue(instantiable: false)
 sealed class $CollaborationResourcesSearchCollectionsResponseApplicationJsonInterface {
   CollaborationResourcesSearchCollectionsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesSearchCollectionsResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesSearchCollectionsResponseApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesSearchCollectionsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesSearchCollectionsResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesSearchCollectionsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesSearchCollectionsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7467,6 +7830,17 @@ abstract class CollaborationResourcesSearchCollectionsResponseApplicationJson
 sealed class $CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Collection> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterface rebuild(
+    void Function($CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7522,6 +7896,17 @@ abstract class CollaborationResourcesGetCollectionsByResourceResponseApplication
 @BuiltValue(instantiable: false)
 sealed class $CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterface {
   CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7576,6 +7961,17 @@ abstract class CollaborationResourcesGetCollectionsByResourceResponseApplication
 sealed class $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterface rebuild(
+    void Function($CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterfaceBuilder].
+  $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults(
     $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterfaceBuilder b,
@@ -7635,6 +8031,17 @@ abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicati
 @BuiltValue(instantiable: false)
 sealed class $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterface {
   CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7754,6 +8161,15 @@ sealed class $ContactsActionInterface {
   String get icon;
   String get hyperlink;
   String get appId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ContactsActionInterfaceBuilder].
+  $ContactsActionInterface rebuild(void Function($ContactsActionInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ContactsActionInterfaceBuilder].
+  $ContactsActionInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ContactsActionInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7801,6 +8217,17 @@ sealed class $HoverCardGetUserResponseApplicationJson_Ocs_DataInterface {
   String get userId;
   String get displayName;
   BuiltList<ContactsAction> get actions;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$HoverCardGetUserResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $HoverCardGetUserResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($HoverCardGetUserResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$HoverCardGetUserResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $HoverCardGetUserResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($HoverCardGetUserResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7855,6 +8282,17 @@ abstract class HoverCardGetUserResponseApplicationJson_Ocs_Data
 sealed class $HoverCardGetUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   HoverCardGetUserResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$HoverCardGetUserResponseApplicationJson_OcsInterfaceBuilder].
+  $HoverCardGetUserResponseApplicationJson_OcsInterface rebuild(
+    void Function($HoverCardGetUserResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$HoverCardGetUserResponseApplicationJson_OcsInterfaceBuilder].
+  $HoverCardGetUserResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($HoverCardGetUserResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7907,6 +8345,17 @@ abstract class HoverCardGetUserResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $HoverCardGetUserResponseApplicationJsonInterface {
   HoverCardGetUserResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$HoverCardGetUserResponseApplicationJsonInterfaceBuilder].
+  $HoverCardGetUserResponseApplicationJsonInterface rebuild(
+    void Function($HoverCardGetUserResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$HoverCardGetUserResponseApplicationJsonInterfaceBuilder].
+  $HoverCardGetUserResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($HoverCardGetUserResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7958,6 +8407,17 @@ abstract class HoverCardGetUserResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $LoginConfirmPasswordResponseApplicationJsonInterface {
   int get lastLogin;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$LoginConfirmPasswordResponseApplicationJsonInterfaceBuilder].
+  $LoginConfirmPasswordResponseApplicationJsonInterface rebuild(
+    void Function($LoginConfirmPasswordResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$LoginConfirmPasswordResponseApplicationJsonInterfaceBuilder].
+  $LoginConfirmPasswordResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($LoginConfirmPasswordResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8086,6 +8546,15 @@ sealed class $NavigationEntryInterface {
   bool get active;
   String get classes;
   int get unread;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NavigationEntryInterfaceBuilder].
+  $NavigationEntryInterface rebuild(void Function($NavigationEntryInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$NavigationEntryInterfaceBuilder].
+  $NavigationEntryInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NavigationEntryInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8134,6 +8603,17 @@ abstract class NavigationEntry implements $NavigationEntryInterface, Built<Navig
 sealed class $NavigationGetAppsNavigationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<NavigationEntry> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NavigationGetAppsNavigationResponseApplicationJson_OcsInterfaceBuilder].
+  $NavigationGetAppsNavigationResponseApplicationJson_OcsInterface rebuild(
+    void Function($NavigationGetAppsNavigationResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$NavigationGetAppsNavigationResponseApplicationJson_OcsInterfaceBuilder].
+  $NavigationGetAppsNavigationResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NavigationGetAppsNavigationResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8187,6 +8667,17 @@ abstract class NavigationGetAppsNavigationResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $NavigationGetAppsNavigationResponseApplicationJsonInterface {
   NavigationGetAppsNavigationResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NavigationGetAppsNavigationResponseApplicationJsonInterfaceBuilder].
+  $NavigationGetAppsNavigationResponseApplicationJsonInterface rebuild(
+    void Function($NavigationGetAppsNavigationResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$NavigationGetAppsNavigationResponseApplicationJsonInterfaceBuilder].
+  $NavigationGetAppsNavigationResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NavigationGetAppsNavigationResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8310,6 +8801,17 @@ class _$NavigationGetSettingsNavigationAbsoluteSerializer
 sealed class $NavigationGetSettingsNavigationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<NavigationEntry> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NavigationGetSettingsNavigationResponseApplicationJson_OcsInterfaceBuilder].
+  $NavigationGetSettingsNavigationResponseApplicationJson_OcsInterface rebuild(
+    void Function($NavigationGetSettingsNavigationResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$NavigationGetSettingsNavigationResponseApplicationJson_OcsInterfaceBuilder].
+  $NavigationGetSettingsNavigationResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NavigationGetSettingsNavigationResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8363,6 +8865,17 @@ abstract class NavigationGetSettingsNavigationResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $NavigationGetSettingsNavigationResponseApplicationJsonInterface {
   NavigationGetSettingsNavigationResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NavigationGetSettingsNavigationResponseApplicationJsonInterfaceBuilder].
+  $NavigationGetSettingsNavigationResponseApplicationJsonInterface rebuild(
+    void Function($NavigationGetSettingsNavigationResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$NavigationGetSettingsNavigationResponseApplicationJsonInterfaceBuilder].
+  $NavigationGetSettingsNavigationResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NavigationGetSettingsNavigationResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8416,6 +8929,17 @@ abstract class NavigationGetSettingsNavigationResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterface {
   String get webdav;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterfaceBuilder].
+  $OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterface rebuild(
+    void Function($OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterfaceBuilder].
+  $OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OcmDiscoveryResponseApplicationJson_ResourceTypes_ProtocolsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8471,6 +8995,17 @@ sealed class $OcmDiscoveryResponseApplicationJson_ResourceTypesInterface {
   String get name;
   BuiltList<String> get shareTypes;
   OcmDiscoveryResponseApplicationJson_ResourceTypes_Protocols get protocols;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OcmDiscoveryResponseApplicationJson_ResourceTypesInterfaceBuilder].
+  $OcmDiscoveryResponseApplicationJson_ResourceTypesInterface rebuild(
+    void Function($OcmDiscoveryResponseApplicationJson_ResourceTypesInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OcmDiscoveryResponseApplicationJson_ResourceTypesInterfaceBuilder].
+  $OcmDiscoveryResponseApplicationJson_ResourceTypesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OcmDiscoveryResponseApplicationJson_ResourceTypesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8527,6 +9062,17 @@ sealed class $OcmDiscoveryResponseApplicationJsonInterface {
   String get apiVersion;
   String get endPoint;
   BuiltList<OcmDiscoveryResponseApplicationJson_ResourceTypes> get resourceTypes;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OcmDiscoveryResponseApplicationJsonInterfaceBuilder].
+  $OcmDiscoveryResponseApplicationJsonInterface rebuild(
+    void Function($OcmDiscoveryResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OcmDiscoveryResponseApplicationJsonInterfaceBuilder].
+  $OcmDiscoveryResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OcmDiscoveryResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8643,6 +9189,15 @@ class _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer
 sealed class $OcmOcmDiscoveryHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-ocm-providers')
   Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?>? get xNextcloudOcmProviders;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OcmOcmDiscoveryHeadersInterfaceBuilder].
+  $OcmOcmDiscoveryHeadersInterface rebuild(void Function($OcmOcmDiscoveryHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OcmOcmDiscoveryHeadersInterfaceBuilder].
+  $OcmOcmDiscoveryHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OcmOcmDiscoveryHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8695,6 +9250,17 @@ sealed class $OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterfac
   String get string;
   String get edition;
   bool get extendedSupport;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterfaceBuilder].
+  $OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterface rebuild(
+    void Function($OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterfaceBuilder].
+  $OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_VersionInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8756,6 +9322,15 @@ sealed class $CoreCapabilities_CoreInterface {
   String get referenceRegex;
   @BuiltValueField(wireName: 'mod-rewrite-working')
   bool? get modRewriteWorking;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CoreCapabilities_CoreInterfaceBuilder].
+  $CoreCapabilities_CoreInterface rebuild(void Function($CoreCapabilities_CoreInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CoreCapabilities_CoreInterfaceBuilder].
+  $CoreCapabilities_CoreInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CoreCapabilities_CoreInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8803,6 +9378,15 @@ abstract class CoreCapabilities_Core
 @BuiltValue(instantiable: false)
 sealed class $CoreCapabilitiesInterface {
   CoreCapabilities_Core get core;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CoreCapabilitiesInterfaceBuilder].
+  $CoreCapabilitiesInterface rebuild(void Function($CoreCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CoreCapabilitiesInterfaceBuilder].
+  $CoreCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CoreCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8851,6 +9435,17 @@ sealed class $CorePublicCapabilities_BruteforceInterface {
   int get delay;
   @BuiltValueField(wireName: 'allow-listed')
   bool get allowListed;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CorePublicCapabilities_BruteforceInterfaceBuilder].
+  $CorePublicCapabilities_BruteforceInterface rebuild(
+    void Function($CorePublicCapabilities_BruteforceInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CorePublicCapabilities_BruteforceInterfaceBuilder].
+  $CorePublicCapabilities_BruteforceInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CorePublicCapabilities_BruteforceInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8901,6 +9496,15 @@ abstract class CorePublicCapabilities_Bruteforce
 @BuiltValue(instantiable: false)
 sealed class $CorePublicCapabilitiesInterface {
   CorePublicCapabilities_Bruteforce get bruteforce;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CorePublicCapabilitiesInterfaceBuilder].
+  $CorePublicCapabilitiesInterface rebuild(void Function($CorePublicCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CorePublicCapabilitiesInterfaceBuilder].
+  $CorePublicCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CorePublicCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8948,6 +9552,15 @@ abstract class CorePublicCapabilities
 @BuiltValue(instantiable: false)
 sealed class $CommentsCapabilities_FilesInterface {
   bool get comments;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CommentsCapabilities_FilesInterfaceBuilder].
+  $CommentsCapabilities_FilesInterface rebuild(void Function($CommentsCapabilities_FilesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CommentsCapabilities_FilesInterfaceBuilder].
+  $CommentsCapabilities_FilesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CommentsCapabilities_FilesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8998,6 +9611,15 @@ abstract class CommentsCapabilities_Files
 @BuiltValue(instantiable: false)
 sealed class $CommentsCapabilitiesInterface {
   CommentsCapabilities_Files get files;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CommentsCapabilitiesInterfaceBuilder].
+  $CommentsCapabilitiesInterface rebuild(void Function($CommentsCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CommentsCapabilitiesInterfaceBuilder].
+  $CommentsCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CommentsCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9046,6 +9668,15 @@ abstract class CommentsCapabilities
 sealed class $DavCapabilities_DavInterface {
   String get chunking;
   String? get bulkupload;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DavCapabilities_DavInterfaceBuilder].
+  $DavCapabilities_DavInterface rebuild(void Function($DavCapabilities_DavInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$DavCapabilities_DavInterfaceBuilder].
+  $DavCapabilities_DavInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DavCapabilities_DavInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9093,6 +9724,15 @@ abstract class DavCapabilities_Dav
 @BuiltValue(instantiable: false)
 sealed class $DavCapabilitiesInterface {
   DavCapabilities_Dav get dav;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DavCapabilitiesInterfaceBuilder].
+  $DavCapabilitiesInterface rebuild(void Function($DavCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$DavCapabilitiesInterfaceBuilder].
+  $DavCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DavCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9139,6 +9779,17 @@ abstract class DavCapabilities implements $DavCapabilitiesInterface, Built<DavCa
 sealed class $DropAccountCapabilities_DropAccount_DelayInterface {
   bool get enabled;
   int get hours;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DropAccountCapabilities_DropAccount_DelayInterfaceBuilder].
+  $DropAccountCapabilities_DropAccount_DelayInterface rebuild(
+    void Function($DropAccountCapabilities_DropAccount_DelayInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DropAccountCapabilities_DropAccount_DelayInterfaceBuilder].
+  $DropAccountCapabilities_DropAccount_DelayInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DropAccountCapabilities_DropAccount_DelayInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9195,6 +9846,17 @@ sealed class $DropAccountCapabilities_DropAccountInterface {
   String get apiVersion;
   DropAccountCapabilities_DropAccount_Delay get delay;
   String? get details;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DropAccountCapabilities_DropAccountInterfaceBuilder].
+  $DropAccountCapabilities_DropAccountInterface rebuild(
+    void Function($DropAccountCapabilities_DropAccountInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DropAccountCapabilities_DropAccountInterfaceBuilder].
+  $DropAccountCapabilities_DropAccountInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DropAccountCapabilities_DropAccountInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9247,6 +9909,15 @@ abstract class DropAccountCapabilities_DropAccount
 sealed class $DropAccountCapabilitiesInterface {
   @BuiltValueField(wireName: 'drop-account')
   DropAccountCapabilities_DropAccount get dropAccount;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DropAccountCapabilitiesInterfaceBuilder].
+  $DropAccountCapabilitiesInterface rebuild(void Function($DropAccountCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$DropAccountCapabilitiesInterfaceBuilder].
+  $DropAccountCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DropAccountCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9296,6 +9967,17 @@ sealed class $FilesCapabilities_Files_DirectEditingInterface {
   String get url;
   String get etag;
   bool get supportsFileId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesCapabilities_Files_DirectEditingInterfaceBuilder].
+  $FilesCapabilities_Files_DirectEditingInterface rebuild(
+    void Function($FilesCapabilities_Files_DirectEditingInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesCapabilities_Files_DirectEditingInterfaceBuilder].
+  $FilesCapabilities_Files_DirectEditingInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesCapabilities_Files_DirectEditingInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9352,6 +10034,15 @@ sealed class $FilesCapabilities_FilesInterface {
   @BuiltValueField(wireName: 'forbidden_filename_characters')
   BuiltList<String> get forbiddenFilenameCharacters;
   FilesCapabilities_Files_DirectEditing get directEditing;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesCapabilities_FilesInterfaceBuilder].
+  $FilesCapabilities_FilesInterface rebuild(void Function($FilesCapabilities_FilesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$FilesCapabilities_FilesInterfaceBuilder].
+  $FilesCapabilities_FilesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesCapabilities_FilesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9399,6 +10090,15 @@ abstract class FilesCapabilities_Files
 @BuiltValue(instantiable: false)
 sealed class $FilesCapabilitiesInterface {
   FilesCapabilities_Files get files;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesCapabilitiesInterfaceBuilder].
+  $FilesCapabilitiesInterface rebuild(void Function($FilesCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$FilesCapabilitiesInterfaceBuilder].
+  $FilesCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9446,6 +10146,17 @@ abstract class FilesCapabilities
 sealed class $FilesSharingCapabilities_FilesSharing_Public_PasswordInterface {
   bool get enforced;
   bool get askForOptionalPassword;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Public_PasswordInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_Public_PasswordInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9501,6 +10212,17 @@ sealed class $FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface {
   bool get enabled;
   int? get days;
   bool? get enforced;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_Public_ExpireDateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9556,6 +10278,17 @@ sealed class $FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInt
   bool get enabled;
   int? get days;
   bool? get enforced;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9611,6 +10344,17 @@ sealed class $FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInter
   bool get enabled;
   int? get days;
   bool? get enforced;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9678,6 +10422,17 @@ sealed class $FilesSharingCapabilities_FilesSharing_PublicInterface {
   bool? get upload;
   @BuiltValueField(wireName: 'upload_files_drop')
   bool? get uploadFilesDrop;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_PublicInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_PublicInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9730,6 +10485,17 @@ abstract class FilesSharingCapabilities_FilesSharing_Public
 @BuiltValue(instantiable: false)
 sealed class $FilesSharingCapabilities_FilesSharing_User_ExpireDateInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_User_ExpireDateInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_User_ExpireDateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9786,6 +10552,17 @@ sealed class $FilesSharingCapabilities_FilesSharing_UserInterface {
   bool get sendMail;
   @BuiltValueField(wireName: 'expire_date')
   FilesSharingCapabilities_FilesSharing_User_ExpireDate? get expireDate;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_UserInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_UserInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9838,6 +10615,17 @@ abstract class FilesSharingCapabilities_FilesSharing_User
 @BuiltValue(instantiable: false)
 sealed class $FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_Group_ExpireDateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9893,6 +10681,17 @@ sealed class $FilesSharingCapabilities_FilesSharing_GroupInterface {
   bool get enabled;
   @BuiltValueField(wireName: 'expire_date')
   FilesSharingCapabilities_FilesSharing_Group_ExpireDate? get expireDate;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_GroupInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_GroupInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9945,6 +10744,17 @@ abstract class FilesSharingCapabilities_FilesSharing_Group
 @BuiltValue(instantiable: false)
 sealed class $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9998,6 +10808,17 @@ abstract class FilesSharingCapabilities_FilesSharing_Federation_ExpireDate
 @BuiltValue(instantiable: false)
 sealed class $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10056,6 +10877,17 @@ sealed class $FilesSharingCapabilities_FilesSharing_FederationInterface {
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDate get expireDate;
   @BuiltValueField(wireName: 'expire_date_supported')
   FilesSharingCapabilities_FilesSharing_Federation_ExpireDateSupported get expireDateSupported;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_FederationInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_FederationInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10112,6 +10944,17 @@ sealed class $FilesSharingCapabilities_FilesSharing_ShareeInterface {
   bool get queryLookupDefault;
   @BuiltValueField(wireName: 'always_show_unique')
   bool get alwaysShowUnique;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_ShareeInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharing_ShareeInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10175,6 +11018,17 @@ sealed class $FilesSharingCapabilities_FilesSharingInterface {
   int? get defaultPermissions;
   FilesSharingCapabilities_FilesSharing_Federation get federation;
   FilesSharingCapabilities_FilesSharing_Sharee get sharee;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilities_FilesSharingInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharingInterface rebuild(
+    void Function($FilesSharingCapabilities_FilesSharingInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesSharingCapabilities_FilesSharingInterfaceBuilder].
+  $FilesSharingCapabilities_FilesSharingInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilities_FilesSharingInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10227,6 +11081,15 @@ abstract class FilesSharingCapabilities_FilesSharing
 sealed class $FilesSharingCapabilitiesInterface {
   @BuiltValueField(wireName: 'files_sharing')
   FilesSharingCapabilities_FilesSharing get filesSharing;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesSharingCapabilitiesInterfaceBuilder].
+  $FilesSharingCapabilitiesInterface rebuild(void Function($FilesSharingCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$FilesSharingCapabilitiesInterfaceBuilder].
+  $FilesSharingCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesSharingCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10274,6 +11137,17 @@ abstract class FilesSharingCapabilities
 @BuiltValue(instantiable: false)
 sealed class $FilesTrashbinCapabilities_FilesInterface {
   bool get undelete;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesTrashbinCapabilities_FilesInterfaceBuilder].
+  $FilesTrashbinCapabilities_FilesInterface rebuild(
+    void Function($FilesTrashbinCapabilities_FilesInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesTrashbinCapabilities_FilesInterfaceBuilder].
+  $FilesTrashbinCapabilities_FilesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesTrashbinCapabilities_FilesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10324,6 +11198,15 @@ abstract class FilesTrashbinCapabilities_Files
 @BuiltValue(instantiable: false)
 sealed class $FilesTrashbinCapabilitiesInterface {
   FilesTrashbinCapabilities_Files get files;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesTrashbinCapabilitiesInterfaceBuilder].
+  $FilesTrashbinCapabilitiesInterface rebuild(void Function($FilesTrashbinCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$FilesTrashbinCapabilitiesInterfaceBuilder].
+  $FilesTrashbinCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesTrashbinCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10375,6 +11258,17 @@ sealed class $FilesVersionsCapabilities_FilesInterface {
   bool get versionLabeling;
   @BuiltValueField(wireName: 'version_deletion')
   bool get versionDeletion;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesVersionsCapabilities_FilesInterfaceBuilder].
+  $FilesVersionsCapabilities_FilesInterface rebuild(
+    void Function($FilesVersionsCapabilities_FilesInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesVersionsCapabilities_FilesInterfaceBuilder].
+  $FilesVersionsCapabilities_FilesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesVersionsCapabilities_FilesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10425,6 +11319,15 @@ abstract class FilesVersionsCapabilities_Files
 @BuiltValue(instantiable: false)
 sealed class $FilesVersionsCapabilitiesInterface {
   FilesVersionsCapabilities_Files get files;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesVersionsCapabilitiesInterfaceBuilder].
+  $FilesVersionsCapabilitiesInterface rebuild(void Function($FilesVersionsCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$FilesVersionsCapabilitiesInterfaceBuilder].
+  $FilesVersionsCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesVersionsCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10476,6 +11379,17 @@ sealed class $NotificationsCapabilities_NotificationsInterface {
   BuiltList<String> get push;
   @BuiltValueField(wireName: 'admin-notifications')
   BuiltList<String> get adminNotifications;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NotificationsCapabilities_NotificationsInterfaceBuilder].
+  $NotificationsCapabilities_NotificationsInterface rebuild(
+    void Function($NotificationsCapabilities_NotificationsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$NotificationsCapabilities_NotificationsInterfaceBuilder].
+  $NotificationsCapabilities_NotificationsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NotificationsCapabilities_NotificationsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10527,6 +11441,15 @@ abstract class NotificationsCapabilities_Notifications
 @BuiltValue(instantiable: false)
 sealed class $NotificationsCapabilitiesInterface {
   NotificationsCapabilities_Notifications get notifications;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NotificationsCapabilitiesInterfaceBuilder].
+  $NotificationsCapabilitiesInterface rebuild(void Function($NotificationsCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$NotificationsCapabilitiesInterfaceBuilder].
+  $NotificationsCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NotificationsCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10580,6 +11503,17 @@ sealed class $ProvisioningApiCapabilities_ProvisioningApiInterface {
   bool get accountPropertyScopesFederatedEnabled;
   @BuiltValueField(wireName: 'AccountPropertyScopesPublishedEnabled')
   bool get accountPropertyScopesPublishedEnabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder].
+  $ProvisioningApiCapabilities_ProvisioningApiInterface rebuild(
+    void Function($ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder].
+  $ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ProvisioningApiCapabilities_ProvisioningApiInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10633,6 +11567,15 @@ abstract class ProvisioningApiCapabilities_ProvisioningApi
 sealed class $ProvisioningApiCapabilitiesInterface {
   @BuiltValueField(wireName: 'provisioning_api')
   ProvisioningApiCapabilities_ProvisioningApi get provisioningApi;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ProvisioningApiCapabilitiesInterfaceBuilder].
+  $ProvisioningApiCapabilitiesInterface rebuild(void Function($ProvisioningApiCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ProvisioningApiCapabilitiesInterfaceBuilder].
+  $ProvisioningApiCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ProvisioningApiCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10683,6 +11626,17 @@ abstract class ProvisioningApiCapabilities
 @BuiltValue(instantiable: false)
 sealed class $SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder].
+  $SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterface rebuild(
+    void Function($SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder].
+  $SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10737,6 +11691,17 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_UploadFilesDrop
 sealed class $SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterface {
   bool get enabled;
   bool get enforced;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder].
+  $SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterface rebuild(
+    void Function($SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder].
+  $SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SharebymailCapabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10791,6 +11756,17 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail_Password
 sealed class $SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterface {
   bool get enabled;
   bool get enforced;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder].
+  $SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterface rebuild(
+    void Function($SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder].
+  $SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10851,6 +11827,17 @@ sealed class $SharebymailCapabilities0_FilesSharing_SharebymailInterface {
   SharebymailCapabilities0_FilesSharing_Sharebymail_Password get password;
   @BuiltValueField(wireName: 'expire_date')
   SharebymailCapabilities0_FilesSharing_Sharebymail_ExpireDate get expireDate;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SharebymailCapabilities0_FilesSharing_SharebymailInterfaceBuilder].
+  $SharebymailCapabilities0_FilesSharing_SharebymailInterface rebuild(
+    void Function($SharebymailCapabilities0_FilesSharing_SharebymailInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SharebymailCapabilities0_FilesSharing_SharebymailInterfaceBuilder].
+  $SharebymailCapabilities0_FilesSharing_SharebymailInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SharebymailCapabilities0_FilesSharing_SharebymailInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10904,6 +11891,17 @@ abstract class SharebymailCapabilities0_FilesSharing_Sharebymail
 @BuiltValue(instantiable: false)
 sealed class $SharebymailCapabilities0_FilesSharingInterface {
   SharebymailCapabilities0_FilesSharing_Sharebymail get sharebymail;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SharebymailCapabilities0_FilesSharingInterfaceBuilder].
+  $SharebymailCapabilities0_FilesSharingInterface rebuild(
+    void Function($SharebymailCapabilities0_FilesSharingInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SharebymailCapabilities0_FilesSharingInterfaceBuilder].
+  $SharebymailCapabilities0_FilesSharingInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SharebymailCapabilities0_FilesSharingInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10956,6 +11954,15 @@ abstract class SharebymailCapabilities0_FilesSharing
 sealed class $SharebymailCapabilities0Interface {
   @BuiltValueField(wireName: 'files_sharing')
   SharebymailCapabilities0_FilesSharing get filesSharing;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SharebymailCapabilities0InterfaceBuilder].
+  $SharebymailCapabilities0Interface rebuild(void Function($SharebymailCapabilities0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SharebymailCapabilities0InterfaceBuilder].
+  $SharebymailCapabilities0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SharebymailCapabilities0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11009,6 +12016,17 @@ typedef SharebymailCapabilities = ({
 sealed class $SpreedCapabilities_Config_AttachmentsInterface {
   bool get allowed;
   String? get folder;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SpreedCapabilities_Config_AttachmentsInterfaceBuilder].
+  $SpreedCapabilities_Config_AttachmentsInterface rebuild(
+    void Function($SpreedCapabilities_Config_AttachmentsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SpreedCapabilities_Config_AttachmentsInterfaceBuilder].
+  $SpreedCapabilities_Config_AttachmentsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SpreedCapabilities_Config_AttachmentsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11077,6 +12095,17 @@ sealed class $SpreedCapabilities_Config_CallInterface {
   bool get sipDialoutEnabled;
   @BuiltValueField(wireName: 'can-enable-sip')
   bool get canEnableSip;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SpreedCapabilities_Config_CallInterfaceBuilder].
+  $SpreedCapabilities_Config_CallInterface rebuild(
+    void Function($SpreedCapabilities_Config_CallInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SpreedCapabilities_Config_CallInterfaceBuilder].
+  $SpreedCapabilities_Config_CallInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SpreedCapabilities_Config_CallInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11134,6 +12163,17 @@ sealed class $SpreedCapabilities_Config_ChatInterface {
   bool get hasTranslationProviders;
   @BuiltValueField(wireName: 'typing-privacy')
   int get typingPrivacy;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SpreedCapabilities_Config_ChatInterfaceBuilder].
+  $SpreedCapabilities_Config_ChatInterface rebuild(
+    void Function($SpreedCapabilities_Config_ChatInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SpreedCapabilities_Config_ChatInterfaceBuilder].
+  $SpreedCapabilities_Config_ChatInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SpreedCapabilities_Config_ChatInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11185,6 +12225,17 @@ abstract class SpreedCapabilities_Config_Chat
 sealed class $SpreedCapabilities_Config_ConversationsInterface {
   @BuiltValueField(wireName: 'can-create')
   bool get canCreate;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SpreedCapabilities_Config_ConversationsInterfaceBuilder].
+  $SpreedCapabilities_Config_ConversationsInterface rebuild(
+    void Function($SpreedCapabilities_Config_ConversationsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SpreedCapabilities_Config_ConversationsInterfaceBuilder].
+  $SpreedCapabilities_Config_ConversationsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SpreedCapabilities_Config_ConversationsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11242,6 +12293,17 @@ sealed class $SpreedCapabilities_Config_FederationInterface {
   bool get outgoingEnabled;
   @BuiltValueField(wireName: 'only-trusted-servers')
   bool get onlyTrustedServers;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SpreedCapabilities_Config_FederationInterfaceBuilder].
+  $SpreedCapabilities_Config_FederationInterface rebuild(
+    void Function($SpreedCapabilities_Config_FederationInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SpreedCapabilities_Config_FederationInterfaceBuilder].
+  $SpreedCapabilities_Config_FederationInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SpreedCapabilities_Config_FederationInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11294,6 +12356,17 @@ abstract class SpreedCapabilities_Config_Federation
 sealed class $SpreedCapabilities_Config_PreviewsInterface {
   @BuiltValueField(wireName: 'max-gif-size')
   int get maxGifSize;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SpreedCapabilities_Config_PreviewsInterfaceBuilder].
+  $SpreedCapabilities_Config_PreviewsInterface rebuild(
+    void Function($SpreedCapabilities_Config_PreviewsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SpreedCapabilities_Config_PreviewsInterfaceBuilder].
+  $SpreedCapabilities_Config_PreviewsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SpreedCapabilities_Config_PreviewsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11347,6 +12420,17 @@ sealed class $SpreedCapabilities_Config_SignalingInterface {
   int get sessionPingLimit;
   @BuiltValueField(wireName: 'hello-v2-token-key')
   String? get helloV2TokenKey;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SpreedCapabilities_Config_SignalingInterfaceBuilder].
+  $SpreedCapabilities_Config_SignalingInterface rebuild(
+    void Function($SpreedCapabilities_Config_SignalingInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SpreedCapabilities_Config_SignalingInterfaceBuilder].
+  $SpreedCapabilities_Config_SignalingInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SpreedCapabilities_Config_SignalingInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11404,6 +12488,15 @@ sealed class $SpreedCapabilities_ConfigInterface {
   SpreedCapabilities_Config_Federation? get federation;
   SpreedCapabilities_Config_Previews get previews;
   SpreedCapabilities_Config_Signaling get signaling;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SpreedCapabilities_ConfigInterfaceBuilder].
+  $SpreedCapabilities_ConfigInterface rebuild(void Function($SpreedCapabilities_ConfigInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SpreedCapabilities_ConfigInterfaceBuilder].
+  $SpreedCapabilities_ConfigInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SpreedCapabilities_ConfigInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11453,6 +12546,15 @@ sealed class $SpreedCapabilitiesInterface {
   BuiltList<String> get features;
   SpreedCapabilities_Config get config;
   String get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SpreedCapabilitiesInterfaceBuilder].
+  $SpreedCapabilitiesInterface rebuild(void Function($SpreedCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SpreedCapabilitiesInterfaceBuilder].
+  $SpreedCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SpreedCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11500,6 +12602,15 @@ abstract class SpreedCapabilities
 @BuiltValue(instantiable: false)
 sealed class $SpreedPublicCapabilities0Interface {
   SpreedCapabilities get spreed;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SpreedPublicCapabilities0InterfaceBuilder].
+  $SpreedPublicCapabilities0Interface rebuild(void Function($SpreedPublicCapabilities0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SpreedPublicCapabilities0InterfaceBuilder].
+  $SpreedPublicCapabilities0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SpreedPublicCapabilities0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11615,6 +12726,17 @@ class _$SystemtagsCapabilities_Systemtags_EnabledSerializer
 @BuiltValue(instantiable: false)
 sealed class $SystemtagsCapabilities_SystemtagsInterface {
   SystemtagsCapabilities_Systemtags_Enabled get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SystemtagsCapabilities_SystemtagsInterfaceBuilder].
+  $SystemtagsCapabilities_SystemtagsInterface rebuild(
+    void Function($SystemtagsCapabilities_SystemtagsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SystemtagsCapabilities_SystemtagsInterfaceBuilder].
+  $SystemtagsCapabilities_SystemtagsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SystemtagsCapabilities_SystemtagsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11665,6 +12787,15 @@ abstract class SystemtagsCapabilities_Systemtags
 @BuiltValue(instantiable: false)
 sealed class $SystemtagsCapabilitiesInterface {
   SystemtagsCapabilities_Systemtags get systemtags;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SystemtagsCapabilitiesInterfaceBuilder].
+  $SystemtagsCapabilitiesInterface rebuild(void Function($SystemtagsCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SystemtagsCapabilitiesInterfaceBuilder].
+  $SystemtagsCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SystemtagsCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11731,6 +12862,17 @@ sealed class $ThemingPublicCapabilities_ThemingInterface {
   bool get backgroundDefault;
   String get logoheader;
   String get favicon;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ThemingPublicCapabilities_ThemingInterfaceBuilder].
+  $ThemingPublicCapabilities_ThemingInterface rebuild(
+    void Function($ThemingPublicCapabilities_ThemingInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ThemingPublicCapabilities_ThemingInterfaceBuilder].
+  $ThemingPublicCapabilities_ThemingInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ThemingPublicCapabilities_ThemingInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11781,6 +12923,15 @@ abstract class ThemingPublicCapabilities_Theming
 @BuiltValue(instantiable: false)
 sealed class $ThemingPublicCapabilitiesInterface {
   ThemingPublicCapabilities_Theming get theming;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ThemingPublicCapabilitiesInterfaceBuilder].
+  $ThemingPublicCapabilitiesInterface rebuild(void Function($ThemingPublicCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ThemingPublicCapabilitiesInterfaceBuilder].
+  $ThemingPublicCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ThemingPublicCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11831,6 +12982,17 @@ sealed class $UserStatusCapabilities_UserStatusInterface {
   bool get restore;
   @BuiltValueField(wireName: 'supports_emoji')
   bool get supportsEmoji;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusCapabilities_UserStatusInterfaceBuilder].
+  $UserStatusCapabilities_UserStatusInterface rebuild(
+    void Function($UserStatusCapabilities_UserStatusInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusCapabilities_UserStatusInterfaceBuilder].
+  $UserStatusCapabilities_UserStatusInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusCapabilities_UserStatusInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11882,6 +13044,15 @@ abstract class UserStatusCapabilities_UserStatus
 sealed class $UserStatusCapabilitiesInterface {
   @BuiltValueField(wireName: 'user_status')
   UserStatusCapabilities_UserStatus get userStatus;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusCapabilitiesInterfaceBuilder].
+  $UserStatusCapabilitiesInterface rebuild(void Function($UserStatusCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$UserStatusCapabilitiesInterfaceBuilder].
+  $UserStatusCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11929,6 +13100,17 @@ abstract class UserStatusCapabilities
 @BuiltValue(instantiable: false)
 sealed class $WeatherStatusCapabilities_WeatherStatusInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusCapabilities_WeatherStatusInterfaceBuilder].
+  $WeatherStatusCapabilities_WeatherStatusInterface rebuild(
+    void Function($WeatherStatusCapabilities_WeatherStatusInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusCapabilities_WeatherStatusInterfaceBuilder].
+  $WeatherStatusCapabilities_WeatherStatusInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusCapabilities_WeatherStatusInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -11981,6 +13163,15 @@ abstract class WeatherStatusCapabilities_WeatherStatus
 sealed class $WeatherStatusCapabilitiesInterface {
   @BuiltValueField(wireName: 'weather_status')
   WeatherStatusCapabilities_WeatherStatus get weatherStatus;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusCapabilitiesInterfaceBuilder].
+  $WeatherStatusCapabilitiesInterface rebuild(void Function($WeatherStatusCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$WeatherStatusCapabilitiesInterfaceBuilder].
+  $WeatherStatusCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12030,6 +13221,15 @@ sealed class $NotesCapabilities_NotesInterface {
   @BuiltValueField(wireName: 'api_version')
   BuiltList<String>? get apiVersion;
   String? get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NotesCapabilities_NotesInterfaceBuilder].
+  $NotesCapabilities_NotesInterface rebuild(void Function($NotesCapabilities_NotesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$NotesCapabilities_NotesInterfaceBuilder].
+  $NotesCapabilities_NotesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NotesCapabilities_NotesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12077,6 +13277,15 @@ abstract class NotesCapabilities_Notes
 @BuiltValue(instantiable: false)
 sealed class $NotesCapabilitiesInterface {
   NotesCapabilities_Notes get notes;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NotesCapabilitiesInterfaceBuilder].
+  $NotesCapabilitiesInterface rebuild(void Function($NotesCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$NotesCapabilitiesInterfaceBuilder].
+  $NotesCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NotesCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12146,6 +13355,17 @@ typedef OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities = ({
 sealed class $OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterface {
   OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Version get version;
   OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_Capabilities get capabilities;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OcsGetCapabilitiesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12202,6 +13422,17 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs_Data
 sealed class $OcsGetCapabilitiesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OcsGetCapabilitiesResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OcsGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder].
+  $OcsGetCapabilitiesResponseApplicationJson_OcsInterface rebuild(
+    void Function($OcsGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OcsGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder].
+  $OcsGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OcsGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12254,6 +13485,17 @@ abstract class OcsGetCapabilitiesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $OcsGetCapabilitiesResponseApplicationJsonInterface {
   OcsGetCapabilitiesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OcsGetCapabilitiesResponseApplicationJsonInterfaceBuilder].
+  $OcsGetCapabilitiesResponseApplicationJsonInterface rebuild(
+    void Function($OcsGetCapabilitiesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OcsGetCapabilitiesResponseApplicationJsonInterfaceBuilder].
+  $OcsGetCapabilitiesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OcsGetCapabilitiesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12692,6 +13934,17 @@ class _$PreviewGetPreviewByFileIdMimeFallbackSerializer
 sealed class $ProfileApiSetVisibilityResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ProfileApiSetVisibilityResponseApplicationJson_OcsInterfaceBuilder].
+  $ProfileApiSetVisibilityResponseApplicationJson_OcsInterface rebuild(
+    void Function($ProfileApiSetVisibilityResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ProfileApiSetVisibilityResponseApplicationJson_OcsInterfaceBuilder].
+  $ProfileApiSetVisibilityResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ProfileApiSetVisibilityResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12745,6 +13998,17 @@ abstract class ProfileApiSetVisibilityResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ProfileApiSetVisibilityResponseApplicationJsonInterface {
   ProfileApiSetVisibilityResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ProfileApiSetVisibilityResponseApplicationJsonInterfaceBuilder].
+  $ProfileApiSetVisibilityResponseApplicationJsonInterface rebuild(
+    void Function($ProfileApiSetVisibilityResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ProfileApiSetVisibilityResponseApplicationJsonInterfaceBuilder].
+  $ProfileApiSetVisibilityResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ProfileApiSetVisibilityResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12863,6 +14127,15 @@ sealed class $ReferenceInterface {
   BuiltMap<String, JsonObject> get richObject;
   OpenGraphObject get openGraphObject;
   bool get accessible;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceInterfaceBuilder].
+  $ReferenceInterface rebuild(void Function($ReferenceInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ReferenceInterfaceBuilder].
+  $ReferenceInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12908,6 +14181,17 @@ abstract class Reference implements $ReferenceInterface, Built<Reference, Refere
 @BuiltValue(instantiable: false)
 sealed class $ReferenceApiExtractResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, Reference?> get references;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ReferenceApiExtractResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12962,6 +14246,17 @@ abstract class ReferenceApiExtractResponseApplicationJson_Ocs_Data
 sealed class $ReferenceApiExtractResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ReferenceApiExtractResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiExtractResponseApplicationJson_OcsInterfaceBuilder].
+  $ReferenceApiExtractResponseApplicationJson_OcsInterface rebuild(
+    void Function($ReferenceApiExtractResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiExtractResponseApplicationJson_OcsInterfaceBuilder].
+  $ReferenceApiExtractResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiExtractResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13014,6 +14309,17 @@ abstract class ReferenceApiExtractResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ReferenceApiExtractResponseApplicationJsonInterface {
   ReferenceApiExtractResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiExtractResponseApplicationJsonInterfaceBuilder].
+  $ReferenceApiExtractResponseApplicationJsonInterface rebuild(
+    void Function($ReferenceApiExtractResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiExtractResponseApplicationJsonInterfaceBuilder].
+  $ReferenceApiExtractResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiExtractResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13066,6 +14372,17 @@ abstract class ReferenceApiExtractResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, Reference?> get references;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13120,6 +14437,17 @@ abstract class ReferenceApiResolveOneResponseApplicationJson_Ocs_Data
 sealed class $ReferenceApiResolveOneResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ReferenceApiResolveOneResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiResolveOneResponseApplicationJson_OcsInterfaceBuilder].
+  $ReferenceApiResolveOneResponseApplicationJson_OcsInterface rebuild(
+    void Function($ReferenceApiResolveOneResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiResolveOneResponseApplicationJson_OcsInterfaceBuilder].
+  $ReferenceApiResolveOneResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiResolveOneResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13173,6 +14501,17 @@ abstract class ReferenceApiResolveOneResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ReferenceApiResolveOneResponseApplicationJsonInterface {
   ReferenceApiResolveOneResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiResolveOneResponseApplicationJsonInterfaceBuilder].
+  $ReferenceApiResolveOneResponseApplicationJsonInterface rebuild(
+    void Function($ReferenceApiResolveOneResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiResolveOneResponseApplicationJsonInterfaceBuilder].
+  $ReferenceApiResolveOneResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiResolveOneResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13225,6 +14564,17 @@ abstract class ReferenceApiResolveOneResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $ReferenceApiResolveResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, Reference?> get references;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ReferenceApiResolveResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13279,6 +14629,17 @@ abstract class ReferenceApiResolveResponseApplicationJson_Ocs_Data
 sealed class $ReferenceApiResolveResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ReferenceApiResolveResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiResolveResponseApplicationJson_OcsInterfaceBuilder].
+  $ReferenceApiResolveResponseApplicationJson_OcsInterface rebuild(
+    void Function($ReferenceApiResolveResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiResolveResponseApplicationJson_OcsInterfaceBuilder].
+  $ReferenceApiResolveResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiResolveResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13331,6 +14692,17 @@ abstract class ReferenceApiResolveResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ReferenceApiResolveResponseApplicationJsonInterface {
   ReferenceApiResolveResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiResolveResponseApplicationJsonInterfaceBuilder].
+  $ReferenceApiResolveResponseApplicationJsonInterface rebuild(
+    void Function($ReferenceApiResolveResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiResolveResponseApplicationJsonInterfaceBuilder].
+  $ReferenceApiResolveResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiResolveResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13389,6 +14761,15 @@ sealed class $ReferenceProviderInterface {
   int get order;
   @BuiltValueField(wireName: 'search_providers_ids')
   BuiltList<String>? get searchProvidersIds;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceProviderInterfaceBuilder].
+  $ReferenceProviderInterface rebuild(void Function($ReferenceProviderInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ReferenceProviderInterfaceBuilder].
+  $ReferenceProviderInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceProviderInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13436,6 +14817,17 @@ abstract class ReferenceProvider
 sealed class $ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ReferenceProvider> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterfaceBuilder].
+  $ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterface rebuild(
+    void Function($ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterfaceBuilder].
+  $ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiGetProvidersInfoResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13489,6 +14881,17 @@ abstract class ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ReferenceApiGetProvidersInfoResponseApplicationJsonInterface {
   ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiGetProvidersInfoResponseApplicationJsonInterfaceBuilder].
+  $ReferenceApiGetProvidersInfoResponseApplicationJsonInterface rebuild(
+    void Function($ReferenceApiGetProvidersInfoResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiGetProvidersInfoResponseApplicationJsonInterfaceBuilder].
+  $ReferenceApiGetProvidersInfoResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiGetProvidersInfoResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13542,6 +14945,17 @@ abstract class ReferenceApiGetProvidersInfoResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterface {
   bool get success;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13596,6 +15010,17 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data
 sealed class $ReferenceApiTouchProviderResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiTouchProviderResponseApplicationJson_OcsInterfaceBuilder].
+  $ReferenceApiTouchProviderResponseApplicationJson_OcsInterface rebuild(
+    void Function($ReferenceApiTouchProviderResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiTouchProviderResponseApplicationJson_OcsInterfaceBuilder].
+  $ReferenceApiTouchProviderResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiTouchProviderResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13649,6 +15074,17 @@ abstract class ReferenceApiTouchProviderResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ReferenceApiTouchProviderResponseApplicationJsonInterface {
   ReferenceApiTouchProviderResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiTouchProviderResponseApplicationJsonInterfaceBuilder].
+  $ReferenceApiTouchProviderResponseApplicationJsonInterface rebuild(
+    void Function($ReferenceApiTouchProviderResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiTouchProviderResponseApplicationJsonInterfaceBuilder].
+  $ReferenceApiTouchProviderResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiTouchProviderResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13707,6 +15143,15 @@ sealed class $TeamResourceInterface {
   String? get iconSvg;
   String? get iconURL;
   String? get iconEmoji;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TeamResourceInterfaceBuilder].
+  $TeamResourceInterface rebuild(void Function($TeamResourceInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$TeamResourceInterfaceBuilder].
+  $TeamResourceInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TeamResourceInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13752,6 +15197,17 @@ abstract class TeamResource implements $TeamResourceInterface, Built<TeamResourc
 @BuiltValue(instantiable: false)
 sealed class $TeamsApiResolveOneResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TeamResource> get resources;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TeamsApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TeamsApiResolveOneResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TeamsApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TeamsApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TeamsApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TeamsApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13806,6 +15262,17 @@ abstract class TeamsApiResolveOneResponseApplicationJson_Ocs_Data
 sealed class $TeamsApiResolveOneResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TeamsApiResolveOneResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TeamsApiResolveOneResponseApplicationJson_OcsInterfaceBuilder].
+  $TeamsApiResolveOneResponseApplicationJson_OcsInterface rebuild(
+    void Function($TeamsApiResolveOneResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TeamsApiResolveOneResponseApplicationJson_OcsInterfaceBuilder].
+  $TeamsApiResolveOneResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TeamsApiResolveOneResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13858,6 +15325,17 @@ abstract class TeamsApiResolveOneResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TeamsApiResolveOneResponseApplicationJsonInterface {
   TeamsApiResolveOneResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TeamsApiResolveOneResponseApplicationJsonInterfaceBuilder].
+  $TeamsApiResolveOneResponseApplicationJsonInterface rebuild(
+    void Function($TeamsApiResolveOneResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TeamsApiResolveOneResponseApplicationJsonInterfaceBuilder].
+  $TeamsApiResolveOneResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TeamsApiResolveOneResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13912,6 +15390,15 @@ sealed class $TeamInterface {
   String get id;
   String get name;
   String get icon;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TeamInterfaceBuilder].
+  $TeamInterface rebuild(void Function($TeamInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$TeamInterfaceBuilder].
+  $TeamInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TeamInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13957,6 +15444,17 @@ abstract class Team implements $TeamInterface, Built<Team, TeamBuilder> {
 @BuiltValue(instantiable: false)
 sealed class $TeamsApiListTeamsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<Team> get teams;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TeamsApiListTeamsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TeamsApiListTeamsResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TeamsApiListTeamsResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TeamsApiListTeamsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TeamsApiListTeamsResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TeamsApiListTeamsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14011,6 +15509,17 @@ abstract class TeamsApiListTeamsResponseApplicationJson_Ocs_Data
 sealed class $TeamsApiListTeamsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TeamsApiListTeamsResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TeamsApiListTeamsResponseApplicationJson_OcsInterfaceBuilder].
+  $TeamsApiListTeamsResponseApplicationJson_OcsInterface rebuild(
+    void Function($TeamsApiListTeamsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TeamsApiListTeamsResponseApplicationJson_OcsInterfaceBuilder].
+  $TeamsApiListTeamsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TeamsApiListTeamsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14063,6 +15572,17 @@ abstract class TeamsApiListTeamsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TeamsApiListTeamsResponseApplicationJsonInterface {
   TeamsApiListTeamsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TeamsApiListTeamsResponseApplicationJsonInterfaceBuilder].
+  $TeamsApiListTeamsResponseApplicationJsonInterface rebuild(
+    void Function($TeamsApiListTeamsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TeamsApiListTeamsResponseApplicationJsonInterfaceBuilder].
+  $TeamsApiListTeamsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TeamsApiListTeamsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14117,6 +15637,17 @@ sealed class $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesIn
   String get id;
   String get name;
   String get description;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesInterfaceBuilder].
+  $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesInterface rebuild(
+    void Function($TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesInterfaceBuilder].
+  $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_TypesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14170,6 +15701,17 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types
 @BuiltValue(instantiable: false)
 sealed class $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types> get types;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiTaskTypesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14224,6 +15766,17 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data
 sealed class $TextProcessingApiTaskTypesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiTaskTypesResponseApplicationJson_OcsInterfaceBuilder].
+  $TextProcessingApiTaskTypesResponseApplicationJson_OcsInterface rebuild(
+    void Function($TextProcessingApiTaskTypesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiTaskTypesResponseApplicationJson_OcsInterfaceBuilder].
+  $TextProcessingApiTaskTypesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiTaskTypesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14277,6 +15830,17 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TextProcessingApiTaskTypesResponseApplicationJsonInterface {
   TextProcessingApiTaskTypesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiTaskTypesResponseApplicationJsonInterfaceBuilder].
+  $TextProcessingApiTaskTypesResponseApplicationJsonInterface rebuild(
+    void Function($TextProcessingApiTaskTypesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiTaskTypesResponseApplicationJsonInterfaceBuilder].
+  $TextProcessingApiTaskTypesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiTaskTypesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14419,6 +15983,15 @@ sealed class $TextProcessingTaskInterface {
   String? get output;
   String get identifier;
   int? get completionExpectedAt;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingTaskInterfaceBuilder].
+  $TextProcessingTaskInterface rebuild(void Function($TextProcessingTaskInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$TextProcessingTaskInterfaceBuilder].
+  $TextProcessingTaskInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingTaskInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14466,6 +16039,17 @@ abstract class TextProcessingTask
 @BuiltValue(instantiable: false)
 sealed class $TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterface {
   TextProcessingTask get task;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14520,6 +16104,17 @@ abstract class TextProcessingApiScheduleResponseApplicationJson_Ocs_Data
 sealed class $TextProcessingApiScheduleResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextProcessingApiScheduleResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiScheduleResponseApplicationJson_OcsInterfaceBuilder].
+  $TextProcessingApiScheduleResponseApplicationJson_OcsInterface rebuild(
+    void Function($TextProcessingApiScheduleResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiScheduleResponseApplicationJson_OcsInterfaceBuilder].
+  $TextProcessingApiScheduleResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiScheduleResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14573,6 +16168,17 @@ abstract class TextProcessingApiScheduleResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TextProcessingApiScheduleResponseApplicationJsonInterface {
   TextProcessingApiScheduleResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiScheduleResponseApplicationJsonInterfaceBuilder].
+  $TextProcessingApiScheduleResponseApplicationJsonInterface rebuild(
+    void Function($TextProcessingApiScheduleResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiScheduleResponseApplicationJsonInterfaceBuilder].
+  $TextProcessingApiScheduleResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiScheduleResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14626,6 +16232,17 @@ abstract class TextProcessingApiScheduleResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterface {
   TextProcessingTask get task;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14680,6 +16297,17 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data
 sealed class $TextProcessingApiGetTaskResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextProcessingApiGetTaskResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiGetTaskResponseApplicationJson_OcsInterfaceBuilder].
+  $TextProcessingApiGetTaskResponseApplicationJson_OcsInterface rebuild(
+    void Function($TextProcessingApiGetTaskResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiGetTaskResponseApplicationJson_OcsInterfaceBuilder].
+  $TextProcessingApiGetTaskResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiGetTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14733,6 +16361,17 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TextProcessingApiGetTaskResponseApplicationJsonInterface {
   TextProcessingApiGetTaskResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiGetTaskResponseApplicationJsonInterfaceBuilder].
+  $TextProcessingApiGetTaskResponseApplicationJsonInterface rebuild(
+    void Function($TextProcessingApiGetTaskResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiGetTaskResponseApplicationJsonInterfaceBuilder].
+  $TextProcessingApiGetTaskResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiGetTaskResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14785,6 +16424,17 @@ abstract class TextProcessingApiGetTaskResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterface {
   TextProcessingTask get task;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14839,6 +16489,17 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data
 sealed class $TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder].
+  $TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterface rebuild(
+    void Function($TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder].
+  $TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14892,6 +16553,17 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TextProcessingApiDeleteTaskResponseApplicationJsonInterface {
   TextProcessingApiDeleteTaskResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiDeleteTaskResponseApplicationJsonInterfaceBuilder].
+  $TextProcessingApiDeleteTaskResponseApplicationJsonInterface rebuild(
+    void Function($TextProcessingApiDeleteTaskResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiDeleteTaskResponseApplicationJsonInterfaceBuilder].
+  $TextProcessingApiDeleteTaskResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiDeleteTaskResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14945,6 +16617,17 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TextProcessingTask> get tasks;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -14999,6 +16682,17 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data
 sealed class $TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder].
+  $TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterface rebuild(
+    void Function($TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder].
+  $TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15052,6 +16746,17 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TextProcessingApiListTasksByAppResponseApplicationJsonInterface {
   TextProcessingApiListTasksByAppResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiListTasksByAppResponseApplicationJsonInterfaceBuilder].
+  $TextProcessingApiListTasksByAppResponseApplicationJsonInterface rebuild(
+    void Function($TextProcessingApiListTasksByAppResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiListTasksByAppResponseApplicationJsonInterfaceBuilder].
+  $TextProcessingApiListTasksByAppResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextProcessingApiListTasksByAppResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15105,6 +16810,17 @@ abstract class TextProcessingApiListTasksByAppResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterface {
   bool get isAvailable;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15159,6 +16875,17 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data
 sealed class $TextToImageApiIsAvailableResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiIsAvailableResponseApplicationJson_OcsInterfaceBuilder].
+  $TextToImageApiIsAvailableResponseApplicationJson_OcsInterface rebuild(
+    void Function($TextToImageApiIsAvailableResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiIsAvailableResponseApplicationJson_OcsInterfaceBuilder].
+  $TextToImageApiIsAvailableResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiIsAvailableResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15212,6 +16939,17 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TextToImageApiIsAvailableResponseApplicationJsonInterface {
   TextToImageApiIsAvailableResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiIsAvailableResponseApplicationJsonInterfaceBuilder].
+  $TextToImageApiIsAvailableResponseApplicationJsonInterface rebuild(
+    void Function($TextToImageApiIsAvailableResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiIsAvailableResponseApplicationJsonInterfaceBuilder].
+  $TextToImageApiIsAvailableResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiIsAvailableResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15353,6 +17091,15 @@ sealed class $TextToImageTaskInterface {
   String? get identifier;
   int get numberOfImages;
   int? get completionExpectedAt;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageTaskInterfaceBuilder].
+  $TextToImageTaskInterface rebuild(void Function($TextToImageTaskInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$TextToImageTaskInterfaceBuilder].
+  $TextToImageTaskInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageTaskInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15398,6 +17145,17 @@ abstract class TextToImageTask implements $TextToImageTaskInterface, Built<TextT
 @BuiltValue(instantiable: false)
 sealed class $TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterface {
   TextToImageTask get task;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiScheduleResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15452,6 +17210,17 @@ abstract class TextToImageApiScheduleResponseApplicationJson_Ocs_Data
 sealed class $TextToImageApiScheduleResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextToImageApiScheduleResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiScheduleResponseApplicationJson_OcsInterfaceBuilder].
+  $TextToImageApiScheduleResponseApplicationJson_OcsInterface rebuild(
+    void Function($TextToImageApiScheduleResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiScheduleResponseApplicationJson_OcsInterfaceBuilder].
+  $TextToImageApiScheduleResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiScheduleResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15505,6 +17274,17 @@ abstract class TextToImageApiScheduleResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TextToImageApiScheduleResponseApplicationJsonInterface {
   TextToImageApiScheduleResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiScheduleResponseApplicationJsonInterfaceBuilder].
+  $TextToImageApiScheduleResponseApplicationJsonInterface rebuild(
+    void Function($TextToImageApiScheduleResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiScheduleResponseApplicationJsonInterfaceBuilder].
+  $TextToImageApiScheduleResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiScheduleResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15557,6 +17337,17 @@ abstract class TextToImageApiScheduleResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterface {
   TextToImageTask get task;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiGetTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15611,6 +17402,17 @@ abstract class TextToImageApiGetTaskResponseApplicationJson_Ocs_Data
 sealed class $TextToImageApiGetTaskResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextToImageApiGetTaskResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiGetTaskResponseApplicationJson_OcsInterfaceBuilder].
+  $TextToImageApiGetTaskResponseApplicationJson_OcsInterface rebuild(
+    void Function($TextToImageApiGetTaskResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiGetTaskResponseApplicationJson_OcsInterfaceBuilder].
+  $TextToImageApiGetTaskResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiGetTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15664,6 +17466,17 @@ abstract class TextToImageApiGetTaskResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TextToImageApiGetTaskResponseApplicationJsonInterface {
   TextToImageApiGetTaskResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiGetTaskResponseApplicationJsonInterfaceBuilder].
+  $TextToImageApiGetTaskResponseApplicationJsonInterface rebuild(
+    void Function($TextToImageApiGetTaskResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiGetTaskResponseApplicationJsonInterfaceBuilder].
+  $TextToImageApiGetTaskResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiGetTaskResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15716,6 +17529,17 @@ abstract class TextToImageApiGetTaskResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterface {
   TextToImageTask get task;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiDeleteTaskResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15770,6 +17594,17 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data
 sealed class $TextToImageApiDeleteTaskResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder].
+  $TextToImageApiDeleteTaskResponseApplicationJson_OcsInterface rebuild(
+    void Function($TextToImageApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder].
+  $TextToImageApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiDeleteTaskResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15823,6 +17658,17 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TextToImageApiDeleteTaskResponseApplicationJsonInterface {
   TextToImageApiDeleteTaskResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiDeleteTaskResponseApplicationJsonInterfaceBuilder].
+  $TextToImageApiDeleteTaskResponseApplicationJsonInterface rebuild(
+    void Function($TextToImageApiDeleteTaskResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiDeleteTaskResponseApplicationJsonInterfaceBuilder].
+  $TextToImageApiDeleteTaskResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiDeleteTaskResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15875,6 +17721,17 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TextToImageTask> get tasks;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15929,6 +17786,17 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data
 sealed class $TextToImageApiListTasksByAppResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder].
+  $TextToImageApiListTasksByAppResponseApplicationJson_OcsInterface rebuild(
+    void Function($TextToImageApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder].
+  $TextToImageApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiListTasksByAppResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -15982,6 +17850,17 @@ abstract class TextToImageApiListTasksByAppResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TextToImageApiListTasksByAppResponseApplicationJsonInterface {
   TextToImageApiListTasksByAppResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiListTasksByAppResponseApplicationJsonInterfaceBuilder].
+  $TextToImageApiListTasksByAppResponseApplicationJsonInterface rebuild(
+    void Function($TextToImageApiListTasksByAppResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiListTasksByAppResponseApplicationJsonInterfaceBuilder].
+  $TextToImageApiListTasksByAppResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TextToImageApiListTasksByAppResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16038,6 +17917,17 @@ sealed class $TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesI
   String get fromLabel;
   String get to;
   String get toLabel;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesInterfaceBuilder].
+  $TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesInterface rebuild(
+    void Function($TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesInterfaceBuilder].
+  $TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TranslationApiLanguagesResponseApplicationJson_Ocs_Data_LanguagesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16092,6 +17982,17 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages
 sealed class $TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages> get languages;
   bool get languageDetection;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TranslationApiLanguagesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16146,6 +18047,17 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs_Data
 sealed class $TranslationApiLanguagesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TranslationApiLanguagesResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TranslationApiLanguagesResponseApplicationJson_OcsInterfaceBuilder].
+  $TranslationApiLanguagesResponseApplicationJson_OcsInterface rebuild(
+    void Function($TranslationApiLanguagesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TranslationApiLanguagesResponseApplicationJson_OcsInterfaceBuilder].
+  $TranslationApiLanguagesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TranslationApiLanguagesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16199,6 +18111,17 @@ abstract class TranslationApiLanguagesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TranslationApiLanguagesResponseApplicationJsonInterface {
   TranslationApiLanguagesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TranslationApiLanguagesResponseApplicationJsonInterfaceBuilder].
+  $TranslationApiLanguagesResponseApplicationJsonInterface rebuild(
+    void Function($TranslationApiLanguagesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TranslationApiLanguagesResponseApplicationJsonInterfaceBuilder].
+  $TranslationApiLanguagesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TranslationApiLanguagesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16252,6 +18175,17 @@ abstract class TranslationApiLanguagesResponseApplicationJson
 sealed class $TranslationApiTranslateResponseApplicationJson_Ocs_DataInterface {
   String get text;
   String? get from;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TranslationApiTranslateResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TranslationApiTranslateResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TranslationApiTranslateResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TranslationApiTranslateResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TranslationApiTranslateResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TranslationApiTranslateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16306,6 +18240,17 @@ abstract class TranslationApiTranslateResponseApplicationJson_Ocs_Data
 sealed class $TranslationApiTranslateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TranslationApiTranslateResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TranslationApiTranslateResponseApplicationJson_OcsInterfaceBuilder].
+  $TranslationApiTranslateResponseApplicationJson_OcsInterface rebuild(
+    void Function($TranslationApiTranslateResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TranslationApiTranslateResponseApplicationJson_OcsInterfaceBuilder].
+  $TranslationApiTranslateResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TranslationApiTranslateResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16359,6 +18304,17 @@ abstract class TranslationApiTranslateResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TranslationApiTranslateResponseApplicationJsonInterface {
   TranslationApiTranslateResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TranslationApiTranslateResponseApplicationJsonInterfaceBuilder].
+  $TranslationApiTranslateResponseApplicationJsonInterface rebuild(
+    void Function($TranslationApiTranslateResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TranslationApiTranslateResponseApplicationJsonInterfaceBuilder].
+  $TranslationApiTranslateResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TranslationApiTranslateResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16418,6 +18374,15 @@ sealed class $UnifiedSearchProviderInterface {
   BuiltList<String> get triggers;
   BuiltMap<String, String> get filters;
   bool get inAppSearch;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedSearchProviderInterfaceBuilder].
+  $UnifiedSearchProviderInterface rebuild(void Function($UnifiedSearchProviderInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$UnifiedSearchProviderInterfaceBuilder].
+  $UnifiedSearchProviderInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UnifiedSearchProviderInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16466,6 +18431,17 @@ abstract class UnifiedSearchProvider
 sealed class $UnifiedSearchGetProvidersResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<UnifiedSearchProvider> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedSearchGetProvidersResponseApplicationJson_OcsInterfaceBuilder].
+  $UnifiedSearchGetProvidersResponseApplicationJson_OcsInterface rebuild(
+    void Function($UnifiedSearchGetProvidersResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UnifiedSearchGetProvidersResponseApplicationJson_OcsInterfaceBuilder].
+  $UnifiedSearchGetProvidersResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UnifiedSearchGetProvidersResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16519,6 +18495,17 @@ abstract class UnifiedSearchGetProvidersResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UnifiedSearchGetProvidersResponseApplicationJsonInterface {
   UnifiedSearchGetProvidersResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedSearchGetProvidersResponseApplicationJsonInterfaceBuilder].
+  $UnifiedSearchGetProvidersResponseApplicationJsonInterface rebuild(
+    void Function($UnifiedSearchGetProvidersResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UnifiedSearchGetProvidersResponseApplicationJsonInterfaceBuilder].
+  $UnifiedSearchGetProvidersResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UnifiedSearchGetProvidersResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16580,6 +18567,15 @@ sealed class $UnifiedSearchResultEntryInterface {
   String get icon;
   bool get rounded;
   BuiltList<String> get attributes;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedSearchResultEntryInterfaceBuilder].
+  $UnifiedSearchResultEntryInterface rebuild(void Function($UnifiedSearchResultEntryInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$UnifiedSearchResultEntryInterfaceBuilder].
+  $UnifiedSearchResultEntryInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UnifiedSearchResultEntryInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16632,6 +18628,15 @@ sealed class $UnifiedSearchResultInterface {
   bool get isPaginated;
   BuiltList<UnifiedSearchResultEntry> get entries;
   UnifiedSearchResult_Cursor? get cursor;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedSearchResultInterfaceBuilder].
+  $UnifiedSearchResultInterface rebuild(void Function($UnifiedSearchResultInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$UnifiedSearchResultInterfaceBuilder].
+  $UnifiedSearchResultInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UnifiedSearchResultInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16682,6 +18687,17 @@ abstract class UnifiedSearchResult
 sealed class $UnifiedSearchSearchResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UnifiedSearchResult get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedSearchSearchResponseApplicationJson_OcsInterfaceBuilder].
+  $UnifiedSearchSearchResponseApplicationJson_OcsInterface rebuild(
+    void Function($UnifiedSearchSearchResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UnifiedSearchSearchResponseApplicationJson_OcsInterfaceBuilder].
+  $UnifiedSearchSearchResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UnifiedSearchSearchResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16734,6 +18750,17 @@ abstract class UnifiedSearchSearchResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UnifiedSearchSearchResponseApplicationJsonInterface {
   UnifiedSearchSearchResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedSearchSearchResponseApplicationJsonInterfaceBuilder].
+  $UnifiedSearchSearchResponseApplicationJsonInterface rebuild(
+    void Function($UnifiedSearchSearchResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UnifiedSearchSearchResponseApplicationJsonInterfaceBuilder].
+  $UnifiedSearchSearchResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UnifiedSearchSearchResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16787,6 +18814,17 @@ abstract class UnifiedSearchSearchResponseApplicationJson
 sealed class $WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterface {
   BuiltList<String> get regular;
   BuiltList<String> get admin;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder].
+  $WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterface rebuild(
+    void Function($WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder].
+  $WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNewInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16843,6 +18881,17 @@ sealed class $WhatsNewGetResponseApplicationJson_Ocs_DataInterface {
   String get product;
   String get version;
   WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew? get whatsNew;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WhatsNewGetResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $WhatsNewGetResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($WhatsNewGetResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WhatsNewGetResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $WhatsNewGetResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WhatsNewGetResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16896,6 +18945,17 @@ abstract class WhatsNewGetResponseApplicationJson_Ocs_Data
 sealed class $WhatsNewGetResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   WhatsNewGetResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WhatsNewGetResponseApplicationJson_OcsInterfaceBuilder].
+  $WhatsNewGetResponseApplicationJson_OcsInterface rebuild(
+    void Function($WhatsNewGetResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WhatsNewGetResponseApplicationJson_OcsInterfaceBuilder].
+  $WhatsNewGetResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WhatsNewGetResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16947,6 +19007,17 @@ abstract class WhatsNewGetResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $WhatsNewGetResponseApplicationJsonInterface {
   WhatsNewGetResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WhatsNewGetResponseApplicationJsonInterfaceBuilder].
+  $WhatsNewGetResponseApplicationJsonInterface rebuild(
+    void Function($WhatsNewGetResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WhatsNewGetResponseApplicationJsonInterfaceBuilder].
+  $WhatsNewGetResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WhatsNewGetResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16999,6 +19070,17 @@ abstract class WhatsNewGetResponseApplicationJson
 sealed class $WhatsNewDismissResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WhatsNewDismissResponseApplicationJson_OcsInterfaceBuilder].
+  $WhatsNewDismissResponseApplicationJson_OcsInterface rebuild(
+    void Function($WhatsNewDismissResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WhatsNewDismissResponseApplicationJson_OcsInterfaceBuilder].
+  $WhatsNewDismissResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WhatsNewDismissResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -17051,6 +19133,17 @@ abstract class WhatsNewDismissResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $WhatsNewDismissResponseApplicationJsonInterface {
   WhatsNewDismissResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WhatsNewDismissResponseApplicationJsonInterfaceBuilder].
+  $WhatsNewDismissResponseApplicationJsonInterface rebuild(
+    void Function($WhatsNewDismissResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WhatsNewDismissResponseApplicationJsonInterfaceBuilder].
+  $WhatsNewDismissResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WhatsNewDismissResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -17102,6 +19195,17 @@ abstract class WhatsNewDismissResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $WipeCheckWipeResponseApplicationJsonInterface {
   bool get wipe;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WipeCheckWipeResponseApplicationJsonInterfaceBuilder].
+  $WipeCheckWipeResponseApplicationJsonInterface rebuild(
+    void Function($WipeCheckWipeResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WipeCheckWipeResponseApplicationJsonInterfaceBuilder].
+  $WipeCheckWipeResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WipeCheckWipeResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -17161,6 +19265,15 @@ sealed class $Capabilities_CoreInterface {
   String get referenceRegex;
   @BuiltValueField(wireName: 'mod-rewrite-working')
   bool get modRewriteWorking;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_CoreInterfaceBuilder].
+  $Capabilities_CoreInterface rebuild(void Function($Capabilities_CoreInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_CoreInterfaceBuilder].
+  $Capabilities_CoreInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_CoreInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -17207,6 +19320,15 @@ abstract class Capabilities_Core
 @BuiltValue(instantiable: false)
 sealed class $CapabilitiesInterface {
   Capabilities_Core get core;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -17254,6 +19376,17 @@ sealed class $PublicCapabilities_BruteforceInterface {
   int get delay;
   @BuiltValueField(wireName: 'allow-listed')
   bool get allowListed;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicCapabilities_BruteforceInterfaceBuilder].
+  $PublicCapabilities_BruteforceInterface rebuild(
+    void Function($PublicCapabilities_BruteforceInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PublicCapabilities_BruteforceInterfaceBuilder].
+  $PublicCapabilities_BruteforceInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PublicCapabilities_BruteforceInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -17304,6 +19437,15 @@ abstract class PublicCapabilities_Bruteforce
 @BuiltValue(instantiable: false)
 sealed class $PublicCapabilitiesInterface {
   PublicCapabilities_Bruteforce get bruteforce;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicCapabilitiesInterfaceBuilder].
+  $PublicCapabilitiesInterface rebuild(void Function($PublicCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PublicCapabilitiesInterfaceBuilder].
+  $PublicCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PublicCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.dart
@@ -394,6 +394,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -441,6 +450,15 @@ sealed class $Widget_ButtonsInterface {
   String get type;
   String get text;
   String get link;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Widget_ButtonsInterfaceBuilder].
+  $Widget_ButtonsInterface rebuild(void Function($Widget_ButtonsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Widget_ButtonsInterfaceBuilder].
+  $Widget_ButtonsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Widget_ButtonsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -501,6 +519,15 @@ sealed class $WidgetInterface {
   @BuiltValueField(wireName: 'reload_interval')
   int get reloadInterval;
   BuiltList<Widget_Buttons>? get buttons;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WidgetInterfaceBuilder].
+  $WidgetInterface rebuild(void Function($WidgetInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$WidgetInterfaceBuilder].
+  $WidgetInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WidgetInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -547,6 +574,17 @@ abstract class Widget implements $WidgetInterface, Built<Widget, WidgetBuilder> 
 sealed class $DashboardApiGetWidgetsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, Widget> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DashboardApiGetWidgetsResponseApplicationJson_OcsInterfaceBuilder].
+  $DashboardApiGetWidgetsResponseApplicationJson_OcsInterface rebuild(
+    void Function($DashboardApiGetWidgetsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DashboardApiGetWidgetsResponseApplicationJson_OcsInterfaceBuilder].
+  $DashboardApiGetWidgetsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DashboardApiGetWidgetsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -600,6 +638,17 @@ abstract class DashboardApiGetWidgetsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DashboardApiGetWidgetsResponseApplicationJsonInterface {
   DashboardApiGetWidgetsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DashboardApiGetWidgetsResponseApplicationJsonInterfaceBuilder].
+  $DashboardApiGetWidgetsResponseApplicationJsonInterface rebuild(
+    void Function($DashboardApiGetWidgetsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DashboardApiGetWidgetsResponseApplicationJsonInterfaceBuilder].
+  $DashboardApiGetWidgetsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DashboardApiGetWidgetsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -657,6 +706,15 @@ sealed class $WidgetItemInterface {
   String get iconUrl;
   String get overlayIconUrl;
   String get sinceId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WidgetItemInterfaceBuilder].
+  $WidgetItemInterface rebuild(void Function($WidgetItemInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$WidgetItemInterfaceBuilder].
+  $WidgetItemInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WidgetItemInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -703,6 +761,17 @@ abstract class WidgetItem implements $WidgetItemInterface, Built<WidgetItem, Wid
 sealed class $DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<WidgetItem>> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterfaceBuilder].
+  $DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterface rebuild(
+    void Function($DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterfaceBuilder].
+  $DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DashboardApiGetWidgetItemsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -756,6 +825,17 @@ abstract class DashboardApiGetWidgetItemsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DashboardApiGetWidgetItemsResponseApplicationJsonInterface {
   DashboardApiGetWidgetItemsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DashboardApiGetWidgetItemsResponseApplicationJsonInterfaceBuilder].
+  $DashboardApiGetWidgetItemsResponseApplicationJsonInterface rebuild(
+    void Function($DashboardApiGetWidgetItemsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DashboardApiGetWidgetItemsResponseApplicationJsonInterfaceBuilder].
+  $DashboardApiGetWidgetItemsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DashboardApiGetWidgetItemsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -811,6 +891,15 @@ sealed class $WidgetItemsInterface {
   BuiltList<WidgetItem> get items;
   String get emptyContentMessage;
   String get halfEmptyContentMessage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WidgetItemsInterfaceBuilder].
+  $WidgetItemsInterface rebuild(void Function($WidgetItemsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$WidgetItemsInterfaceBuilder].
+  $WidgetItemsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WidgetItemsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -857,6 +946,17 @@ abstract class WidgetItems implements $WidgetItemsInterface, Built<WidgetItems, 
 sealed class $DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, WidgetItems> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterfaceBuilder].
+  $DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterface rebuild(
+    void Function($DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterfaceBuilder].
+  $DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DashboardApiGetWidgetItemsV2ResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -910,6 +1010,17 @@ abstract class DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterface {
   DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterfaceBuilder].
+  $DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterface rebuild(
+    void Function($DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterfaceBuilder].
+  $DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DashboardApiGetWidgetItemsV2ResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -599,6 +599,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -644,6 +653,17 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 @BuiltValue(instantiable: false)
 sealed class $DirectGetUrlResponseApplicationJson_Ocs_DataInterface {
   String get url;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectGetUrlResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $DirectGetUrlResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($DirectGetUrlResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectGetUrlResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $DirectGetUrlResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectGetUrlResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -697,6 +717,17 @@ abstract class DirectGetUrlResponseApplicationJson_Ocs_Data
 sealed class $DirectGetUrlResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   DirectGetUrlResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectGetUrlResponseApplicationJson_OcsInterfaceBuilder].
+  $DirectGetUrlResponseApplicationJson_OcsInterface rebuild(
+    void Function($DirectGetUrlResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectGetUrlResponseApplicationJson_OcsInterfaceBuilder].
+  $DirectGetUrlResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectGetUrlResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -748,6 +779,17 @@ abstract class DirectGetUrlResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DirectGetUrlResponseApplicationJsonInterface {
   DirectGetUrlResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectGetUrlResponseApplicationJsonInterfaceBuilder].
+  $DirectGetUrlResponseApplicationJsonInterface rebuild(
+    void Function($DirectGetUrlResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectGetUrlResponseApplicationJsonInterfaceBuilder].
+  $DirectGetUrlResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectGetUrlResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -800,6 +842,15 @@ abstract class DirectGetUrlResponseApplicationJson
 sealed class $OutOfOfficeDataCommonInterface {
   String get userId;
   String get message;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeDataCommonInterfaceBuilder].
+  $OutOfOfficeDataCommonInterface rebuild(void Function($OutOfOfficeDataCommonInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OutOfOfficeDataCommonInterfaceBuilder].
+  $OutOfOfficeDataCommonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OutOfOfficeDataCommonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -850,6 +901,17 @@ sealed class $CurrentOutOfOfficeDataInterface implements $OutOfOfficeDataCommonI
   int get startDate;
   int get endDate;
   String get shortMessage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CurrentOutOfOfficeDataInterfaceBuilder].
+  @override
+  $CurrentOutOfOfficeDataInterface rebuild(void Function($CurrentOutOfOfficeDataInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CurrentOutOfOfficeDataInterfaceBuilder].
+  @override
+  $CurrentOutOfOfficeDataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CurrentOutOfOfficeDataInterfaceBuilder b) {
     $OutOfOfficeDataCommonInterface._defaults(b);
@@ -903,6 +965,17 @@ abstract class CurrentOutOfOfficeData
 sealed class $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   CurrentOutOfOfficeData get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterfaceBuilder].
+  $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterface rebuild(
+    void Function($OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterfaceBuilder].
+  $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -956,6 +1029,17 @@ abstract class OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterface {
   OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterfaceBuilder].
+  $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterface rebuild(
+    void Function($OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterfaceBuilder].
+  $OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1012,6 +1096,17 @@ sealed class $OutOfOfficeDataInterface implements $OutOfOfficeDataCommonInterfac
   String get firstDay;
   String get lastDay;
   String get status;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeDataInterfaceBuilder].
+  @override
+  $OutOfOfficeDataInterface rebuild(void Function($OutOfOfficeDataInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OutOfOfficeDataInterfaceBuilder].
+  @override
+  $OutOfOfficeDataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OutOfOfficeDataInterfaceBuilder b) {
     $OutOfOfficeDataCommonInterface._defaults(b);
@@ -1063,6 +1158,17 @@ abstract class OutOfOfficeData implements $OutOfOfficeDataInterface, Built<OutOf
 sealed class $OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OutOfOfficeData get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder].
+  $OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterface rebuild(
+    void Function($OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder].
+  $OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OutOfOfficeGetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1116,6 +1222,17 @@ abstract class OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterface {
   OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterfaceBuilder].
+  $OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterface rebuild(
+    void Function($OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterfaceBuilder].
+  $OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OutOfOfficeGetOutOfOfficeResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1170,6 +1287,17 @@ abstract class OutOfOfficeGetOutOfOfficeResponseApplicationJson
 sealed class $OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OutOfOfficeData get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder].
+  $OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterface rebuild(
+    void Function($OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder].
+  $OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1223,6 +1351,17 @@ abstract class OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterface {
   OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterfaceBuilder].
+  $OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterface rebuild(
+    void Function($OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterfaceBuilder].
+  $OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OutOfOfficeSetOutOfOfficeResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1277,6 +1416,17 @@ abstract class OutOfOfficeSetOutOfOfficeResponseApplicationJson
 sealed class $OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject? get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder].
+  $OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterface rebuild(
+    void Function($OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder].
+  $OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OutOfOfficeClearOutOfOfficeResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1330,6 +1480,17 @@ abstract class OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterface {
   OutOfOfficeClearOutOfOfficeResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterfaceBuilder].
+  $OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterface rebuild(
+    void Function($OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterfaceBuilder].
+  $OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OutOfOfficeClearOutOfOfficeResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1384,6 +1545,15 @@ abstract class OutOfOfficeClearOutOfOfficeResponseApplicationJson
 sealed class $Capabilities_DavInterface {
   String get chunking;
   String? get bulkupload;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_DavInterfaceBuilder].
+  $Capabilities_DavInterface rebuild(void Function($Capabilities_DavInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_DavInterfaceBuilder].
+  $Capabilities_DavInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_DavInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1430,6 +1600,15 @@ abstract class Capabilities_Dav
 @BuiltValue(instantiable: false)
 sealed class $CapabilitiesInterface {
   Capabilities_Dav get dav;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/drop_account.openapi.dart
+++ b/packages/nextcloud/lib/src/api/drop_account.openapi.dart
@@ -28,6 +28,17 @@ part 'drop_account.openapi.g.dart';
 sealed class $Capabilities_DropAccount_DelayInterface {
   bool get enabled;
   int get hours;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_DropAccount_DelayInterfaceBuilder].
+  $Capabilities_DropAccount_DelayInterface rebuild(
+    void Function($Capabilities_DropAccount_DelayInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_DropAccount_DelayInterfaceBuilder].
+  $Capabilities_DropAccount_DelayInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_DropAccount_DelayInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -82,6 +93,15 @@ sealed class $Capabilities_DropAccountInterface {
   String get apiVersion;
   Capabilities_DropAccount_Delay get delay;
   String? get details;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_DropAccountInterfaceBuilder].
+  $Capabilities_DropAccountInterface rebuild(void Function($Capabilities_DropAccountInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_DropAccountInterfaceBuilder].
+  $Capabilities_DropAccountInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_DropAccountInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -130,6 +150,15 @@ abstract class Capabilities_DropAccount
 sealed class $CapabilitiesInterface {
   @BuiltValueField(wireName: 'drop-account')
   Capabilities_DropAccount get dropAccount;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -1428,6 +1428,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1477,6 +1486,17 @@ sealed class $DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterface
   BuiltList<String> get mimetypes;
   BuiltList<String> get optionalMimetypes;
   bool get secure;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterfaceBuilder].
+  $DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterface rebuild(
+    void Function($DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterfaceBuilder].
+  $DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingInfoResponseApplicationJson_Ocs_Data_EditorsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1536,6 +1556,17 @@ sealed class $DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterfac
   String get $extension;
   bool get templates;
   BuiltList<String> get mimetypes;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterfaceBuilder].
+  $DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterface rebuild(
+    void Function($DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterfaceBuilder].
+  $DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingInfoResponseApplicationJson_Ocs_Data_CreatorsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1590,6 +1621,17 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators
 sealed class $DirectEditingInfoResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors> get editors;
   BuiltMap<String, DirectEditingInfoResponseApplicationJson_Ocs_Data_Creators> get creators;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingInfoResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $DirectEditingInfoResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($DirectEditingInfoResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingInfoResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $DirectEditingInfoResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingInfoResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1644,6 +1686,17 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs_Data
 sealed class $DirectEditingInfoResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   DirectEditingInfoResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingInfoResponseApplicationJson_OcsInterfaceBuilder].
+  $DirectEditingInfoResponseApplicationJson_OcsInterface rebuild(
+    void Function($DirectEditingInfoResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingInfoResponseApplicationJson_OcsInterfaceBuilder].
+  $DirectEditingInfoResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingInfoResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1696,6 +1749,17 @@ abstract class DirectEditingInfoResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DirectEditingInfoResponseApplicationJsonInterface {
   DirectEditingInfoResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingInfoResponseApplicationJsonInterfaceBuilder].
+  $DirectEditingInfoResponseApplicationJsonInterface rebuild(
+    void Function($DirectEditingInfoResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingInfoResponseApplicationJsonInterfaceBuilder].
+  $DirectEditingInfoResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingInfoResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1753,6 +1817,17 @@ sealed class $DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesIn
   @BuiltValueField(wireName: 'extension')
   String get $extension;
   String get mimetype;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesInterfaceBuilder].
+  $DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesInterface rebuild(
+    void Function($DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesInterfaceBuilder].
+  $DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingTemplatesResponseApplicationJson_Ocs_Data_TemplatesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1806,6 +1881,17 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates
 @BuiltValue(instantiable: false)
 sealed class $DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates> get templates;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingTemplatesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1860,6 +1946,17 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs_Data
 sealed class $DirectEditingTemplatesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   DirectEditingTemplatesResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingTemplatesResponseApplicationJson_OcsInterfaceBuilder].
+  $DirectEditingTemplatesResponseApplicationJson_OcsInterface rebuild(
+    void Function($DirectEditingTemplatesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingTemplatesResponseApplicationJson_OcsInterfaceBuilder].
+  $DirectEditingTemplatesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingTemplatesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1913,6 +2010,17 @@ abstract class DirectEditingTemplatesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DirectEditingTemplatesResponseApplicationJsonInterface {
   DirectEditingTemplatesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingTemplatesResponseApplicationJsonInterfaceBuilder].
+  $DirectEditingTemplatesResponseApplicationJsonInterface rebuild(
+    void Function($DirectEditingTemplatesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingTemplatesResponseApplicationJsonInterfaceBuilder].
+  $DirectEditingTemplatesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingTemplatesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1965,6 +2073,17 @@ abstract class DirectEditingTemplatesResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $DirectEditingOpenResponseApplicationJson_Ocs_DataInterface {
   String get url;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingOpenResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $DirectEditingOpenResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($DirectEditingOpenResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingOpenResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $DirectEditingOpenResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingOpenResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2019,6 +2138,17 @@ abstract class DirectEditingOpenResponseApplicationJson_Ocs_Data
 sealed class $DirectEditingOpenResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   DirectEditingOpenResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingOpenResponseApplicationJson_OcsInterfaceBuilder].
+  $DirectEditingOpenResponseApplicationJson_OcsInterface rebuild(
+    void Function($DirectEditingOpenResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingOpenResponseApplicationJson_OcsInterfaceBuilder].
+  $DirectEditingOpenResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingOpenResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2071,6 +2201,17 @@ abstract class DirectEditingOpenResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DirectEditingOpenResponseApplicationJsonInterface {
   DirectEditingOpenResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingOpenResponseApplicationJsonInterfaceBuilder].
+  $DirectEditingOpenResponseApplicationJsonInterface rebuild(
+    void Function($DirectEditingOpenResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingOpenResponseApplicationJsonInterfaceBuilder].
+  $DirectEditingOpenResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingOpenResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2123,6 +2264,17 @@ abstract class DirectEditingOpenResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $DirectEditingCreateResponseApplicationJson_Ocs_DataInterface {
   String get url;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingCreateResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $DirectEditingCreateResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($DirectEditingCreateResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingCreateResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $DirectEditingCreateResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingCreateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2177,6 +2329,17 @@ abstract class DirectEditingCreateResponseApplicationJson_Ocs_Data
 sealed class $DirectEditingCreateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   DirectEditingCreateResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingCreateResponseApplicationJson_OcsInterfaceBuilder].
+  $DirectEditingCreateResponseApplicationJson_OcsInterface rebuild(
+    void Function($DirectEditingCreateResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingCreateResponseApplicationJson_OcsInterfaceBuilder].
+  $DirectEditingCreateResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2229,6 +2392,17 @@ abstract class DirectEditingCreateResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DirectEditingCreateResponseApplicationJsonInterface {
   DirectEditingCreateResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingCreateResponseApplicationJsonInterfaceBuilder].
+  $DirectEditingCreateResponseApplicationJsonInterface rebuild(
+    void Function($DirectEditingCreateResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingCreateResponseApplicationJsonInterfaceBuilder].
+  $DirectEditingCreateResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DirectEditingCreateResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2284,6 +2458,17 @@ sealed class $OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterface {
   String get pathHash;
   int get expirationTime;
   String get token;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2338,6 +2523,17 @@ abstract class OpenLocalEditorCreateResponseApplicationJson_Ocs_Data
 sealed class $OpenLocalEditorCreateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OpenLocalEditorCreateResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OpenLocalEditorCreateResponseApplicationJson_OcsInterfaceBuilder].
+  $OpenLocalEditorCreateResponseApplicationJson_OcsInterface rebuild(
+    void Function($OpenLocalEditorCreateResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OpenLocalEditorCreateResponseApplicationJson_OcsInterfaceBuilder].
+  $OpenLocalEditorCreateResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OpenLocalEditorCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2391,6 +2587,17 @@ abstract class OpenLocalEditorCreateResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $OpenLocalEditorCreateResponseApplicationJsonInterface {
   OpenLocalEditorCreateResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OpenLocalEditorCreateResponseApplicationJsonInterfaceBuilder].
+  $OpenLocalEditorCreateResponseApplicationJsonInterface rebuild(
+    void Function($OpenLocalEditorCreateResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OpenLocalEditorCreateResponseApplicationJsonInterfaceBuilder].
+  $OpenLocalEditorCreateResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OpenLocalEditorCreateResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2446,6 +2653,17 @@ sealed class $OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterface {
   String get pathHash;
   int get expirationTime;
   String get token;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OpenLocalEditorValidateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2500,6 +2718,17 @@ abstract class OpenLocalEditorValidateResponseApplicationJson_Ocs_Data
 sealed class $OpenLocalEditorValidateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OpenLocalEditorValidateResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OpenLocalEditorValidateResponseApplicationJson_OcsInterfaceBuilder].
+  $OpenLocalEditorValidateResponseApplicationJson_OcsInterface rebuild(
+    void Function($OpenLocalEditorValidateResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OpenLocalEditorValidateResponseApplicationJson_OcsInterfaceBuilder].
+  $OpenLocalEditorValidateResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OpenLocalEditorValidateResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2553,6 +2782,17 @@ abstract class OpenLocalEditorValidateResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $OpenLocalEditorValidateResponseApplicationJsonInterface {
   OpenLocalEditorValidateResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OpenLocalEditorValidateResponseApplicationJsonInterfaceBuilder].
+  $OpenLocalEditorValidateResponseApplicationJsonInterface rebuild(
+    void Function($OpenLocalEditorValidateResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OpenLocalEditorValidateResponseApplicationJsonInterfaceBuilder].
+  $OpenLocalEditorValidateResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OpenLocalEditorValidateResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2613,6 +2853,15 @@ sealed class $TemplateFileCreatorInterface {
   BuiltList<String> get mimetypes;
   double? get ratio;
   String get actionLabel;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplateFileCreatorInterfaceBuilder].
+  $TemplateFileCreatorInterface rebuild(void Function($TemplateFileCreatorInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$TemplateFileCreatorInterfaceBuilder].
+  $TemplateFileCreatorInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TemplateFileCreatorInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2661,6 +2910,17 @@ abstract class TemplateFileCreator
 sealed class $TemplateListResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<TemplateFileCreator> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplateListResponseApplicationJson_OcsInterfaceBuilder].
+  $TemplateListResponseApplicationJson_OcsInterface rebuild(
+    void Function($TemplateListResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TemplateListResponseApplicationJson_OcsInterfaceBuilder].
+  $TemplateListResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TemplateListResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2712,6 +2972,17 @@ abstract class TemplateListResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TemplateListResponseApplicationJsonInterface {
   TemplateListResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplateListResponseApplicationJsonInterfaceBuilder].
+  $TemplateListResponseApplicationJsonInterface rebuild(
+    void Function($TemplateListResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TemplateListResponseApplicationJsonInterfaceBuilder].
+  $TemplateListResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TemplateListResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2771,6 +3042,15 @@ sealed class $TemplateFileInterface {
   int get size;
   String get type;
   bool get hasPreview;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplateFileInterfaceBuilder].
+  $TemplateFileInterface rebuild(void Function($TemplateFileInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$TemplateFileInterfaceBuilder].
+  $TemplateFileInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TemplateFileInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2817,6 +3097,17 @@ abstract class TemplateFile implements $TemplateFileInterface, Built<TemplateFil
 sealed class $TemplateCreateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TemplateFile get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplateCreateResponseApplicationJson_OcsInterfaceBuilder].
+  $TemplateCreateResponseApplicationJson_OcsInterface rebuild(
+    void Function($TemplateCreateResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TemplateCreateResponseApplicationJson_OcsInterfaceBuilder].
+  $TemplateCreateResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TemplateCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2869,6 +3160,17 @@ abstract class TemplateCreateResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TemplateCreateResponseApplicationJsonInterface {
   TemplateCreateResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplateCreateResponseApplicationJsonInterfaceBuilder].
+  $TemplateCreateResponseApplicationJsonInterface rebuild(
+    void Function($TemplateCreateResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TemplateCreateResponseApplicationJsonInterfaceBuilder].
+  $TemplateCreateResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TemplateCreateResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2986,6 +3288,17 @@ sealed class $TemplatePathResponseApplicationJson_Ocs_DataInterface {
   @BuiltValueField(wireName: 'template_path')
   String get templatePath;
   BuiltList<TemplateFileCreator> get templates;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplatePathResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TemplatePathResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($TemplatePathResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TemplatePathResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $TemplatePathResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TemplatePathResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3039,6 +3352,17 @@ abstract class TemplatePathResponseApplicationJson_Ocs_Data
 sealed class $TemplatePathResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   TemplatePathResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplatePathResponseApplicationJson_OcsInterfaceBuilder].
+  $TemplatePathResponseApplicationJson_OcsInterface rebuild(
+    void Function($TemplatePathResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TemplatePathResponseApplicationJson_OcsInterfaceBuilder].
+  $TemplatePathResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TemplatePathResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3090,6 +3414,17 @@ abstract class TemplatePathResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TemplatePathResponseApplicationJsonInterface {
   TemplatePathResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplatePathResponseApplicationJsonInterfaceBuilder].
+  $TemplatePathResponseApplicationJsonInterface rebuild(
+    void Function($TemplatePathResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TemplatePathResponseApplicationJsonInterfaceBuilder].
+  $TemplatePathResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TemplatePathResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3142,6 +3477,17 @@ abstract class TemplatePathResponseApplicationJson
 sealed class $TransferOwnershipTransferResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TransferOwnershipTransferResponseApplicationJson_OcsInterfaceBuilder].
+  $TransferOwnershipTransferResponseApplicationJson_OcsInterface rebuild(
+    void Function($TransferOwnershipTransferResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TransferOwnershipTransferResponseApplicationJson_OcsInterfaceBuilder].
+  $TransferOwnershipTransferResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TransferOwnershipTransferResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3195,6 +3541,17 @@ abstract class TransferOwnershipTransferResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TransferOwnershipTransferResponseApplicationJsonInterface {
   TransferOwnershipTransferResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TransferOwnershipTransferResponseApplicationJsonInterfaceBuilder].
+  $TransferOwnershipTransferResponseApplicationJsonInterface rebuild(
+    void Function($TransferOwnershipTransferResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TransferOwnershipTransferResponseApplicationJsonInterfaceBuilder].
+  $TransferOwnershipTransferResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TransferOwnershipTransferResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3249,6 +3606,17 @@ abstract class TransferOwnershipTransferResponseApplicationJson
 sealed class $TransferOwnershipAcceptResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TransferOwnershipAcceptResponseApplicationJson_OcsInterfaceBuilder].
+  $TransferOwnershipAcceptResponseApplicationJson_OcsInterface rebuild(
+    void Function($TransferOwnershipAcceptResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TransferOwnershipAcceptResponseApplicationJson_OcsInterfaceBuilder].
+  $TransferOwnershipAcceptResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TransferOwnershipAcceptResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3302,6 +3670,17 @@ abstract class TransferOwnershipAcceptResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TransferOwnershipAcceptResponseApplicationJsonInterface {
   TransferOwnershipAcceptResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TransferOwnershipAcceptResponseApplicationJsonInterfaceBuilder].
+  $TransferOwnershipAcceptResponseApplicationJsonInterface rebuild(
+    void Function($TransferOwnershipAcceptResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TransferOwnershipAcceptResponseApplicationJsonInterfaceBuilder].
+  $TransferOwnershipAcceptResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TransferOwnershipAcceptResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3355,6 +3734,17 @@ abstract class TransferOwnershipAcceptResponseApplicationJson
 sealed class $TransferOwnershipRejectResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TransferOwnershipRejectResponseApplicationJson_OcsInterfaceBuilder].
+  $TransferOwnershipRejectResponseApplicationJson_OcsInterface rebuild(
+    void Function($TransferOwnershipRejectResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TransferOwnershipRejectResponseApplicationJson_OcsInterfaceBuilder].
+  $TransferOwnershipRejectResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TransferOwnershipRejectResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3408,6 +3798,17 @@ abstract class TransferOwnershipRejectResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TransferOwnershipRejectResponseApplicationJsonInterface {
   TransferOwnershipRejectResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TransferOwnershipRejectResponseApplicationJsonInterfaceBuilder].
+  $TransferOwnershipRejectResponseApplicationJsonInterface rebuild(
+    void Function($TransferOwnershipRejectResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TransferOwnershipRejectResponseApplicationJsonInterfaceBuilder].
+  $TransferOwnershipRejectResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TransferOwnershipRejectResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3462,6 +3863,17 @@ sealed class $Capabilities_Files_DirectEditingInterface {
   String get url;
   String get etag;
   bool get supportsFileId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_Files_DirectEditingInterfaceBuilder].
+  $Capabilities_Files_DirectEditingInterface rebuild(
+    void Function($Capabilities_Files_DirectEditingInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_Files_DirectEditingInterfaceBuilder].
+  $Capabilities_Files_DirectEditingInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_Files_DirectEditingInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3517,6 +3929,15 @@ sealed class $Capabilities_FilesInterface {
   @BuiltValueField(wireName: 'forbidden_filename_characters')
   BuiltList<String> get forbiddenFilenameCharacters;
   Capabilities_Files_DirectEditing get directEditing;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesInterfaceBuilder].
+  $Capabilities_FilesInterface rebuild(void Function($Capabilities_FilesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_FilesInterfaceBuilder].
+  $Capabilities_FilesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3564,6 +3985,15 @@ abstract class Capabilities_Files
 @BuiltValue(instantiable: false)
 sealed class $CapabilitiesInterface {
   Capabilities_Files get files;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/files_external.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.dart
@@ -145,6 +145,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -380,6 +389,15 @@ sealed class $StorageConfigInterface {
   String? get statusMessage;
   StorageConfig_Type get type;
   bool get userProvided;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$StorageConfigInterfaceBuilder].
+  $StorageConfigInterface rebuild(void Function($StorageConfigInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$StorageConfigInterfaceBuilder].
+  $StorageConfigInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($StorageConfigInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -434,6 +452,15 @@ sealed class $MountInterface {
   @BuiltValueField(wireName: 'class')
   String get $class;
   StorageConfig get config;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MountInterfaceBuilder].
+  $MountInterface rebuild(void Function($MountInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$MountInterfaceBuilder].
+  $MountInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MountInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -480,6 +507,17 @@ abstract class Mount implements $MountInterface, Built<Mount, MountBuilder> {
 sealed class $ApiGetUserMountsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Mount> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetUserMountsResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiGetUserMountsResponseApplicationJson_OcsInterface rebuild(
+    void Function($ApiGetUserMountsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetUserMountsResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiGetUserMountsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetUserMountsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -532,6 +570,17 @@ abstract class ApiGetUserMountsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ApiGetUserMountsResponseApplicationJsonInterface {
   ApiGetUserMountsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetUserMountsResponseApplicationJsonInterfaceBuilder].
+  $ApiGetUserMountsResponseApplicationJsonInterface rebuild(
+    void Function($ApiGetUserMountsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetUserMountsResponseApplicationJsonInterfaceBuilder].
+  $ApiGetUserMountsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetUserMountsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
@@ -401,6 +401,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -446,6 +455,17 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 @BuiltValue(instantiable: false)
 sealed class $ApiGetResponseApplicationJson_Ocs_DataInterface {
   String? get dueDate;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ApiGetResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($ApiGetResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ApiGetResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -498,6 +518,17 @@ abstract class ApiGetResponseApplicationJson_Ocs_Data
 sealed class $ApiGetResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ApiGetResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiGetResponseApplicationJson_OcsInterface rebuild(
+    void Function($ApiGetResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiGetResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -548,6 +579,17 @@ abstract class ApiGetResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ApiGetResponseApplicationJsonInterface {
   ApiGetResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetResponseApplicationJsonInterfaceBuilder].
+  $ApiGetResponseApplicationJsonInterface rebuild(
+    void Function($ApiGetResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetResponseApplicationJsonInterfaceBuilder].
+  $ApiGetResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -599,6 +641,17 @@ abstract class ApiGetResponseApplicationJson
 sealed class $ApiSetResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiSetResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiSetResponseApplicationJson_OcsInterface rebuild(
+    void Function($ApiSetResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiSetResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiSetResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiSetResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -649,6 +702,17 @@ abstract class ApiSetResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ApiSetResponseApplicationJsonInterface {
   ApiSetResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiSetResponseApplicationJsonInterfaceBuilder].
+  $ApiSetResponseApplicationJsonInterface rebuild(
+    void Function($ApiSetResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiSetResponseApplicationJsonInterfaceBuilder].
+  $ApiSetResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiSetResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -700,6 +764,17 @@ abstract class ApiSetResponseApplicationJson
 sealed class $ApiRemoveResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiRemoveResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiRemoveResponseApplicationJson_OcsInterface rebuild(
+    void Function($ApiRemoveResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiRemoveResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiRemoveResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiRemoveResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -751,6 +826,17 @@ abstract class ApiRemoveResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ApiRemoveResponseApplicationJsonInterface {
   ApiRemoveResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiRemoveResponseApplicationJsonInterfaceBuilder].
+  $ApiRemoveResponseApplicationJsonInterface rebuild(
+    void Function($ApiRemoveResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiRemoveResponseApplicationJsonInterfaceBuilder].
+  $ApiRemoveResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiRemoveResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -2366,6 +2366,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2443,6 +2452,15 @@ sealed class $DeletedShareInterface {
   String? get shareWithDisplayname;
   @BuiltValueField(wireName: 'share_with_link')
   String? get shareWithLink;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeletedShareInterfaceBuilder].
+  $DeletedShareInterface rebuild(void Function($DeletedShareInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$DeletedShareInterfaceBuilder].
+  $DeletedShareInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeletedShareInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2489,6 +2507,17 @@ abstract class DeletedShare implements $DeletedShareInterface, Built<DeletedShar
 sealed class $DeletedShareapiIndexResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<DeletedShare> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeletedShareapiIndexResponseApplicationJson_OcsInterfaceBuilder].
+  $DeletedShareapiIndexResponseApplicationJson_OcsInterface rebuild(
+    void Function($DeletedShareapiIndexResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeletedShareapiIndexResponseApplicationJson_OcsInterfaceBuilder].
+  $DeletedShareapiIndexResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeletedShareapiIndexResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2541,6 +2570,17 @@ abstract class DeletedShareapiIndexResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DeletedShareapiIndexResponseApplicationJsonInterface {
   DeletedShareapiIndexResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeletedShareapiIndexResponseApplicationJsonInterfaceBuilder].
+  $DeletedShareapiIndexResponseApplicationJsonInterface rebuild(
+    void Function($DeletedShareapiIndexResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeletedShareapiIndexResponseApplicationJsonInterfaceBuilder].
+  $DeletedShareapiIndexResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeletedShareapiIndexResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2594,6 +2634,17 @@ abstract class DeletedShareapiIndexResponseApplicationJson
 sealed class $DeletedShareapiUndeleteResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeletedShareapiUndeleteResponseApplicationJson_OcsInterfaceBuilder].
+  $DeletedShareapiUndeleteResponseApplicationJson_OcsInterface rebuild(
+    void Function($DeletedShareapiUndeleteResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeletedShareapiUndeleteResponseApplicationJson_OcsInterfaceBuilder].
+  $DeletedShareapiUndeleteResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeletedShareapiUndeleteResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2647,6 +2698,17 @@ abstract class DeletedShareapiUndeleteResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DeletedShareapiUndeleteResponseApplicationJsonInterface {
   DeletedShareapiUndeleteResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeletedShareapiUndeleteResponseApplicationJsonInterfaceBuilder].
+  $DeletedShareapiUndeleteResponseApplicationJsonInterface rebuild(
+    void Function($DeletedShareapiUndeleteResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeletedShareapiUndeleteResponseApplicationJsonInterfaceBuilder].
+  $DeletedShareapiUndeleteResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeletedShareapiUndeleteResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2781,6 +2843,15 @@ sealed class $RemoteShareInterface {
   int get shareType;
   String? get type;
   String get user;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteShareInterfaceBuilder].
+  $RemoteShareInterface rebuild(void Function($RemoteShareInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$RemoteShareInterfaceBuilder].
+  $RemoteShareInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteShareInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2827,6 +2898,17 @@ abstract class RemoteShare implements $RemoteShareInterface, Built<RemoteShare, 
 sealed class $RemoteGetSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<RemoteShare> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteGetSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteGetSharesResponseApplicationJson_OcsInterface rebuild(
+    void Function($RemoteGetSharesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteGetSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteGetSharesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteGetSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2879,6 +2961,17 @@ abstract class RemoteGetSharesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RemoteGetSharesResponseApplicationJsonInterface {
   RemoteGetSharesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteGetSharesResponseApplicationJsonInterfaceBuilder].
+  $RemoteGetSharesResponseApplicationJsonInterface rebuild(
+    void Function($RemoteGetSharesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteGetSharesResponseApplicationJsonInterfaceBuilder].
+  $RemoteGetSharesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteGetSharesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2931,6 +3024,17 @@ abstract class RemoteGetSharesResponseApplicationJson
 sealed class $RemoteGetOpenSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<RemoteShare> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteGetOpenSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteGetOpenSharesResponseApplicationJson_OcsInterface rebuild(
+    void Function($RemoteGetOpenSharesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteGetOpenSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteGetOpenSharesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteGetOpenSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2983,6 +3087,17 @@ abstract class RemoteGetOpenSharesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RemoteGetOpenSharesResponseApplicationJsonInterface {
   RemoteGetOpenSharesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteGetOpenSharesResponseApplicationJsonInterfaceBuilder].
+  $RemoteGetOpenSharesResponseApplicationJsonInterface rebuild(
+    void Function($RemoteGetOpenSharesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteGetOpenSharesResponseApplicationJsonInterfaceBuilder].
+  $RemoteGetOpenSharesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteGetOpenSharesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3036,6 +3151,17 @@ abstract class RemoteGetOpenSharesResponseApplicationJson
 sealed class $RemoteAcceptShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteAcceptShareResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteAcceptShareResponseApplicationJson_OcsInterface rebuild(
+    void Function($RemoteAcceptShareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteAcceptShareResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteAcceptShareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteAcceptShareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3088,6 +3214,17 @@ abstract class RemoteAcceptShareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RemoteAcceptShareResponseApplicationJsonInterface {
   RemoteAcceptShareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteAcceptShareResponseApplicationJsonInterfaceBuilder].
+  $RemoteAcceptShareResponseApplicationJsonInterface rebuild(
+    void Function($RemoteAcceptShareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteAcceptShareResponseApplicationJsonInterfaceBuilder].
+  $RemoteAcceptShareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteAcceptShareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3141,6 +3278,17 @@ abstract class RemoteAcceptShareResponseApplicationJson
 sealed class $RemoteDeclineShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteDeclineShareResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteDeclineShareResponseApplicationJson_OcsInterface rebuild(
+    void Function($RemoteDeclineShareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteDeclineShareResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteDeclineShareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteDeclineShareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3193,6 +3341,17 @@ abstract class RemoteDeclineShareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RemoteDeclineShareResponseApplicationJsonInterface {
   RemoteDeclineShareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteDeclineShareResponseApplicationJsonInterfaceBuilder].
+  $RemoteDeclineShareResponseApplicationJsonInterface rebuild(
+    void Function($RemoteDeclineShareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteDeclineShareResponseApplicationJsonInterfaceBuilder].
+  $RemoteDeclineShareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteDeclineShareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3246,6 +3405,17 @@ abstract class RemoteDeclineShareResponseApplicationJson
 sealed class $RemoteGetShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   RemoteShare get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteGetShareResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteGetShareResponseApplicationJson_OcsInterface rebuild(
+    void Function($RemoteGetShareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteGetShareResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteGetShareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteGetShareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3298,6 +3468,17 @@ abstract class RemoteGetShareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RemoteGetShareResponseApplicationJsonInterface {
   RemoteGetShareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteGetShareResponseApplicationJsonInterfaceBuilder].
+  $RemoteGetShareResponseApplicationJsonInterface rebuild(
+    void Function($RemoteGetShareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteGetShareResponseApplicationJsonInterfaceBuilder].
+  $RemoteGetShareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteGetShareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3350,6 +3531,17 @@ abstract class RemoteGetShareResponseApplicationJson
 sealed class $RemoteUnshareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteUnshareResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteUnshareResponseApplicationJson_OcsInterface rebuild(
+    void Function($RemoteUnshareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteUnshareResponseApplicationJson_OcsInterfaceBuilder].
+  $RemoteUnshareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteUnshareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3402,6 +3594,17 @@ abstract class RemoteUnshareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RemoteUnshareResponseApplicationJsonInterface {
   RemoteUnshareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RemoteUnshareResponseApplicationJsonInterfaceBuilder].
+  $RemoteUnshareResponseApplicationJsonInterface rebuild(
+    void Function($RemoteUnshareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RemoteUnshareResponseApplicationJsonInterfaceBuilder].
+  $RemoteUnshareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RemoteUnshareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3462,6 +3665,15 @@ sealed class $ShareInfoInterface {
   String get type;
   String get etag;
   BuiltList<BuiltMap<String, JsonObject>>? get children;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareInfoInterfaceBuilder].
+  $ShareInfoInterface rebuild(void Function($ShareInfoInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareInfoInterfaceBuilder].
+  $ShareInfoInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareInfoInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3697,6 +3909,15 @@ sealed class $Share_StatusInterface {
   String? get icon;
   String? get message;
   String get status;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Share_StatusInterfaceBuilder].
+  $Share_StatusInterface rebuild(void Function($Share_StatusInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Share_StatusInterfaceBuilder].
+  $Share_StatusInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Share_StatusInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3808,6 +4029,15 @@ sealed class $ShareInterface {
   @BuiltValueField(wireName: 'uid_owner')
   String get uidOwner;
   String? get url;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareInterfaceBuilder].
+  $ShareInterface rebuild(void Function($ShareInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareInterfaceBuilder].
+  $ShareInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3854,6 +4084,17 @@ abstract class Share implements $ShareInterface, Built<Share, ShareBuilder> {
 sealed class $ShareapiGetSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Share> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiGetSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiGetSharesResponseApplicationJson_OcsInterface rebuild(
+    void Function($ShareapiGetSharesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiGetSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiGetSharesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiGetSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3906,6 +4147,17 @@ abstract class ShareapiGetSharesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ShareapiGetSharesResponseApplicationJsonInterface {
   ShareapiGetSharesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiGetSharesResponseApplicationJsonInterfaceBuilder].
+  $ShareapiGetSharesResponseApplicationJsonInterface rebuild(
+    void Function($ShareapiGetSharesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiGetSharesResponseApplicationJsonInterfaceBuilder].
+  $ShareapiGetSharesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiGetSharesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3959,6 +4211,17 @@ abstract class ShareapiGetSharesResponseApplicationJson
 sealed class $ShareapiCreateShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Share get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiCreateShareResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiCreateShareResponseApplicationJson_OcsInterface rebuild(
+    void Function($ShareapiCreateShareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiCreateShareResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiCreateShareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiCreateShareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4011,6 +4274,17 @@ abstract class ShareapiCreateShareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ShareapiCreateShareResponseApplicationJsonInterface {
   ShareapiCreateShareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiCreateShareResponseApplicationJsonInterfaceBuilder].
+  $ShareapiCreateShareResponseApplicationJsonInterface rebuild(
+    void Function($ShareapiCreateShareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiCreateShareResponseApplicationJsonInterfaceBuilder].
+  $ShareapiCreateShareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiCreateShareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4064,6 +4338,17 @@ abstract class ShareapiCreateShareResponseApplicationJson
 sealed class $ShareapiGetInheritedSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Share> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiGetInheritedSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiGetInheritedSharesResponseApplicationJson_OcsInterface rebuild(
+    void Function($ShareapiGetInheritedSharesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiGetInheritedSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiGetInheritedSharesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiGetInheritedSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4117,6 +4402,17 @@ abstract class ShareapiGetInheritedSharesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ShareapiGetInheritedSharesResponseApplicationJsonInterface {
   ShareapiGetInheritedSharesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiGetInheritedSharesResponseApplicationJsonInterfaceBuilder].
+  $ShareapiGetInheritedSharesResponseApplicationJsonInterface rebuild(
+    void Function($ShareapiGetInheritedSharesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiGetInheritedSharesResponseApplicationJsonInterfaceBuilder].
+  $ShareapiGetInheritedSharesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiGetInheritedSharesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4171,6 +4467,17 @@ abstract class ShareapiGetInheritedSharesResponseApplicationJson
 sealed class $ShareapiPendingSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Share> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiPendingSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiPendingSharesResponseApplicationJson_OcsInterface rebuild(
+    void Function($ShareapiPendingSharesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiPendingSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiPendingSharesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiPendingSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4224,6 +4531,17 @@ abstract class ShareapiPendingSharesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ShareapiPendingSharesResponseApplicationJsonInterface {
   ShareapiPendingSharesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiPendingSharesResponseApplicationJsonInterfaceBuilder].
+  $ShareapiPendingSharesResponseApplicationJsonInterface rebuild(
+    void Function($ShareapiPendingSharesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiPendingSharesResponseApplicationJsonInterfaceBuilder].
+  $ShareapiPendingSharesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiPendingSharesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4340,6 +4658,17 @@ class _$ShareapiGetShareIncludeTagsSerializer implements PrimitiveSerializer<Sha
 sealed class $ShareapiGetShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Share get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiGetShareResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiGetShareResponseApplicationJson_OcsInterface rebuild(
+    void Function($ShareapiGetShareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiGetShareResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiGetShareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiGetShareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4392,6 +4721,17 @@ abstract class ShareapiGetShareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ShareapiGetShareResponseApplicationJsonInterface {
   ShareapiGetShareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiGetShareResponseApplicationJsonInterfaceBuilder].
+  $ShareapiGetShareResponseApplicationJsonInterface rebuild(
+    void Function($ShareapiGetShareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiGetShareResponseApplicationJsonInterfaceBuilder].
+  $ShareapiGetShareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiGetShareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4444,6 +4784,17 @@ abstract class ShareapiGetShareResponseApplicationJson
 sealed class $ShareapiUpdateShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Share get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiUpdateShareResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiUpdateShareResponseApplicationJson_OcsInterface rebuild(
+    void Function($ShareapiUpdateShareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiUpdateShareResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiUpdateShareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiUpdateShareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4496,6 +4847,17 @@ abstract class ShareapiUpdateShareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ShareapiUpdateShareResponseApplicationJsonInterface {
   ShareapiUpdateShareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiUpdateShareResponseApplicationJsonInterfaceBuilder].
+  $ShareapiUpdateShareResponseApplicationJsonInterface rebuild(
+    void Function($ShareapiUpdateShareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiUpdateShareResponseApplicationJsonInterfaceBuilder].
+  $ShareapiUpdateShareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiUpdateShareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4549,6 +4911,17 @@ abstract class ShareapiUpdateShareResponseApplicationJson
 sealed class $ShareapiDeleteShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiDeleteShareResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiDeleteShareResponseApplicationJson_OcsInterface rebuild(
+    void Function($ShareapiDeleteShareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiDeleteShareResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiDeleteShareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiDeleteShareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4601,6 +4974,17 @@ abstract class ShareapiDeleteShareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ShareapiDeleteShareResponseApplicationJsonInterface {
   ShareapiDeleteShareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiDeleteShareResponseApplicationJsonInterfaceBuilder].
+  $ShareapiDeleteShareResponseApplicationJsonInterface rebuild(
+    void Function($ShareapiDeleteShareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiDeleteShareResponseApplicationJsonInterfaceBuilder].
+  $ShareapiDeleteShareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiDeleteShareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4654,6 +5038,17 @@ abstract class ShareapiDeleteShareResponseApplicationJson
 sealed class $ShareapiAcceptShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiAcceptShareResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiAcceptShareResponseApplicationJson_OcsInterface rebuild(
+    void Function($ShareapiAcceptShareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiAcceptShareResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareapiAcceptShareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiAcceptShareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4706,6 +5101,17 @@ abstract class ShareapiAcceptShareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ShareapiAcceptShareResponseApplicationJsonInterface {
   ShareapiAcceptShareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiAcceptShareResponseApplicationJsonInterfaceBuilder].
+  $ShareapiAcceptShareResponseApplicationJsonInterface rebuild(
+    void Function($ShareapiAcceptShareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiAcceptShareResponseApplicationJsonInterfaceBuilder].
+  $ShareapiAcceptShareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareapiAcceptShareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4824,6 +5230,15 @@ class _$ShareesapiSearchLookupSerializer implements PrimitiveSerializer<Shareesa
 sealed class $ShareeInterface {
   int? get count;
   String get label;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeInterfaceBuilder].
+  $ShareeInterface rebuild(void Function($ShareeInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeInterfaceBuilder].
+  $ShareeInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4870,6 +5285,15 @@ abstract class Sharee implements $ShareeInterface, Built<Sharee, ShareeBuilder> 
 sealed class $ShareeValueInterface {
   int get shareType;
   String get shareWith;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeValueInterfaceBuilder].
+  $ShareeValueInterface rebuild(void Function($ShareeValueInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeValueInterfaceBuilder].
+  $ShareeValueInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeValueInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4915,6 +5339,17 @@ abstract class ShareeValue implements $ShareeValueInterface, Built<ShareeValue, 
 @BuiltValue(instantiable: false)
 sealed class $ShareeCircle_ValueInterface implements $ShareeValueInterface {
   String get circle;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeCircle_ValueInterfaceBuilder].
+  @override
+  $ShareeCircle_ValueInterface rebuild(void Function($ShareeCircle_ValueInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeCircle_ValueInterfaceBuilder].
+  @override
+  $ShareeCircle_ValueInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeCircle_ValueInterfaceBuilder b) {
     $ShareeValueInterface._defaults(b);
@@ -4968,6 +5403,17 @@ abstract class ShareeCircle_Value
 sealed class $ShareeCircleInterface implements $ShareeInterface {
   String get shareWithDescription;
   ShareeCircle_Value get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeCircleInterfaceBuilder].
+  @override
+  $ShareeCircleInterface rebuild(void Function($ShareeCircleInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeCircleInterfaceBuilder].
+  @override
+  $ShareeCircleInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeCircleInterfaceBuilder b) {
     $ShareeInterface._defaults(b);
@@ -5022,6 +5468,17 @@ sealed class $ShareeEmailInterface implements $ShareeInterface {
   String get type;
   String get shareWithDisplayNameUnique;
   ShareeValue get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeEmailInterfaceBuilder].
+  @override
+  $ShareeEmailInterface rebuild(void Function($ShareeEmailInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeEmailInterfaceBuilder].
+  @override
+  $ShareeEmailInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeEmailInterfaceBuilder b) {
     $ShareeInterface._defaults(b);
@@ -5072,6 +5529,17 @@ abstract class ShareeEmail implements $ShareeEmailInterface, Built<ShareeEmail, 
 @BuiltValue(instantiable: false)
 sealed class $ShareeRemoteGroup_ValueInterface implements $ShareeValueInterface {
   String get server;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeRemoteGroup_ValueInterfaceBuilder].
+  @override
+  $ShareeRemoteGroup_ValueInterface rebuild(void Function($ShareeRemoteGroup_ValueInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeRemoteGroup_ValueInterfaceBuilder].
+  @override
+  $ShareeRemoteGroup_ValueInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeRemoteGroup_ValueInterfaceBuilder b) {
     $ShareeValueInterface._defaults(b);
@@ -5126,6 +5594,17 @@ sealed class $ShareeRemoteGroupInterface implements $ShareeInterface {
   String get guid;
   String get name;
   ShareeRemoteGroup_Value get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeRemoteGroupInterfaceBuilder].
+  @override
+  $ShareeRemoteGroupInterface rebuild(void Function($ShareeRemoteGroupInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeRemoteGroupInterfaceBuilder].
+  @override
+  $ShareeRemoteGroupInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeRemoteGroupInterfaceBuilder b) {
     $ShareeInterface._defaults(b);
@@ -5177,6 +5656,17 @@ abstract class ShareeRemoteGroup
 @BuiltValue(instantiable: false)
 sealed class $ShareeRemote_ValueInterface implements $ShareeValueInterface {
   String get server;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeRemote_ValueInterfaceBuilder].
+  @override
+  $ShareeRemote_ValueInterface rebuild(void Function($ShareeRemote_ValueInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeRemote_ValueInterfaceBuilder].
+  @override
+  $ShareeRemote_ValueInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeRemote_ValueInterfaceBuilder b) {
     $ShareeValueInterface._defaults(b);
@@ -5232,6 +5722,17 @@ sealed class $ShareeRemoteInterface implements $ShareeInterface {
   String get name;
   String get type;
   ShareeRemote_Value get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeRemoteInterfaceBuilder].
+  @override
+  $ShareeRemoteInterface rebuild(void Function($ShareeRemoteInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeRemoteInterfaceBuilder].
+  @override
+  $ShareeRemoteInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeRemoteInterfaceBuilder b) {
     $ShareeInterface._defaults(b);
@@ -5285,6 +5786,15 @@ sealed class $ShareeUser_StatusInterface {
   String get message;
   String get icon;
   int? get clearAt;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeUser_StatusInterfaceBuilder].
+  $ShareeUser_StatusInterface rebuild(void Function($ShareeUser_StatusInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeUser_StatusInterfaceBuilder].
+  $ShareeUser_StatusInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeUser_StatusInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5335,6 +5845,17 @@ sealed class $ShareeUserInterface implements $ShareeInterface {
   String get shareWithDisplayNameUnique;
   ShareeUser_Status get status;
   ShareeValue get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeUserInterfaceBuilder].
+  @override
+  $ShareeUserInterface rebuild(void Function($ShareeUserInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeUserInterfaceBuilder].
+  @override
+  $ShareeUserInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeUserInterfaceBuilder b) {
     $ShareeInterface._defaults(b);
@@ -5392,6 +5913,15 @@ sealed class $ShareesSearchResult_ExactInterface {
   BuiltList<ShareeRemote> get remotes;
   BuiltList<Sharee> get rooms;
   BuiltList<ShareeUser> get users;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesSearchResult_ExactInterfaceBuilder].
+  $ShareesSearchResult_ExactInterface rebuild(void Function($ShareesSearchResult_ExactInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareesSearchResult_ExactInterfaceBuilder].
+  $ShareesSearchResult_ExactInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareesSearchResult_ExactInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5440,6 +5970,15 @@ abstract class ShareesSearchResult_Exact
 sealed class $LookupInterface {
   String get value;
   int get verified;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$LookupInterfaceBuilder].
+  $LookupInterface rebuild(void Function($LookupInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$LookupInterfaceBuilder].
+  $LookupInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($LookupInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5496,6 +6035,15 @@ sealed class $ShareeLookup_ExtraInterface {
   @BuiltValueField(wireName: 'website_signature')
   Lookup? get websiteSignature;
   Lookup? get userid;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeLookup_ExtraInterfaceBuilder].
+  $ShareeLookup_ExtraInterface rebuild(void Function($ShareeLookup_ExtraInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeLookup_ExtraInterfaceBuilder].
+  $ShareeLookup_ExtraInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeLookup_ExtraInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5543,6 +6091,17 @@ abstract class ShareeLookup_Extra
 @BuiltValue(instantiable: false)
 sealed class $ShareeLookup_ValueInterface implements $ShareeValueInterface {
   bool get globalScale;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeLookup_ValueInterfaceBuilder].
+  @override
+  $ShareeLookup_ValueInterface rebuild(void Function($ShareeLookup_ValueInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeLookup_ValueInterfaceBuilder].
+  @override
+  $ShareeLookup_ValueInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeLookup_ValueInterfaceBuilder b) {
     $ShareeValueInterface._defaults(b);
@@ -5596,6 +6155,17 @@ abstract class ShareeLookup_Value
 sealed class $ShareeLookupInterface implements $ShareeInterface {
   ShareeLookup_Extra get extra;
   ShareeLookup_Value get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareeLookupInterfaceBuilder].
+  @override
+  $ShareeLookupInterface rebuild(void Function($ShareeLookupInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareeLookupInterfaceBuilder].
+  @override
+  $ShareeLookupInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareeLookupInterfaceBuilder b) {
     $ShareeInterface._defaults(b);
@@ -5656,6 +6226,15 @@ sealed class $ShareesSearchResultInterface {
   BuiltList<Sharee> get rooms;
   BuiltList<ShareeUser> get users;
   bool get lookupEnabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesSearchResultInterfaceBuilder].
+  $ShareesSearchResultInterface rebuild(void Function($ShareesSearchResultInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareesSearchResultInterfaceBuilder].
+  $ShareesSearchResultInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareesSearchResultInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5704,6 +6283,17 @@ abstract class ShareesSearchResult
 sealed class $ShareesapiSearchResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ShareesSearchResult get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesapiSearchResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareesapiSearchResponseApplicationJson_OcsInterface rebuild(
+    void Function($ShareesapiSearchResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareesapiSearchResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareesapiSearchResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareesapiSearchResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5756,6 +6346,17 @@ abstract class ShareesapiSearchResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ShareesapiSearchResponseApplicationJsonInterface {
   ShareesapiSearchResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesapiSearchResponseApplicationJsonInterfaceBuilder].
+  $ShareesapiSearchResponseApplicationJsonInterface rebuild(
+    void Function($ShareesapiSearchResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareesapiSearchResponseApplicationJsonInterfaceBuilder].
+  $ShareesapiSearchResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareesapiSearchResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5807,6 +6408,17 @@ abstract class ShareesapiSearchResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $ShareesapiShareesapiSearchHeadersInterface {
   String? get link;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesapiShareesapiSearchHeadersInterfaceBuilder].
+  $ShareesapiShareesapiSearchHeadersInterface rebuild(
+    void Function($ShareesapiShareesapiSearchHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareesapiShareesapiSearchHeadersInterfaceBuilder].
+  $ShareesapiShareesapiSearchHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareesapiShareesapiSearchHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5864,6 +6476,17 @@ sealed class $ShareesRecommendedResult_ExactInterface {
   BuiltList<ShareeRemoteGroup> get remoteGroups;
   BuiltList<ShareeRemote> get remotes;
   BuiltList<ShareeUser> get users;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesRecommendedResult_ExactInterfaceBuilder].
+  $ShareesRecommendedResult_ExactInterface rebuild(
+    void Function($ShareesRecommendedResult_ExactInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareesRecommendedResult_ExactInterfaceBuilder].
+  $ShareesRecommendedResult_ExactInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareesRecommendedResult_ExactInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5920,6 +6543,15 @@ sealed class $ShareesRecommendedResultInterface {
   BuiltList<ShareeRemoteGroup> get remoteGroups;
   BuiltList<ShareeRemote> get remotes;
   BuiltList<ShareeUser> get users;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesRecommendedResultInterfaceBuilder].
+  $ShareesRecommendedResultInterface rebuild(void Function($ShareesRecommendedResultInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ShareesRecommendedResultInterfaceBuilder].
+  $ShareesRecommendedResultInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareesRecommendedResultInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5968,6 +6600,17 @@ abstract class ShareesRecommendedResult
 sealed class $ShareesapiFindRecommendedResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ShareesRecommendedResult get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesapiFindRecommendedResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareesapiFindRecommendedResponseApplicationJson_OcsInterface rebuild(
+    void Function($ShareesapiFindRecommendedResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareesapiFindRecommendedResponseApplicationJson_OcsInterfaceBuilder].
+  $ShareesapiFindRecommendedResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareesapiFindRecommendedResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6021,6 +6664,17 @@ abstract class ShareesapiFindRecommendedResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ShareesapiFindRecommendedResponseApplicationJsonInterface {
   ShareesapiFindRecommendedResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesapiFindRecommendedResponseApplicationJsonInterfaceBuilder].
+  $ShareesapiFindRecommendedResponseApplicationJsonInterface rebuild(
+    void Function($ShareesapiFindRecommendedResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareesapiFindRecommendedResponseApplicationJsonInterfaceBuilder].
+  $ShareesapiFindRecommendedResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ShareesapiFindRecommendedResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6075,6 +6729,17 @@ abstract class ShareesapiFindRecommendedResponseApplicationJson
 sealed class $Capabilities_FilesSharing_Public_PasswordInterface {
   bool get enforced;
   bool get askForOptionalPassword;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_Public_PasswordInterfaceBuilder].
+  $Capabilities_FilesSharing_Public_PasswordInterface rebuild(
+    void Function($Capabilities_FilesSharing_Public_PasswordInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_Public_PasswordInterfaceBuilder].
+  $Capabilities_FilesSharing_Public_PasswordInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_Public_PasswordInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6129,6 +6794,17 @@ sealed class $Capabilities_FilesSharing_Public_ExpireDateInterface {
   bool get enabled;
   int? get days;
   bool? get enforced;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_Public_ExpireDateInterfaceBuilder].
+  $Capabilities_FilesSharing_Public_ExpireDateInterface rebuild(
+    void Function($Capabilities_FilesSharing_Public_ExpireDateInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_Public_ExpireDateInterfaceBuilder].
+  $Capabilities_FilesSharing_Public_ExpireDateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_Public_ExpireDateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6183,6 +6859,17 @@ sealed class $Capabilities_FilesSharing_Public_ExpireDateInternalInterface {
   bool get enabled;
   int? get days;
   bool? get enforced;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder].
+  $Capabilities_FilesSharing_Public_ExpireDateInternalInterface rebuild(
+    void Function($Capabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder].
+  $Capabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_Public_ExpireDateInternalInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6238,6 +6925,17 @@ sealed class $Capabilities_FilesSharing_Public_ExpireDateRemoteInterface {
   bool get enabled;
   int? get days;
   bool? get enforced;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder].
+  $Capabilities_FilesSharing_Public_ExpireDateRemoteInterface rebuild(
+    void Function($Capabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder].
+  $Capabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_Public_ExpireDateRemoteInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6305,6 +7003,17 @@ sealed class $Capabilities_FilesSharing_PublicInterface {
   bool? get upload;
   @BuiltValueField(wireName: 'upload_files_drop')
   bool? get uploadFilesDrop;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_PublicInterfaceBuilder].
+  $Capabilities_FilesSharing_PublicInterface rebuild(
+    void Function($Capabilities_FilesSharing_PublicInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_PublicInterfaceBuilder].
+  $Capabilities_FilesSharing_PublicInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_PublicInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6355,6 +7064,17 @@ abstract class Capabilities_FilesSharing_Public
 @BuiltValue(instantiable: false)
 sealed class $Capabilities_FilesSharing_User_ExpireDateInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_User_ExpireDateInterfaceBuilder].
+  $Capabilities_FilesSharing_User_ExpireDateInterface rebuild(
+    void Function($Capabilities_FilesSharing_User_ExpireDateInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_User_ExpireDateInterfaceBuilder].
+  $Capabilities_FilesSharing_User_ExpireDateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_User_ExpireDateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6410,6 +7130,17 @@ sealed class $Capabilities_FilesSharing_UserInterface {
   bool get sendMail;
   @BuiltValueField(wireName: 'expire_date')
   Capabilities_FilesSharing_User_ExpireDate? get expireDate;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_UserInterfaceBuilder].
+  $Capabilities_FilesSharing_UserInterface rebuild(
+    void Function($Capabilities_FilesSharing_UserInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_UserInterfaceBuilder].
+  $Capabilities_FilesSharing_UserInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_UserInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6460,6 +7191,17 @@ abstract class Capabilities_FilesSharing_User
 @BuiltValue(instantiable: false)
 sealed class $Capabilities_FilesSharing_Group_ExpireDateInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_Group_ExpireDateInterfaceBuilder].
+  $Capabilities_FilesSharing_Group_ExpireDateInterface rebuild(
+    void Function($Capabilities_FilesSharing_Group_ExpireDateInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_Group_ExpireDateInterfaceBuilder].
+  $Capabilities_FilesSharing_Group_ExpireDateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_Group_ExpireDateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6514,6 +7256,17 @@ sealed class $Capabilities_FilesSharing_GroupInterface {
   bool get enabled;
   @BuiltValueField(wireName: 'expire_date')
   Capabilities_FilesSharing_Group_ExpireDate? get expireDate;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_GroupInterfaceBuilder].
+  $Capabilities_FilesSharing_GroupInterface rebuild(
+    void Function($Capabilities_FilesSharing_GroupInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_GroupInterfaceBuilder].
+  $Capabilities_FilesSharing_GroupInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_GroupInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6564,6 +7317,17 @@ abstract class Capabilities_FilesSharing_Group
 @BuiltValue(instantiable: false)
 sealed class $Capabilities_FilesSharing_Federation_ExpireDateInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder].
+  $Capabilities_FilesSharing_Federation_ExpireDateInterface rebuild(
+    void Function($Capabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder].
+  $Capabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_Federation_ExpireDateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6616,6 +7380,17 @@ abstract class Capabilities_FilesSharing_Federation_ExpireDate
 @BuiltValue(instantiable: false)
 sealed class $Capabilities_FilesSharing_Federation_ExpireDateSupportedInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder].
+  $Capabilities_FilesSharing_Federation_ExpireDateSupportedInterface rebuild(
+    void Function($Capabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder].
+  $Capabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_Federation_ExpireDateSupportedInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6674,6 +7449,17 @@ sealed class $Capabilities_FilesSharing_FederationInterface {
   Capabilities_FilesSharing_Federation_ExpireDate get expireDate;
   @BuiltValueField(wireName: 'expire_date_supported')
   Capabilities_FilesSharing_Federation_ExpireDateSupported get expireDateSupported;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_FederationInterfaceBuilder].
+  $Capabilities_FilesSharing_FederationInterface rebuild(
+    void Function($Capabilities_FilesSharing_FederationInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_FederationInterfaceBuilder].
+  $Capabilities_FilesSharing_FederationInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_FederationInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6728,6 +7514,17 @@ sealed class $Capabilities_FilesSharing_ShareeInterface {
   bool get queryLookupDefault;
   @BuiltValueField(wireName: 'always_show_unique')
   bool get alwaysShowUnique;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharing_ShareeInterfaceBuilder].
+  $Capabilities_FilesSharing_ShareeInterface rebuild(
+    void Function($Capabilities_FilesSharing_ShareeInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharing_ShareeInterfaceBuilder].
+  $Capabilities_FilesSharing_ShareeInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharing_ShareeInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6789,6 +7586,15 @@ sealed class $Capabilities_FilesSharingInterface {
   int? get defaultPermissions;
   Capabilities_FilesSharing_Federation get federation;
   Capabilities_FilesSharing_Sharee get sharee;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesSharingInterfaceBuilder].
+  $Capabilities_FilesSharingInterface rebuild(void Function($Capabilities_FilesSharingInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_FilesSharingInterfaceBuilder].
+  $Capabilities_FilesSharingInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesSharingInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6837,6 +7643,15 @@ abstract class Capabilities_FilesSharing
 sealed class $CapabilitiesInterface {
   @BuiltValueField(wireName: 'files_sharing')
   Capabilities_FilesSharing get filesSharing;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -237,6 +237,15 @@ class _$PreviewGetPreviewASerializer implements PrimitiveSerializer<PreviewGetPr
 @BuiltValue(instantiable: false)
 sealed class $Capabilities_FilesInterface {
   bool get undelete;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesInterfaceBuilder].
+  $Capabilities_FilesInterface rebuild(void Function($Capabilities_FilesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_FilesInterfaceBuilder].
+  $Capabilities_FilesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -284,6 +293,15 @@ abstract class Capabilities_Files
 @BuiltValue(instantiable: false)
 sealed class $CapabilitiesInterface {
   Capabilities_Files get files;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.dart
@@ -177,6 +177,15 @@ sealed class $Capabilities_FilesInterface {
   bool get versionLabeling;
   @BuiltValueField(wireName: 'version_deletion')
   bool get versionDeletion;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_FilesInterfaceBuilder].
+  $Capabilities_FilesInterface rebuild(void Function($Capabilities_FilesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_FilesInterfaceBuilder].
+  $Capabilities_FilesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_FilesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -224,6 +233,15 @@ abstract class Capabilities_Files
 @BuiltValue(instantiable: false)
 sealed class $CapabilitiesInterface {
   Capabilities_Files get files;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/news.openapi.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.dart
@@ -1441,6 +1441,15 @@ class $Client extends _i1.DynamiteClient {
 @BuiltValue(instantiable: false)
 sealed class $SupportedAPIVersionsInterface {
   BuiltList<String>? get apiLevels;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SupportedAPIVersionsInterfaceBuilder].
+  $SupportedAPIVersionsInterface rebuild(void Function($SupportedAPIVersionsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SupportedAPIVersionsInterfaceBuilder].
+  $SupportedAPIVersionsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SupportedAPIVersionsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1507,6 +1516,15 @@ sealed class $ArticleInterface {
   bool get rtl;
   String get fingerprint;
   String get contentHash;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ArticleInterfaceBuilder].
+  $ArticleInterface rebuild(void Function($ArticleInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ArticleInterfaceBuilder].
+  $ArticleInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ArticleInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1564,6 +1582,15 @@ sealed class $FeedInterface {
   int get updateErrorCount;
   String? get lastUpdateError;
   BuiltList<Article> get items;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FeedInterfaceBuilder].
+  $FeedInterface rebuild(void Function($FeedInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$FeedInterfaceBuilder].
+  $FeedInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FeedInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1615,6 +1642,15 @@ sealed class $FolderInterface {
   /// This seems to be broken. In testing it is always empty.
   @Deprecated('')
   BuiltList<Feed> get feeds;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FolderInterfaceBuilder].
+  $FolderInterface rebuild(void Function($FolderInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$FolderInterfaceBuilder].
+  $FolderInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FolderInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1660,6 +1696,15 @@ abstract class Folder implements $FolderInterface, Built<Folder, FolderBuilder> 
 @BuiltValue(instantiable: false)
 sealed class $ListFoldersInterface {
   BuiltList<Folder> get folders;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ListFoldersInterfaceBuilder].
+  $ListFoldersInterface rebuild(void Function($ListFoldersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ListFoldersInterfaceBuilder].
+  $ListFoldersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ListFoldersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1707,6 +1752,15 @@ sealed class $ListFeedsInterface {
   int? get starredCount;
   int? get newestItemId;
   BuiltList<Feed> get feeds;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ListFeedsInterfaceBuilder].
+  $ListFeedsInterface rebuild(void Function($ListFeedsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ListFeedsInterfaceBuilder].
+  $ListFeedsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ListFeedsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1752,6 +1806,15 @@ abstract class ListFeeds implements $ListFeedsInterface, Built<ListFeeds, ListFe
 @BuiltValue(instantiable: false)
 sealed class $ListArticlesInterface {
   BuiltList<Article> get items;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ListArticlesInterfaceBuilder].
+  $ListArticlesInterface rebuild(void Function($ListArticlesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ListArticlesInterfaceBuilder].
+  $ListArticlesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ListArticlesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1801,6 +1864,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1847,6 +1919,15 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 sealed class $EmptyOCS_OcsInterface {
   OCSMeta get meta;
   BuiltList<JsonObject> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EmptyOCS_OcsInterfaceBuilder].
+  $EmptyOCS_OcsInterface rebuild(void Function($EmptyOCS_OcsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$EmptyOCS_OcsInterfaceBuilder].
+  $EmptyOCS_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EmptyOCS_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1892,6 +1973,15 @@ abstract class EmptyOCS_Ocs implements $EmptyOCS_OcsInterface, Built<EmptyOCS_Oc
 @BuiltValue(instantiable: false)
 sealed class $EmptyOCSInterface {
   EmptyOCS_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EmptyOCSInterfaceBuilder].
+  $EmptyOCSInterface rebuild(void Function($EmptyOCSInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$EmptyOCSInterfaceBuilder].
+  $EmptyOCSInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EmptyOCSInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/notes.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.dart
@@ -723,6 +723,15 @@ sealed class $NoteInterface {
   int get modified;
   bool get error;
   String get errorType;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NoteInterfaceBuilder].
+  $NoteInterface rebuild(void Function($NoteInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$NoteInterfaceBuilder].
+  $NoteInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NoteInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -836,6 +845,15 @@ sealed class $SettingsInterface {
   String get notesPath;
   String get fileSuffix;
   Settings_NoteMode get noteMode;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsInterfaceBuilder].
+  $SettingsInterface rebuild(void Function($SettingsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SettingsInterfaceBuilder].
+  $SettingsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SettingsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -883,6 +901,15 @@ sealed class $Capabilities_NotesInterface {
   @BuiltValueField(wireName: 'api_version')
   BuiltList<String>? get apiVersion;
   String? get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_NotesInterfaceBuilder].
+  $Capabilities_NotesInterface rebuild(void Function($Capabilities_NotesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_NotesInterfaceBuilder].
+  $Capabilities_NotesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_NotesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -930,6 +957,15 @@ abstract class Capabilities_Notes
 @BuiltValue(instantiable: false)
 sealed class $CapabilitiesInterface {
   Capabilities_Notes get notes;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -979,6 +1015,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1025,6 +1070,15 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 sealed class $EmptyOCS_OcsInterface {
   OCSMeta get meta;
   BuiltList<JsonObject> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EmptyOCS_OcsInterfaceBuilder].
+  $EmptyOCS_OcsInterface rebuild(void Function($EmptyOCS_OcsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$EmptyOCS_OcsInterfaceBuilder].
+  $EmptyOCS_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EmptyOCS_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1070,6 +1124,15 @@ abstract class EmptyOCS_Ocs implements $EmptyOCS_OcsInterface, Built<EmptyOCS_Oc
 @BuiltValue(instantiable: false)
 sealed class $EmptyOCSInterface {
   EmptyOCS_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EmptyOCSInterfaceBuilder].
+  $EmptyOCSInterface rebuild(void Function($EmptyOCSInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$EmptyOCSInterfaceBuilder].
+  $EmptyOCSInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EmptyOCSInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/notifications.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.dart
@@ -1280,6 +1280,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1326,6 +1335,17 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 sealed class $ApiGenerateNotificationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGenerateNotificationResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiGenerateNotificationResponseApplicationJson_OcsInterface rebuild(
+    void Function($ApiGenerateNotificationResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGenerateNotificationResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiGenerateNotificationResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGenerateNotificationResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1379,6 +1399,17 @@ abstract class ApiGenerateNotificationResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ApiGenerateNotificationResponseApplicationJsonInterface {
   ApiGenerateNotificationResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGenerateNotificationResponseApplicationJsonInterfaceBuilder].
+  $ApiGenerateNotificationResponseApplicationJsonInterface rebuild(
+    void Function($ApiGenerateNotificationResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGenerateNotificationResponseApplicationJsonInterfaceBuilder].
+  $ApiGenerateNotificationResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGenerateNotificationResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1498,6 +1529,15 @@ sealed class $NotificationActionInterface {
   String get link;
   String get type;
   bool get primary;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NotificationActionInterfaceBuilder].
+  $NotificationActionInterface rebuild(void Function($NotificationActionInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$NotificationActionInterfaceBuilder].
+  $NotificationActionInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NotificationActionInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1563,6 +1603,15 @@ sealed class $NotificationInterface {
   BuiltMap<String, JsonObject>? get messageRichParameters;
   String? get icon;
   bool? get shouldNotify;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NotificationInterfaceBuilder].
+  $NotificationInterface rebuild(void Function($NotificationInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$NotificationInterfaceBuilder].
+  $NotificationInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($NotificationInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1609,6 +1658,17 @@ abstract class Notification implements $NotificationInterface, Built<Notificatio
 sealed class $EndpointListNotificationsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Notification> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointListNotificationsResponseApplicationJson_OcsInterfaceBuilder].
+  $EndpointListNotificationsResponseApplicationJson_OcsInterface rebuild(
+    void Function($EndpointListNotificationsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointListNotificationsResponseApplicationJson_OcsInterfaceBuilder].
+  $EndpointListNotificationsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointListNotificationsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1662,6 +1722,17 @@ abstract class EndpointListNotificationsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $EndpointListNotificationsResponseApplicationJsonInterface {
   EndpointListNotificationsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointListNotificationsResponseApplicationJsonInterfaceBuilder].
+  $EndpointListNotificationsResponseApplicationJsonInterface rebuild(
+    void Function($EndpointListNotificationsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointListNotificationsResponseApplicationJsonInterfaceBuilder].
+  $EndpointListNotificationsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointListNotificationsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1716,6 +1787,17 @@ abstract class EndpointListNotificationsResponseApplicationJson
 sealed class $EndpointEndpointListNotificationsHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-user-status')
   String? get xNextcloudUserStatus;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointEndpointListNotificationsHeadersInterfaceBuilder].
+  $EndpointEndpointListNotificationsHeadersInterface rebuild(
+    void Function($EndpointEndpointListNotificationsHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointEndpointListNotificationsHeadersInterfaceBuilder].
+  $EndpointEndpointListNotificationsHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointEndpointListNotificationsHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1836,6 +1918,17 @@ class _$EndpointDeleteAllNotificationsApiVersionSerializer
 sealed class $EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterfaceBuilder].
+  $EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterface rebuild(
+    void Function($EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterfaceBuilder].
+  $EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointDeleteAllNotificationsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1889,6 +1982,17 @@ abstract class EndpointDeleteAllNotificationsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $EndpointDeleteAllNotificationsResponseApplicationJsonInterface {
   EndpointDeleteAllNotificationsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointDeleteAllNotificationsResponseApplicationJsonInterfaceBuilder].
+  $EndpointDeleteAllNotificationsResponseApplicationJsonInterface rebuild(
+    void Function($EndpointDeleteAllNotificationsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointDeleteAllNotificationsResponseApplicationJsonInterfaceBuilder].
+  $EndpointDeleteAllNotificationsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointDeleteAllNotificationsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2005,6 +2109,17 @@ class _$EndpointGetNotificationApiVersionSerializer implements PrimitiveSerializ
 sealed class $EndpointGetNotificationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Notification get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointGetNotificationResponseApplicationJson_OcsInterfaceBuilder].
+  $EndpointGetNotificationResponseApplicationJson_OcsInterface rebuild(
+    void Function($EndpointGetNotificationResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointGetNotificationResponseApplicationJson_OcsInterfaceBuilder].
+  $EndpointGetNotificationResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointGetNotificationResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2058,6 +2173,17 @@ abstract class EndpointGetNotificationResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $EndpointGetNotificationResponseApplicationJsonInterface {
   EndpointGetNotificationResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointGetNotificationResponseApplicationJsonInterfaceBuilder].
+  $EndpointGetNotificationResponseApplicationJsonInterface rebuild(
+    void Function($EndpointGetNotificationResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointGetNotificationResponseApplicationJsonInterfaceBuilder].
+  $EndpointGetNotificationResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointGetNotificationResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2177,6 +2303,17 @@ class _$EndpointDeleteNotificationApiVersionSerializer
 sealed class $EndpointDeleteNotificationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointDeleteNotificationResponseApplicationJson_OcsInterfaceBuilder].
+  $EndpointDeleteNotificationResponseApplicationJson_OcsInterface rebuild(
+    void Function($EndpointDeleteNotificationResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointDeleteNotificationResponseApplicationJson_OcsInterfaceBuilder].
+  $EndpointDeleteNotificationResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointDeleteNotificationResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2230,6 +2367,17 @@ abstract class EndpointDeleteNotificationResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $EndpointDeleteNotificationResponseApplicationJsonInterface {
   EndpointDeleteNotificationResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointDeleteNotificationResponseApplicationJsonInterfaceBuilder].
+  $EndpointDeleteNotificationResponseApplicationJsonInterface rebuild(
+    void Function($EndpointDeleteNotificationResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointDeleteNotificationResponseApplicationJsonInterfaceBuilder].
+  $EndpointDeleteNotificationResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointDeleteNotificationResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2348,6 +2496,17 @@ class _$EndpointConfirmIdsForUserApiVersionSerializer
 sealed class $EndpointConfirmIdsForUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<int> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointConfirmIdsForUserResponseApplicationJson_OcsInterfaceBuilder].
+  $EndpointConfirmIdsForUserResponseApplicationJson_OcsInterface rebuild(
+    void Function($EndpointConfirmIdsForUserResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointConfirmIdsForUserResponseApplicationJson_OcsInterfaceBuilder].
+  $EndpointConfirmIdsForUserResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointConfirmIdsForUserResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2401,6 +2560,17 @@ abstract class EndpointConfirmIdsForUserResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $EndpointConfirmIdsForUserResponseApplicationJsonInterface {
   EndpointConfirmIdsForUserResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointConfirmIdsForUserResponseApplicationJsonInterfaceBuilder].
+  $EndpointConfirmIdsForUserResponseApplicationJsonInterface rebuild(
+    void Function($EndpointConfirmIdsForUserResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointConfirmIdsForUserResponseApplicationJsonInterfaceBuilder].
+  $EndpointConfirmIdsForUserResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($EndpointConfirmIdsForUserResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2512,6 +2682,15 @@ sealed class $PushDeviceInterface {
   String get publicKey;
   String get deviceIdentifier;
   String get signature;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PushDeviceInterfaceBuilder].
+  $PushDeviceInterface rebuild(void Function($PushDeviceInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PushDeviceInterfaceBuilder].
+  $PushDeviceInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PushDeviceInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2558,6 +2737,17 @@ abstract class PushDevice implements $PushDeviceInterface, Built<PushDevice, Pus
 sealed class $PushRegisterDeviceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   PushDevice get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PushRegisterDeviceResponseApplicationJson_OcsInterfaceBuilder].
+  $PushRegisterDeviceResponseApplicationJson_OcsInterface rebuild(
+    void Function($PushRegisterDeviceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PushRegisterDeviceResponseApplicationJson_OcsInterfaceBuilder].
+  $PushRegisterDeviceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PushRegisterDeviceResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2610,6 +2800,17 @@ abstract class PushRegisterDeviceResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PushRegisterDeviceResponseApplicationJsonInterface {
   PushRegisterDeviceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PushRegisterDeviceResponseApplicationJsonInterfaceBuilder].
+  $PushRegisterDeviceResponseApplicationJsonInterface rebuild(
+    void Function($PushRegisterDeviceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PushRegisterDeviceResponseApplicationJsonInterfaceBuilder].
+  $PushRegisterDeviceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PushRegisterDeviceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2719,6 +2920,17 @@ class _$PushRemoveDeviceApiVersionSerializer implements PrimitiveSerializer<Push
 sealed class $PushRemoveDeviceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PushRemoveDeviceResponseApplicationJson_OcsInterfaceBuilder].
+  $PushRemoveDeviceResponseApplicationJson_OcsInterface rebuild(
+    void Function($PushRemoveDeviceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PushRemoveDeviceResponseApplicationJson_OcsInterfaceBuilder].
+  $PushRemoveDeviceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PushRemoveDeviceResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2771,6 +2983,17 @@ abstract class PushRemoveDeviceResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PushRemoveDeviceResponseApplicationJsonInterface {
   PushRemoveDeviceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PushRemoveDeviceResponseApplicationJsonInterfaceBuilder].
+  $PushRemoveDeviceResponseApplicationJsonInterface rebuild(
+    void Function($PushRemoveDeviceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PushRemoveDeviceResponseApplicationJsonInterfaceBuilder].
+  $PushRemoveDeviceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PushRemoveDeviceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2879,6 +3102,17 @@ class _$SettingsPersonalApiVersionSerializer implements PrimitiveSerializer<Sett
 sealed class $SettingsPersonalResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsPersonalResponseApplicationJson_OcsInterfaceBuilder].
+  $SettingsPersonalResponseApplicationJson_OcsInterface rebuild(
+    void Function($SettingsPersonalResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsPersonalResponseApplicationJson_OcsInterfaceBuilder].
+  $SettingsPersonalResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SettingsPersonalResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2931,6 +3165,17 @@ abstract class SettingsPersonalResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $SettingsPersonalResponseApplicationJsonInterface {
   SettingsPersonalResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsPersonalResponseApplicationJsonInterfaceBuilder].
+  $SettingsPersonalResponseApplicationJsonInterface rebuild(
+    void Function($SettingsPersonalResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsPersonalResponseApplicationJsonInterfaceBuilder].
+  $SettingsPersonalResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SettingsPersonalResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3039,6 +3284,17 @@ class _$SettingsAdminApiVersionSerializer implements PrimitiveSerializer<Setting
 sealed class $SettingsAdminResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsAdminResponseApplicationJson_OcsInterfaceBuilder].
+  $SettingsAdminResponseApplicationJson_OcsInterface rebuild(
+    void Function($SettingsAdminResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsAdminResponseApplicationJson_OcsInterfaceBuilder].
+  $SettingsAdminResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SettingsAdminResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3091,6 +3347,17 @@ abstract class SettingsAdminResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $SettingsAdminResponseApplicationJsonInterface {
   SettingsAdminResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsAdminResponseApplicationJsonInterfaceBuilder].
+  $SettingsAdminResponseApplicationJsonInterface rebuild(
+    void Function($SettingsAdminResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsAdminResponseApplicationJsonInterfaceBuilder].
+  $SettingsAdminResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SettingsAdminResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3146,6 +3413,15 @@ sealed class $Capabilities_NotificationsInterface {
   BuiltList<String> get push;
   @BuiltValueField(wireName: 'admin-notifications')
   BuiltList<String> get adminNotifications;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_NotificationsInterfaceBuilder].
+  $Capabilities_NotificationsInterface rebuild(void Function($Capabilities_NotificationsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_NotificationsInterfaceBuilder].
+  $Capabilities_NotificationsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_NotificationsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -3196,6 +3472,15 @@ abstract class Capabilities_Notifications
 @BuiltValue(instantiable: false)
 sealed class $CapabilitiesInterface {
   Capabilities_Notifications get notifications;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -4173,6 +4173,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4218,6 +4227,17 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 @BuiltValue(instantiable: false)
 sealed class $AppConfigGetAppsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppConfigGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppConfigGetAppsResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($AppConfigGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppConfigGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppConfigGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppConfigGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4272,6 +4292,17 @@ abstract class AppConfigGetAppsResponseApplicationJson_Ocs_Data
 sealed class $AppConfigGetAppsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppConfigGetAppsResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppConfigGetAppsResponseApplicationJson_OcsInterfaceBuilder].
+  $AppConfigGetAppsResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppConfigGetAppsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppConfigGetAppsResponseApplicationJson_OcsInterfaceBuilder].
+  $AppConfigGetAppsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppConfigGetAppsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4324,6 +4355,17 @@ abstract class AppConfigGetAppsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppConfigGetAppsResponseApplicationJsonInterface {
   AppConfigGetAppsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppConfigGetAppsResponseApplicationJsonInterfaceBuilder].
+  $AppConfigGetAppsResponseApplicationJsonInterface rebuild(
+    void Function($AppConfigGetAppsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppConfigGetAppsResponseApplicationJsonInterfaceBuilder].
+  $AppConfigGetAppsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppConfigGetAppsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4375,6 +4417,17 @@ abstract class AppConfigGetAppsResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $AppConfigGetKeysResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppConfigGetKeysResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppConfigGetKeysResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($AppConfigGetKeysResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppConfigGetKeysResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppConfigGetKeysResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppConfigGetKeysResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4429,6 +4482,17 @@ abstract class AppConfigGetKeysResponseApplicationJson_Ocs_Data
 sealed class $AppConfigGetKeysResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppConfigGetKeysResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppConfigGetKeysResponseApplicationJson_OcsInterfaceBuilder].
+  $AppConfigGetKeysResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppConfigGetKeysResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppConfigGetKeysResponseApplicationJson_OcsInterfaceBuilder].
+  $AppConfigGetKeysResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppConfigGetKeysResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4481,6 +4545,17 @@ abstract class AppConfigGetKeysResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppConfigGetKeysResponseApplicationJsonInterface {
   AppConfigGetKeysResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppConfigGetKeysResponseApplicationJsonInterfaceBuilder].
+  $AppConfigGetKeysResponseApplicationJsonInterface rebuild(
+    void Function($AppConfigGetKeysResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppConfigGetKeysResponseApplicationJsonInterfaceBuilder].
+  $AppConfigGetKeysResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppConfigGetKeysResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4533,6 +4608,17 @@ abstract class AppConfigGetKeysResponseApplicationJson
 sealed class $AppConfigSetValueResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppConfigSetValueResponseApplicationJson_OcsInterfaceBuilder].
+  $AppConfigSetValueResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppConfigSetValueResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppConfigSetValueResponseApplicationJson_OcsInterfaceBuilder].
+  $AppConfigSetValueResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppConfigSetValueResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4585,6 +4671,17 @@ abstract class AppConfigSetValueResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppConfigSetValueResponseApplicationJsonInterface {
   AppConfigSetValueResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppConfigSetValueResponseApplicationJsonInterfaceBuilder].
+  $AppConfigSetValueResponseApplicationJsonInterface rebuild(
+    void Function($AppConfigSetValueResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppConfigSetValueResponseApplicationJsonInterfaceBuilder].
+  $AppConfigSetValueResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppConfigSetValueResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4637,6 +4734,17 @@ abstract class AppConfigSetValueResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $AppsGetAppsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get apps;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppsGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppsGetAppsResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($AppsGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppsGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $AppsGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppsGetAppsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4690,6 +4798,17 @@ abstract class AppsGetAppsResponseApplicationJson_Ocs_Data
 sealed class $AppsGetAppsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   AppsGetAppsResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppsGetAppsResponseApplicationJson_OcsInterfaceBuilder].
+  $AppsGetAppsResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppsGetAppsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppsGetAppsResponseApplicationJson_OcsInterfaceBuilder].
+  $AppsGetAppsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppsGetAppsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4741,6 +4860,17 @@ abstract class AppsGetAppsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppsGetAppsResponseApplicationJsonInterface {
   AppsGetAppsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppsGetAppsResponseApplicationJsonInterfaceBuilder].
+  $AppsGetAppsResponseApplicationJsonInterface rebuild(
+    void Function($AppsGetAppsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppsGetAppsResponseApplicationJsonInterfaceBuilder].
+  $AppsGetAppsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppsGetAppsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4793,6 +4923,17 @@ abstract class AppsGetAppsResponseApplicationJson
 sealed class $AppsGetAppInfoResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, JsonObject?> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppsGetAppInfoResponseApplicationJson_OcsInterfaceBuilder].
+  $AppsGetAppInfoResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppsGetAppInfoResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppsGetAppInfoResponseApplicationJson_OcsInterfaceBuilder].
+  $AppsGetAppInfoResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppsGetAppInfoResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4845,6 +4986,17 @@ abstract class AppsGetAppInfoResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppsGetAppInfoResponseApplicationJsonInterface {
   AppsGetAppInfoResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppsGetAppInfoResponseApplicationJsonInterfaceBuilder].
+  $AppsGetAppInfoResponseApplicationJsonInterface rebuild(
+    void Function($AppsGetAppInfoResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppsGetAppInfoResponseApplicationJsonInterfaceBuilder].
+  $AppsGetAppInfoResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppsGetAppInfoResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4897,6 +5049,17 @@ abstract class AppsGetAppInfoResponseApplicationJson
 sealed class $AppsEnableResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppsEnableResponseApplicationJson_OcsInterfaceBuilder].
+  $AppsEnableResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppsEnableResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppsEnableResponseApplicationJson_OcsInterfaceBuilder].
+  $AppsEnableResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppsEnableResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4948,6 +5111,17 @@ abstract class AppsEnableResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppsEnableResponseApplicationJsonInterface {
   AppsEnableResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppsEnableResponseApplicationJsonInterfaceBuilder].
+  $AppsEnableResponseApplicationJsonInterface rebuild(
+    void Function($AppsEnableResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppsEnableResponseApplicationJsonInterfaceBuilder].
+  $AppsEnableResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppsEnableResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -4999,6 +5173,17 @@ abstract class AppsEnableResponseApplicationJson
 sealed class $AppsDisableResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppsDisableResponseApplicationJson_OcsInterfaceBuilder].
+  $AppsDisableResponseApplicationJson_OcsInterface rebuild(
+    void Function($AppsDisableResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppsDisableResponseApplicationJson_OcsInterfaceBuilder].
+  $AppsDisableResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppsDisableResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5050,6 +5235,17 @@ abstract class AppsDisableResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AppsDisableResponseApplicationJsonInterface {
   AppsDisableResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppsDisableResponseApplicationJsonInterfaceBuilder].
+  $AppsDisableResponseApplicationJsonInterface rebuild(
+    void Function($AppsDisableResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppsDisableResponseApplicationJsonInterfaceBuilder].
+  $AppsDisableResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppsDisableResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5102,6 +5298,17 @@ abstract class AppsDisableResponseApplicationJson
 sealed class $GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<String> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterface rebuild(
+    void Function($GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetSubAdminsOfGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5155,6 +5362,17 @@ abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetSubAdminsOfGroupResponseApplicationJsonInterface {
   GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetSubAdminsOfGroupResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetSubAdminsOfGroupResponseApplicationJsonInterface rebuild(
+    void Function($GroupsGetSubAdminsOfGroupResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetSubAdminsOfGroupResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetSubAdminsOfGroupResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetSubAdminsOfGroupResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5208,6 +5426,17 @@ abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get groups;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $GroupsGetGroupsResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($GroupsGetGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $GroupsGetGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5261,6 +5490,17 @@ abstract class GroupsGetGroupsResponseApplicationJson_Ocs_Data
 sealed class $GroupsGetGroupsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   GroupsGetGroupsResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupsResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetGroupsResponseApplicationJson_OcsInterface rebuild(
+    void Function($GroupsGetGroupsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupsResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetGroupsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5313,6 +5553,17 @@ abstract class GroupsGetGroupsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupsResponseApplicationJsonInterface {
   GroupsGetGroupsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupsResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupsResponseApplicationJsonInterface rebuild(
+    void Function($GroupsGetGroupsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupsResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5364,6 +5615,17 @@ abstract class GroupsGetGroupsResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get users;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $GroupsGetGroupResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($GroupsGetGroupResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $GroupsGetGroupResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5417,6 +5679,17 @@ abstract class GroupsGetGroupResponseApplicationJson_Ocs_Data
 sealed class $GroupsGetGroupResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   GroupsGetGroupResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetGroupResponseApplicationJson_OcsInterface rebuild(
+    void Function($GroupsGetGroupResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetGroupResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5469,6 +5742,17 @@ abstract class GroupsGetGroupResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupResponseApplicationJsonInterface {
   GroupsGetGroupResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupResponseApplicationJsonInterface rebuild(
+    void Function($GroupsGetGroupResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5528,6 +5812,15 @@ sealed class $GroupDetailsInterface {
   GroupDetails_Disabled get disabled;
   bool get canAdd;
   bool get canRemove;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupDetailsInterfaceBuilder].
+  $GroupDetailsInterface rebuild(void Function($GroupDetailsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$GroupDetailsInterfaceBuilder].
+  $GroupDetailsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupDetailsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5576,6 +5869,17 @@ abstract class GroupDetails implements $GroupDetailsInterface, Built<GroupDetail
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<GroupDetails> get groups;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupsDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5630,6 +5934,17 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data
 sealed class $GroupsGetGroupsDetailsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupsDetailsResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetGroupsDetailsResponseApplicationJson_OcsInterface rebuild(
+    void Function($GroupsGetGroupsDetailsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupsDetailsResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetGroupsDetailsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupsDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5683,6 +5998,17 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupsDetailsResponseApplicationJsonInterface {
   GroupsGetGroupsDetailsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupsDetailsResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupsDetailsResponseApplicationJsonInterface rebuild(
+    void Function($GroupsGetGroupsDetailsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupsDetailsResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupsDetailsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupsDetailsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5735,6 +6061,17 @@ abstract class GroupsGetGroupsDetailsResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get users;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupUsersResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5789,6 +6126,17 @@ abstract class GroupsGetGroupUsersResponseApplicationJson_Ocs_Data
 sealed class $GroupsGetGroupUsersResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   GroupsGetGroupUsersResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupUsersResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetGroupUsersResponseApplicationJson_OcsInterface rebuild(
+    void Function($GroupsGetGroupUsersResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupUsersResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetGroupUsersResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupUsersResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5841,6 +6189,17 @@ abstract class GroupsGetGroupUsersResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupUsersResponseApplicationJsonInterface {
   GroupsGetGroupUsersResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupUsersResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupUsersResponseApplicationJsonInterface rebuild(
+    void Function($GroupsGetGroupUsersResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupUsersResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupUsersResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupUsersResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5894,6 +6253,17 @@ abstract class GroupsGetGroupUsersResponseApplicationJson
 sealed class $UserDetails_BackendCapabilitiesInterface {
   bool get setDisplayName;
   bool get setPassword;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserDetails_BackendCapabilitiesInterfaceBuilder].
+  $UserDetails_BackendCapabilitiesInterface rebuild(
+    void Function($UserDetails_BackendCapabilitiesInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserDetails_BackendCapabilitiesInterfaceBuilder].
+  $UserDetails_BackendCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserDetails_BackendCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -5950,6 +6320,15 @@ sealed class $UserDetailsQuotaInterface {
   num get relative;
   num get total;
   num get used;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserDetailsQuotaInterfaceBuilder].
+  $UserDetailsQuotaInterface rebuild(void Function($UserDetailsQuotaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$UserDetailsQuotaInterfaceBuilder].
+  $UserDetailsQuotaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserDetailsQuotaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6044,6 +6423,15 @@ sealed class $UserDetailsInterface {
   String? get twitterScope;
   String get website;
   String? get websiteScope;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserDetailsInterfaceBuilder].
+  $UserDetailsInterface rebuild(void Function($UserDetailsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$UserDetailsInterfaceBuilder].
+  $UserDetailsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserDetailsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6089,6 +6477,17 @@ abstract class UserDetails implements $UserDetailsInterface, Built<UserDetails, 
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface {
   String get id;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder].
+  $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface rebuild(
+    void Function($GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder].
+  $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6147,6 +6546,17 @@ typedef GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users = ({
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users> get users;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6201,6 +6611,17 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data
 sealed class $GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterface rebuild(
+    void Function($GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterfaceBuilder].
+  $GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupUsersDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6254,6 +6675,17 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupUsersDetailsResponseApplicationJsonInterface {
   GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupUsersDetailsResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupUsersDetailsResponseApplicationJsonInterface rebuild(
+    void Function($GroupsGetGroupUsersDetailsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupUsersDetailsResponseApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupUsersDetailsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GroupsGetGroupUsersDetailsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6308,6 +6740,17 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson
 sealed class $PreferencesSetPreferenceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesSetPreferenceResponseApplicationJson_OcsInterfaceBuilder].
+  $PreferencesSetPreferenceResponseApplicationJson_OcsInterface rebuild(
+    void Function($PreferencesSetPreferenceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesSetPreferenceResponseApplicationJson_OcsInterfaceBuilder].
+  $PreferencesSetPreferenceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PreferencesSetPreferenceResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6361,6 +6804,17 @@ abstract class PreferencesSetPreferenceResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PreferencesSetPreferenceResponseApplicationJsonInterface {
   PreferencesSetPreferenceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesSetPreferenceResponseApplicationJsonInterfaceBuilder].
+  $PreferencesSetPreferenceResponseApplicationJsonInterface rebuild(
+    void Function($PreferencesSetPreferenceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesSetPreferenceResponseApplicationJsonInterfaceBuilder].
+  $PreferencesSetPreferenceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PreferencesSetPreferenceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6414,6 +6868,17 @@ abstract class PreferencesSetPreferenceResponseApplicationJson
 sealed class $PreferencesDeletePreferenceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesDeletePreferenceResponseApplicationJson_OcsInterfaceBuilder].
+  $PreferencesDeletePreferenceResponseApplicationJson_OcsInterface rebuild(
+    void Function($PreferencesDeletePreferenceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesDeletePreferenceResponseApplicationJson_OcsInterfaceBuilder].
+  $PreferencesDeletePreferenceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PreferencesDeletePreferenceResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6467,6 +6932,17 @@ abstract class PreferencesDeletePreferenceResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PreferencesDeletePreferenceResponseApplicationJsonInterface {
   PreferencesDeletePreferenceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesDeletePreferenceResponseApplicationJsonInterfaceBuilder].
+  $PreferencesDeletePreferenceResponseApplicationJsonInterface rebuild(
+    void Function($PreferencesDeletePreferenceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesDeletePreferenceResponseApplicationJsonInterfaceBuilder].
+  $PreferencesDeletePreferenceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PreferencesDeletePreferenceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6521,6 +6997,17 @@ abstract class PreferencesDeletePreferenceResponseApplicationJson
 sealed class $PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterfaceBuilder].
+  $PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterface rebuild(
+    void Function($PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterfaceBuilder].
+  $PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6574,6 +7061,17 @@ abstract class PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PreferencesSetMultiplePreferencesResponseApplicationJsonInterface {
   PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesSetMultiplePreferencesResponseApplicationJsonInterfaceBuilder].
+  $PreferencesSetMultiplePreferencesResponseApplicationJsonInterface rebuild(
+    void Function($PreferencesSetMultiplePreferencesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesSetMultiplePreferencesResponseApplicationJsonInterfaceBuilder].
+  $PreferencesSetMultiplePreferencesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PreferencesSetMultiplePreferencesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6628,6 +7126,17 @@ abstract class PreferencesSetMultiplePreferencesResponseApplicationJson
 sealed class $PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterfaceBuilder].
+  $PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterface rebuild(
+    void Function($PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterfaceBuilder].
+  $PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6681,6 +7190,17 @@ abstract class PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterface {
   PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterfaceBuilder].
+  $PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterface rebuild(
+    void Function($PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterfaceBuilder].
+  $PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PreferencesDeleteMultiplePreferenceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6735,6 +7255,17 @@ abstract class PreferencesDeleteMultiplePreferenceResponseApplicationJson
 sealed class $UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<String> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUserSubAdminGroupsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6788,6 +7319,17 @@ abstract class UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersGetUserSubAdminGroupsResponseApplicationJsonInterface {
   UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUserSubAdminGroupsResponseApplicationJsonInterfaceBuilder].
+  $UsersGetUserSubAdminGroupsResponseApplicationJsonInterface rebuild(
+    void Function($UsersGetUserSubAdminGroupsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUserSubAdminGroupsResponseApplicationJsonInterfaceBuilder].
+  $UsersGetUserSubAdminGroupsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUserSubAdminGroupsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6842,6 +7384,17 @@ abstract class UsersGetUserSubAdminGroupsResponseApplicationJson
 sealed class $UsersAddSubAdminResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersAddSubAdminResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersAddSubAdminResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersAddSubAdminResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersAddSubAdminResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersAddSubAdminResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersAddSubAdminResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6894,6 +7447,17 @@ abstract class UsersAddSubAdminResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersAddSubAdminResponseApplicationJsonInterface {
   UsersAddSubAdminResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersAddSubAdminResponseApplicationJsonInterfaceBuilder].
+  $UsersAddSubAdminResponseApplicationJsonInterface rebuild(
+    void Function($UsersAddSubAdminResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersAddSubAdminResponseApplicationJsonInterfaceBuilder].
+  $UsersAddSubAdminResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersAddSubAdminResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6946,6 +7510,17 @@ abstract class UsersAddSubAdminResponseApplicationJson
 sealed class $UsersRemoveSubAdminResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersRemoveSubAdminResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersRemoveSubAdminResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersRemoveSubAdminResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersRemoveSubAdminResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersRemoveSubAdminResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersRemoveSubAdminResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6998,6 +7573,17 @@ abstract class UsersRemoveSubAdminResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersRemoveSubAdminResponseApplicationJsonInterface {
   UsersRemoveSubAdminResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersRemoveSubAdminResponseApplicationJsonInterfaceBuilder].
+  $UsersRemoveSubAdminResponseApplicationJsonInterface rebuild(
+    void Function($UsersRemoveSubAdminResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersRemoveSubAdminResponseApplicationJsonInterfaceBuilder].
+  $UsersRemoveSubAdminResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersRemoveSubAdminResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7050,6 +7636,17 @@ abstract class UsersRemoveSubAdminResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $UsersGetUsersResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get users;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $UsersGetUsersResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($UsersGetUsersResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $UsersGetUsersResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUsersResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7103,6 +7700,17 @@ abstract class UsersGetUsersResponseApplicationJson_Ocs_Data
 sealed class $UsersGetUsersResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UsersGetUsersResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetUsersResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersGetUsersResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetUsersResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUsersResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7155,6 +7763,17 @@ abstract class UsersGetUsersResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersGetUsersResponseApplicationJsonInterface {
   UsersGetUsersResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersResponseApplicationJsonInterfaceBuilder].
+  $UsersGetUsersResponseApplicationJsonInterface rebuild(
+    void Function($UsersGetUsersResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersResponseApplicationJsonInterfaceBuilder].
+  $UsersGetUsersResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUsersResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7206,6 +7825,17 @@ abstract class UsersGetUsersResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $UsersAddUserResponseApplicationJson_Ocs_DataInterface {
   String get id;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersAddUserResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $UsersAddUserResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($UsersAddUserResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersAddUserResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $UsersAddUserResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersAddUserResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7259,6 +7889,17 @@ abstract class UsersAddUserResponseApplicationJson_Ocs_Data
 sealed class $UsersAddUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UsersAddUserResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersAddUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersAddUserResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersAddUserResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersAddUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersAddUserResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersAddUserResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7310,6 +7951,17 @@ abstract class UsersAddUserResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersAddUserResponseApplicationJsonInterface {
   UsersAddUserResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersAddUserResponseApplicationJsonInterfaceBuilder].
+  $UsersAddUserResponseApplicationJsonInterface rebuild(
+    void Function($UsersAddUserResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersAddUserResponseApplicationJsonInterfaceBuilder].
+  $UsersAddUserResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersAddUserResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7361,6 +8013,17 @@ abstract class UsersAddUserResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface {
   String get id;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder].
+  $UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface rebuild(
+    void Function($UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder].
+  $UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7419,6 +8082,17 @@ typedef UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users = ({
 @BuiltValue(instantiable: false)
 sealed class $UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users> get users;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7473,6 +8147,17 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs_Data
 sealed class $UsersGetUsersDetailsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UsersGetUsersDetailsResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersDetailsResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetUsersDetailsResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersGetUsersDetailsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersDetailsResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetUsersDetailsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUsersDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7525,6 +8210,17 @@ abstract class UsersGetUsersDetailsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersGetUsersDetailsResponseApplicationJsonInterface {
   UsersGetUsersDetailsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersDetailsResponseApplicationJsonInterfaceBuilder].
+  $UsersGetUsersDetailsResponseApplicationJsonInterface rebuild(
+    void Function($UsersGetUsersDetailsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersDetailsResponseApplicationJsonInterfaceBuilder].
+  $UsersGetUsersDetailsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUsersDetailsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7577,6 +8273,17 @@ abstract class UsersGetUsersDetailsResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface {
   String get id;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder].
+  $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Interface rebuild(
+    void Function($UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder].
+  $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7635,6 +8342,17 @@ typedef UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users = ({
 @BuiltValue(instantiable: false)
 sealed class $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users> get users;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7689,6 +8407,17 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data
 sealed class $UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetDisabledUsersDetailsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7742,6 +8471,17 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersGetDisabledUsersDetailsResponseApplicationJsonInterface {
   UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetDisabledUsersDetailsResponseApplicationJsonInterfaceBuilder].
+  $UsersGetDisabledUsersDetailsResponseApplicationJsonInterface rebuild(
+    void Function($UsersGetDisabledUsersDetailsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetDisabledUsersDetailsResponseApplicationJsonInterfaceBuilder].
+  $UsersGetDisabledUsersDetailsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetDisabledUsersDetailsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7796,6 +8536,17 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson
 sealed class $UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, String> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7849,6 +8600,17 @@ abstract class UsersSearchByPhoneNumbersResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersSearchByPhoneNumbersResponseApplicationJsonInterface {
   UsersSearchByPhoneNumbersResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersSearchByPhoneNumbersResponseApplicationJsonInterfaceBuilder].
+  $UsersSearchByPhoneNumbersResponseApplicationJsonInterface rebuild(
+    void Function($UsersSearchByPhoneNumbersResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersSearchByPhoneNumbersResponseApplicationJsonInterfaceBuilder].
+  $UsersSearchByPhoneNumbersResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersSearchByPhoneNumbersResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7903,6 +8665,17 @@ abstract class UsersSearchByPhoneNumbersResponseApplicationJson
 sealed class $UsersGetUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UserDetails get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetUserResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersGetUserResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetUserResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUserResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -7954,6 +8727,17 @@ abstract class UsersGetUserResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersGetUserResponseApplicationJsonInterface {
   UsersGetUserResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUserResponseApplicationJsonInterfaceBuilder].
+  $UsersGetUserResponseApplicationJsonInterface rebuild(
+    void Function($UsersGetUserResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUserResponseApplicationJsonInterfaceBuilder].
+  $UsersGetUserResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUserResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8006,6 +8790,17 @@ abstract class UsersGetUserResponseApplicationJson
 sealed class $UsersEditUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersEditUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersEditUserResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersEditUserResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersEditUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersEditUserResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersEditUserResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8058,6 +8853,17 @@ abstract class UsersEditUserResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersEditUserResponseApplicationJsonInterface {
   UsersEditUserResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersEditUserResponseApplicationJsonInterfaceBuilder].
+  $UsersEditUserResponseApplicationJsonInterface rebuild(
+    void Function($UsersEditUserResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersEditUserResponseApplicationJsonInterfaceBuilder].
+  $UsersEditUserResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersEditUserResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8110,6 +8916,17 @@ abstract class UsersEditUserResponseApplicationJson
 sealed class $UsersDeleteUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersDeleteUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersDeleteUserResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersDeleteUserResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersDeleteUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersDeleteUserResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersDeleteUserResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8162,6 +8979,17 @@ abstract class UsersDeleteUserResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersDeleteUserResponseApplicationJsonInterface {
   UsersDeleteUserResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersDeleteUserResponseApplicationJsonInterfaceBuilder].
+  $UsersDeleteUserResponseApplicationJsonInterface rebuild(
+    void Function($UsersDeleteUserResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersDeleteUserResponseApplicationJsonInterfaceBuilder].
+  $UsersDeleteUserResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersDeleteUserResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8214,6 +9042,17 @@ abstract class UsersDeleteUserResponseApplicationJson
 sealed class $UsersGetCurrentUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UserDetails get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetCurrentUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetCurrentUserResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersGetCurrentUserResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetCurrentUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetCurrentUserResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetCurrentUserResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8266,6 +9105,17 @@ abstract class UsersGetCurrentUserResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersGetCurrentUserResponseApplicationJsonInterface {
   UsersGetCurrentUserResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetCurrentUserResponseApplicationJsonInterfaceBuilder].
+  $UsersGetCurrentUserResponseApplicationJsonInterface rebuild(
+    void Function($UsersGetCurrentUserResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetCurrentUserResponseApplicationJsonInterfaceBuilder].
+  $UsersGetCurrentUserResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetCurrentUserResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8319,6 +9169,17 @@ abstract class UsersGetCurrentUserResponseApplicationJson
 sealed class $UsersGetEditableFieldsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<String> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetEditableFieldsResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetEditableFieldsResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersGetEditableFieldsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetEditableFieldsResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetEditableFieldsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetEditableFieldsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8372,6 +9233,17 @@ abstract class UsersGetEditableFieldsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersGetEditableFieldsResponseApplicationJsonInterface {
   UsersGetEditableFieldsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetEditableFieldsResponseApplicationJsonInterfaceBuilder].
+  $UsersGetEditableFieldsResponseApplicationJsonInterface rebuild(
+    void Function($UsersGetEditableFieldsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetEditableFieldsResponseApplicationJsonInterfaceBuilder].
+  $UsersGetEditableFieldsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetEditableFieldsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8425,6 +9297,17 @@ abstract class UsersGetEditableFieldsResponseApplicationJson
 sealed class $UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<String> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetEditableFieldsForUserResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8478,6 +9361,17 @@ abstract class UsersGetEditableFieldsForUserResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersGetEditableFieldsForUserResponseApplicationJsonInterface {
   UsersGetEditableFieldsForUserResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetEditableFieldsForUserResponseApplicationJsonInterfaceBuilder].
+  $UsersGetEditableFieldsForUserResponseApplicationJsonInterface rebuild(
+    void Function($UsersGetEditableFieldsForUserResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetEditableFieldsForUserResponseApplicationJsonInterfaceBuilder].
+  $UsersGetEditableFieldsForUserResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetEditableFieldsForUserResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8532,6 +9426,17 @@ abstract class UsersGetEditableFieldsForUserResponseApplicationJson
 sealed class $UsersEditUserMultiValueResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersEditUserMultiValueResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersEditUserMultiValueResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersEditUserMultiValueResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersEditUserMultiValueResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersEditUserMultiValueResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersEditUserMultiValueResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8585,6 +9490,17 @@ abstract class UsersEditUserMultiValueResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersEditUserMultiValueResponseApplicationJsonInterface {
   UsersEditUserMultiValueResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersEditUserMultiValueResponseApplicationJsonInterfaceBuilder].
+  $UsersEditUserMultiValueResponseApplicationJsonInterface rebuild(
+    void Function($UsersEditUserMultiValueResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersEditUserMultiValueResponseApplicationJsonInterfaceBuilder].
+  $UsersEditUserMultiValueResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersEditUserMultiValueResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8638,6 +9554,17 @@ abstract class UsersEditUserMultiValueResponseApplicationJson
 sealed class $UsersWipeUserDevicesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersWipeUserDevicesResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersWipeUserDevicesResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersWipeUserDevicesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersWipeUserDevicesResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersWipeUserDevicesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersWipeUserDevicesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8690,6 +9617,17 @@ abstract class UsersWipeUserDevicesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersWipeUserDevicesResponseApplicationJsonInterface {
   UsersWipeUserDevicesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersWipeUserDevicesResponseApplicationJsonInterfaceBuilder].
+  $UsersWipeUserDevicesResponseApplicationJsonInterface rebuild(
+    void Function($UsersWipeUserDevicesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersWipeUserDevicesResponseApplicationJsonInterfaceBuilder].
+  $UsersWipeUserDevicesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersWipeUserDevicesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8743,6 +9681,17 @@ abstract class UsersWipeUserDevicesResponseApplicationJson
 sealed class $UsersEnableUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersEnableUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersEnableUserResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersEnableUserResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersEnableUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersEnableUserResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersEnableUserResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8795,6 +9744,17 @@ abstract class UsersEnableUserResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersEnableUserResponseApplicationJsonInterface {
   UsersEnableUserResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersEnableUserResponseApplicationJsonInterfaceBuilder].
+  $UsersEnableUserResponseApplicationJsonInterface rebuild(
+    void Function($UsersEnableUserResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersEnableUserResponseApplicationJsonInterfaceBuilder].
+  $UsersEnableUserResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersEnableUserResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8847,6 +9807,17 @@ abstract class UsersEnableUserResponseApplicationJson
 sealed class $UsersDisableUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersDisableUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersDisableUserResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersDisableUserResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersDisableUserResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersDisableUserResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersDisableUserResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8899,6 +9870,17 @@ abstract class UsersDisableUserResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersDisableUserResponseApplicationJsonInterface {
   UsersDisableUserResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersDisableUserResponseApplicationJsonInterfaceBuilder].
+  $UsersDisableUserResponseApplicationJsonInterface rebuild(
+    void Function($UsersDisableUserResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersDisableUserResponseApplicationJsonInterfaceBuilder].
+  $UsersDisableUserResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersDisableUserResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8950,6 +9932,17 @@ abstract class UsersDisableUserResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get groups;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUsersGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9004,6 +9997,17 @@ abstract class UsersGetUsersGroupsResponseApplicationJson_Ocs_Data
 sealed class $UsersGetUsersGroupsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UsersGetUsersGroupsResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersGroupsResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetUsersGroupsResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersGetUsersGroupsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersGroupsResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersGetUsersGroupsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUsersGroupsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9056,6 +10060,17 @@ abstract class UsersGetUsersGroupsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersGetUsersGroupsResponseApplicationJsonInterface {
   UsersGetUsersGroupsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersGroupsResponseApplicationJsonInterfaceBuilder].
+  $UsersGetUsersGroupsResponseApplicationJsonInterface rebuild(
+    void Function($UsersGetUsersGroupsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersGroupsResponseApplicationJsonInterfaceBuilder].
+  $UsersGetUsersGroupsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersGetUsersGroupsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9109,6 +10124,17 @@ abstract class UsersGetUsersGroupsResponseApplicationJson
 sealed class $UsersAddToGroupResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersAddToGroupResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersAddToGroupResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersAddToGroupResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersAddToGroupResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersAddToGroupResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersAddToGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9161,6 +10187,17 @@ abstract class UsersAddToGroupResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersAddToGroupResponseApplicationJsonInterface {
   UsersAddToGroupResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersAddToGroupResponseApplicationJsonInterfaceBuilder].
+  $UsersAddToGroupResponseApplicationJsonInterface rebuild(
+    void Function($UsersAddToGroupResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersAddToGroupResponseApplicationJsonInterfaceBuilder].
+  $UsersAddToGroupResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersAddToGroupResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9213,6 +10250,17 @@ abstract class UsersAddToGroupResponseApplicationJson
 sealed class $UsersRemoveFromGroupResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersRemoveFromGroupResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersRemoveFromGroupResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersRemoveFromGroupResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersRemoveFromGroupResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersRemoveFromGroupResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersRemoveFromGroupResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9265,6 +10313,17 @@ abstract class UsersRemoveFromGroupResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersRemoveFromGroupResponseApplicationJsonInterface {
   UsersRemoveFromGroupResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersRemoveFromGroupResponseApplicationJsonInterfaceBuilder].
+  $UsersRemoveFromGroupResponseApplicationJsonInterface rebuild(
+    void Function($UsersRemoveFromGroupResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersRemoveFromGroupResponseApplicationJsonInterfaceBuilder].
+  $UsersRemoveFromGroupResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersRemoveFromGroupResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9318,6 +10377,17 @@ abstract class UsersRemoveFromGroupResponseApplicationJson
 sealed class $UsersResendWelcomeMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersResendWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersResendWelcomeMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($UsersResendWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersResendWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $UsersResendWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersResendWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9371,6 +10441,17 @@ abstract class UsersResendWelcomeMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UsersResendWelcomeMessageResponseApplicationJsonInterface {
   UsersResendWelcomeMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersResendWelcomeMessageResponseApplicationJsonInterfaceBuilder].
+  $UsersResendWelcomeMessageResponseApplicationJsonInterface rebuild(
+    void Function($UsersResendWelcomeMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersResendWelcomeMessageResponseApplicationJsonInterfaceBuilder].
+  $UsersResendWelcomeMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UsersResendWelcomeMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9430,6 +10511,15 @@ sealed class $Capabilities_ProvisioningApiInterface {
   bool get accountPropertyScopesFederatedEnabled;
   @BuiltValueField(wireName: 'AccountPropertyScopesPublishedEnabled')
   bool get accountPropertyScopesPublishedEnabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_ProvisioningApiInterfaceBuilder].
+  $Capabilities_ProvisioningApiInterface rebuild(void Function($Capabilities_ProvisioningApiInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_ProvisioningApiInterfaceBuilder].
+  $Capabilities_ProvisioningApiInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_ProvisioningApiInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -9481,6 +10571,15 @@ abstract class Capabilities_ProvisioningApi
 sealed class $CapabilitiesInterface {
   @BuiltValueField(wireName: 'provisioning_api')
   Capabilities_ProvisioningApi get provisioningApi;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/settings.openapi.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.dart
@@ -357,6 +357,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -403,6 +412,17 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 sealed class $DeclarativeSettingsSetValueResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject? get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeclarativeSettingsSetValueResponseApplicationJson_OcsInterfaceBuilder].
+  $DeclarativeSettingsSetValueResponseApplicationJson_OcsInterface rebuild(
+    void Function($DeclarativeSettingsSetValueResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeclarativeSettingsSetValueResponseApplicationJson_OcsInterfaceBuilder].
+  $DeclarativeSettingsSetValueResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeclarativeSettingsSetValueResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -456,6 +476,17 @@ abstract class DeclarativeSettingsSetValueResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DeclarativeSettingsSetValueResponseApplicationJsonInterface {
   DeclarativeSettingsSetValueResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeclarativeSettingsSetValueResponseApplicationJsonInterfaceBuilder].
+  $DeclarativeSettingsSetValueResponseApplicationJsonInterface rebuild(
+    void Function($DeclarativeSettingsSetValueResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeclarativeSettingsSetValueResponseApplicationJsonInterfaceBuilder].
+  $DeclarativeSettingsSetValueResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeclarativeSettingsSetValueResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -741,6 +772,17 @@ class _$DeclarativeFormField_TypeSerializer implements PrimitiveSerializer<Decla
 sealed class $DeclarativeFormField_Options1Interface {
   String get name;
   JsonObject get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeclarativeFormField_Options1InterfaceBuilder].
+  $DeclarativeFormField_Options1Interface rebuild(
+    void Function($DeclarativeFormField_Options1InterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeclarativeFormField_Options1InterfaceBuilder].
+  $DeclarativeFormField_Options1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeclarativeFormField_Options1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -803,6 +845,15 @@ sealed class $DeclarativeFormFieldInterface {
   JsonObject get $default;
   BuiltList<DeclarativeFormField_Options>? get options;
   DeclarativeFormField_Value get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeclarativeFormFieldInterfaceBuilder].
+  $DeclarativeFormFieldInterface rebuild(void Function($DeclarativeFormFieldInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$DeclarativeFormFieldInterfaceBuilder].
+  $DeclarativeFormFieldInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeclarativeFormFieldInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -865,6 +916,15 @@ sealed class $DeclarativeFormInterface {
   String? get docUrl;
   String get app;
   BuiltList<DeclarativeFormField> get fields;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeclarativeFormInterfaceBuilder].
+  $DeclarativeFormInterface rebuild(void Function($DeclarativeFormInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$DeclarativeFormInterfaceBuilder].
+  $DeclarativeFormInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeclarativeFormInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -911,6 +971,17 @@ abstract class DeclarativeForm implements $DeclarativeFormInterface, Built<Decla
 sealed class $DeclarativeSettingsGetFormsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<DeclarativeForm> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeclarativeSettingsGetFormsResponseApplicationJson_OcsInterfaceBuilder].
+  $DeclarativeSettingsGetFormsResponseApplicationJson_OcsInterface rebuild(
+    void Function($DeclarativeSettingsGetFormsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeclarativeSettingsGetFormsResponseApplicationJson_OcsInterfaceBuilder].
+  $DeclarativeSettingsGetFormsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeclarativeSettingsGetFormsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -964,6 +1035,17 @@ abstract class DeclarativeSettingsGetFormsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $DeclarativeSettingsGetFormsResponseApplicationJsonInterface {
   DeclarativeSettingsGetFormsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeclarativeSettingsGetFormsResponseApplicationJsonInterfaceBuilder].
+  $DeclarativeSettingsGetFormsResponseApplicationJsonInterface rebuild(
+    void Function($DeclarativeSettingsGetFormsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeclarativeSettingsGetFormsResponseApplicationJsonInterfaceBuilder].
+  $DeclarativeSettingsGetFormsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeclarativeSettingsGetFormsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1018,6 +1100,17 @@ abstract class DeclarativeSettingsGetFormsResponseApplicationJson
 sealed class $LogSettingsLogSettingsDownloadHeadersInterface {
   @BuiltValueField(wireName: 'content-disposition')
   String? get contentDisposition;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$LogSettingsLogSettingsDownloadHeadersInterfaceBuilder].
+  $LogSettingsLogSettingsDownloadHeadersInterface rebuild(
+    void Function($LogSettingsLogSettingsDownloadHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$LogSettingsLogSettingsDownloadHeadersInterfaceBuilder].
+  $LogSettingsLogSettingsDownloadHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($LogSettingsLogSettingsDownloadHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
+++ b/packages/nextcloud/lib/src/api/sharebymail.openapi.dart
@@ -29,6 +29,17 @@ part 'sharebymail.openapi.g.dart';
 @BuiltValue(instantiable: false)
 sealed class $Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder].
+  $Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterface rebuild(
+    void Function($Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder].
+  $Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities0_FilesSharing_Sharebymail_UploadFilesDropInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -83,6 +94,17 @@ abstract class Capabilities0_FilesSharing_Sharebymail_UploadFilesDrop
 sealed class $Capabilities0_FilesSharing_Sharebymail_PasswordInterface {
   bool get enabled;
   bool get enforced;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder].
+  $Capabilities0_FilesSharing_Sharebymail_PasswordInterface rebuild(
+    void Function($Capabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder].
+  $Capabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities0_FilesSharing_Sharebymail_PasswordInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -136,6 +158,17 @@ abstract class Capabilities0_FilesSharing_Sharebymail_Password
 sealed class $Capabilities0_FilesSharing_Sharebymail_ExpireDateInterface {
   bool get enabled;
   bool get enforced;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder].
+  $Capabilities0_FilesSharing_Sharebymail_ExpireDateInterface rebuild(
+    void Function($Capabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder].
+  $Capabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities0_FilesSharing_Sharebymail_ExpireDateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -196,6 +229,17 @@ sealed class $Capabilities0_FilesSharing_SharebymailInterface {
   Capabilities0_FilesSharing_Sharebymail_Password get password;
   @BuiltValueField(wireName: 'expire_date')
   Capabilities0_FilesSharing_Sharebymail_ExpireDate get expireDate;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities0_FilesSharing_SharebymailInterfaceBuilder].
+  $Capabilities0_FilesSharing_SharebymailInterface rebuild(
+    void Function($Capabilities0_FilesSharing_SharebymailInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities0_FilesSharing_SharebymailInterfaceBuilder].
+  $Capabilities0_FilesSharing_SharebymailInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities0_FilesSharing_SharebymailInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -247,6 +291,15 @@ abstract class Capabilities0_FilesSharing_Sharebymail
 @BuiltValue(instantiable: false)
 sealed class $Capabilities0_FilesSharingInterface {
   Capabilities0_FilesSharing_Sharebymail get sharebymail;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities0_FilesSharingInterfaceBuilder].
+  $Capabilities0_FilesSharingInterface rebuild(void Function($Capabilities0_FilesSharingInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities0_FilesSharingInterfaceBuilder].
+  $Capabilities0_FilesSharingInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities0_FilesSharingInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -298,6 +351,15 @@ abstract class Capabilities0_FilesSharing
 sealed class $Capabilities0Interface {
   @BuiltValueField(wireName: 'files_sharing')
   Capabilities0_FilesSharing get filesSharing;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities0InterfaceBuilder].
+  $Capabilities0Interface rebuild(void Function($Capabilities0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities0InterfaceBuilder].
+  $Capabilities0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -15889,6 +15889,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16325,6 +16334,15 @@ sealed class $RichObjectParameterInterface {
   String? get etag;
   RichObjectParameter_Width? get width;
   RichObjectParameter_Height? get height;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RichObjectParameterInterfaceBuilder].
+  $RichObjectParameterInterface rebuild(void Function($RichObjectParameterInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$RichObjectParameterInterfaceBuilder].
+  $RichObjectParameterInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RichObjectParameterInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16490,6 +16508,15 @@ sealed class $BaseMessageInterface {
   BuiltMap<String, RichObjectParameter> get messageParameters;
   MessageType get messageType;
   String get systemMessage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BaseMessageInterfaceBuilder].
+  $BaseMessageInterface rebuild(void Function($BaseMessageInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BaseMessageInterfaceBuilder].
+  $BaseMessageInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BaseMessageInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16605,6 +16632,17 @@ sealed class $ChatMessageInterface implements $BaseMessageInterface {
   int? get lastEditTimestamp;
   bool? get silent;
   BuiltList<String>? get reactionsSelf;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatMessageInterfaceBuilder].
+  @override
+  $ChatMessageInterface rebuild(void Function($ChatMessageInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ChatMessageInterfaceBuilder].
+  @override
+  $ChatMessageInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatMessageInterfaceBuilder b) {
     $BaseMessageInterface._defaults(b);
@@ -16711,6 +16749,15 @@ sealed class $RoomInterface {
   bool get unreadMention;
   bool get unreadMentionDirect;
   int get unreadMessages;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomInterfaceBuilder].
+  $RoomInterface rebuild(void Function($RoomInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$RoomInterfaceBuilder].
+  $RoomInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16759,6 +16806,17 @@ abstract class Room implements $RoomInterface, Built<Room, RoomBuilder> {
 sealed class $AvatarUploadAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarUploadAvatarResponseApplicationJson_OcsInterfaceBuilder].
+  $AvatarUploadAvatarResponseApplicationJson_OcsInterface rebuild(
+    void Function($AvatarUploadAvatarResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarUploadAvatarResponseApplicationJson_OcsInterfaceBuilder].
+  $AvatarUploadAvatarResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AvatarUploadAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16811,6 +16869,17 @@ abstract class AvatarUploadAvatarResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AvatarUploadAvatarResponseApplicationJsonInterface {
   AvatarUploadAvatarResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarUploadAvatarResponseApplicationJsonInterfaceBuilder].
+  $AvatarUploadAvatarResponseApplicationJsonInterface rebuild(
+    void Function($AvatarUploadAvatarResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarUploadAvatarResponseApplicationJsonInterfaceBuilder].
+  $AvatarUploadAvatarResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AvatarUploadAvatarResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16920,6 +16989,17 @@ class _$AvatarDeleteAvatarApiVersionSerializer implements PrimitiveSerializer<Av
 sealed class $AvatarDeleteAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder].
+  $AvatarDeleteAvatarResponseApplicationJson_OcsInterface rebuild(
+    void Function($AvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder].
+  $AvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -16972,6 +17052,17 @@ abstract class AvatarDeleteAvatarResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AvatarDeleteAvatarResponseApplicationJsonInterface {
   AvatarDeleteAvatarResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder].
+  $AvatarDeleteAvatarResponseApplicationJsonInterface rebuild(
+    void Function($AvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder].
+  $AvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -17081,6 +17172,17 @@ class _$AvatarEmojiAvatarApiVersionSerializer implements PrimitiveSerializer<Ava
 sealed class $AvatarEmojiAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarEmojiAvatarResponseApplicationJson_OcsInterfaceBuilder].
+  $AvatarEmojiAvatarResponseApplicationJson_OcsInterface rebuild(
+    void Function($AvatarEmojiAvatarResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarEmojiAvatarResponseApplicationJson_OcsInterfaceBuilder].
+  $AvatarEmojiAvatarResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AvatarEmojiAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -17133,6 +17235,17 @@ abstract class AvatarEmojiAvatarResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $AvatarEmojiAvatarResponseApplicationJsonInterface {
   AvatarEmojiAvatarResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarEmojiAvatarResponseApplicationJsonInterfaceBuilder].
+  $AvatarEmojiAvatarResponseApplicationJsonInterface rebuild(
+    void Function($AvatarEmojiAvatarResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarEmojiAvatarResponseApplicationJsonInterfaceBuilder].
+  $AvatarEmojiAvatarResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AvatarEmojiAvatarResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -17942,6 +18055,15 @@ sealed class $BotInterface {
   int get id;
   String get name;
   int get state;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotInterfaceBuilder].
+  $BotInterface rebuild(void Function($BotInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BotInterfaceBuilder].
+  $BotInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -17988,6 +18110,17 @@ abstract class Bot implements $BotInterface, Built<Bot, BotBuilder> {
 sealed class $BotListBotsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Bot> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotListBotsResponseApplicationJson_OcsInterfaceBuilder].
+  $BotListBotsResponseApplicationJson_OcsInterface rebuild(
+    void Function($BotListBotsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotListBotsResponseApplicationJson_OcsInterfaceBuilder].
+  $BotListBotsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotListBotsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18039,6 +18172,17 @@ abstract class BotListBotsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BotListBotsResponseApplicationJsonInterface {
   BotListBotsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotListBotsResponseApplicationJsonInterfaceBuilder].
+  $BotListBotsResponseApplicationJsonInterface rebuild(
+    void Function($BotListBotsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotListBotsResponseApplicationJsonInterfaceBuilder].
+  $BotListBotsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotListBotsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18147,6 +18291,17 @@ class _$BotEnableBotApiVersionSerializer implements PrimitiveSerializer<BotEnabl
 sealed class $BotEnableBotResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Bot? get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotEnableBotResponseApplicationJson_OcsInterfaceBuilder].
+  $BotEnableBotResponseApplicationJson_OcsInterface rebuild(
+    void Function($BotEnableBotResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotEnableBotResponseApplicationJson_OcsInterfaceBuilder].
+  $BotEnableBotResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotEnableBotResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18198,6 +18353,17 @@ abstract class BotEnableBotResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BotEnableBotResponseApplicationJsonInterface {
   BotEnableBotResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotEnableBotResponseApplicationJsonInterfaceBuilder].
+  $BotEnableBotResponseApplicationJsonInterface rebuild(
+    void Function($BotEnableBotResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotEnableBotResponseApplicationJsonInterfaceBuilder].
+  $BotEnableBotResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotEnableBotResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18306,6 +18472,17 @@ class _$BotDisableBotApiVersionSerializer implements PrimitiveSerializer<BotDisa
 sealed class $BotDisableBotResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Bot? get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotDisableBotResponseApplicationJson_OcsInterfaceBuilder].
+  $BotDisableBotResponseApplicationJson_OcsInterface rebuild(
+    void Function($BotDisableBotResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotDisableBotResponseApplicationJson_OcsInterfaceBuilder].
+  $BotDisableBotResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotDisableBotResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18358,6 +18535,17 @@ abstract class BotDisableBotResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BotDisableBotResponseApplicationJsonInterface {
   BotDisableBotResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotDisableBotResponseApplicationJsonInterfaceBuilder].
+  $BotDisableBotResponseApplicationJsonInterface rebuild(
+    void Function($BotDisableBotResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotDisableBotResponseApplicationJsonInterfaceBuilder].
+  $BotDisableBotResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotDisableBotResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18529,6 +18717,17 @@ class _$BotSendMessageApiVersionSerializer implements PrimitiveSerializer<BotSen
 sealed class $BotSendMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotSendMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $BotSendMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($BotSendMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotSendMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $BotSendMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotSendMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18581,6 +18780,17 @@ abstract class BotSendMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BotSendMessageResponseApplicationJsonInterface {
   BotSendMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotSendMessageResponseApplicationJsonInterfaceBuilder].
+  $BotSendMessageResponseApplicationJsonInterface rebuild(
+    void Function($BotSendMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotSendMessageResponseApplicationJsonInterfaceBuilder].
+  $BotSendMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotSendMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18689,6 +18899,17 @@ class _$BotReactApiVersionSerializer implements PrimitiveSerializer<BotReactApiV
 sealed class $BotReactResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotReactResponseApplicationJson_OcsInterfaceBuilder].
+  $BotReactResponseApplicationJson_OcsInterface rebuild(
+    void Function($BotReactResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotReactResponseApplicationJson_OcsInterfaceBuilder].
+  $BotReactResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotReactResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18740,6 +18961,17 @@ abstract class BotReactResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BotReactResponseApplicationJsonInterface {
   BotReactResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotReactResponseApplicationJsonInterfaceBuilder].
+  $BotReactResponseApplicationJsonInterface rebuild(
+    void Function($BotReactResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotReactResponseApplicationJsonInterfaceBuilder].
+  $BotReactResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotReactResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18847,6 +19079,17 @@ class _$BotDeleteReactionApiVersionSerializer implements PrimitiveSerializer<Bot
 sealed class $BotDeleteReactionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotDeleteReactionResponseApplicationJson_OcsInterfaceBuilder].
+  $BotDeleteReactionResponseApplicationJson_OcsInterface rebuild(
+    void Function($BotDeleteReactionResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotDeleteReactionResponseApplicationJson_OcsInterfaceBuilder].
+  $BotDeleteReactionResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotDeleteReactionResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18899,6 +19142,17 @@ abstract class BotDeleteReactionResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BotDeleteReactionResponseApplicationJsonInterface {
   BotDeleteReactionResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotDeleteReactionResponseApplicationJsonInterfaceBuilder].
+  $BotDeleteReactionResponseApplicationJsonInterface rebuild(
+    void Function($BotDeleteReactionResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotDeleteReactionResponseApplicationJsonInterfaceBuilder].
+  $BotDeleteReactionResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotDeleteReactionResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19094,6 +19348,17 @@ class _$BreakoutRoomConfigureBreakoutRoomsApiVersionSerializer
 sealed class $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterface rebuild(
+    void Function($BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19147,6 +19412,17 @@ abstract class BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterface {
   BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19263,6 +19539,17 @@ class _$BreakoutRoomRemoveBreakoutRoomsApiVersionSerializer
 sealed class $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterface rebuild(
+    void Function($BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19316,6 +19603,17 @@ abstract class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterface {
   BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19432,6 +19730,17 @@ class _$BreakoutRoomBroadcastChatMessageApiVersionSerializer
 sealed class $BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19485,6 +19794,17 @@ abstract class BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterface {
   BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomBroadcastChatMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19600,6 +19920,17 @@ class _$BreakoutRoomApplyAttendeeMapApiVersionSerializer
 sealed class $BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterface rebuild(
+    void Function($BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19653,6 +19984,17 @@ abstract class BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterface {
   BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomApplyAttendeeMapResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19769,6 +20111,17 @@ class _$BreakoutRoomRequestAssistanceApiVersionSerializer
 sealed class $BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterface rebuild(
+    void Function($BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomRequestAssistanceResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19822,6 +20175,17 @@ abstract class BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BreakoutRoomRequestAssistanceResponseApplicationJsonInterface {
   BreakoutRoomRequestAssistanceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomRequestAssistanceResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomRequestAssistanceResponseApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomRequestAssistanceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomRequestAssistanceResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomRequestAssistanceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomRequestAssistanceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19938,6 +20302,17 @@ class _$BreakoutRoomResetRequestForAssistanceApiVersionSerializer
 sealed class $BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterface rebuild(
+    void Function($BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomResetRequestForAssistanceResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -19991,6 +20366,17 @@ abstract class BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterface {
   BreakoutRoomResetRequestForAssistanceResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomResetRequestForAssistanceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20107,6 +20493,17 @@ class _$BreakoutRoomStartBreakoutRoomsApiVersionSerializer
 sealed class $BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterface rebuild(
+    void Function($BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomStartBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20160,6 +20557,17 @@ abstract class BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterface {
   BreakoutRoomStartBreakoutRoomsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomStartBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20276,6 +20684,17 @@ class _$BreakoutRoomStopBreakoutRoomsApiVersionSerializer
 sealed class $BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterface rebuild(
+    void Function($BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomStopBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20329,6 +20748,17 @@ abstract class BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterface {
   BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomStopBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20445,6 +20875,17 @@ class _$BreakoutRoomSwitchBreakoutRoomApiVersionSerializer
 sealed class $BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20498,6 +20939,17 @@ abstract class BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterface {
   BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterfaceBuilder].
+  $BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20612,6 +21064,15 @@ sealed class $CallPeerInterface {
   int get lastPing;
   String get sessionId;
   String get token;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallPeerInterfaceBuilder].
+  $CallPeerInterface rebuild(void Function($CallPeerInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CallPeerInterfaceBuilder].
+  $CallPeerInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallPeerInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20658,6 +21119,17 @@ abstract class CallPeer implements $CallPeerInterface, Built<CallPeer, CallPeerB
 sealed class $CallGetPeersForCallResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<CallPeer> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallGetPeersForCallResponseApplicationJson_OcsInterfaceBuilder].
+  $CallGetPeersForCallResponseApplicationJson_OcsInterface rebuild(
+    void Function($CallGetPeersForCallResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallGetPeersForCallResponseApplicationJson_OcsInterfaceBuilder].
+  $CallGetPeersForCallResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallGetPeersForCallResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20710,6 +21182,17 @@ abstract class CallGetPeersForCallResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CallGetPeersForCallResponseApplicationJsonInterface {
   CallGetPeersForCallResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallGetPeersForCallResponseApplicationJsonInterfaceBuilder].
+  $CallGetPeersForCallResponseApplicationJsonInterface rebuild(
+    void Function($CallGetPeersForCallResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallGetPeersForCallResponseApplicationJsonInterfaceBuilder].
+  $CallGetPeersForCallResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallGetPeersForCallResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20819,6 +21302,17 @@ class _$CallUpdateCallFlagsApiVersionSerializer implements PrimitiveSerializer<C
 sealed class $CallUpdateCallFlagsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallUpdateCallFlagsResponseApplicationJson_OcsInterfaceBuilder].
+  $CallUpdateCallFlagsResponseApplicationJson_OcsInterface rebuild(
+    void Function($CallUpdateCallFlagsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallUpdateCallFlagsResponseApplicationJson_OcsInterfaceBuilder].
+  $CallUpdateCallFlagsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallUpdateCallFlagsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -20871,6 +21365,17 @@ abstract class CallUpdateCallFlagsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CallUpdateCallFlagsResponseApplicationJsonInterface {
   CallUpdateCallFlagsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallUpdateCallFlagsResponseApplicationJsonInterfaceBuilder].
+  $CallUpdateCallFlagsResponseApplicationJsonInterface rebuild(
+    void Function($CallUpdateCallFlagsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallUpdateCallFlagsResponseApplicationJsonInterfaceBuilder].
+  $CallUpdateCallFlagsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallUpdateCallFlagsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -21106,6 +21611,17 @@ class _$CallJoinCallApiVersionSerializer implements PrimitiveSerializer<CallJoin
 sealed class $CallJoinCallResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallJoinCallResponseApplicationJson_OcsInterfaceBuilder].
+  $CallJoinCallResponseApplicationJson_OcsInterface rebuild(
+    void Function($CallJoinCallResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallJoinCallResponseApplicationJson_OcsInterfaceBuilder].
+  $CallJoinCallResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallJoinCallResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -21157,6 +21673,17 @@ abstract class CallJoinCallResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CallJoinCallResponseApplicationJsonInterface {
   CallJoinCallResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallJoinCallResponseApplicationJsonInterfaceBuilder].
+  $CallJoinCallResponseApplicationJsonInterface rebuild(
+    void Function($CallJoinCallResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallJoinCallResponseApplicationJsonInterfaceBuilder].
+  $CallJoinCallResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallJoinCallResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -21328,6 +21855,17 @@ class _$CallLeaveCallApiVersionSerializer implements PrimitiveSerializer<CallLea
 sealed class $CallLeaveCallResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallLeaveCallResponseApplicationJson_OcsInterfaceBuilder].
+  $CallLeaveCallResponseApplicationJson_OcsInterface rebuild(
+    void Function($CallLeaveCallResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallLeaveCallResponseApplicationJson_OcsInterfaceBuilder].
+  $CallLeaveCallResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallLeaveCallResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -21380,6 +21918,17 @@ abstract class CallLeaveCallResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CallLeaveCallResponseApplicationJsonInterface {
   CallLeaveCallResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallLeaveCallResponseApplicationJsonInterfaceBuilder].
+  $CallLeaveCallResponseApplicationJsonInterface rebuild(
+    void Function($CallLeaveCallResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallLeaveCallResponseApplicationJsonInterfaceBuilder].
+  $CallLeaveCallResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallLeaveCallResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -21488,6 +22037,17 @@ class _$CallRingAttendeeApiVersionSerializer implements PrimitiveSerializer<Call
 sealed class $CallRingAttendeeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallRingAttendeeResponseApplicationJson_OcsInterfaceBuilder].
+  $CallRingAttendeeResponseApplicationJson_OcsInterface rebuild(
+    void Function($CallRingAttendeeResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallRingAttendeeResponseApplicationJson_OcsInterfaceBuilder].
+  $CallRingAttendeeResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallRingAttendeeResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -21540,6 +22100,17 @@ abstract class CallRingAttendeeResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CallRingAttendeeResponseApplicationJsonInterface {
   CallRingAttendeeResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallRingAttendeeResponseApplicationJsonInterfaceBuilder].
+  $CallRingAttendeeResponseApplicationJsonInterface rebuild(
+    void Function($CallRingAttendeeResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallRingAttendeeResponseApplicationJsonInterfaceBuilder].
+  $CallRingAttendeeResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallRingAttendeeResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -21648,6 +22219,17 @@ class _$CallSipDialOutApiVersionSerializer implements PrimitiveSerializer<CallSi
 sealed class $CallSipDialOutResponseApplicationJson_Ocs_DataInterface {
   String? get error;
   String? get message;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallSipDialOutResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $CallSipDialOutResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($CallSipDialOutResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallSipDialOutResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $CallSipDialOutResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallSipDialOutResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -21701,6 +22283,17 @@ abstract class CallSipDialOutResponseApplicationJson_Ocs_Data
 sealed class $CallSipDialOutResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   CallSipDialOutResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallSipDialOutResponseApplicationJson_OcsInterfaceBuilder].
+  $CallSipDialOutResponseApplicationJson_OcsInterface rebuild(
+    void Function($CallSipDialOutResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallSipDialOutResponseApplicationJson_OcsInterfaceBuilder].
+  $CallSipDialOutResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallSipDialOutResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -21753,6 +22346,17 @@ abstract class CallSipDialOutResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CallSipDialOutResponseApplicationJsonInterface {
   CallSipDialOutResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallSipDialOutResponseApplicationJsonInterfaceBuilder].
+  $CallSipDialOutResponseApplicationJsonInterface rebuild(
+    void Function($CallSipDialOutResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallSipDialOutResponseApplicationJsonInterfaceBuilder].
+  $CallSipDialOutResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CallSipDialOutResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22187,6 +22791,17 @@ class _$ChatReceiveMessagesApiVersionSerializer implements PrimitiveSerializer<C
 @BuiltValue(instantiable: false)
 sealed class $ChatMessageWithParentInterface implements $ChatMessageInterface {
   ChatMessage? get parent;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatMessageWithParentInterfaceBuilder].
+  @override
+  $ChatMessageWithParentInterface rebuild(void Function($ChatMessageWithParentInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ChatMessageWithParentInterfaceBuilder].
+  @override
+  $ChatMessageWithParentInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatMessageWithParentInterfaceBuilder b) {
     $ChatMessageInterface._defaults(b);
@@ -22240,6 +22855,17 @@ abstract class ChatMessageWithParent
 sealed class $ChatReceiveMessagesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ChatMessageWithParent> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatReceiveMessagesResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatReceiveMessagesResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatReceiveMessagesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatReceiveMessagesResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatReceiveMessagesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatReceiveMessagesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22292,6 +22918,17 @@ abstract class ChatReceiveMessagesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatReceiveMessagesResponseApplicationJsonInterface {
   ChatReceiveMessagesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatReceiveMessagesResponseApplicationJsonInterfaceBuilder].
+  $ChatReceiveMessagesResponseApplicationJsonInterface rebuild(
+    void Function($ChatReceiveMessagesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatReceiveMessagesResponseApplicationJsonInterfaceBuilder].
+  $ChatReceiveMessagesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatReceiveMessagesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22347,6 +22984,17 @@ sealed class $ChatChatReceiveMessagesHeadersInterface {
   String? get xChatLastCommonRead;
   @BuiltValueField(wireName: 'x-chat-last-given')
   String? get xChatLastGiven;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatChatReceiveMessagesHeadersInterfaceBuilder].
+  $ChatChatReceiveMessagesHeadersInterface rebuild(
+    void Function($ChatChatReceiveMessagesHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatChatReceiveMessagesHeadersInterfaceBuilder].
+  $ChatChatReceiveMessagesHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatChatReceiveMessagesHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22517,6 +23165,17 @@ class _$ChatSendMessageApiVersionSerializer implements PrimitiveSerializer<ChatS
 sealed class $ChatSendMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessageWithParent? get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatSendMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatSendMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatSendMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatSendMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatSendMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatSendMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22569,6 +23228,17 @@ abstract class ChatSendMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatSendMessageResponseApplicationJsonInterface {
   ChatSendMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatSendMessageResponseApplicationJsonInterfaceBuilder].
+  $ChatSendMessageResponseApplicationJsonInterface rebuild(
+    void Function($ChatSendMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatSendMessageResponseApplicationJsonInterfaceBuilder].
+  $ChatSendMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatSendMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22621,6 +23291,15 @@ abstract class ChatSendMessageResponseApplicationJson
 sealed class $ChatChatSendMessageHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatChatSendMessageHeadersInterfaceBuilder].
+  $ChatChatSendMessageHeadersInterface rebuild(void Function($ChatChatSendMessageHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ChatChatSendMessageHeadersInterfaceBuilder].
+  $ChatChatSendMessageHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatChatSendMessageHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22728,6 +23407,17 @@ class _$ChatClearHistoryApiVersionSerializer implements PrimitiveSerializer<Chat
 sealed class $ChatClearHistoryResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessage get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatClearHistoryResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatClearHistoryResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatClearHistoryResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatClearHistoryResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatClearHistoryResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatClearHistoryResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22780,6 +23470,17 @@ abstract class ChatClearHistoryResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatClearHistoryResponseApplicationJsonInterface {
   ChatClearHistoryResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatClearHistoryResponseApplicationJsonInterfaceBuilder].
+  $ChatClearHistoryResponseApplicationJsonInterface rebuild(
+    void Function($ChatClearHistoryResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatClearHistoryResponseApplicationJsonInterfaceBuilder].
+  $ChatClearHistoryResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatClearHistoryResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22832,6 +23533,15 @@ abstract class ChatClearHistoryResponseApplicationJson
 sealed class $ChatChatClearHistoryHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatChatClearHistoryHeadersInterfaceBuilder].
+  $ChatChatClearHistoryHeadersInterface rebuild(void Function($ChatChatClearHistoryHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ChatChatClearHistoryHeadersInterfaceBuilder].
+  $ChatChatClearHistoryHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatChatClearHistoryHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22939,6 +23649,17 @@ class _$ChatEditMessageApiVersionSerializer implements PrimitiveSerializer<ChatE
 sealed class $ChatEditMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessageWithParent get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatEditMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatEditMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatEditMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatEditMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatEditMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatEditMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -22991,6 +23712,17 @@ abstract class ChatEditMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatEditMessageResponseApplicationJsonInterface {
   ChatEditMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatEditMessageResponseApplicationJsonInterfaceBuilder].
+  $ChatEditMessageResponseApplicationJsonInterface rebuild(
+    void Function($ChatEditMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatEditMessageResponseApplicationJsonInterfaceBuilder].
+  $ChatEditMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatEditMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23043,6 +23775,15 @@ abstract class ChatEditMessageResponseApplicationJson
 sealed class $ChatChatEditMessageHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatChatEditMessageHeadersInterfaceBuilder].
+  $ChatChatEditMessageHeadersInterface rebuild(void Function($ChatChatEditMessageHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ChatChatEditMessageHeadersInterfaceBuilder].
+  $ChatChatEditMessageHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatChatEditMessageHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23150,6 +23891,17 @@ class _$ChatDeleteMessageApiVersionSerializer implements PrimitiveSerializer<Cha
 sealed class $ChatDeleteMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessageWithParent get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatDeleteMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatDeleteMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatDeleteMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatDeleteMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatDeleteMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatDeleteMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23202,6 +23954,17 @@ abstract class ChatDeleteMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatDeleteMessageResponseApplicationJsonInterface {
   ChatDeleteMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatDeleteMessageResponseApplicationJsonInterfaceBuilder].
+  $ChatDeleteMessageResponseApplicationJsonInterface rebuild(
+    void Function($ChatDeleteMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatDeleteMessageResponseApplicationJsonInterfaceBuilder].
+  $ChatDeleteMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatDeleteMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23255,6 +24018,15 @@ abstract class ChatDeleteMessageResponseApplicationJson
 sealed class $ChatChatDeleteMessageHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatChatDeleteMessageHeadersInterfaceBuilder].
+  $ChatChatDeleteMessageHeadersInterface rebuild(void Function($ChatChatDeleteMessageHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ChatChatDeleteMessageHeadersInterfaceBuilder].
+  $ChatChatDeleteMessageHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatChatDeleteMessageHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23363,6 +24135,17 @@ class _$ChatGetMessageContextApiVersionSerializer implements PrimitiveSerializer
 sealed class $ChatGetMessageContextResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ChatMessageWithParent> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetMessageContextResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatGetMessageContextResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatGetMessageContextResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetMessageContextResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatGetMessageContextResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatGetMessageContextResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23416,6 +24199,17 @@ abstract class ChatGetMessageContextResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatGetMessageContextResponseApplicationJsonInterface {
   ChatGetMessageContextResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetMessageContextResponseApplicationJsonInterfaceBuilder].
+  $ChatGetMessageContextResponseApplicationJsonInterface rebuild(
+    void Function($ChatGetMessageContextResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetMessageContextResponseApplicationJsonInterfaceBuilder].
+  $ChatGetMessageContextResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatGetMessageContextResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23471,6 +24265,17 @@ sealed class $ChatChatGetMessageContextHeadersInterface {
   String? get xChatLastCommonRead;
   @BuiltValueField(wireName: 'x-chat-last-given')
   String? get xChatLastGiven;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatChatGetMessageContextHeadersInterfaceBuilder].
+  $ChatChatGetMessageContextHeadersInterface rebuild(
+    void Function($ChatChatGetMessageContextHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatChatGetMessageContextHeadersInterfaceBuilder].
+  $ChatChatGetMessageContextHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatChatGetMessageContextHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23580,6 +24385,15 @@ sealed class $ChatReminderInterface {
   int get timestamp;
   String get token;
   String get userId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatReminderInterfaceBuilder].
+  $ChatReminderInterface rebuild(void Function($ChatReminderInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ChatReminderInterfaceBuilder].
+  $ChatReminderInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatReminderInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23626,6 +24440,17 @@ abstract class ChatReminder implements $ChatReminderInterface, Built<ChatReminde
 sealed class $ChatGetReminderResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatReminder get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetReminderResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatGetReminderResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatGetReminderResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetReminderResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatGetReminderResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatGetReminderResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23678,6 +24503,17 @@ abstract class ChatGetReminderResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatGetReminderResponseApplicationJsonInterface {
   ChatGetReminderResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetReminderResponseApplicationJsonInterfaceBuilder].
+  $ChatGetReminderResponseApplicationJsonInterface rebuild(
+    void Function($ChatGetReminderResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetReminderResponseApplicationJsonInterfaceBuilder].
+  $ChatGetReminderResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatGetReminderResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23786,6 +24622,17 @@ class _$ChatSetReminderApiVersionSerializer implements PrimitiveSerializer<ChatS
 sealed class $ChatSetReminderResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatReminder get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatSetReminderResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatSetReminderResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatSetReminderResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatSetReminderResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatSetReminderResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatSetReminderResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23838,6 +24685,17 @@ abstract class ChatSetReminderResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatSetReminderResponseApplicationJsonInterface {
   ChatSetReminderResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatSetReminderResponseApplicationJsonInterfaceBuilder].
+  $ChatSetReminderResponseApplicationJsonInterface rebuild(
+    void Function($ChatSetReminderResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatSetReminderResponseApplicationJsonInterfaceBuilder].
+  $ChatSetReminderResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatSetReminderResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23945,6 +24803,17 @@ class _$ChatDeleteReminderApiVersionSerializer implements PrimitiveSerializer<Ch
 @BuiltValue(instantiable: false)
 sealed class $ChatDeleteReminderResponseApplicationJson_Ocs_DataInterface {
   String? get error;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatDeleteReminderResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ChatDeleteReminderResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($ChatDeleteReminderResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatDeleteReminderResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ChatDeleteReminderResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatDeleteReminderResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -23999,6 +24868,17 @@ abstract class ChatDeleteReminderResponseApplicationJson_Ocs_Data
 sealed class $ChatDeleteReminderResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatDeleteReminderResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatDeleteReminderResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatDeleteReminderResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatDeleteReminderResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatDeleteReminderResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatDeleteReminderResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatDeleteReminderResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24051,6 +24931,17 @@ abstract class ChatDeleteReminderResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatDeleteReminderResponseApplicationJsonInterface {
   ChatDeleteReminderResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatDeleteReminderResponseApplicationJsonInterfaceBuilder].
+  $ChatDeleteReminderResponseApplicationJsonInterface rebuild(
+    void Function($ChatDeleteReminderResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatDeleteReminderResponseApplicationJsonInterfaceBuilder].
+  $ChatDeleteReminderResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatDeleteReminderResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24160,6 +25051,17 @@ class _$ChatSetReadMarkerApiVersionSerializer implements PrimitiveSerializer<Cha
 sealed class $ChatSetReadMarkerResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatSetReadMarkerResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatSetReadMarkerResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatSetReadMarkerResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatSetReadMarkerResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatSetReadMarkerResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatSetReadMarkerResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24212,6 +25114,17 @@ abstract class ChatSetReadMarkerResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatSetReadMarkerResponseApplicationJsonInterface {
   ChatSetReadMarkerResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatSetReadMarkerResponseApplicationJsonInterfaceBuilder].
+  $ChatSetReadMarkerResponseApplicationJsonInterface rebuild(
+    void Function($ChatSetReadMarkerResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatSetReadMarkerResponseApplicationJsonInterfaceBuilder].
+  $ChatSetReadMarkerResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatSetReadMarkerResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24265,6 +25178,15 @@ abstract class ChatSetReadMarkerResponseApplicationJson
 sealed class $ChatChatSetReadMarkerHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatChatSetReadMarkerHeadersInterfaceBuilder].
+  $ChatChatSetReadMarkerHeadersInterface rebuild(void Function($ChatChatSetReadMarkerHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ChatChatSetReadMarkerHeadersInterfaceBuilder].
+  $ChatChatSetReadMarkerHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatChatSetReadMarkerHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24372,6 +25294,17 @@ class _$ChatMarkUnreadApiVersionSerializer implements PrimitiveSerializer<ChatMa
 sealed class $ChatMarkUnreadResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatMarkUnreadResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatMarkUnreadResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatMarkUnreadResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatMarkUnreadResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatMarkUnreadResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatMarkUnreadResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24424,6 +25357,17 @@ abstract class ChatMarkUnreadResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatMarkUnreadResponseApplicationJsonInterface {
   ChatMarkUnreadResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatMarkUnreadResponseApplicationJsonInterfaceBuilder].
+  $ChatMarkUnreadResponseApplicationJsonInterface rebuild(
+    void Function($ChatMarkUnreadResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatMarkUnreadResponseApplicationJsonInterfaceBuilder].
+  $ChatMarkUnreadResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatMarkUnreadResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24476,6 +25420,15 @@ abstract class ChatMarkUnreadResponseApplicationJson
 sealed class $ChatChatMarkUnreadHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatChatMarkUnreadHeadersInterfaceBuilder].
+  $ChatChatMarkUnreadHeadersInterface rebuild(void Function($ChatChatMarkUnreadHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ChatChatMarkUnreadHeadersInterfaceBuilder].
+  $ChatChatMarkUnreadHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatChatMarkUnreadHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24649,6 +25602,15 @@ sealed class $ChatMentionSuggestionInterface {
   int? get statusClearAt;
   String? get statusIcon;
   String? get statusMessage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatMentionSuggestionInterfaceBuilder].
+  $ChatMentionSuggestionInterface rebuild(void Function($ChatMentionSuggestionInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ChatMentionSuggestionInterfaceBuilder].
+  $ChatMentionSuggestionInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatMentionSuggestionInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24697,6 +25659,17 @@ abstract class ChatMentionSuggestion
 sealed class $ChatMentionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ChatMentionSuggestion> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatMentionsResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatMentionsResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatMentionsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatMentionsResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatMentionsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatMentionsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24748,6 +25721,17 @@ abstract class ChatMentionsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatMentionsResponseApplicationJsonInterface {
   ChatMentionsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatMentionsResponseApplicationJsonInterfaceBuilder].
+  $ChatMentionsResponseApplicationJsonInterface rebuild(
+    void Function($ChatMentionsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatMentionsResponseApplicationJsonInterfaceBuilder].
+  $ChatMentionsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatMentionsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24861,6 +25845,17 @@ class _$ChatGetObjectsSharedInRoomApiVersionSerializer
 sealed class $ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ChatMessage> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24914,6 +25909,17 @@ abstract class ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatGetObjectsSharedInRoomResponseApplicationJsonInterface {
   ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetObjectsSharedInRoomResponseApplicationJsonInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomResponseApplicationJsonInterface rebuild(
+    void Function($ChatGetObjectsSharedInRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetObjectsSharedInRoomResponseApplicationJsonInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatGetObjectsSharedInRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -24968,6 +25974,17 @@ abstract class ChatGetObjectsSharedInRoomResponseApplicationJson
 sealed class $ChatChatGetObjectsSharedInRoomHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-given')
   String? get xChatLastGiven;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder].
+  $ChatChatGetObjectsSharedInRoomHeadersInterface rebuild(
+    void Function($ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder].
+  $ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatChatGetObjectsSharedInRoomHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25077,6 +26094,17 @@ class _$ChatShareObjectToChatApiVersionSerializer implements PrimitiveSerializer
 sealed class $ChatShareObjectToChatResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessageWithParent? get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatShareObjectToChatResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatShareObjectToChatResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatShareObjectToChatResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatShareObjectToChatResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatShareObjectToChatResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatShareObjectToChatResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25130,6 +26158,17 @@ abstract class ChatShareObjectToChatResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatShareObjectToChatResponseApplicationJsonInterface {
   ChatShareObjectToChatResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatShareObjectToChatResponseApplicationJsonInterfaceBuilder].
+  $ChatShareObjectToChatResponseApplicationJsonInterface rebuild(
+    void Function($ChatShareObjectToChatResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatShareObjectToChatResponseApplicationJsonInterfaceBuilder].
+  $ChatShareObjectToChatResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatShareObjectToChatResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25183,6 +26222,17 @@ abstract class ChatShareObjectToChatResponseApplicationJson
 sealed class $ChatChatShareObjectToChatHeadersInterface {
   @BuiltValueField(wireName: 'x-chat-last-common-read')
   String? get xChatLastCommonRead;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatChatShareObjectToChatHeadersInterfaceBuilder].
+  $ChatChatShareObjectToChatHeadersInterface rebuild(
+    void Function($ChatChatShareObjectToChatHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatChatShareObjectToChatHeadersInterfaceBuilder].
+  $ChatChatShareObjectToChatHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatChatShareObjectToChatHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25296,6 +26346,17 @@ class _$ChatGetObjectsSharedInRoomOverviewApiVersionSerializer
 sealed class $ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<ChatMessage>> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterface rebuild(
+    void Function($ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25349,6 +26410,17 @@ abstract class ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterface {
   ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterface rebuild(
+    void Function($ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25460,6 +26532,17 @@ class _$SignalingGetSettingsApiVersionSerializer implements PrimitiveSerializer<
 sealed class $SignalingSettings_HelloAuthParams_10Interface {
   String? get userid;
   String get ticket;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingSettings_HelloAuthParams_10InterfaceBuilder].
+  $SignalingSettings_HelloAuthParams_10Interface rebuild(
+    void Function($SignalingSettings_HelloAuthParams_10InterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingSettings_HelloAuthParams_10InterfaceBuilder].
+  $SignalingSettings_HelloAuthParams_10InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingSettings_HelloAuthParams_10InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25511,6 +26594,17 @@ abstract class SignalingSettings_HelloAuthParams_10
 @BuiltValue(instantiable: false)
 sealed class $SignalingSettings_HelloAuthParams_20Interface {
   String get token;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingSettings_HelloAuthParams_20InterfaceBuilder].
+  $SignalingSettings_HelloAuthParams_20Interface rebuild(
+    void Function($SignalingSettings_HelloAuthParams_20InterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingSettings_HelloAuthParams_20InterfaceBuilder].
+  $SignalingSettings_HelloAuthParams_20InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingSettings_HelloAuthParams_20InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25565,6 +26659,17 @@ sealed class $SignalingSettings_HelloAuthParamsInterface {
   SignalingSettings_HelloAuthParams_10 get $10;
   @BuiltValueField(wireName: '2.0')
   SignalingSettings_HelloAuthParams_20 get $20;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingSettings_HelloAuthParamsInterfaceBuilder].
+  $SignalingSettings_HelloAuthParamsInterface rebuild(
+    void Function($SignalingSettings_HelloAuthParamsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingSettings_HelloAuthParamsInterfaceBuilder].
+  $SignalingSettings_HelloAuthParamsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingSettings_HelloAuthParamsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25615,6 +26720,17 @@ abstract class SignalingSettings_HelloAuthParams
 @BuiltValue(instantiable: false)
 sealed class $SignalingSettings_StunserversInterface {
   BuiltList<String> get urls;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingSettings_StunserversInterfaceBuilder].
+  $SignalingSettings_StunserversInterface rebuild(
+    void Function($SignalingSettings_StunserversInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingSettings_StunserversInterfaceBuilder].
+  $SignalingSettings_StunserversInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingSettings_StunserversInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25667,6 +26783,17 @@ sealed class $SignalingSettings_TurnserversInterface {
   BuiltList<String> get urls;
   String get username;
   JsonObject get credential;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingSettings_TurnserversInterfaceBuilder].
+  $SignalingSettings_TurnserversInterface rebuild(
+    void Function($SignalingSettings_TurnserversInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingSettings_TurnserversInterfaceBuilder].
+  $SignalingSettings_TurnserversInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingSettings_TurnserversInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25725,6 +26852,15 @@ sealed class $SignalingSettingsInterface {
   String get ticket;
   BuiltList<SignalingSettings_Turnservers> get turnservers;
   String? get userId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingSettingsInterfaceBuilder].
+  $SignalingSettingsInterface rebuild(void Function($SignalingSettingsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SignalingSettingsInterfaceBuilder].
+  $SignalingSettingsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingSettingsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25772,6 +26908,17 @@ abstract class SignalingSettings
 sealed class $SignalingGetSettingsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   SignalingSettings get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingGetSettingsResponseApplicationJson_OcsInterfaceBuilder].
+  $SignalingGetSettingsResponseApplicationJson_OcsInterface rebuild(
+    void Function($SignalingGetSettingsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingGetSettingsResponseApplicationJson_OcsInterfaceBuilder].
+  $SignalingGetSettingsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingGetSettingsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25824,6 +26971,17 @@ abstract class SignalingGetSettingsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $SignalingGetSettingsResponseApplicationJsonInterface {
   SignalingGetSettingsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingGetSettingsResponseApplicationJsonInterfaceBuilder].
+  $SignalingGetSettingsResponseApplicationJsonInterface rebuild(
+    void Function($SignalingGetSettingsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingGetSettingsResponseApplicationJsonInterfaceBuilder].
+  $SignalingGetSettingsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingGetSettingsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25934,6 +27092,17 @@ class _$FederationAcceptShareApiVersionSerializer implements PrimitiveSerializer
 sealed class $FederationAcceptShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FederationAcceptShareResponseApplicationJson_OcsInterfaceBuilder].
+  $FederationAcceptShareResponseApplicationJson_OcsInterface rebuild(
+    void Function($FederationAcceptShareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FederationAcceptShareResponseApplicationJson_OcsInterfaceBuilder].
+  $FederationAcceptShareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FederationAcceptShareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -25987,6 +27156,17 @@ abstract class FederationAcceptShareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $FederationAcceptShareResponseApplicationJsonInterface {
   FederationAcceptShareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FederationAcceptShareResponseApplicationJsonInterfaceBuilder].
+  $FederationAcceptShareResponseApplicationJsonInterface rebuild(
+    void Function($FederationAcceptShareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FederationAcceptShareResponseApplicationJsonInterfaceBuilder].
+  $FederationAcceptShareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FederationAcceptShareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26097,6 +27277,17 @@ class _$FederationRejectShareApiVersionSerializer implements PrimitiveSerializer
 sealed class $FederationRejectShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FederationRejectShareResponseApplicationJson_OcsInterfaceBuilder].
+  $FederationRejectShareResponseApplicationJson_OcsInterface rebuild(
+    void Function($FederationRejectShareResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FederationRejectShareResponseApplicationJson_OcsInterfaceBuilder].
+  $FederationRejectShareResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FederationRejectShareResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26150,6 +27341,17 @@ abstract class FederationRejectShareResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $FederationRejectShareResponseApplicationJsonInterface {
   FederationRejectShareResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FederationRejectShareResponseApplicationJsonInterfaceBuilder].
+  $FederationRejectShareResponseApplicationJsonInterface rebuild(
+    void Function($FederationRejectShareResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FederationRejectShareResponseApplicationJsonInterfaceBuilder].
+  $FederationRejectShareResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FederationRejectShareResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26268,6 +27470,15 @@ sealed class $FederationInviteInterface {
   String get userId;
   String get inviterCloudId;
   String get inviterDisplayName;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FederationInviteInterfaceBuilder].
+  $FederationInviteInterface rebuild(void Function($FederationInviteInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$FederationInviteInterfaceBuilder].
+  $FederationInviteInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FederationInviteInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26315,6 +27526,17 @@ abstract class FederationInvite
 sealed class $FederationGetSharesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<FederationInvite> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FederationGetSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $FederationGetSharesResponseApplicationJson_OcsInterface rebuild(
+    void Function($FederationGetSharesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FederationGetSharesResponseApplicationJson_OcsInterfaceBuilder].
+  $FederationGetSharesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FederationGetSharesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26367,6 +27589,17 @@ abstract class FederationGetSharesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $FederationGetSharesResponseApplicationJsonInterface {
   FederationGetSharesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FederationGetSharesResponseApplicationJsonInterfaceBuilder].
+  $FederationGetSharesResponseApplicationJsonInterface rebuild(
+    void Function($FederationGetSharesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FederationGetSharesResponseApplicationJsonInterfaceBuilder].
+  $FederationGetSharesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FederationGetSharesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26481,6 +27714,17 @@ class _$FilesIntegrationGetRoomByFileIdApiVersionSerializer
 @BuiltValue(instantiable: false)
 sealed class $FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterface {
   String get token;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26535,6 +27779,17 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data
 sealed class $FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterfaceBuilder].
+  $FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterface rebuild(
+    void Function($FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterfaceBuilder].
+  $FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesIntegrationGetRoomByFileIdResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26588,6 +27843,17 @@ abstract class FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterface {
   FilesIntegrationGetRoomByFileIdResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterfaceBuilder].
+  $FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterface rebuild(
+    void Function($FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterfaceBuilder].
+  $FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesIntegrationGetRoomByFileIdResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26705,6 +27971,17 @@ sealed class $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Dat
   String get token;
   String get userId;
   String get userDisplayName;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26759,6 +28036,17 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Da
 sealed class $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterfaceBuilder].
+  $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterface rebuild(
+    void Function($FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterfaceBuilder].
+  $FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesIntegrationGetRoomByShareTokenResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26812,6 +28100,17 @@ abstract class FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterface {
   FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterfaceBuilder].
+  $FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterface rebuild(
+    void Function($FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterfaceBuilder].
+  $FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($FilesIntegrationGetRoomByShareTokenResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26926,6 +28225,17 @@ sealed class $PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterface
   String get token;
   String get name;
   String get displayName;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -26980,6 +28290,17 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data
 sealed class $PublicShareAuthCreateRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicShareAuthCreateRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $PublicShareAuthCreateRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($PublicShareAuthCreateRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PublicShareAuthCreateRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $PublicShareAuthCreateRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PublicShareAuthCreateRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27033,6 +28354,17 @@ abstract class PublicShareAuthCreateRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PublicShareAuthCreateRoomResponseApplicationJsonInterface {
   PublicShareAuthCreateRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicShareAuthCreateRoomResponseApplicationJsonInterfaceBuilder].
+  $PublicShareAuthCreateRoomResponseApplicationJsonInterface rebuild(
+    void Function($PublicShareAuthCreateRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PublicShareAuthCreateRoomResponseApplicationJsonInterfaceBuilder].
+  $PublicShareAuthCreateRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PublicShareAuthCreateRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27143,6 +28475,17 @@ class _$GuestSetDisplayNameApiVersionSerializer implements PrimitiveSerializer<G
 sealed class $GuestSetDisplayNameResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GuestSetDisplayNameResponseApplicationJson_OcsInterfaceBuilder].
+  $GuestSetDisplayNameResponseApplicationJson_OcsInterface rebuild(
+    void Function($GuestSetDisplayNameResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GuestSetDisplayNameResponseApplicationJson_OcsInterfaceBuilder].
+  $GuestSetDisplayNameResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GuestSetDisplayNameResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27195,6 +28538,17 @@ abstract class GuestSetDisplayNameResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $GuestSetDisplayNameResponseApplicationJsonInterface {
   GuestSetDisplayNameResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GuestSetDisplayNameResponseApplicationJsonInterfaceBuilder].
+  $GuestSetDisplayNameResponseApplicationJsonInterface rebuild(
+    void Function($GuestSetDisplayNameResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GuestSetDisplayNameResponseApplicationJsonInterfaceBuilder].
+  $GuestSetDisplayNameResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GuestSetDisplayNameResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27310,6 +28664,17 @@ class _$HostedSignalingServerRequestTrialApiVersionSerializer
 sealed class $HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, JsonObject> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterfaceBuilder].
+  $HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterface rebuild(
+    void Function($HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterfaceBuilder].
+  $HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($HostedSignalingServerRequestTrialResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27363,6 +28728,17 @@ abstract class HostedSignalingServerRequestTrialResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $HostedSignalingServerRequestTrialResponseApplicationJsonInterface {
   HostedSignalingServerRequestTrialResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$HostedSignalingServerRequestTrialResponseApplicationJsonInterfaceBuilder].
+  $HostedSignalingServerRequestTrialResponseApplicationJsonInterface rebuild(
+    void Function($HostedSignalingServerRequestTrialResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$HostedSignalingServerRequestTrialResponseApplicationJsonInterfaceBuilder].
+  $HostedSignalingServerRequestTrialResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($HostedSignalingServerRequestTrialResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27540,6 +28916,15 @@ sealed class $SignalingSessionInterface {
   int get roomId;
   String get sessionId;
   String get userId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingSessionInterfaceBuilder].
+  $SignalingSessionInterface rebuild(void Function($SignalingSessionInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SignalingSessionInterfaceBuilder].
+  $SignalingSessionInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingSessionInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27592,6 +28977,17 @@ typedef SignalingPullMessagesResponseApplicationJson_Ocs_Data_Data = ({
 sealed class $SignalingPullMessagesResponseApplicationJson_Ocs_DataInterface {
   String get type;
   SignalingPullMessagesResponseApplicationJson_Ocs_Data_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingPullMessagesResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $SignalingPullMessagesResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($SignalingPullMessagesResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingPullMessagesResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $SignalingPullMessagesResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingPullMessagesResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27648,6 +29044,17 @@ abstract class SignalingPullMessagesResponseApplicationJson_Ocs_Data
 sealed class $SignalingPullMessagesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<SignalingPullMessagesResponseApplicationJson_Ocs_Data> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingPullMessagesResponseApplicationJson_OcsInterfaceBuilder].
+  $SignalingPullMessagesResponseApplicationJson_OcsInterface rebuild(
+    void Function($SignalingPullMessagesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingPullMessagesResponseApplicationJson_OcsInterfaceBuilder].
+  $SignalingPullMessagesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingPullMessagesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27701,6 +29108,17 @@ abstract class SignalingPullMessagesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $SignalingPullMessagesResponseApplicationJsonInterface {
   SignalingPullMessagesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingPullMessagesResponseApplicationJsonInterfaceBuilder].
+  $SignalingPullMessagesResponseApplicationJsonInterface rebuild(
+    void Function($SignalingPullMessagesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingPullMessagesResponseApplicationJsonInterfaceBuilder].
+  $SignalingPullMessagesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingPullMessagesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27811,6 +29229,17 @@ class _$SignalingSendMessagesApiVersionSerializer implements PrimitiveSerializer
 sealed class $SignalingSendMessagesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingSendMessagesResponseApplicationJson_OcsInterfaceBuilder].
+  $SignalingSendMessagesResponseApplicationJson_OcsInterface rebuild(
+    void Function($SignalingSendMessagesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingSendMessagesResponseApplicationJson_OcsInterfaceBuilder].
+  $SignalingSendMessagesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingSendMessagesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27864,6 +29293,17 @@ abstract class SignalingSendMessagesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $SignalingSendMessagesResponseApplicationJsonInterface {
   SignalingSendMessagesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingSendMessagesResponseApplicationJsonInterfaceBuilder].
+  $SignalingSendMessagesResponseApplicationJsonInterface rebuild(
+    void Function($SignalingSendMessagesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingSendMessagesResponseApplicationJsonInterfaceBuilder].
+  $SignalingSendMessagesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingSendMessagesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -27979,6 +29419,15 @@ sealed class $MatterbridgeInterface {
   bool get enabled;
   BuiltList<BuiltMap<String, JsonObject>> get parts;
   int get pid;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeInterfaceBuilder].
+  $MatterbridgeInterface rebuild(void Function($MatterbridgeInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$MatterbridgeInterfaceBuilder].
+  $MatterbridgeInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28025,6 +29474,15 @@ abstract class Matterbridge implements $MatterbridgeInterface, Built<Matterbridg
 sealed class $MatterbridgeProcessStateInterface {
   String get log;
   bool get running;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeProcessStateInterfaceBuilder].
+  $MatterbridgeProcessStateInterface rebuild(void Function($MatterbridgeProcessStateInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$MatterbridgeProcessStateInterfaceBuilder].
+  $MatterbridgeProcessStateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeProcessStateInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28072,6 +29530,14 @@ abstract class MatterbridgeProcessState
 @BuiltValue(instantiable: false)
 sealed class $MatterbridgeWithProcessStateInterface
     implements $MatterbridgeInterface, $MatterbridgeProcessStateInterface {
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeWithProcessStateInterfaceBuilder].
+  $MatterbridgeWithProcessStateInterface rebuild(void Function($MatterbridgeWithProcessStateInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$MatterbridgeWithProcessStateInterfaceBuilder].
+  $MatterbridgeWithProcessStateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeWithProcessStateInterfaceBuilder b) {
     $MatterbridgeInterface._defaults(b);
@@ -28130,6 +29596,17 @@ abstract class MatterbridgeWithProcessState
 sealed class $MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   MatterbridgeWithProcessState get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeGetBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28183,6 +29660,17 @@ abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterface {
   MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterface rebuild(
+    void Function($MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeGetBridgeOfRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28364,6 +29852,17 @@ class _$MatterbridgeEditBridgeOfRoomApiVersionSerializer
 sealed class $MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   MatterbridgeProcessState get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28417,6 +29916,17 @@ abstract class MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterface {
   MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterface rebuild(
+    void Function($MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeEditBridgeOfRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28533,6 +30043,17 @@ class _$MatterbridgeDeleteBridgeOfRoomApiVersionSerializer
 sealed class $MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   bool get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28586,6 +30107,17 @@ abstract class MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterface {
   MatterbridgeDeleteBridgeOfRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterface rebuild(
+    void Function($MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeDeleteBridgeOfRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28702,6 +30234,17 @@ class _$MatterbridgeGetBridgeProcessStateApiVersionSerializer
 sealed class $MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   MatterbridgeProcessState get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterface rebuild(
+    void Function($MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeGetBridgeProcessStateResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28755,6 +30298,17 @@ abstract class MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterface {
   MatterbridgeGetBridgeProcessStateResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterface rebuild(
+    void Function($MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeGetBridgeProcessStateResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28871,6 +30425,17 @@ class _$MatterbridgeSettingsStopAllBridgesApiVersionSerializer
 sealed class $MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   bool get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterface rebuild(
+    void Function($MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeSettingsStopAllBridgesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -28924,6 +30489,17 @@ abstract class MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterface {
   MatterbridgeSettingsStopAllBridgesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterface rebuild(
+    void Function($MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeSettingsStopAllBridgesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29040,6 +30616,17 @@ class _$MatterbridgeSettingsGetMatterbridgeVersionApiVersionSerializer
 @BuiltValue(instantiable: false)
 sealed class $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterface {
   String get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults(
     $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataInterfaceBuilder b,
@@ -29100,6 +30687,17 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
 sealed class $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterface rebuild(
+    void Function($MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterfaceBuilder].
+  $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29153,6 +30751,17 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterface {
   MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterface rebuild(
+    void Function($MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterfaceBuilder].
+  $MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29328,6 +30937,15 @@ sealed class $PollVoteInterface {
   String get actorId;
   ActorType get actorType;
   int get optionId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollVoteInterfaceBuilder].
+  $PollVoteInterface rebuild(void Function($PollVoteInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PollVoteInterfaceBuilder].
+  $PollVoteInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PollVoteInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29385,6 +31003,15 @@ sealed class $PollInterface {
   int get status;
   BuiltList<int>? get votedSelf;
   BuiltMap<String, int>? get votes;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollInterfaceBuilder].
+  $PollInterface rebuild(void Function($PollInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PollInterfaceBuilder].
+  $PollInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PollInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29431,6 +31058,17 @@ abstract class Poll implements $PollInterface, Built<Poll, PollBuilder> {
 sealed class $PollCreatePollResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Poll get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollCreatePollResponseApplicationJson_OcsInterfaceBuilder].
+  $PollCreatePollResponseApplicationJson_OcsInterface rebuild(
+    void Function($PollCreatePollResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PollCreatePollResponseApplicationJson_OcsInterfaceBuilder].
+  $PollCreatePollResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PollCreatePollResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29483,6 +31121,17 @@ abstract class PollCreatePollResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PollCreatePollResponseApplicationJsonInterface {
   PollCreatePollResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollCreatePollResponseApplicationJsonInterfaceBuilder].
+  $PollCreatePollResponseApplicationJsonInterface rebuild(
+    void Function($PollCreatePollResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PollCreatePollResponseApplicationJsonInterfaceBuilder].
+  $PollCreatePollResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PollCreatePollResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29591,6 +31240,17 @@ class _$PollShowPollApiVersionSerializer implements PrimitiveSerializer<PollShow
 sealed class $PollShowPollResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Poll get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollShowPollResponseApplicationJson_OcsInterfaceBuilder].
+  $PollShowPollResponseApplicationJson_OcsInterface rebuild(
+    void Function($PollShowPollResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PollShowPollResponseApplicationJson_OcsInterfaceBuilder].
+  $PollShowPollResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PollShowPollResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29642,6 +31302,17 @@ abstract class PollShowPollResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PollShowPollResponseApplicationJsonInterface {
   PollShowPollResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollShowPollResponseApplicationJsonInterfaceBuilder].
+  $PollShowPollResponseApplicationJsonInterface rebuild(
+    void Function($PollShowPollResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PollShowPollResponseApplicationJsonInterfaceBuilder].
+  $PollShowPollResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PollShowPollResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29750,6 +31421,17 @@ class _$PollVotePollApiVersionSerializer implements PrimitiveSerializer<PollVote
 sealed class $PollVotePollResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Poll get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollVotePollResponseApplicationJson_OcsInterfaceBuilder].
+  $PollVotePollResponseApplicationJson_OcsInterface rebuild(
+    void Function($PollVotePollResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PollVotePollResponseApplicationJson_OcsInterfaceBuilder].
+  $PollVotePollResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PollVotePollResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29801,6 +31483,17 @@ abstract class PollVotePollResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PollVotePollResponseApplicationJsonInterface {
   PollVotePollResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollVotePollResponseApplicationJsonInterfaceBuilder].
+  $PollVotePollResponseApplicationJsonInterface rebuild(
+    void Function($PollVotePollResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PollVotePollResponseApplicationJsonInterfaceBuilder].
+  $PollVotePollResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PollVotePollResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29909,6 +31602,17 @@ class _$PollClosePollApiVersionSerializer implements PrimitiveSerializer<PollClo
 sealed class $PollClosePollResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Poll get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollClosePollResponseApplicationJson_OcsInterfaceBuilder].
+  $PollClosePollResponseApplicationJson_OcsInterface rebuild(
+    void Function($PollClosePollResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PollClosePollResponseApplicationJson_OcsInterfaceBuilder].
+  $PollClosePollResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PollClosePollResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -29961,6 +31665,17 @@ abstract class PollClosePollResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PollClosePollResponseApplicationJsonInterface {
   PollClosePollResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollClosePollResponseApplicationJsonInterfaceBuilder].
+  $PollClosePollResponseApplicationJsonInterface rebuild(
+    void Function($PollClosePollResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PollClosePollResponseApplicationJsonInterfaceBuilder].
+  $PollClosePollResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PollClosePollResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30072,6 +31787,15 @@ sealed class $ReactionInterface {
   String get actorId;
   ActorType get actorType;
   int get timestamp;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReactionInterfaceBuilder].
+  $ReactionInterface rebuild(void Function($ReactionInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ReactionInterfaceBuilder].
+  $ReactionInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReactionInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30118,6 +31842,17 @@ abstract class Reaction implements $ReactionInterface, Built<Reaction, ReactionB
 sealed class $ReactionGetReactionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<Reaction>> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReactionGetReactionsResponseApplicationJson_OcsInterfaceBuilder].
+  $ReactionGetReactionsResponseApplicationJson_OcsInterface rebuild(
+    void Function($ReactionGetReactionsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReactionGetReactionsResponseApplicationJson_OcsInterfaceBuilder].
+  $ReactionGetReactionsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReactionGetReactionsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30170,6 +31905,17 @@ abstract class ReactionGetReactionsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ReactionGetReactionsResponseApplicationJsonInterface {
   ReactionGetReactionsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReactionGetReactionsResponseApplicationJsonInterfaceBuilder].
+  $ReactionGetReactionsResponseApplicationJsonInterface rebuild(
+    void Function($ReactionGetReactionsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReactionGetReactionsResponseApplicationJsonInterfaceBuilder].
+  $ReactionGetReactionsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReactionGetReactionsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30279,6 +32025,17 @@ class _$ReactionReactApiVersionSerializer implements PrimitiveSerializer<Reactio
 sealed class $ReactionReactResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<Reaction>> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReactionReactResponseApplicationJson_OcsInterfaceBuilder].
+  $ReactionReactResponseApplicationJson_OcsInterface rebuild(
+    void Function($ReactionReactResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReactionReactResponseApplicationJson_OcsInterfaceBuilder].
+  $ReactionReactResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReactionReactResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30331,6 +32088,17 @@ abstract class ReactionReactResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ReactionReactResponseApplicationJsonInterface {
   ReactionReactResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReactionReactResponseApplicationJsonInterfaceBuilder].
+  $ReactionReactResponseApplicationJsonInterface rebuild(
+    void Function($ReactionReactResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReactionReactResponseApplicationJsonInterfaceBuilder].
+  $ReactionReactResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReactionReactResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30439,6 +32207,17 @@ class _$ReactionDeleteApiVersionSerializer implements PrimitiveSerializer<Reacti
 sealed class $ReactionDeleteResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<Reaction>> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReactionDeleteResponseApplicationJson_OcsInterfaceBuilder].
+  $ReactionDeleteResponseApplicationJson_OcsInterface rebuild(
+    void Function($ReactionDeleteResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReactionDeleteResponseApplicationJson_OcsInterfaceBuilder].
+  $ReactionDeleteResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReactionDeleteResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30491,6 +32270,17 @@ abstract class ReactionDeleteResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ReactionDeleteResponseApplicationJsonInterface {
   ReactionDeleteResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReactionDeleteResponseApplicationJsonInterfaceBuilder].
+  $ReactionDeleteResponseApplicationJsonInterface rebuild(
+    void Function($ReactionDeleteResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReactionDeleteResponseApplicationJsonInterfaceBuilder].
+  $ReactionDeleteResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReactionDeleteResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30599,6 +32389,17 @@ class _$RecordingStartApiVersionSerializer implements PrimitiveSerializer<Record
 sealed class $RecordingStartResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingStartResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingStartResponseApplicationJson_OcsInterface rebuild(
+    void Function($RecordingStartResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingStartResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingStartResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingStartResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30651,6 +32452,17 @@ abstract class RecordingStartResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RecordingStartResponseApplicationJsonInterface {
   RecordingStartResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingStartResponseApplicationJsonInterfaceBuilder].
+  $RecordingStartResponseApplicationJsonInterface rebuild(
+    void Function($RecordingStartResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingStartResponseApplicationJsonInterfaceBuilder].
+  $RecordingStartResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingStartResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30759,6 +32571,17 @@ class _$RecordingStopApiVersionSerializer implements PrimitiveSerializer<Recordi
 sealed class $RecordingStopResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingStopResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingStopResponseApplicationJson_OcsInterface rebuild(
+    void Function($RecordingStopResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingStopResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingStopResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingStopResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30811,6 +32634,17 @@ abstract class RecordingStopResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RecordingStopResponseApplicationJsonInterface {
   RecordingStopResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingStopResponseApplicationJsonInterfaceBuilder].
+  $RecordingStopResponseApplicationJsonInterface rebuild(
+    void Function($RecordingStopResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingStopResponseApplicationJsonInterfaceBuilder].
+  $RecordingStopResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingStopResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30924,6 +32758,17 @@ class _$RecordingNotificationDismissApiVersionSerializer
 sealed class $RecordingNotificationDismissResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingNotificationDismissResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingNotificationDismissResponseApplicationJson_OcsInterface rebuild(
+    void Function($RecordingNotificationDismissResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingNotificationDismissResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingNotificationDismissResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingNotificationDismissResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -30977,6 +32822,17 @@ abstract class RecordingNotificationDismissResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RecordingNotificationDismissResponseApplicationJsonInterface {
   RecordingNotificationDismissResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingNotificationDismissResponseApplicationJsonInterfaceBuilder].
+  $RecordingNotificationDismissResponseApplicationJsonInterface rebuild(
+    void Function($RecordingNotificationDismissResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingNotificationDismissResponseApplicationJsonInterfaceBuilder].
+  $RecordingNotificationDismissResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingNotificationDismissResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31088,6 +32944,17 @@ class _$RecordingShareToChatApiVersionSerializer implements PrimitiveSerializer<
 sealed class $RecordingShareToChatResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingShareToChatResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingShareToChatResponseApplicationJson_OcsInterface rebuild(
+    void Function($RecordingShareToChatResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingShareToChatResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingShareToChatResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingShareToChatResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31140,6 +33007,17 @@ abstract class RecordingShareToChatResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RecordingShareToChatResponseApplicationJsonInterface {
   RecordingShareToChatResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingShareToChatResponseApplicationJsonInterfaceBuilder].
+  $RecordingShareToChatResponseApplicationJsonInterface rebuild(
+    void Function($RecordingShareToChatResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingShareToChatResponseApplicationJsonInterfaceBuilder].
+  $RecordingShareToChatResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingShareToChatResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31249,6 +33127,17 @@ class _$RecordingBackendApiVersionSerializer implements PrimitiveSerializer<Reco
 sealed class $RecordingBackendResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingBackendResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingBackendResponseApplicationJson_OcsInterface rebuild(
+    void Function($RecordingBackendResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingBackendResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingBackendResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingBackendResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31301,6 +33190,17 @@ abstract class RecordingBackendResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RecordingBackendResponseApplicationJsonInterface {
   RecordingBackendResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingBackendResponseApplicationJsonInterfaceBuilder].
+  $RecordingBackendResponseApplicationJsonInterface rebuild(
+    void Function($RecordingBackendResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingBackendResponseApplicationJsonInterfaceBuilder].
+  $RecordingBackendResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingBackendResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31409,6 +33309,17 @@ class _$RecordingStoreApiVersionSerializer implements PrimitiveSerializer<Record
 sealed class $RecordingStoreResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingStoreResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingStoreResponseApplicationJson_OcsInterface rebuild(
+    void Function($RecordingStoreResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingStoreResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingStoreResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingStoreResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31461,6 +33372,17 @@ abstract class RecordingStoreResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RecordingStoreResponseApplicationJsonInterface {
   RecordingStoreResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingStoreResponseApplicationJsonInterfaceBuilder].
+  $RecordingStoreResponseApplicationJsonInterface rebuild(
+    void Function($RecordingStoreResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingStoreResponseApplicationJsonInterfaceBuilder].
+  $RecordingStoreResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingStoreResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31695,6 +33617,17 @@ class _$RoomGetRoomsApiVersionSerializer implements PrimitiveSerializer<RoomGetR
 sealed class $RoomGetRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetRoomsResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomGetRoomsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetRoomsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31746,6 +33679,17 @@ abstract class RoomGetRoomsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomGetRoomsResponseApplicationJsonInterface {
   RoomGetRoomsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetRoomsResponseApplicationJsonInterfaceBuilder].
+  $RoomGetRoomsResponseApplicationJsonInterface rebuild(
+    void Function($RoomGetRoomsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetRoomsResponseApplicationJsonInterfaceBuilder].
+  $RoomGetRoomsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetRoomsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31802,6 +33746,15 @@ sealed class $RoomRoomGetRoomsHeadersInterface {
   String? get xNextcloudTalkModifiedBefore;
   @BuiltValueField(wireName: 'x-nextcloud-talk-federation-invites')
   String? get xNextcloudTalkFederationInvites;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRoomGetRoomsHeadersInterfaceBuilder].
+  $RoomRoomGetRoomsHeadersInterface rebuild(void Function($RoomRoomGetRoomsHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$RoomRoomGetRoomsHeadersInterfaceBuilder].
+  $RoomRoomGetRoomsHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRoomGetRoomsHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31906,6 +33859,17 @@ class _$RoomCreateRoomApiVersionSerializer implements PrimitiveSerializer<RoomCr
 sealed class $RoomCreateRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomCreateRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomCreateRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomCreateRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomCreateRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomCreateRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomCreateRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -31958,6 +33922,17 @@ abstract class RoomCreateRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomCreateRoomResponseApplicationJsonInterface {
   RoomCreateRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomCreateRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomCreateRoomResponseApplicationJsonInterface rebuild(
+    void Function($RoomCreateRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomCreateRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomCreateRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomCreateRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32066,6 +34041,17 @@ class _$RoomGetListedRoomsApiVersionSerializer implements PrimitiveSerializer<Ro
 sealed class $RoomGetListedRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetListedRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetListedRoomsResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomGetListedRoomsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetListedRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetListedRoomsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetListedRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32118,6 +34104,17 @@ abstract class RoomGetListedRoomsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomGetListedRoomsResponseApplicationJsonInterface {
   RoomGetListedRoomsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetListedRoomsResponseApplicationJsonInterfaceBuilder].
+  $RoomGetListedRoomsResponseApplicationJsonInterface rebuild(
+    void Function($RoomGetListedRoomsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetListedRoomsResponseApplicationJsonInterfaceBuilder].
+  $RoomGetListedRoomsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetListedRoomsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32233,6 +34230,17 @@ class _$RoomGetNoteToSelfConversationApiVersionSerializer
 sealed class $RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetNoteToSelfConversationResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32286,6 +34294,17 @@ abstract class RoomGetNoteToSelfConversationResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomGetNoteToSelfConversationResponseApplicationJsonInterface {
   RoomGetNoteToSelfConversationResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetNoteToSelfConversationResponseApplicationJsonInterfaceBuilder].
+  $RoomGetNoteToSelfConversationResponseApplicationJsonInterface rebuild(
+    void Function($RoomGetNoteToSelfConversationResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetNoteToSelfConversationResponseApplicationJsonInterfaceBuilder].
+  $RoomGetNoteToSelfConversationResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetNoteToSelfConversationResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32340,6 +34359,17 @@ abstract class RoomGetNoteToSelfConversationResponseApplicationJson
 sealed class $RoomRoomGetNoteToSelfConversationHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
   String? get xNextcloudTalkHash;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder].
+  $RoomRoomGetNoteToSelfConversationHeadersInterface rebuild(
+    void Function($RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder].
+  $RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRoomGetNoteToSelfConversationHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32449,6 +34479,17 @@ class _$RoomGetSingleRoomApiVersionSerializer implements PrimitiveSerializer<Roo
 sealed class $RoomGetSingleRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetSingleRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetSingleRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomGetSingleRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetSingleRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetSingleRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetSingleRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32501,6 +34542,17 @@ abstract class RoomGetSingleRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomGetSingleRoomResponseApplicationJsonInterface {
   RoomGetSingleRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetSingleRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomGetSingleRoomResponseApplicationJsonInterface rebuild(
+    void Function($RoomGetSingleRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetSingleRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomGetSingleRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetSingleRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32554,6 +34606,15 @@ abstract class RoomGetSingleRoomResponseApplicationJson
 sealed class $RoomRoomGetSingleRoomHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
   String? get xNextcloudTalkHash;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRoomGetSingleRoomHeadersInterfaceBuilder].
+  $RoomRoomGetSingleRoomHeadersInterface rebuild(void Function($RoomRoomGetSingleRoomHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$RoomRoomGetSingleRoomHeadersInterfaceBuilder].
+  $RoomRoomGetSingleRoomHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRoomGetSingleRoomHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32662,6 +34723,17 @@ class _$RoomGetBreakoutRoomsApiVersionSerializer implements PrimitiveSerializer<
 sealed class $RoomGetBreakoutRoomsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetBreakoutRoomsResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomGetBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetBreakoutRoomsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32714,6 +34786,17 @@ abstract class RoomGetBreakoutRoomsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomGetBreakoutRoomsResponseApplicationJsonInterface {
   RoomGetBreakoutRoomsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetBreakoutRoomsResponseApplicationJsonInterfaceBuilder].
+  $RoomGetBreakoutRoomsResponseApplicationJsonInterface rebuild(
+    void Function($RoomGetBreakoutRoomsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetBreakoutRoomsResponseApplicationJsonInterfaceBuilder].
+  $RoomGetBreakoutRoomsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetBreakoutRoomsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32823,6 +34906,17 @@ class _$RoomMakePublicApiVersionSerializer implements PrimitiveSerializer<RoomMa
 sealed class $RoomMakePublicResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomMakePublicResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomMakePublicResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomMakePublicResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomMakePublicResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomMakePublicResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomMakePublicResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32875,6 +34969,17 @@ abstract class RoomMakePublicResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomMakePublicResponseApplicationJsonInterface {
   RoomMakePublicResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomMakePublicResponseApplicationJsonInterfaceBuilder].
+  $RoomMakePublicResponseApplicationJsonInterface rebuild(
+    void Function($RoomMakePublicResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomMakePublicResponseApplicationJsonInterfaceBuilder].
+  $RoomMakePublicResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomMakePublicResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -32983,6 +35088,17 @@ class _$RoomMakePrivateApiVersionSerializer implements PrimitiveSerializer<RoomM
 sealed class $RoomMakePrivateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomMakePrivateResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomMakePrivateResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomMakePrivateResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomMakePrivateResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomMakePrivateResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomMakePrivateResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -33035,6 +35151,17 @@ abstract class RoomMakePrivateResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomMakePrivateResponseApplicationJsonInterface {
   RoomMakePrivateResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomMakePrivateResponseApplicationJsonInterfaceBuilder].
+  $RoomMakePrivateResponseApplicationJsonInterface rebuild(
+    void Function($RoomMakePrivateResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomMakePrivateResponseApplicationJsonInterfaceBuilder].
+  $RoomMakePrivateResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomMakePrivateResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -33143,6 +35270,17 @@ class _$RoomSetDescriptionApiVersionSerializer implements PrimitiveSerializer<Ro
 sealed class $RoomSetDescriptionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetDescriptionResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetDescriptionResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetDescriptionResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetDescriptionResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetDescriptionResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetDescriptionResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -33195,6 +35333,17 @@ abstract class RoomSetDescriptionResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetDescriptionResponseApplicationJsonInterface {
   RoomSetDescriptionResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetDescriptionResponseApplicationJsonInterfaceBuilder].
+  $RoomSetDescriptionResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetDescriptionResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetDescriptionResponseApplicationJsonInterfaceBuilder].
+  $RoomSetDescriptionResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetDescriptionResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -33367,6 +35516,17 @@ class _$RoomSetReadOnlyApiVersionSerializer implements PrimitiveSerializer<RoomS
 sealed class $RoomSetReadOnlyResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetReadOnlyResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetReadOnlyResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetReadOnlyResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetReadOnlyResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetReadOnlyResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetReadOnlyResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -33419,6 +35579,17 @@ abstract class RoomSetReadOnlyResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetReadOnlyResponseApplicationJsonInterface {
   RoomSetReadOnlyResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetReadOnlyResponseApplicationJsonInterfaceBuilder].
+  $RoomSetReadOnlyResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetReadOnlyResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetReadOnlyResponseApplicationJsonInterfaceBuilder].
+  $RoomSetReadOnlyResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetReadOnlyResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -33596,6 +35767,17 @@ class _$RoomSetListableApiVersionSerializer implements PrimitiveSerializer<RoomS
 sealed class $RoomSetListableResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetListableResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetListableResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetListableResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetListableResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetListableResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetListableResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -33648,6 +35830,17 @@ abstract class RoomSetListableResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetListableResponseApplicationJsonInterface {
   RoomSetListableResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetListableResponseApplicationJsonInterfaceBuilder].
+  $RoomSetListableResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetListableResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetListableResponseApplicationJsonInterfaceBuilder].
+  $RoomSetListableResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetListableResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -33756,6 +35949,17 @@ class _$RoomSetPasswordApiVersionSerializer implements PrimitiveSerializer<RoomS
 sealed class $RoomSetPasswordResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetPasswordResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetPasswordResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetPasswordResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetPasswordResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetPasswordResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetPasswordResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -33808,6 +36012,17 @@ abstract class RoomSetPasswordResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetPasswordResponseApplicationJsonInterface {
   RoomSetPasswordResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetPasswordResponseApplicationJsonInterfaceBuilder].
+  $RoomSetPasswordResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetPasswordResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetPasswordResponseApplicationJsonInterfaceBuilder].
+  $RoomSetPasswordResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetPasswordResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -33978,6 +36193,17 @@ class _$RoomSetPermissionsApiVersionSerializer implements PrimitiveSerializer<Ro
 sealed class $RoomSetPermissionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetPermissionsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetPermissionsResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetPermissionsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetPermissionsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetPermissionsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetPermissionsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34030,6 +36256,17 @@ abstract class RoomSetPermissionsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetPermissionsResponseApplicationJsonInterface {
   RoomSetPermissionsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetPermissionsResponseApplicationJsonInterfaceBuilder].
+  $RoomSetPermissionsResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetPermissionsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetPermissionsResponseApplicationJsonInterfaceBuilder].
+  $RoomSetPermissionsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetPermissionsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34219,6 +36456,15 @@ sealed class $ParticipantInterface {
   String? get statusMessage;
   String? get phoneNumber;
   String? get callId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ParticipantInterfaceBuilder].
+  $ParticipantInterface rebuild(void Function($ParticipantInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ParticipantInterfaceBuilder].
+  $ParticipantInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ParticipantInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34265,6 +36511,17 @@ abstract class Participant implements $ParticipantInterface, Built<Participant, 
 sealed class $RoomGetParticipantsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Participant> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetParticipantsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetParticipantsResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomGetParticipantsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetParticipantsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetParticipantsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetParticipantsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34317,6 +36574,17 @@ abstract class RoomGetParticipantsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomGetParticipantsResponseApplicationJsonInterface {
   RoomGetParticipantsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetParticipantsResponseApplicationJsonInterfaceBuilder].
+  $RoomGetParticipantsResponseApplicationJsonInterface rebuild(
+    void Function($RoomGetParticipantsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetParticipantsResponseApplicationJsonInterfaceBuilder].
+  $RoomGetParticipantsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetParticipantsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34370,6 +36638,17 @@ abstract class RoomGetParticipantsResponseApplicationJson
 sealed class $RoomRoomGetParticipantsHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-has-user-statuses')
   Header<bool?>? get xNextcloudHasUserStatuses;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRoomGetParticipantsHeadersInterfaceBuilder].
+  $RoomRoomGetParticipantsHeadersInterface rebuild(
+    void Function($RoomRoomGetParticipantsHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRoomGetParticipantsHeadersInterfaceBuilder].
+  $RoomRoomGetParticipantsHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRoomGetParticipantsHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34561,6 +36840,17 @@ class _$RoomAddParticipantToRoomApiVersionSerializer
 @BuiltValue(instantiable: false)
 sealed class $RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Interface {
   int get type;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder].
+  $RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Interface rebuild(
+    void Function($RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder].
+  $RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34620,6 +36910,17 @@ typedef RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data = ({
 sealed class $RoomAddParticipantToRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomAddParticipantToRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomAddParticipantToRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomAddParticipantToRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomAddParticipantToRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomAddParticipantToRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomAddParticipantToRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34675,6 +36976,17 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomAddParticipantToRoomResponseApplicationJsonInterface {
   RoomAddParticipantToRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomAddParticipantToRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomAddParticipantToRoomResponseApplicationJsonInterface rebuild(
+    void Function($RoomAddParticipantToRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomAddParticipantToRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomAddParticipantToRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomAddParticipantToRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34859,6 +37171,17 @@ class _$RoomGetBreakoutRoomParticipantsApiVersionSerializer
 sealed class $RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Participant> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34912,6 +37235,17 @@ abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterface {
   RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterfaceBuilder].
+  $RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterface rebuild(
+    void Function($RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterfaceBuilder].
+  $RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetBreakoutRoomParticipantsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34966,6 +37300,17 @@ abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson
 sealed class $RoomRoomGetBreakoutRoomParticipantsHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-has-user-statuses')
   Header<bool?>? get xNextcloudHasUserStatuses;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder].
+  $RoomRoomGetBreakoutRoomParticipantsHeadersInterface rebuild(
+    void Function($RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder].
+  $RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -35076,6 +37421,17 @@ class _$RoomRemoveSelfFromRoomApiVersionSerializer implements PrimitiveSerialize
 sealed class $RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRemoveSelfFromRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -35129,6 +37485,17 @@ abstract class RoomRemoveSelfFromRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomRemoveSelfFromRoomResponseApplicationJsonInterface {
   RoomRemoveSelfFromRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRemoveSelfFromRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomRemoveSelfFromRoomResponseApplicationJsonInterface rebuild(
+    void Function($RoomRemoveSelfFromRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRemoveSelfFromRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomRemoveSelfFromRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRemoveSelfFromRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -35243,6 +37610,17 @@ class _$RoomRemoveAttendeeFromRoomApiVersionSerializer
 sealed class $RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -35296,6 +37674,17 @@ abstract class RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomRemoveAttendeeFromRoomResponseApplicationJsonInterface {
   RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRemoveAttendeeFromRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomRemoveAttendeeFromRoomResponseApplicationJsonInterface rebuild(
+    void Function($RoomRemoveAttendeeFromRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRemoveAttendeeFromRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomRemoveAttendeeFromRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRemoveAttendeeFromRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -35479,6 +37868,17 @@ class _$RoomSetAttendeePermissionsApiVersionSerializer
 sealed class $RoomSetAttendeePermissionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetAttendeePermissionsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetAttendeePermissionsResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetAttendeePermissionsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetAttendeePermissionsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetAttendeePermissionsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetAttendeePermissionsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -35532,6 +37932,17 @@ abstract class RoomSetAttendeePermissionsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetAttendeePermissionsResponseApplicationJsonInterface {
   RoomSetAttendeePermissionsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetAttendeePermissionsResponseApplicationJsonInterfaceBuilder].
+  $RoomSetAttendeePermissionsResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetAttendeePermissionsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetAttendeePermissionsResponseApplicationJsonInterfaceBuilder].
+  $RoomSetAttendeePermissionsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetAttendeePermissionsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -35720,6 +38131,17 @@ class _$RoomSetAllAttendeesPermissionsApiVersionSerializer
 sealed class $RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -35773,6 +38195,17 @@ abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetAllAttendeesPermissionsResponseApplicationJsonInterface {
   RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetAllAttendeesPermissionsResponseApplicationJsonInterfaceBuilder].
+  $RoomSetAllAttendeesPermissionsResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetAllAttendeesPermissionsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetAllAttendeesPermissionsResponseApplicationJsonInterfaceBuilder].
+  $RoomSetAllAttendeesPermissionsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetAllAttendeesPermissionsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -35946,6 +38379,17 @@ class _$RoomJoinRoomApiVersionSerializer implements PrimitiveSerializer<RoomJoin
 sealed class $RoomJoinRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomJoinRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomJoinRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomJoinRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomJoinRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomJoinRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomJoinRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -35997,6 +38441,17 @@ abstract class RoomJoinRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomJoinRoomResponseApplicationJsonInterface {
   RoomJoinRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomJoinRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomJoinRoomResponseApplicationJsonInterface rebuild(
+    void Function($RoomJoinRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomJoinRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomJoinRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomJoinRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36049,6 +38504,15 @@ abstract class RoomJoinRoomResponseApplicationJson
 sealed class $RoomRoomJoinRoomHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-talk-proxy-hash')
   String? get xNextcloudTalkProxyHash;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRoomJoinRoomHeadersInterfaceBuilder].
+  $RoomRoomJoinRoomHeadersInterface rebuild(void Function($RoomRoomJoinRoomHeadersInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$RoomRoomJoinRoomHeadersInterfaceBuilder].
+  $RoomRoomJoinRoomHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRoomJoinRoomHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36153,6 +38617,17 @@ class _$RoomLeaveRoomApiVersionSerializer implements PrimitiveSerializer<RoomLea
 sealed class $RoomLeaveRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomLeaveRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomLeaveRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomLeaveRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomLeaveRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomLeaveRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomLeaveRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36205,6 +38680,17 @@ abstract class RoomLeaveRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomLeaveRoomResponseApplicationJsonInterface {
   RoomLeaveRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomLeaveRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomLeaveRoomResponseApplicationJsonInterface rebuild(
+    void Function($RoomLeaveRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomLeaveRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomLeaveRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomLeaveRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36314,6 +38800,17 @@ class _$RoomResendInvitationsApiVersionSerializer implements PrimitiveSerializer
 sealed class $RoomResendInvitationsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomResendInvitationsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomResendInvitationsResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomResendInvitationsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomResendInvitationsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomResendInvitationsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomResendInvitationsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36367,6 +38864,17 @@ abstract class RoomResendInvitationsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomResendInvitationsResponseApplicationJsonInterface {
   RoomResendInvitationsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomResendInvitationsResponseApplicationJsonInterfaceBuilder].
+  $RoomResendInvitationsResponseApplicationJsonInterface rebuild(
+    void Function($RoomResendInvitationsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomResendInvitationsResponseApplicationJsonInterfaceBuilder].
+  $RoomResendInvitationsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomResendInvitationsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36539,6 +39047,17 @@ class _$RoomSetSessionStateApiVersionSerializer implements PrimitiveSerializer<R
 sealed class $RoomSetSessionStateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetSessionStateResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetSessionStateResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetSessionStateResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetSessionStateResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetSessionStateResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetSessionStateResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36591,6 +39110,17 @@ abstract class RoomSetSessionStateResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetSessionStateResponseApplicationJsonInterface {
   RoomSetSessionStateResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetSessionStateResponseApplicationJsonInterfaceBuilder].
+  $RoomSetSessionStateResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetSessionStateResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetSessionStateResponseApplicationJsonInterfaceBuilder].
+  $RoomSetSessionStateResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetSessionStateResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36701,6 +39231,17 @@ class _$RoomPromoteModeratorApiVersionSerializer implements PrimitiveSerializer<
 sealed class $RoomPromoteModeratorResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomPromoteModeratorResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomPromoteModeratorResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomPromoteModeratorResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomPromoteModeratorResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomPromoteModeratorResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomPromoteModeratorResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36753,6 +39294,17 @@ abstract class RoomPromoteModeratorResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomPromoteModeratorResponseApplicationJsonInterface {
   RoomPromoteModeratorResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomPromoteModeratorResponseApplicationJsonInterfaceBuilder].
+  $RoomPromoteModeratorResponseApplicationJsonInterface rebuild(
+    void Function($RoomPromoteModeratorResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomPromoteModeratorResponseApplicationJsonInterfaceBuilder].
+  $RoomPromoteModeratorResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomPromoteModeratorResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36862,6 +39414,17 @@ class _$RoomDemoteModeratorApiVersionSerializer implements PrimitiveSerializer<R
 sealed class $RoomDemoteModeratorResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomDemoteModeratorResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomDemoteModeratorResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomDemoteModeratorResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomDemoteModeratorResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomDemoteModeratorResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomDemoteModeratorResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -36914,6 +39477,17 @@ abstract class RoomDemoteModeratorResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomDemoteModeratorResponseApplicationJsonInterface {
   RoomDemoteModeratorResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomDemoteModeratorResponseApplicationJsonInterfaceBuilder].
+  $RoomDemoteModeratorResponseApplicationJsonInterface rebuild(
+    void Function($RoomDemoteModeratorResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomDemoteModeratorResponseApplicationJsonInterfaceBuilder].
+  $RoomDemoteModeratorResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomDemoteModeratorResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37023,6 +39597,17 @@ class _$RoomAddToFavoritesApiVersionSerializer implements PrimitiveSerializer<Ro
 sealed class $RoomAddToFavoritesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomAddToFavoritesResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomAddToFavoritesResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomAddToFavoritesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomAddToFavoritesResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomAddToFavoritesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomAddToFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37075,6 +39660,17 @@ abstract class RoomAddToFavoritesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomAddToFavoritesResponseApplicationJsonInterface {
   RoomAddToFavoritesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomAddToFavoritesResponseApplicationJsonInterfaceBuilder].
+  $RoomAddToFavoritesResponseApplicationJsonInterface rebuild(
+    void Function($RoomAddToFavoritesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomAddToFavoritesResponseApplicationJsonInterfaceBuilder].
+  $RoomAddToFavoritesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomAddToFavoritesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37185,6 +39781,17 @@ class _$RoomRemoveFromFavoritesApiVersionSerializer implements PrimitiveSerializ
 sealed class $RoomRemoveFromFavoritesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRemoveFromFavoritesResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomRemoveFromFavoritesResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomRemoveFromFavoritesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRemoveFromFavoritesResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomRemoveFromFavoritesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRemoveFromFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37238,6 +39845,17 @@ abstract class RoomRemoveFromFavoritesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomRemoveFromFavoritesResponseApplicationJsonInterface {
   RoomRemoveFromFavoritesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRemoveFromFavoritesResponseApplicationJsonInterfaceBuilder].
+  $RoomRemoveFromFavoritesResponseApplicationJsonInterface rebuild(
+    void Function($RoomRemoveFromFavoritesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRemoveFromFavoritesResponseApplicationJsonInterfaceBuilder].
+  $RoomRemoveFromFavoritesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRemoveFromFavoritesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37349,6 +39967,17 @@ class _$RoomSetNotificationLevelApiVersionSerializer
 sealed class $RoomSetNotificationLevelResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetNotificationLevelResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetNotificationLevelResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetNotificationLevelResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetNotificationLevelResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetNotificationLevelResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetNotificationLevelResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37402,6 +40031,17 @@ abstract class RoomSetNotificationLevelResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetNotificationLevelResponseApplicationJsonInterface {
   RoomSetNotificationLevelResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetNotificationLevelResponseApplicationJsonInterfaceBuilder].
+  $RoomSetNotificationLevelResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetNotificationLevelResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetNotificationLevelResponseApplicationJsonInterfaceBuilder].
+  $RoomSetNotificationLevelResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetNotificationLevelResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37513,6 +40153,17 @@ class _$RoomSetNotificationCallsApiVersionSerializer
 sealed class $RoomSetNotificationCallsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetNotificationCallsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetNotificationCallsResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetNotificationCallsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetNotificationCallsResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetNotificationCallsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetNotificationCallsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37566,6 +40217,17 @@ abstract class RoomSetNotificationCallsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetNotificationCallsResponseApplicationJsonInterface {
   RoomSetNotificationCallsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetNotificationCallsResponseApplicationJsonInterfaceBuilder].
+  $RoomSetNotificationCallsResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetNotificationCallsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetNotificationCallsResponseApplicationJsonInterfaceBuilder].
+  $RoomSetNotificationCallsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetNotificationCallsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37675,6 +40337,17 @@ class _$RoomSetLobbyApiVersionSerializer implements PrimitiveSerializer<RoomSetL
 sealed class $RoomSetLobbyResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetLobbyResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetLobbyResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetLobbyResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetLobbyResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetLobbyResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetLobbyResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37726,6 +40399,17 @@ abstract class RoomSetLobbyResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetLobbyResponseApplicationJsonInterface {
   RoomSetLobbyResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetLobbyResponseApplicationJsonInterfaceBuilder].
+  $RoomSetLobbyResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetLobbyResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetLobbyResponseApplicationJsonInterfaceBuilder].
+  $RoomSetLobbyResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetLobbyResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37903,6 +40587,17 @@ class _$RoomSetsipEnabledApiVersionSerializer implements PrimitiveSerializer<Roo
 sealed class $RoomSetsipEnabledResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetsipEnabledResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetsipEnabledResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetsipEnabledResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetsipEnabledResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetsipEnabledResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetsipEnabledResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -37955,6 +40650,17 @@ abstract class RoomSetsipEnabledResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetsipEnabledResponseApplicationJsonInterface {
   RoomSetsipEnabledResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetsipEnabledResponseApplicationJsonInterfaceBuilder].
+  $RoomSetsipEnabledResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetsipEnabledResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetsipEnabledResponseApplicationJsonInterfaceBuilder].
+  $RoomSetsipEnabledResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetsipEnabledResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38065,6 +40771,17 @@ class _$RoomSetRecordingConsentApiVersionSerializer implements PrimitiveSerializ
 sealed class $RoomSetRecordingConsentResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetRecordingConsentResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetRecordingConsentResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetRecordingConsentResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetRecordingConsentResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetRecordingConsentResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetRecordingConsentResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38118,6 +40835,17 @@ abstract class RoomSetRecordingConsentResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetRecordingConsentResponseApplicationJsonInterface {
   RoomSetRecordingConsentResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetRecordingConsentResponseApplicationJsonInterfaceBuilder].
+  $RoomSetRecordingConsentResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetRecordingConsentResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetRecordingConsentResponseApplicationJsonInterfaceBuilder].
+  $RoomSetRecordingConsentResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetRecordingConsentResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38229,6 +40957,17 @@ class _$RoomSetMessageExpirationApiVersionSerializer
 sealed class $RoomSetMessageExpirationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetMessageExpirationResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetMessageExpirationResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomSetMessageExpirationResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetMessageExpirationResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomSetMessageExpirationResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetMessageExpirationResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38282,6 +41021,17 @@ abstract class RoomSetMessageExpirationResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomSetMessageExpirationResponseApplicationJsonInterface {
   RoomSetMessageExpirationResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetMessageExpirationResponseApplicationJsonInterfaceBuilder].
+  $RoomSetMessageExpirationResponseApplicationJsonInterface rebuild(
+    void Function($RoomSetMessageExpirationResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetMessageExpirationResponseApplicationJsonInterfaceBuilder].
+  $RoomSetMessageExpirationResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomSetMessageExpirationResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38391,6 +41141,17 @@ class _$RoomGetCapabilitiesApiVersionSerializer implements PrimitiveSerializer<R
 sealed class $Capabilities_Config_AttachmentsInterface {
   bool get allowed;
   String? get folder;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_Config_AttachmentsInterfaceBuilder].
+  $Capabilities_Config_AttachmentsInterface rebuild(
+    void Function($Capabilities_Config_AttachmentsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_Config_AttachmentsInterfaceBuilder].
+  $Capabilities_Config_AttachmentsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_Config_AttachmentsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38458,6 +41219,15 @@ sealed class $Capabilities_Config_CallInterface {
   bool get sipDialoutEnabled;
   @BuiltValueField(wireName: 'can-enable-sip')
   bool get canEnableSip;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_Config_CallInterfaceBuilder].
+  $Capabilities_Config_CallInterface rebuild(void Function($Capabilities_Config_CallInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_Config_CallInterfaceBuilder].
+  $Capabilities_Config_CallInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_Config_CallInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38512,6 +41282,15 @@ sealed class $Capabilities_Config_ChatInterface {
   bool get hasTranslationProviders;
   @BuiltValueField(wireName: 'typing-privacy')
   int get typingPrivacy;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_Config_ChatInterfaceBuilder].
+  $Capabilities_Config_ChatInterface rebuild(void Function($Capabilities_Config_ChatInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_Config_ChatInterfaceBuilder].
+  $Capabilities_Config_ChatInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_Config_ChatInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38560,6 +41339,17 @@ abstract class Capabilities_Config_Chat
 sealed class $Capabilities_Config_ConversationsInterface {
   @BuiltValueField(wireName: 'can-create')
   bool get canCreate;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_Config_ConversationsInterfaceBuilder].
+  $Capabilities_Config_ConversationsInterface rebuild(
+    void Function($Capabilities_Config_ConversationsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_Config_ConversationsInterfaceBuilder].
+  $Capabilities_Config_ConversationsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_Config_ConversationsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38616,6 +41406,17 @@ sealed class $Capabilities_Config_FederationInterface {
   bool get outgoingEnabled;
   @BuiltValueField(wireName: 'only-trusted-servers')
   bool get onlyTrustedServers;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_Config_FederationInterfaceBuilder].
+  $Capabilities_Config_FederationInterface rebuild(
+    void Function($Capabilities_Config_FederationInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_Config_FederationInterfaceBuilder].
+  $Capabilities_Config_FederationInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_Config_FederationInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38667,6 +41468,15 @@ abstract class Capabilities_Config_Federation
 sealed class $Capabilities_Config_PreviewsInterface {
   @BuiltValueField(wireName: 'max-gif-size')
   int get maxGifSize;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_Config_PreviewsInterfaceBuilder].
+  $Capabilities_Config_PreviewsInterface rebuild(void Function($Capabilities_Config_PreviewsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_Config_PreviewsInterfaceBuilder].
+  $Capabilities_Config_PreviewsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_Config_PreviewsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38720,6 +41530,17 @@ sealed class $Capabilities_Config_SignalingInterface {
   int get sessionPingLimit;
   @BuiltValueField(wireName: 'hello-v2-token-key')
   String? get helloV2TokenKey;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_Config_SignalingInterfaceBuilder].
+  $Capabilities_Config_SignalingInterface rebuild(
+    void Function($Capabilities_Config_SignalingInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Capabilities_Config_SignalingInterfaceBuilder].
+  $Capabilities_Config_SignalingInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_Config_SignalingInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38776,6 +41597,15 @@ sealed class $Capabilities_ConfigInterface {
   Capabilities_Config_Federation? get federation;
   Capabilities_Config_Previews get previews;
   Capabilities_Config_Signaling get signaling;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_ConfigInterfaceBuilder].
+  $Capabilities_ConfigInterface rebuild(void Function($Capabilities_ConfigInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_ConfigInterfaceBuilder].
+  $Capabilities_ConfigInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_ConfigInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38825,6 +41655,15 @@ sealed class $CapabilitiesInterface {
   BuiltList<String> get features;
   Capabilities_Config get config;
   String get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38876,6 +41715,17 @@ typedef RoomGetCapabilitiesResponseApplicationJson_Ocs_Data = ({
 sealed class $RoomGetCapabilitiesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   RoomGetCapabilitiesResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetCapabilitiesResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetCapabilitiesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38930,6 +41780,17 @@ abstract class RoomGetCapabilitiesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomGetCapabilitiesResponseApplicationJsonInterface {
   RoomGetCapabilitiesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetCapabilitiesResponseApplicationJsonInterfaceBuilder].
+  $RoomGetCapabilitiesResponseApplicationJsonInterface rebuild(
+    void Function($RoomGetCapabilitiesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetCapabilitiesResponseApplicationJsonInterfaceBuilder].
+  $RoomGetCapabilitiesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomGetCapabilitiesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -38985,6 +41846,17 @@ sealed class $RoomRoomGetCapabilitiesHeadersInterface {
   String? get xNextcloudTalkHash;
   @BuiltValueField(wireName: 'x-nextcloud-talk-proxy-hash')
   String? get xNextcloudTalkProxyHash;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRoomGetCapabilitiesHeadersInterfaceBuilder].
+  $RoomRoomGetCapabilitiesHeadersInterface rebuild(
+    void Function($RoomRoomGetCapabilitiesHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRoomGetCapabilitiesHeadersInterfaceBuilder].
+  $RoomRoomGetCapabilitiesHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRoomGetCapabilitiesHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39093,6 +41965,17 @@ class _$RoomJoinFederatedRoomApiVersionSerializer implements PrimitiveSerializer
 sealed class $RoomJoinFederatedRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomJoinFederatedRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomJoinFederatedRoomResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomJoinFederatedRoomResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomJoinFederatedRoomResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomJoinFederatedRoomResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomJoinFederatedRoomResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39146,6 +42029,17 @@ abstract class RoomJoinFederatedRoomResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomJoinFederatedRoomResponseApplicationJsonInterface {
   RoomJoinFederatedRoomResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomJoinFederatedRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomJoinFederatedRoomResponseApplicationJsonInterface rebuild(
+    void Function($RoomJoinFederatedRoomResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomJoinFederatedRoomResponseApplicationJsonInterfaceBuilder].
+  $RoomJoinFederatedRoomResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomJoinFederatedRoomResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39199,6 +42093,17 @@ abstract class RoomJoinFederatedRoomResponseApplicationJson
 sealed class $RoomRoomJoinFederatedRoomHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-talk-hash')
   String? get xNextcloudTalkHash;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRoomJoinFederatedRoomHeadersInterfaceBuilder].
+  $RoomRoomJoinFederatedRoomHeadersInterface rebuild(
+    void Function($RoomRoomJoinFederatedRoomHeadersInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRoomJoinFederatedRoomHeadersInterfaceBuilder].
+  $RoomRoomJoinFederatedRoomHeadersInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRoomJoinFederatedRoomHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39312,6 +42217,17 @@ class _$RoomVerifyDialInPinDeprecatedApiVersionSerializer
 sealed class $RoomVerifyDialInPinDeprecatedResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomVerifyDialInPinDeprecatedResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomVerifyDialInPinDeprecatedResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomVerifyDialInPinDeprecatedResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomVerifyDialInPinDeprecatedResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomVerifyDialInPinDeprecatedResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomVerifyDialInPinDeprecatedResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39365,6 +42281,17 @@ abstract class RoomVerifyDialInPinDeprecatedResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomVerifyDialInPinDeprecatedResponseApplicationJsonInterface {
   RoomVerifyDialInPinDeprecatedResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomVerifyDialInPinDeprecatedResponseApplicationJsonInterfaceBuilder].
+  $RoomVerifyDialInPinDeprecatedResponseApplicationJsonInterface rebuild(
+    void Function($RoomVerifyDialInPinDeprecatedResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomVerifyDialInPinDeprecatedResponseApplicationJsonInterfaceBuilder].
+  $RoomVerifyDialInPinDeprecatedResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomVerifyDialInPinDeprecatedResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39475,6 +42402,17 @@ class _$RoomVerifyDialInPinApiVersionSerializer implements PrimitiveSerializer<R
 sealed class $RoomVerifyDialInPinResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomVerifyDialInPinResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomVerifyDialInPinResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomVerifyDialInPinResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomVerifyDialInPinResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomVerifyDialInPinResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomVerifyDialInPinResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39527,6 +42465,17 @@ abstract class RoomVerifyDialInPinResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomVerifyDialInPinResponseApplicationJsonInterface {
   RoomVerifyDialInPinResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomVerifyDialInPinResponseApplicationJsonInterfaceBuilder].
+  $RoomVerifyDialInPinResponseApplicationJsonInterface rebuild(
+    void Function($RoomVerifyDialInPinResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomVerifyDialInPinResponseApplicationJsonInterfaceBuilder].
+  $RoomVerifyDialInPinResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomVerifyDialInPinResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39582,6 +42531,17 @@ sealed class $RoomVerifyDialOutNumberOptionsInterface {
   String? get actorId;
   ActorType? get actorType;
   int? get attendeeId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomVerifyDialOutNumberOptionsInterfaceBuilder].
+  $RoomVerifyDialOutNumberOptionsInterface rebuild(
+    void Function($RoomVerifyDialOutNumberOptionsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomVerifyDialOutNumberOptionsInterfaceBuilder].
+  $RoomVerifyDialOutNumberOptionsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomVerifyDialOutNumberOptionsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39691,6 +42651,17 @@ class _$RoomVerifyDialOutNumberApiVersionSerializer implements PrimitiveSerializ
 sealed class $RoomVerifyDialOutNumberResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomVerifyDialOutNumberResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomVerifyDialOutNumberResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomVerifyDialOutNumberResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomVerifyDialOutNumberResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomVerifyDialOutNumberResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomVerifyDialOutNumberResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39744,6 +42715,17 @@ abstract class RoomVerifyDialOutNumberResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomVerifyDialOutNumberResponseApplicationJsonInterface {
   RoomVerifyDialOutNumberResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomVerifyDialOutNumberResponseApplicationJsonInterfaceBuilder].
+  $RoomVerifyDialOutNumberResponseApplicationJsonInterface rebuild(
+    void Function($RoomVerifyDialOutNumberResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomVerifyDialOutNumberResponseApplicationJsonInterfaceBuilder].
+  $RoomVerifyDialOutNumberResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomVerifyDialOutNumberResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39854,6 +42836,17 @@ class _$RoomCreateGuestByDialInApiVersionSerializer implements PrimitiveSerializ
 sealed class $RoomCreateGuestByDialInResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomCreateGuestByDialInResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomCreateGuestByDialInResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomCreateGuestByDialInResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomCreateGuestByDialInResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomCreateGuestByDialInResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomCreateGuestByDialInResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39907,6 +42900,17 @@ abstract class RoomCreateGuestByDialInResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomCreateGuestByDialInResponseApplicationJsonInterface {
   RoomCreateGuestByDialInResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomCreateGuestByDialInResponseApplicationJsonInterfaceBuilder].
+  $RoomCreateGuestByDialInResponseApplicationJsonInterface rebuild(
+    void Function($RoomCreateGuestByDialInResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomCreateGuestByDialInResponseApplicationJsonInterfaceBuilder].
+  $RoomCreateGuestByDialInResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomCreateGuestByDialInResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -39962,6 +42966,17 @@ sealed class $RoomRejectedDialOutRequestOptionsInterface {
   String? get actorId;
   ActorType? get actorType;
   int? get attendeeId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRejectedDialOutRequestOptionsInterfaceBuilder].
+  $RoomRejectedDialOutRequestOptionsInterface rebuild(
+    void Function($RoomRejectedDialOutRequestOptionsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRejectedDialOutRequestOptionsInterfaceBuilder].
+  $RoomRejectedDialOutRequestOptionsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRejectedDialOutRequestOptionsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40075,6 +43090,17 @@ class _$RoomRejectedDialOutRequestApiVersionSerializer
 sealed class $RoomRejectedDialOutRequestResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRejectedDialOutRequestResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomRejectedDialOutRequestResponseApplicationJson_OcsInterface rebuild(
+    void Function($RoomRejectedDialOutRequestResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRejectedDialOutRequestResponseApplicationJson_OcsInterfaceBuilder].
+  $RoomRejectedDialOutRequestResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRejectedDialOutRequestResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40128,6 +43154,17 @@ abstract class RoomRejectedDialOutRequestResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RoomRejectedDialOutRequestResponseApplicationJsonInterface {
   RoomRejectedDialOutRequestResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRejectedDialOutRequestResponseApplicationJsonInterfaceBuilder].
+  $RoomRejectedDialOutRequestResponseApplicationJsonInterface rebuild(
+    void Function($RoomRejectedDialOutRequestResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRejectedDialOutRequestResponseApplicationJsonInterfaceBuilder].
+  $RoomRejectedDialOutRequestResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRejectedDialOutRequestResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40316,6 +43353,17 @@ class _$SettingsSetUserSettingApiVersionSerializer implements PrimitiveSerialize
 sealed class $SettingsSetUserSettingResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsSetUserSettingResponseApplicationJson_OcsInterfaceBuilder].
+  $SettingsSetUserSettingResponseApplicationJson_OcsInterface rebuild(
+    void Function($SettingsSetUserSettingResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsSetUserSettingResponseApplicationJson_OcsInterfaceBuilder].
+  $SettingsSetUserSettingResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SettingsSetUserSettingResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40369,6 +43417,17 @@ abstract class SettingsSetUserSettingResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $SettingsSetUserSettingResponseApplicationJsonInterface {
   SettingsSetUserSettingResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsSetUserSettingResponseApplicationJsonInterfaceBuilder].
+  $SettingsSetUserSettingResponseApplicationJsonInterface rebuild(
+    void Function($SettingsSetUserSettingResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsSetUserSettingResponseApplicationJsonInterfaceBuilder].
+  $SettingsSetUserSettingResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SettingsSetUserSettingResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40486,6 +43545,17 @@ sealed class $BotWithDetailsInterface implements $BotInterface {
   String get url;
   @BuiltValueField(wireName: 'url_hash')
   String get urlHash;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotWithDetailsInterfaceBuilder].
+  @override
+  $BotWithDetailsInterface rebuild(void Function($BotWithDetailsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BotWithDetailsInterfaceBuilder].
+  @override
+  $BotWithDetailsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotWithDetailsInterfaceBuilder b) {
     $BotInterface._defaults(b);
@@ -40537,6 +43607,17 @@ abstract class BotWithDetails implements $BotWithDetailsInterface, Built<BotWith
 sealed class $BotAdminListBotsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<BotWithDetails> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotAdminListBotsResponseApplicationJson_OcsInterfaceBuilder].
+  $BotAdminListBotsResponseApplicationJson_OcsInterface rebuild(
+    void Function($BotAdminListBotsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotAdminListBotsResponseApplicationJson_OcsInterfaceBuilder].
+  $BotAdminListBotsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotAdminListBotsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40589,6 +43670,17 @@ abstract class BotAdminListBotsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $BotAdminListBotsResponseApplicationJsonInterface {
   BotAdminListBotsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotAdminListBotsResponseApplicationJsonInterfaceBuilder].
+  $BotAdminListBotsResponseApplicationJsonInterface rebuild(
+    void Function($BotAdminListBotsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotAdminListBotsResponseApplicationJsonInterfaceBuilder].
+  $BotAdminListBotsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotAdminListBotsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40703,6 +43795,17 @@ class _$CertificateGetCertificateExpirationApiVersionSerializer
 sealed class $CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterface {
   @BuiltValueField(wireName: 'expiration_in_days')
   int? get expirationInDays;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40757,6 +43860,17 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Da
 sealed class $CertificateGetCertificateExpirationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CertificateGetCertificateExpirationResponseApplicationJson_OcsInterfaceBuilder].
+  $CertificateGetCertificateExpirationResponseApplicationJson_OcsInterface rebuild(
+    void Function($CertificateGetCertificateExpirationResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CertificateGetCertificateExpirationResponseApplicationJson_OcsInterfaceBuilder].
+  $CertificateGetCertificateExpirationResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CertificateGetCertificateExpirationResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40810,6 +43924,17 @@ abstract class CertificateGetCertificateExpirationResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $CertificateGetCertificateExpirationResponseApplicationJsonInterface {
   CertificateGetCertificateExpirationResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CertificateGetCertificateExpirationResponseApplicationJsonInterfaceBuilder].
+  $CertificateGetCertificateExpirationResponseApplicationJsonInterface rebuild(
+    void Function($CertificateGetCertificateExpirationResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CertificateGetCertificateExpirationResponseApplicationJsonInterfaceBuilder].
+  $CertificateGetCertificateExpirationResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CertificateGetCertificateExpirationResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40924,6 +44049,17 @@ class _$RecordingGetWelcomeMessageApiVersionSerializer
 @BuiltValue(instantiable: false)
 sealed class $RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterface {
   double get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingGetWelcomeMessageResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -40978,6 +44114,17 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data
 sealed class $RecordingGetWelcomeMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingGetWelcomeMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($RecordingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $RecordingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41031,6 +44178,17 @@ abstract class RecordingGetWelcomeMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $RecordingGetWelcomeMessageResponseApplicationJsonInterface {
   RecordingGetWelcomeMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder].
+  $RecordingGetWelcomeMessageResponseApplicationJsonInterface rebuild(
+    void Function($RecordingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder].
+  $RecordingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RecordingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41142,6 +44300,17 @@ class _$SettingsSetsipSettingsApiVersionSerializer implements PrimitiveSerialize
 sealed class $SettingsSetsipSettingsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsSetsipSettingsResponseApplicationJson_OcsInterfaceBuilder].
+  $SettingsSetsipSettingsResponseApplicationJson_OcsInterface rebuild(
+    void Function($SettingsSetsipSettingsResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsSetsipSettingsResponseApplicationJson_OcsInterfaceBuilder].
+  $SettingsSetsipSettingsResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SettingsSetsipSettingsResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41195,6 +44364,17 @@ abstract class SettingsSetsipSettingsResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $SettingsSetsipSettingsResponseApplicationJsonInterface {
   SettingsSetsipSettingsResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsSetsipSettingsResponseApplicationJsonInterfaceBuilder].
+  $SettingsSetsipSettingsResponseApplicationJsonInterface rebuild(
+    void Function($SettingsSetsipSettingsResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsSetsipSettingsResponseApplicationJsonInterfaceBuilder].
+  $SettingsSetsipSettingsResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SettingsSetsipSettingsResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41309,6 +44489,17 @@ class _$SignalingGetWelcomeMessageApiVersionSerializer
 sealed class $SignalingGetWelcomeMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, JsonObject> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $SignalingGetWelcomeMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($SignalingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $SignalingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingGetWelcomeMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41362,6 +44553,17 @@ abstract class SignalingGetWelcomeMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $SignalingGetWelcomeMessageResponseApplicationJsonInterface {
   SignalingGetWelcomeMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder].
+  $SignalingGetWelcomeMessageResponseApplicationJsonInterface rebuild(
+    void Function($SignalingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder].
+  $SignalingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingGetWelcomeMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41472,6 +44674,17 @@ class _$SignalingBackendApiVersionSerializer implements PrimitiveSerializer<Sign
 sealed class $SignalingBackendResponseApplicationJson_Ocs_Data_ErrorInterface {
   String get code;
   String get message;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingBackendResponseApplicationJson_Ocs_Data_ErrorInterfaceBuilder].
+  $SignalingBackendResponseApplicationJson_Ocs_Data_ErrorInterface rebuild(
+    void Function($SignalingBackendResponseApplicationJson_Ocs_Data_ErrorInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingBackendResponseApplicationJson_Ocs_Data_ErrorInterfaceBuilder].
+  $SignalingBackendResponseApplicationJson_Ocs_Data_ErrorInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingBackendResponseApplicationJson_Ocs_Data_ErrorInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41527,6 +44740,17 @@ sealed class $SignalingBackendResponseApplicationJson_Ocs_Data_AuthInterface {
   String get version;
   String? get userid;
   BuiltMap<String, JsonObject>? get user;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingBackendResponseApplicationJson_Ocs_Data_AuthInterfaceBuilder].
+  $SignalingBackendResponseApplicationJson_Ocs_Data_AuthInterface rebuild(
+    void Function($SignalingBackendResponseApplicationJson_Ocs_Data_AuthInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingBackendResponseApplicationJson_Ocs_Data_AuthInterfaceBuilder].
+  $SignalingBackendResponseApplicationJson_Ocs_Data_AuthInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingBackendResponseApplicationJson_Ocs_Data_AuthInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41584,6 +44808,17 @@ sealed class $SignalingBackendResponseApplicationJson_Ocs_Data_RoomInterface {
   BuiltMap<String, JsonObject>? get properties;
   BuiltList<String>? get permissions;
   BuiltMap<String, JsonObject>? get session;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingBackendResponseApplicationJson_Ocs_Data_RoomInterfaceBuilder].
+  $SignalingBackendResponseApplicationJson_Ocs_Data_RoomInterface rebuild(
+    void Function($SignalingBackendResponseApplicationJson_Ocs_Data_RoomInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingBackendResponseApplicationJson_Ocs_Data_RoomInterfaceBuilder].
+  $SignalingBackendResponseApplicationJson_Ocs_Data_RoomInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingBackendResponseApplicationJson_Ocs_Data_RoomInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41640,6 +44875,17 @@ sealed class $SignalingBackendResponseApplicationJson_Ocs_DataInterface {
   SignalingBackendResponseApplicationJson_Ocs_Data_Error? get error;
   SignalingBackendResponseApplicationJson_Ocs_Data_Auth? get auth;
   SignalingBackendResponseApplicationJson_Ocs_Data_Room? get room;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingBackendResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $SignalingBackendResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($SignalingBackendResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingBackendResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $SignalingBackendResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingBackendResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41694,6 +44940,17 @@ abstract class SignalingBackendResponseApplicationJson_Ocs_Data
 sealed class $SignalingBackendResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   SignalingBackendResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingBackendResponseApplicationJson_OcsInterfaceBuilder].
+  $SignalingBackendResponseApplicationJson_OcsInterface rebuild(
+    void Function($SignalingBackendResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingBackendResponseApplicationJson_OcsInterfaceBuilder].
+  $SignalingBackendResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingBackendResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41746,6 +45003,17 @@ abstract class SignalingBackendResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $SignalingBackendResponseApplicationJsonInterface {
   SignalingBackendResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingBackendResponseApplicationJsonInterfaceBuilder].
+  $SignalingBackendResponseApplicationJsonInterface rebuild(
+    void Function($SignalingBackendResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingBackendResponseApplicationJsonInterfaceBuilder].
+  $SignalingBackendResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SignalingBackendResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41798,6 +45066,17 @@ abstract class SignalingBackendResponseApplicationJson
 sealed class $TempAvatarPostAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TempAvatarPostAvatarResponseApplicationJson_OcsInterfaceBuilder].
+  $TempAvatarPostAvatarResponseApplicationJson_OcsInterface rebuild(
+    void Function($TempAvatarPostAvatarResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TempAvatarPostAvatarResponseApplicationJson_OcsInterfaceBuilder].
+  $TempAvatarPostAvatarResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TempAvatarPostAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41850,6 +45129,17 @@ abstract class TempAvatarPostAvatarResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TempAvatarPostAvatarResponseApplicationJsonInterface {
   TempAvatarPostAvatarResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TempAvatarPostAvatarResponseApplicationJsonInterfaceBuilder].
+  $TempAvatarPostAvatarResponseApplicationJsonInterface rebuild(
+    void Function($TempAvatarPostAvatarResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TempAvatarPostAvatarResponseApplicationJsonInterfaceBuilder].
+  $TempAvatarPostAvatarResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TempAvatarPostAvatarResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41903,6 +45193,17 @@ abstract class TempAvatarPostAvatarResponseApplicationJson
 sealed class $TempAvatarDeleteAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TempAvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder].
+  $TempAvatarDeleteAvatarResponseApplicationJson_OcsInterface rebuild(
+    void Function($TempAvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TempAvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder].
+  $TempAvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TempAvatarDeleteAvatarResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -41956,6 +45257,17 @@ abstract class TempAvatarDeleteAvatarResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $TempAvatarDeleteAvatarResponseApplicationJsonInterface {
   TempAvatarDeleteAvatarResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TempAvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder].
+  $TempAvatarDeleteAvatarResponseApplicationJsonInterface rebuild(
+    void Function($TempAvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TempAvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder].
+  $TempAvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($TempAvatarDeleteAvatarResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -42008,6 +45320,17 @@ abstract class TempAvatarDeleteAvatarResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $BotWithDetailsAndSecretInterface implements $BotWithDetailsInterface {
   String get secret;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotWithDetailsAndSecretInterfaceBuilder].
+  @override
+  $BotWithDetailsAndSecretInterface rebuild(void Function($BotWithDetailsAndSecretInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$BotWithDetailsAndSecretInterfaceBuilder].
+  @override
+  $BotWithDetailsAndSecretInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($BotWithDetailsAndSecretInterfaceBuilder b) {
     $BotWithDetailsInterface._defaults(b);
@@ -42060,6 +45383,15 @@ abstract class BotWithDetailsAndSecret
 @BuiltValue(instantiable: false)
 sealed class $PublicCapabilities0Interface {
   Capabilities get spreed;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicCapabilities0InterfaceBuilder].
+  $PublicCapabilities0Interface rebuild(void Function($PublicCapabilities0InterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PublicCapabilities0InterfaceBuilder].
+  $PublicCapabilities0InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PublicCapabilities0InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/systemtags.openapi.dart
+++ b/packages/nextcloud/lib/src/api/systemtags.openapi.dart
@@ -86,6 +86,15 @@ class _$Capabilities_Systemtags_EnabledSerializer implements PrimitiveSerializer
 @BuiltValue(instantiable: false)
 sealed class $Capabilities_SystemtagsInterface {
   Capabilities_Systemtags_Enabled get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_SystemtagsInterfaceBuilder].
+  $Capabilities_SystemtagsInterface rebuild(void Function($Capabilities_SystemtagsInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_SystemtagsInterfaceBuilder].
+  $Capabilities_SystemtagsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_SystemtagsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -133,6 +142,15 @@ abstract class Capabilities_Systemtags
 @BuiltValue(instantiable: false)
 sealed class $CapabilitiesInterface {
   Capabilities_Systemtags get systemtags;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -1080,6 +1080,17 @@ sealed class $ThemingGetManifestResponseApplicationJson_IconsInterface {
   String get src;
   String get type;
   String get sizes;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ThemingGetManifestResponseApplicationJson_IconsInterfaceBuilder].
+  $ThemingGetManifestResponseApplicationJson_IconsInterface rebuild(
+    void Function($ThemingGetManifestResponseApplicationJson_IconsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ThemingGetManifestResponseApplicationJson_IconsInterfaceBuilder].
+  $ThemingGetManifestResponseApplicationJson_IconsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ThemingGetManifestResponseApplicationJson_IconsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1149,6 +1160,17 @@ sealed class $ThemingGetManifestResponseApplicationJsonInterface {
   String get description;
   BuiltList<ThemingGetManifestResponseApplicationJson_Icons> get icons;
   String get display;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ThemingGetManifestResponseApplicationJsonInterfaceBuilder].
+  $ThemingGetManifestResponseApplicationJsonInterface rebuild(
+    void Function($ThemingGetManifestResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ThemingGetManifestResponseApplicationJsonInterfaceBuilder].
+  $ThemingGetManifestResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ThemingGetManifestResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1205,6 +1227,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1251,6 +1282,17 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 sealed class $UserThemeEnableThemeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserThemeEnableThemeResponseApplicationJson_OcsInterfaceBuilder].
+  $UserThemeEnableThemeResponseApplicationJson_OcsInterface rebuild(
+    void Function($UserThemeEnableThemeResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserThemeEnableThemeResponseApplicationJson_OcsInterfaceBuilder].
+  $UserThemeEnableThemeResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserThemeEnableThemeResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1303,6 +1345,17 @@ abstract class UserThemeEnableThemeResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UserThemeEnableThemeResponseApplicationJsonInterface {
   UserThemeEnableThemeResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserThemeEnableThemeResponseApplicationJsonInterfaceBuilder].
+  $UserThemeEnableThemeResponseApplicationJsonInterface rebuild(
+    void Function($UserThemeEnableThemeResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserThemeEnableThemeResponseApplicationJsonInterfaceBuilder].
+  $UserThemeEnableThemeResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserThemeEnableThemeResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1356,6 +1409,17 @@ abstract class UserThemeEnableThemeResponseApplicationJson
 sealed class $UserThemeDisableThemeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserThemeDisableThemeResponseApplicationJson_OcsInterfaceBuilder].
+  $UserThemeDisableThemeResponseApplicationJson_OcsInterface rebuild(
+    void Function($UserThemeDisableThemeResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserThemeDisableThemeResponseApplicationJson_OcsInterfaceBuilder].
+  $UserThemeDisableThemeResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserThemeDisableThemeResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1409,6 +1473,17 @@ abstract class UserThemeDisableThemeResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UserThemeDisableThemeResponseApplicationJsonInterface {
   UserThemeDisableThemeResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserThemeDisableThemeResponseApplicationJsonInterfaceBuilder].
+  $UserThemeDisableThemeResponseApplicationJsonInterface rebuild(
+    void Function($UserThemeDisableThemeResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserThemeDisableThemeResponseApplicationJsonInterfaceBuilder].
+  $UserThemeDisableThemeResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserThemeDisableThemeResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1480,6 +1555,15 @@ sealed class $PublicCapabilities_ThemingInterface {
   bool get backgroundDefault;
   String get logoheader;
   String get favicon;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicCapabilities_ThemingInterfaceBuilder].
+  $PublicCapabilities_ThemingInterface rebuild(void Function($PublicCapabilities_ThemingInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PublicCapabilities_ThemingInterfaceBuilder].
+  $PublicCapabilities_ThemingInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PublicCapabilities_ThemingInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1530,6 +1614,15 @@ abstract class PublicCapabilities_Theming
 @BuiltValue(instantiable: false)
 sealed class $PublicCapabilitiesInterface {
   PublicCapabilities_Theming get theming;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicCapabilitiesInterfaceBuilder].
+  $PublicCapabilitiesInterface rebuild(void Function($PublicCapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PublicCapabilitiesInterfaceBuilder].
+  $PublicCapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PublicCapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
@@ -345,6 +345,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -391,6 +400,15 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 sealed class $AppInterface {
   String get appId;
   String get appName;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppInterfaceBuilder].
+  $AppInterface rebuild(void Function($AppInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$AppInterfaceBuilder].
+  $AppInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -437,6 +455,17 @@ abstract class App implements $AppInterface, Built<App, AppBuilder> {
 sealed class $ApiGetAppListResponseApplicationJson_Ocs_DataInterface {
   BuiltList<App> get missing;
   BuiltList<App> get available;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetAppListResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ApiGetAppListResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($ApiGetAppListResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetAppListResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ApiGetAppListResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetAppListResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -490,6 +519,17 @@ abstract class ApiGetAppListResponseApplicationJson_Ocs_Data
 sealed class $ApiGetAppListResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ApiGetAppListResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetAppListResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiGetAppListResponseApplicationJson_OcsInterface rebuild(
+    void Function($ApiGetAppListResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetAppListResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiGetAppListResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetAppListResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -542,6 +582,17 @@ abstract class ApiGetAppListResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ApiGetAppListResponseApplicationJsonInterface {
   ApiGetAppListResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetAppListResponseApplicationJsonInterfaceBuilder].
+  $ApiGetAppListResponseApplicationJsonInterface rebuild(
+    void Function($ApiGetAppListResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetAppListResponseApplicationJsonInterfaceBuilder].
+  $ApiGetAppListResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetAppListResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -652,6 +703,17 @@ sealed class $ApiGetAppChangelogEntryResponseApplicationJson_Ocs_DataInterface {
   String get appName;
   String get content;
   String get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetAppChangelogEntryResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ApiGetAppChangelogEntryResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($ApiGetAppChangelogEntryResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetAppChangelogEntryResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ApiGetAppChangelogEntryResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetAppChangelogEntryResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -706,6 +768,17 @@ abstract class ApiGetAppChangelogEntryResponseApplicationJson_Ocs_Data
 sealed class $ApiGetAppChangelogEntryResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ApiGetAppChangelogEntryResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetAppChangelogEntryResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiGetAppChangelogEntryResponseApplicationJson_OcsInterface rebuild(
+    void Function($ApiGetAppChangelogEntryResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetAppChangelogEntryResponseApplicationJson_OcsInterfaceBuilder].
+  $ApiGetAppChangelogEntryResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetAppChangelogEntryResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -759,6 +832,17 @@ abstract class ApiGetAppChangelogEntryResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ApiGetAppChangelogEntryResponseApplicationJsonInterface {
   ApiGetAppChangelogEntryResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetAppChangelogEntryResponseApplicationJsonInterfaceBuilder].
+  $ApiGetAppChangelogEntryResponseApplicationJsonInterface rebuild(
+    void Function($ApiGetAppChangelogEntryResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetAppChangelogEntryResponseApplicationJsonInterfaceBuilder].
+  $ApiGetAppChangelogEntryResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ApiGetAppChangelogEntryResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/uppush.openapi.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.dart
@@ -883,6 +883,15 @@ class $Client extends _i1.DynamiteClient {
 @BuiltValue(instantiable: false)
 sealed class $CheckResponseApplicationJsonInterface {
   bool get success;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CheckResponseApplicationJsonInterfaceBuilder].
+  $CheckResponseApplicationJsonInterface rebuild(void Function($CheckResponseApplicationJsonInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CheckResponseApplicationJsonInterfaceBuilder].
+  $CheckResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CheckResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -933,6 +942,17 @@ abstract class CheckResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $SetKeepaliveResponseApplicationJsonInterface {
   bool get success;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SetKeepaliveResponseApplicationJsonInterfaceBuilder].
+  $SetKeepaliveResponseApplicationJsonInterface rebuild(
+    void Function($SetKeepaliveResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SetKeepaliveResponseApplicationJsonInterfaceBuilder].
+  $SetKeepaliveResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SetKeepaliveResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -985,6 +1005,17 @@ abstract class SetKeepaliveResponseApplicationJson
 sealed class $CreateDeviceResponseApplicationJsonInterface {
   bool get success;
   String get deviceId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CreateDeviceResponseApplicationJsonInterfaceBuilder].
+  $CreateDeviceResponseApplicationJsonInterface rebuild(
+    void Function($CreateDeviceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CreateDeviceResponseApplicationJsonInterfaceBuilder].
+  $CreateDeviceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CreateDeviceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1036,6 +1067,17 @@ abstract class CreateDeviceResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $SyncDeviceResponseApplicationJsonInterface {
   bool get success;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SyncDeviceResponseApplicationJsonInterfaceBuilder].
+  $SyncDeviceResponseApplicationJsonInterface rebuild(
+    void Function($SyncDeviceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SyncDeviceResponseApplicationJsonInterfaceBuilder].
+  $SyncDeviceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SyncDeviceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1086,6 +1128,17 @@ abstract class SyncDeviceResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $DeleteDeviceResponseApplicationJsonInterface {
   bool get success;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeleteDeviceResponseApplicationJsonInterfaceBuilder].
+  $DeleteDeviceResponseApplicationJsonInterface rebuild(
+    void Function($DeleteDeviceResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeleteDeviceResponseApplicationJsonInterfaceBuilder].
+  $DeleteDeviceResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeleteDeviceResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1138,6 +1191,17 @@ abstract class DeleteDeviceResponseApplicationJson
 sealed class $CreateAppResponseApplicationJsonInterface {
   bool get success;
   String get token;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CreateAppResponseApplicationJsonInterfaceBuilder].
+  $CreateAppResponseApplicationJsonInterface rebuild(
+    void Function($CreateAppResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CreateAppResponseApplicationJsonInterfaceBuilder].
+  $CreateAppResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CreateAppResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1188,6 +1252,17 @@ abstract class CreateAppResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $DeleteAppResponseApplicationJsonInterface {
   bool get success;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeleteAppResponseApplicationJsonInterfaceBuilder].
+  $DeleteAppResponseApplicationJsonInterface rebuild(
+    void Function($DeleteAppResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeleteAppResponseApplicationJsonInterfaceBuilder].
+  $DeleteAppResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($DeleteAppResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1238,6 +1313,17 @@ abstract class DeleteAppResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterface {
   int get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder].
+  $UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterface rebuild(
+    void Function($UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder].
+  $UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UnifiedpushDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1291,6 +1377,17 @@ abstract class UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush
 @BuiltValue(instantiable: false)
 sealed class $UnifiedpushDiscoveryResponseApplicationJsonInterface {
   UnifiedpushDiscoveryResponseApplicationJson_Unifiedpush get unifiedpush;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedpushDiscoveryResponseApplicationJsonInterfaceBuilder].
+  $UnifiedpushDiscoveryResponseApplicationJsonInterface rebuild(
+    void Function($UnifiedpushDiscoveryResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UnifiedpushDiscoveryResponseApplicationJsonInterfaceBuilder].
+  $UnifiedpushDiscoveryResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UnifiedpushDiscoveryResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1343,6 +1440,15 @@ abstract class UnifiedpushDiscoveryResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $PushResponseApplicationJsonInterface {
   bool get success;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PushResponseApplicationJsonInterfaceBuilder].
+  $PushResponseApplicationJsonInterface rebuild(void Function($PushResponseApplicationJsonInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PushResponseApplicationJsonInterfaceBuilder].
+  $PushResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PushResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1393,6 +1499,17 @@ abstract class PushResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterface {
   String get gateway;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder].
+  $GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterface rebuild(
+    void Function($GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder].
+  $GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GatewayMatrixDiscoveryResponseApplicationJson_UnifiedpushInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1446,6 +1563,17 @@ abstract class GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush
 @BuiltValue(instantiable: false)
 sealed class $GatewayMatrixDiscoveryResponseApplicationJsonInterface {
   GatewayMatrixDiscoveryResponseApplicationJson_Unifiedpush get unifiedpush;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GatewayMatrixDiscoveryResponseApplicationJsonInterfaceBuilder].
+  $GatewayMatrixDiscoveryResponseApplicationJsonInterface rebuild(
+    void Function($GatewayMatrixDiscoveryResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GatewayMatrixDiscoveryResponseApplicationJsonInterfaceBuilder].
+  $GatewayMatrixDiscoveryResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GatewayMatrixDiscoveryResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1498,6 +1626,17 @@ abstract class GatewayMatrixDiscoveryResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $GatewayMatrixResponseApplicationJsonInterface {
   BuiltList<String> get rejected;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GatewayMatrixResponseApplicationJsonInterfaceBuilder].
+  $GatewayMatrixResponseApplicationJsonInterface rebuild(
+    void Function($GatewayMatrixResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GatewayMatrixResponseApplicationJsonInterfaceBuilder].
+  $GatewayMatrixResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($GatewayMatrixResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
@@ -471,6 +471,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -516,6 +525,17 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 @BuiltValue(instantiable: false)
 sealed class $ConfigapiCreateResponseApplicationJson_Ocs_DataInterface {
   String get configID;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiCreateResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ConfigapiCreateResponseApplicationJson_Ocs_DataInterface rebuild(
+    void Function($ConfigapiCreateResponseApplicationJson_Ocs_DataInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ConfigapiCreateResponseApplicationJson_Ocs_DataInterfaceBuilder].
+  $ConfigapiCreateResponseApplicationJson_Ocs_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ConfigapiCreateResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -569,6 +589,17 @@ abstract class ConfigapiCreateResponseApplicationJson_Ocs_Data
 sealed class $ConfigapiCreateResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ConfigapiCreateResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiCreateResponseApplicationJson_OcsInterfaceBuilder].
+  $ConfigapiCreateResponseApplicationJson_OcsInterface rebuild(
+    void Function($ConfigapiCreateResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ConfigapiCreateResponseApplicationJson_OcsInterfaceBuilder].
+  $ConfigapiCreateResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ConfigapiCreateResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -621,6 +652,17 @@ abstract class ConfigapiCreateResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ConfigapiCreateResponseApplicationJsonInterface {
   ConfigapiCreateResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiCreateResponseApplicationJsonInterfaceBuilder].
+  $ConfigapiCreateResponseApplicationJsonInterface rebuild(
+    void Function($ConfigapiCreateResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ConfigapiCreateResponseApplicationJsonInterfaceBuilder].
+  $ConfigapiCreateResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ConfigapiCreateResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -736,6 +778,17 @@ class _$ConfigapiShowShowPasswordSerializer implements PrimitiveSerializer<Confi
 sealed class $ConfigapiShowResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, JsonObject> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiShowResponseApplicationJson_OcsInterfaceBuilder].
+  $ConfigapiShowResponseApplicationJson_OcsInterface rebuild(
+    void Function($ConfigapiShowResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ConfigapiShowResponseApplicationJson_OcsInterfaceBuilder].
+  $ConfigapiShowResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ConfigapiShowResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -788,6 +841,17 @@ abstract class ConfigapiShowResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ConfigapiShowResponseApplicationJsonInterface {
   ConfigapiShowResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiShowResponseApplicationJsonInterfaceBuilder].
+  $ConfigapiShowResponseApplicationJsonInterface rebuild(
+    void Function($ConfigapiShowResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ConfigapiShowResponseApplicationJsonInterfaceBuilder].
+  $ConfigapiShowResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ConfigapiShowResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -840,6 +904,17 @@ abstract class ConfigapiShowResponseApplicationJson
 sealed class $ConfigapiModifyResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiModifyResponseApplicationJson_OcsInterfaceBuilder].
+  $ConfigapiModifyResponseApplicationJson_OcsInterface rebuild(
+    void Function($ConfigapiModifyResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ConfigapiModifyResponseApplicationJson_OcsInterfaceBuilder].
+  $ConfigapiModifyResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ConfigapiModifyResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -892,6 +967,17 @@ abstract class ConfigapiModifyResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ConfigapiModifyResponseApplicationJsonInterface {
   ConfigapiModifyResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiModifyResponseApplicationJsonInterfaceBuilder].
+  $ConfigapiModifyResponseApplicationJsonInterface rebuild(
+    void Function($ConfigapiModifyResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ConfigapiModifyResponseApplicationJsonInterfaceBuilder].
+  $ConfigapiModifyResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ConfigapiModifyResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -944,6 +1030,17 @@ abstract class ConfigapiModifyResponseApplicationJson
 sealed class $ConfigapiDeleteResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiDeleteResponseApplicationJson_OcsInterfaceBuilder].
+  $ConfigapiDeleteResponseApplicationJson_OcsInterface rebuild(
+    void Function($ConfigapiDeleteResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ConfigapiDeleteResponseApplicationJson_OcsInterfaceBuilder].
+  $ConfigapiDeleteResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ConfigapiDeleteResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -996,6 +1093,17 @@ abstract class ConfigapiDeleteResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $ConfigapiDeleteResponseApplicationJsonInterface {
   ConfigapiDeleteResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiDeleteResponseApplicationJsonInterfaceBuilder].
+  $ConfigapiDeleteResponseApplicationJsonInterface rebuild(
+    void Function($ConfigapiDeleteResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ConfigapiDeleteResponseApplicationJsonInterfaceBuilder].
+  $ConfigapiDeleteResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ConfigapiDeleteResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -1042,6 +1042,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1172,6 +1181,15 @@ sealed class $PublicInterface {
   String? get icon;
   int? get clearAt;
   $Type get status;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicInterfaceBuilder].
+  $PublicInterface rebuild(void Function($PublicInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PublicInterfaceBuilder].
+  $PublicInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PublicInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1219,6 +1237,17 @@ sealed class $PrivateInterface implements $PublicInterface {
   String? get messageId;
   bool get messageIsPredefined;
   bool get statusIsUserDefined;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PrivateInterfaceBuilder].
+  @override
+  $PrivateInterface rebuild(void Function($PrivateInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PrivateInterfaceBuilder].
+  @override
+  $PrivateInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PrivateInterfaceBuilder b) {
     $PublicInterface._defaults(b);
@@ -1270,6 +1299,17 @@ abstract class Private implements $PrivateInterface, Built<Private, PrivateBuild
 sealed class $HeartbeatHeartbeatResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$HeartbeatHeartbeatResponseApplicationJson_OcsInterfaceBuilder].
+  $HeartbeatHeartbeatResponseApplicationJson_OcsInterface rebuild(
+    void Function($HeartbeatHeartbeatResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$HeartbeatHeartbeatResponseApplicationJson_OcsInterfaceBuilder].
+  $HeartbeatHeartbeatResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($HeartbeatHeartbeatResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1322,6 +1362,17 @@ abstract class HeartbeatHeartbeatResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $HeartbeatHeartbeatResponseApplicationJsonInterface {
   HeartbeatHeartbeatResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$HeartbeatHeartbeatResponseApplicationJsonInterfaceBuilder].
+  $HeartbeatHeartbeatResponseApplicationJsonInterface rebuild(
+    void Function($HeartbeatHeartbeatResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$HeartbeatHeartbeatResponseApplicationJsonInterfaceBuilder].
+  $HeartbeatHeartbeatResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($HeartbeatHeartbeatResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1500,6 +1551,15 @@ typedef ClearAt_Time = ({ClearAtTimeType? clearAtTimeType, int? $int});
 sealed class $ClearAtInterface {
   ClearAt_Type get type;
   ClearAt_Time get time;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ClearAtInterfaceBuilder].
+  $ClearAtInterface rebuild(void Function($ClearAtInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ClearAtInterfaceBuilder].
+  $ClearAtInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ClearAtInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1551,6 +1611,15 @@ sealed class $PredefinedInterface {
   String get message;
   ClearAt? get clearAt;
   bool? get visible;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PredefinedInterfaceBuilder].
+  $PredefinedInterface rebuild(void Function($PredefinedInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$PredefinedInterfaceBuilder].
+  $PredefinedInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PredefinedInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1597,6 +1666,17 @@ abstract class Predefined implements $PredefinedInterface, Built<Predefined, Pre
 sealed class $PredefinedStatusFindAllResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Predefined> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PredefinedStatusFindAllResponseApplicationJson_OcsInterfaceBuilder].
+  $PredefinedStatusFindAllResponseApplicationJson_OcsInterface rebuild(
+    void Function($PredefinedStatusFindAllResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PredefinedStatusFindAllResponseApplicationJson_OcsInterfaceBuilder].
+  $PredefinedStatusFindAllResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PredefinedStatusFindAllResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1650,6 +1730,17 @@ abstract class PredefinedStatusFindAllResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $PredefinedStatusFindAllResponseApplicationJsonInterface {
   PredefinedStatusFindAllResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PredefinedStatusFindAllResponseApplicationJsonInterfaceBuilder].
+  $PredefinedStatusFindAllResponseApplicationJsonInterface rebuild(
+    void Function($PredefinedStatusFindAllResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PredefinedStatusFindAllResponseApplicationJsonInterfaceBuilder].
+  $PredefinedStatusFindAllResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($PredefinedStatusFindAllResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1703,6 +1794,17 @@ abstract class PredefinedStatusFindAllResponseApplicationJson
 sealed class $StatusesFindAllResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Public> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$StatusesFindAllResponseApplicationJson_OcsInterfaceBuilder].
+  $StatusesFindAllResponseApplicationJson_OcsInterface rebuild(
+    void Function($StatusesFindAllResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$StatusesFindAllResponseApplicationJson_OcsInterfaceBuilder].
+  $StatusesFindAllResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($StatusesFindAllResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1755,6 +1857,17 @@ abstract class StatusesFindAllResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $StatusesFindAllResponseApplicationJsonInterface {
   StatusesFindAllResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$StatusesFindAllResponseApplicationJsonInterfaceBuilder].
+  $StatusesFindAllResponseApplicationJsonInterface rebuild(
+    void Function($StatusesFindAllResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$StatusesFindAllResponseApplicationJsonInterfaceBuilder].
+  $StatusesFindAllResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($StatusesFindAllResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1807,6 +1920,17 @@ abstract class StatusesFindAllResponseApplicationJson
 sealed class $StatusesFindResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Public get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$StatusesFindResponseApplicationJson_OcsInterfaceBuilder].
+  $StatusesFindResponseApplicationJson_OcsInterface rebuild(
+    void Function($StatusesFindResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$StatusesFindResponseApplicationJson_OcsInterfaceBuilder].
+  $StatusesFindResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($StatusesFindResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1858,6 +1982,17 @@ abstract class StatusesFindResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $StatusesFindResponseApplicationJsonInterface {
   StatusesFindResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$StatusesFindResponseApplicationJsonInterfaceBuilder].
+  $StatusesFindResponseApplicationJsonInterface rebuild(
+    void Function($StatusesFindResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$StatusesFindResponseApplicationJsonInterfaceBuilder].
+  $StatusesFindResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($StatusesFindResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1910,6 +2045,17 @@ abstract class StatusesFindResponseApplicationJson
 sealed class $UserStatusGetStatusResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusGetStatusResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusGetStatusResponseApplicationJson_OcsInterface rebuild(
+    void Function($UserStatusGetStatusResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusGetStatusResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusGetStatusResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusGetStatusResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1962,6 +2108,17 @@ abstract class UserStatusGetStatusResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UserStatusGetStatusResponseApplicationJsonInterface {
   UserStatusGetStatusResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusGetStatusResponseApplicationJsonInterfaceBuilder].
+  $UserStatusGetStatusResponseApplicationJsonInterface rebuild(
+    void Function($UserStatusGetStatusResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusGetStatusResponseApplicationJsonInterfaceBuilder].
+  $UserStatusGetStatusResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusGetStatusResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2015,6 +2172,17 @@ abstract class UserStatusGetStatusResponseApplicationJson
 sealed class $UserStatusSetStatusResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusSetStatusResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusSetStatusResponseApplicationJson_OcsInterface rebuild(
+    void Function($UserStatusSetStatusResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusSetStatusResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusSetStatusResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusSetStatusResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2067,6 +2235,17 @@ abstract class UserStatusSetStatusResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UserStatusSetStatusResponseApplicationJsonInterface {
   UserStatusSetStatusResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusSetStatusResponseApplicationJsonInterfaceBuilder].
+  $UserStatusSetStatusResponseApplicationJsonInterface rebuild(
+    void Function($UserStatusSetStatusResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusSetStatusResponseApplicationJsonInterfaceBuilder].
+  $UserStatusSetStatusResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusSetStatusResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2120,6 +2299,17 @@ abstract class UserStatusSetStatusResponseApplicationJson
 sealed class $UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusSetPredefinedMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2173,6 +2363,17 @@ abstract class UserStatusSetPredefinedMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UserStatusSetPredefinedMessageResponseApplicationJsonInterface {
   UserStatusSetPredefinedMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusSetPredefinedMessageResponseApplicationJsonInterfaceBuilder].
+  $UserStatusSetPredefinedMessageResponseApplicationJsonInterface rebuild(
+    void Function($UserStatusSetPredefinedMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusSetPredefinedMessageResponseApplicationJsonInterfaceBuilder].
+  $UserStatusSetPredefinedMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusSetPredefinedMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2227,6 +2428,17 @@ abstract class UserStatusSetPredefinedMessageResponseApplicationJson
 sealed class $UserStatusSetCustomMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusSetCustomMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusSetCustomMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($UserStatusSetCustomMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusSetCustomMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusSetCustomMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusSetCustomMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2280,6 +2492,17 @@ abstract class UserStatusSetCustomMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UserStatusSetCustomMessageResponseApplicationJsonInterface {
   UserStatusSetCustomMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusSetCustomMessageResponseApplicationJsonInterfaceBuilder].
+  $UserStatusSetCustomMessageResponseApplicationJsonInterface rebuild(
+    void Function($UserStatusSetCustomMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusSetCustomMessageResponseApplicationJsonInterfaceBuilder].
+  $UserStatusSetCustomMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusSetCustomMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2334,6 +2557,17 @@ abstract class UserStatusSetCustomMessageResponseApplicationJson
 sealed class $UserStatusClearMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusClearMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusClearMessageResponseApplicationJson_OcsInterface rebuild(
+    void Function($UserStatusClearMessageResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusClearMessageResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusClearMessageResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusClearMessageResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2387,6 +2621,17 @@ abstract class UserStatusClearMessageResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UserStatusClearMessageResponseApplicationJsonInterface {
   UserStatusClearMessageResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusClearMessageResponseApplicationJsonInterfaceBuilder].
+  $UserStatusClearMessageResponseApplicationJsonInterface rebuild(
+    void Function($UserStatusClearMessageResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusClearMessageResponseApplicationJsonInterfaceBuilder].
+  $UserStatusClearMessageResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusClearMessageResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2442,6 +2687,17 @@ typedef UserStatusRevertStatusResponseApplicationJson_Ocs_Data = ({BuiltList<Nev
 sealed class $UserStatusRevertStatusResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   UserStatusRevertStatusResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusRevertStatusResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusRevertStatusResponseApplicationJson_OcsInterface rebuild(
+    void Function($UserStatusRevertStatusResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusRevertStatusResponseApplicationJson_OcsInterfaceBuilder].
+  $UserStatusRevertStatusResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusRevertStatusResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2497,6 +2753,17 @@ abstract class UserStatusRevertStatusResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $UserStatusRevertStatusResponseApplicationJsonInterface {
   UserStatusRevertStatusResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusRevertStatusResponseApplicationJsonInterfaceBuilder].
+  $UserStatusRevertStatusResponseApplicationJsonInterface rebuild(
+    void Function($UserStatusRevertStatusResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusRevertStatusResponseApplicationJsonInterfaceBuilder].
+  $UserStatusRevertStatusResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($UserStatusRevertStatusResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2552,6 +2819,15 @@ sealed class $Capabilities_UserStatusInterface {
   bool get restore;
   @BuiltValueField(wireName: 'supports_emoji')
   bool get supportsEmoji;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_UserStatusInterfaceBuilder].
+  $Capabilities_UserStatusInterface rebuild(void Function($Capabilities_UserStatusInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_UserStatusInterfaceBuilder].
+  $Capabilities_UserStatusInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_UserStatusInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2600,6 +2876,15 @@ abstract class Capabilities_UserStatus
 sealed class $CapabilitiesInterface {
   @BuiltValueField(wireName: 'user_status')
   Capabilities_UserStatus get userStatus;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -694,6 +694,15 @@ sealed class $OCSMetaInterface {
   String? get message;
   String? get totalitems;
   String? get itemsperpage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterface rebuild(void Function($OCSMetaInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$OCSMetaInterfaceBuilder].
+  $OCSMetaInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OCSMetaInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -739,6 +748,15 @@ abstract class OCSMeta implements $OCSMetaInterface, Built<OCSMeta, OCSMetaBuild
 @BuiltValue(instantiable: false)
 sealed class $SuccessInterface {
   bool get success;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SuccessInterfaceBuilder].
+  $SuccessInterface rebuild(void Function($SuccessInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$SuccessInterfaceBuilder].
+  $SuccessInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($SuccessInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -785,6 +803,17 @@ abstract class Success implements $SuccessInterface, Built<Success, SuccessBuild
 sealed class $WeatherStatusSetModeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Success get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusSetModeResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusSetModeResponseApplicationJson_OcsInterface rebuild(
+    void Function($WeatherStatusSetModeResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusSetModeResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusSetModeResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusSetModeResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -837,6 +866,17 @@ abstract class WeatherStatusSetModeResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $WeatherStatusSetModeResponseApplicationJsonInterface {
   WeatherStatusSetModeResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusSetModeResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetModeResponseApplicationJsonInterface rebuild(
+    void Function($WeatherStatusSetModeResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusSetModeResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetModeResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusSetModeResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -891,6 +931,15 @@ sealed class $LocationInterface {
   String? get lat;
   String? get lon;
   String? get address;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$LocationInterfaceBuilder].
+  $LocationInterface rebuild(void Function($LocationInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$LocationInterfaceBuilder].
+  $LocationInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($LocationInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -935,6 +984,14 @@ abstract class Location implements $LocationInterface, Built<Location, LocationB
 
 @BuiltValue(instantiable: false)
 sealed class $LocationWithSuccessInterface implements $LocationInterface, $SuccessInterface {
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$LocationWithSuccessInterfaceBuilder].
+  $LocationWithSuccessInterface rebuild(void Function($LocationWithSuccessInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$LocationWithSuccessInterfaceBuilder].
+  $LocationWithSuccessInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($LocationWithSuccessInterfaceBuilder b) {
     $LocationInterface._defaults(b);
@@ -990,6 +1047,17 @@ abstract class LocationWithSuccess
 sealed class $WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   LocationWithSuccess get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterface rebuild(
+    void Function($WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusUsePersonalAddressResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1043,6 +1111,17 @@ abstract class WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $WeatherStatusUsePersonalAddressResponseApplicationJsonInterface {
   WeatherStatusUsePersonalAddressResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusUsePersonalAddressResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusUsePersonalAddressResponseApplicationJsonInterface rebuild(
+    void Function($WeatherStatusUsePersonalAddressResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusUsePersonalAddressResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusUsePersonalAddressResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusUsePersonalAddressResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1096,6 +1175,15 @@ abstract class WeatherStatusUsePersonalAddressResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $ModeInterface {
   int get mode;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ModeInterfaceBuilder].
+  $ModeInterface rebuild(void Function($ModeInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ModeInterfaceBuilder].
+  $ModeInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ModeInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1140,6 +1228,14 @@ abstract class Mode implements $ModeInterface, Built<Mode, ModeBuilder> {
 
 @BuiltValue(instantiable: false)
 sealed class $LocationWithModeInterface implements $LocationInterface, $ModeInterface {
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$LocationWithModeInterfaceBuilder].
+  $LocationWithModeInterface rebuild(void Function($LocationWithModeInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$LocationWithModeInterfaceBuilder].
+  $LocationWithModeInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($LocationWithModeInterfaceBuilder b) {
     $LocationInterface._defaults(b);
@@ -1194,6 +1290,17 @@ abstract class LocationWithMode
 sealed class $WeatherStatusGetLocationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   LocationWithMode get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusGetLocationResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusGetLocationResponseApplicationJson_OcsInterface rebuild(
+    void Function($WeatherStatusGetLocationResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusGetLocationResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusGetLocationResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusGetLocationResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1247,6 +1354,17 @@ abstract class WeatherStatusGetLocationResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $WeatherStatusGetLocationResponseApplicationJsonInterface {
   WeatherStatusGetLocationResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusGetLocationResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusGetLocationResponseApplicationJsonInterface rebuild(
+    void Function($WeatherStatusGetLocationResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusGetLocationResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusGetLocationResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusGetLocationResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1300,6 +1418,17 @@ abstract class WeatherStatusGetLocationResponseApplicationJson
 sealed class $WeatherStatusSetLocationResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   LocationWithSuccess get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusSetLocationResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusSetLocationResponseApplicationJson_OcsInterface rebuild(
+    void Function($WeatherStatusSetLocationResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusSetLocationResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusSetLocationResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusSetLocationResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1353,6 +1482,17 @@ abstract class WeatherStatusSetLocationResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $WeatherStatusSetLocationResponseApplicationJsonInterface {
   WeatherStatusSetLocationResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusSetLocationResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetLocationResponseApplicationJsonInterface rebuild(
+    void Function($WeatherStatusSetLocationResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusSetLocationResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetLocationResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusSetLocationResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1416,6 +1556,17 @@ sealed class $Forecast_Data_Instant_DetailsInterface {
   num get windFromDirection;
   @BuiltValueField(wireName: 'wind_speed')
   num get windSpeed;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_Instant_DetailsInterfaceBuilder].
+  $Forecast_Data_Instant_DetailsInterface rebuild(
+    void Function($Forecast_Data_Instant_DetailsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Forecast_Data_Instant_DetailsInterfaceBuilder].
+  $Forecast_Data_Instant_DetailsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_Instant_DetailsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1466,6 +1617,15 @@ abstract class Forecast_Data_Instant_Details
 @BuiltValue(instantiable: false)
 sealed class $Forecast_Data_InstantInterface {
   Forecast_Data_Instant_Details get details;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_InstantInterfaceBuilder].
+  $Forecast_Data_InstantInterface rebuild(void Function($Forecast_Data_InstantInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Forecast_Data_InstantInterfaceBuilder].
+  $Forecast_Data_InstantInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_InstantInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1514,6 +1674,17 @@ abstract class Forecast_Data_Instant
 sealed class $Forecast_Data_Next12Hours_SummaryInterface {
   @BuiltValueField(wireName: 'symbol_code')
   String get symbolCode;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_Next12Hours_SummaryInterfaceBuilder].
+  $Forecast_Data_Next12Hours_SummaryInterface rebuild(
+    void Function($Forecast_Data_Next12Hours_SummaryInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Forecast_Data_Next12Hours_SummaryInterfaceBuilder].
+  $Forecast_Data_Next12Hours_SummaryInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_Next12Hours_SummaryInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1565,6 +1736,17 @@ abstract class Forecast_Data_Next12Hours_Summary
 sealed class $Forecast_Data_Next12Hours_DetailsInterface {
   @BuiltValueField(wireName: 'precipitation_amount')
   num? get precipitationAmount;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_Next12Hours_DetailsInterfaceBuilder].
+  $Forecast_Data_Next12Hours_DetailsInterface rebuild(
+    void Function($Forecast_Data_Next12Hours_DetailsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Forecast_Data_Next12Hours_DetailsInterfaceBuilder].
+  $Forecast_Data_Next12Hours_DetailsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_Next12Hours_DetailsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1616,6 +1798,15 @@ abstract class Forecast_Data_Next12Hours_Details
 sealed class $Forecast_Data_Next12HoursInterface {
   Forecast_Data_Next12Hours_Summary get summary;
   Forecast_Data_Next12Hours_Details get details;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_Next12HoursInterfaceBuilder].
+  $Forecast_Data_Next12HoursInterface rebuild(void Function($Forecast_Data_Next12HoursInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Forecast_Data_Next12HoursInterfaceBuilder].
+  $Forecast_Data_Next12HoursInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_Next12HoursInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1664,6 +1855,17 @@ abstract class Forecast_Data_Next12Hours
 sealed class $Forecast_Data_Next1Hours_SummaryInterface {
   @BuiltValueField(wireName: 'symbol_code')
   String get symbolCode;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_Next1Hours_SummaryInterfaceBuilder].
+  $Forecast_Data_Next1Hours_SummaryInterface rebuild(
+    void Function($Forecast_Data_Next1Hours_SummaryInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Forecast_Data_Next1Hours_SummaryInterfaceBuilder].
+  $Forecast_Data_Next1Hours_SummaryInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_Next1Hours_SummaryInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1715,6 +1917,17 @@ abstract class Forecast_Data_Next1Hours_Summary
 sealed class $Forecast_Data_Next1Hours_DetailsInterface {
   @BuiltValueField(wireName: 'precipitation_amount')
   num? get precipitationAmount;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_Next1Hours_DetailsInterfaceBuilder].
+  $Forecast_Data_Next1Hours_DetailsInterface rebuild(
+    void Function($Forecast_Data_Next1Hours_DetailsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Forecast_Data_Next1Hours_DetailsInterfaceBuilder].
+  $Forecast_Data_Next1Hours_DetailsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_Next1Hours_DetailsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1766,6 +1979,15 @@ abstract class Forecast_Data_Next1Hours_Details
 sealed class $Forecast_Data_Next1HoursInterface {
   Forecast_Data_Next1Hours_Summary get summary;
   Forecast_Data_Next1Hours_Details get details;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_Next1HoursInterfaceBuilder].
+  $Forecast_Data_Next1HoursInterface rebuild(void Function($Forecast_Data_Next1HoursInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Forecast_Data_Next1HoursInterfaceBuilder].
+  $Forecast_Data_Next1HoursInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_Next1HoursInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1814,6 +2036,17 @@ abstract class Forecast_Data_Next1Hours
 sealed class $Forecast_Data_Next6Hours_SummaryInterface {
   @BuiltValueField(wireName: 'symbol_code')
   String get symbolCode;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_Next6Hours_SummaryInterfaceBuilder].
+  $Forecast_Data_Next6Hours_SummaryInterface rebuild(
+    void Function($Forecast_Data_Next6Hours_SummaryInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Forecast_Data_Next6Hours_SummaryInterfaceBuilder].
+  $Forecast_Data_Next6Hours_SummaryInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_Next6Hours_SummaryInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1865,6 +2098,17 @@ abstract class Forecast_Data_Next6Hours_Summary
 sealed class $Forecast_Data_Next6Hours_DetailsInterface {
   @BuiltValueField(wireName: 'precipitation_amount')
   num? get precipitationAmount;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_Next6Hours_DetailsInterfaceBuilder].
+  $Forecast_Data_Next6Hours_DetailsInterface rebuild(
+    void Function($Forecast_Data_Next6Hours_DetailsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$Forecast_Data_Next6Hours_DetailsInterfaceBuilder].
+  $Forecast_Data_Next6Hours_DetailsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_Next6Hours_DetailsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1916,6 +2160,15 @@ abstract class Forecast_Data_Next6Hours_Details
 sealed class $Forecast_Data_Next6HoursInterface {
   Forecast_Data_Next6Hours_Summary get summary;
   Forecast_Data_Next6Hours_Details get details;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_Data_Next6HoursInterfaceBuilder].
+  $Forecast_Data_Next6HoursInterface rebuild(void Function($Forecast_Data_Next6HoursInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Forecast_Data_Next6HoursInterfaceBuilder].
+  $Forecast_Data_Next6HoursInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_Data_Next6HoursInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -1969,6 +2222,15 @@ sealed class $Forecast_DataInterface {
   Forecast_Data_Next1Hours get next1Hours;
   @BuiltValueField(wireName: 'next_6_hours')
   Forecast_Data_Next6Hours get next6Hours;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Forecast_DataInterfaceBuilder].
+  $Forecast_DataInterface rebuild(void Function($Forecast_DataInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Forecast_DataInterfaceBuilder].
+  $Forecast_DataInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Forecast_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2015,6 +2277,15 @@ abstract class Forecast_Data implements $Forecast_DataInterface, Built<Forecast_
 sealed class $ForecastInterface {
   String get time;
   Forecast_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ForecastInterfaceBuilder].
+  $ForecastInterface rebuild(void Function($ForecastInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ForecastInterfaceBuilder].
+  $ForecastInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ForecastInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2060,6 +2331,17 @@ abstract class Forecast implements $ForecastInterface, Built<Forecast, ForecastB
 @BuiltValue(instantiable: false)
 sealed class $WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Interface {
   String get error;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1InterfaceBuilder].
+  $WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1Interface rebuild(
+    void Function($WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1InterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1InterfaceBuilder].
+  $WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1InterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusGetForecastResponseApplicationJson_Ocs_Data1InterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2119,6 +2401,17 @@ typedef WeatherStatusGetForecastResponseApplicationJson_Ocs_Data = ({
 sealed class $WeatherStatusGetForecastResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   WeatherStatusGetForecastResponseApplicationJson_Ocs_Data get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusGetForecastResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusGetForecastResponseApplicationJson_OcsInterface rebuild(
+    void Function($WeatherStatusGetForecastResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusGetForecastResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusGetForecastResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusGetForecastResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2174,6 +2467,17 @@ abstract class WeatherStatusGetForecastResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $WeatherStatusGetForecastResponseApplicationJsonInterface {
   WeatherStatusGetForecastResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusGetForecastResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusGetForecastResponseApplicationJsonInterface rebuild(
+    void Function($WeatherStatusGetForecastResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusGetForecastResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusGetForecastResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusGetForecastResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2227,6 +2531,17 @@ abstract class WeatherStatusGetForecastResponseApplicationJson
 sealed class $WeatherStatusGetFavoritesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<String> get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusGetFavoritesResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusGetFavoritesResponseApplicationJson_OcsInterface rebuild(
+    void Function($WeatherStatusGetFavoritesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusGetFavoritesResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusGetFavoritesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusGetFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2280,6 +2595,17 @@ abstract class WeatherStatusGetFavoritesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $WeatherStatusGetFavoritesResponseApplicationJsonInterface {
   WeatherStatusGetFavoritesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusGetFavoritesResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusGetFavoritesResponseApplicationJsonInterface rebuild(
+    void Function($WeatherStatusGetFavoritesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusGetFavoritesResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusGetFavoritesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusGetFavoritesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2334,6 +2660,17 @@ abstract class WeatherStatusGetFavoritesResponseApplicationJson
 sealed class $WeatherStatusSetFavoritesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Success get data;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusSetFavoritesResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusSetFavoritesResponseApplicationJson_OcsInterface rebuild(
+    void Function($WeatherStatusSetFavoritesResponseApplicationJson_OcsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusSetFavoritesResponseApplicationJson_OcsInterfaceBuilder].
+  $WeatherStatusSetFavoritesResponseApplicationJson_OcsInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusSetFavoritesResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2387,6 +2724,17 @@ abstract class WeatherStatusSetFavoritesResponseApplicationJson_Ocs
 @BuiltValue(instantiable: false)
 sealed class $WeatherStatusSetFavoritesResponseApplicationJsonInterface {
   WeatherStatusSetFavoritesResponseApplicationJson_Ocs get ocs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusSetFavoritesResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetFavoritesResponseApplicationJsonInterface rebuild(
+    void Function($WeatherStatusSetFavoritesResponseApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusSetFavoritesResponseApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetFavoritesResponseApplicationJsonInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($WeatherStatusSetFavoritesResponseApplicationJsonInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2440,6 +2788,15 @@ abstract class WeatherStatusSetFavoritesResponseApplicationJson
 @BuiltValue(instantiable: false)
 sealed class $Capabilities_WeatherStatusInterface {
   bool get enabled;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$Capabilities_WeatherStatusInterfaceBuilder].
+  $Capabilities_WeatherStatusInterface rebuild(void Function($Capabilities_WeatherStatusInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$Capabilities_WeatherStatusInterfaceBuilder].
+  $Capabilities_WeatherStatusInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($Capabilities_WeatherStatusInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -2491,6 +2848,15 @@ abstract class Capabilities_WeatherStatus
 sealed class $CapabilitiesInterface {
   @BuiltValueField(wireName: 'weather_status')
   Capabilities_WeatherStatus get weatherStatus;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterface rebuild(void Function($CapabilitiesInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$CapabilitiesInterfaceBuilder].
+  $CapabilitiesInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($CapabilitiesInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)


### PR DESCRIPTION
Allows calling `toBuilder` and `rebuild` on the interface making it a drop in replacement to the built class itself.
related to #1995 

As this is not needed yet I'd like to wait until other breaking changes accumulate.