### PR TITLE
fix(neon_framework): Fix loading timezone database on web

### DIFF
--- a/packages/neon_framework/lib/neon.dart
+++ b/packages/neon_framework/lib/neon.dart
@@ -19,7 +19,7 @@ import 'package:neon_framework/src/utils/user_agent.dart';
 import 'package:neon_framework/storage.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
-import 'package:timezone/timezone.dart' as tz;
+import 'package:timezone/data/latest.dart' as tz;
 
 /// Runs Neon with the given [appImplementations].
 ///
@@ -38,7 +38,7 @@ Future<void> runNeon({
   FlutterNativeSplash.preserve(widgetsBinding: binding);
 
   await NeonPlatform.instance.init();
-  assert(tz.timeZoneDatabase.isInitialized, 'Timezone database not initialized by NeonPlatform');
+  tz.initializeTimeZones();
 
   await NeonStorage().init();
 

--- a/packages/neon_framework/lib/src/platform/android.dart
+++ b/packages/neon_framework/lib/src/platform/android.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:file_picker/file_picker.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/src/platform/platform.dart';
-import 'package:timezone/data/latest.dart' as tz;
 
 /// Android specific platform information.
 ///
@@ -42,9 +41,7 @@ class AndroidNeonPlatform implements NeonPlatform {
   bool get canUsePaths => true;
 
   @override
-  void init() {
-    tz.initializeTimeZones();
-  }
+  void init() {}
 
   @override
   Future<void> saveFileWithPickDialog(String fileName, String mimeType, Uint8List data) async {

--- a/packages/neon_framework/lib/src/platform/linux.dart
+++ b/packages/neon_framework/lib/src/platform/linux.dart
@@ -4,7 +4,6 @@ import 'package:file_picker/file_picker.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/src/platform/platform.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
-import 'package:timezone/data/latest.dart' as tz;
 import 'package:universal_io/io.dart';
 
 /// Linux specific platform information.
@@ -47,8 +46,6 @@ class LinuxNeonPlatform implements NeonPlatform {
   void init() {
     sqfliteFfiInit();
     databaseFactory = databaseFactoryFfi;
-
-    tz.initializeTimeZones();
   }
 
   @override

--- a/packages/neon_framework/lib/src/platform/web.dart
+++ b/packages/neon_framework/lib/src/platform/web.dart
@@ -6,7 +6,6 @@ import 'package:meta/meta.dart';
 import 'package:neon_framework/src/platform/platform.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:sqflite_common_ffi_web/sqflite_ffi_web.dart';
-import 'package:timezone/browser.dart' as tz;
 import 'package:web/web.dart';
 
 @immutable
@@ -42,8 +41,6 @@ class WebNeonPlatform implements NeonPlatform {
   @override
   Future<void> init() async {
     databaseFactory = databaseFactoryFfiWeb;
-
-    await tz.initializeTimeZone();
   }
 
   @override


### PR DESCRIPTION
The database was loading successfully on web in debug mode, but not in release mode. As per https://github.com/srawlins/timezone/issues/68#issuecomment-1366153638 the "normal" way to load the database just works fine on web, so we don't need to have the platform handle it and can use a single method for it.