### PR TITLE
fix(app): remove ndk version constraint

### DIFF
--- a/packages/app/android/app/build.gradle
+++ b/packages/app/android/app/build.gradle
@@ -25,7 +25,6 @@ if (flutterVersionName == null) {
 android {
     namespace "de.provokateurin.neon"
     compileSdkVersion 34
-    ndkVersion "25.1.8937393"
 
     compileOptions {
         coreLibraryDesugaringEnabled true


### PR DESCRIPTION
The ndk version will fall back to the one supported by the Android Gradle Plugin

Should be safe to do: https://github.com/flutter/flutter/issues/139427#issuecomment-1989024985
