### PR TITLE
fix(neon_framework): Fix cyclic dependency between AccountOptions and AppsBloc

### DIFF
--- a/packages/neon_framework/lib/src/blocs/accounts.dart
+++ b/packages/neon_framework/lib/src/blocs/accounts.dart
@@ -329,7 +329,6 @@ class _AccountsBloc extends Bloc implements AccountsBloc {
   @override
   AccountOptions getOptionsFor(Account account) => accountsOptions[account] ??= AccountOptions(
         NeonStorage().settingsStore(StorageKeys.accountOptions, account.id),
-        getAppsBlocFor(account),
       );
 
   @override

--- a/packages/neon_framework/lib/src/blocs/apps.dart
+++ b/packages/neon_framework/lib/src/blocs/apps.dart
@@ -93,6 +93,12 @@ class _AppsBloc extends InteractiveBloc implements AppsBloc {
       }
     });
 
+    appImplementations.listen((result) {
+      if (result.hasData) {
+        accountOptions.updateAppImplementations(result.requireData);
+      }
+    });
+
     unawaited(refresh());
   }
 

--- a/packages/neon_framework/lib/src/utils/account_options.dart
+++ b/packages/neon_framework/lib/src/utils/account_options.dart
@@ -1,6 +1,7 @@
+import 'package:built_collection/built_collection.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/l10n/localizations.dart';
-import 'package:neon_framework/src/blocs/apps.dart';
+import 'package:neon_framework/models.dart';
 import 'package:neon_framework/src/settings/models/option.dart';
 import 'package:neon_framework/src/settings/models/options_collection.dart';
 import 'package:neon_framework/storage.dart';
@@ -10,22 +11,13 @@ import 'package:neon_framework/storage.dart';
 @immutable
 class AccountOptions extends OptionsCollection {
   /// Creates a new account options collection.
-  AccountOptions(
-    super.storage,
-    this._appsBloc,
-  ) {
-    _appsBloc.appImplementations.listen((result) {
-      if (!result.hasData) {
-        return;
-      }
+  AccountOptions(super.storage);
 
-      initialApp.values = {
-        null: (context) => NeonLocalizations.of(context).accountOptionsAutomatic,
-      }..addEntries(result.requireData.map((app) => MapEntry(app.id, app.name)));
-    });
+  void updateAppImplementations(BuiltSet<AppImplementation> appImplementations) {
+    initialApp.values = {
+      null: (context) => NeonLocalizations.of(context).accountOptionsAutomatic,
+    }..addEntries(appImplementations.map((app) => MapEntry(app.id, app.name)));
   }
-
-  final AppsBloc _appsBloc;
 
   @override
   late final List<Option<dynamic>> options = [


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/pull/2020
I had to revert some of the changes of that PR because the two methods were calling each other causing an infinite loop resulting in a stackoverflow.