### PR TITLE
fix(neon_framework): Use clean URLs for routing

### DIFF
--- a/packages/neon_framework/lib/src/router.dart
+++ b/packages/neon_framework/lib/src/router.dart
@@ -41,8 +41,15 @@ GoRouter buildAppRouter({
         if (accountsBloc.hasAccounts) {
           final activeAccount = accountsBloc.activeAccount.value!;
 
+          var uri = state.uri;
+          final capabilities = accountsBloc.activeCapabilitiesBloc.capabilities.valueOrNull?.data;
+          final modRewriteWorking = capabilities?.capabilities.coreCapabilities?.core.modRewriteWorking ?? false;
+          if (!modRewriteWorking) {
+            uri = state.uri.replace(path: '/index.php${state.uri}');
+          }
+
           await launchUrl(
-            activeAccount.completeUri(state.uri),
+            activeAccount.completeUri(uri),
             mode: LaunchMode.externalApplication,
           );
 
@@ -56,6 +63,10 @@ GoRouter buildAppRouter({
         await router.push(RouteNotFoundRoute(uri: state.uri).location);
       },
       redirect: (context, state) {
+        if (state.uri.path.startsWith('/index.php/')) {
+          return state.uri.path.substring(10);
+        }
+
         final loginQRcode = LoginQRcode.tryParse(state.uri.toString());
         if (loginQRcode != null) {
           return LoginCheckServerStatusRoute.withCredentials(


### PR DESCRIPTION
Closes https://github.com/nextcloud/neon/issues/1720

Apps shouldn't have to match against `/index.php/...` routes as well. In case the route is not found and opened in a browser the index.php is prepended again conditionally (mod rewrite means / will point to /index.php in the web server).