### PR TITLE
feat(neon_framework): Allow passing Providers through TestApp

### DIFF
--- a/packages/neon/neon_dashboard/test/widget_test.dart
+++ b/packages/neon/neon_dashboard/test/widget_test.dart
@@ -18,10 +18,10 @@ import 'package:rxdart/rxdart.dart';
 Widget wrapWidget(AccountsBloc accountsBloc, Widget child) => TestApp(
       localizationsDelegates: DashboardLocalizations.localizationsDelegates,
       supportedLocales: DashboardLocalizations.supportedLocales,
-      child: NeonProvider<AccountsBloc>.value(
-        value: accountsBloc,
-        child: child,
-      ),
+      providers: [
+        NeonProvider<AccountsBloc>.value(value: accountsBloc),
+      ],
+      child: child,
     );
 
 void main() {

--- a/packages/neon/neon_talk/test/actor_avatar_test.dart
+++ b/packages/neon/neon_talk/test/actor_avatar_test.dart
@@ -29,12 +29,12 @@ void main() {
 
       await tester.pumpWidget(
         TestApp(
-          child: NeonProvider<AccountsBloc>.value(
-            value: accountsBloc,
-            child: TalkActorAvatar(
-              actorId: '',
-              actorType: type,
-            ),
+          providers: [
+            NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          ],
+          child: TalkActorAvatar(
+            actorId: '',
+            actorType: type,
           ),
         ),
       );

--- a/packages/neon/neon_talk/test/main_page_test.dart
+++ b/packages/neon/neon_talk/test/main_page_test.dart
@@ -64,13 +64,11 @@ void main() {
       TestApp(
         localizationsDelegates: TalkLocalizations.localizationsDelegates,
         supportedLocales: TalkLocalizations.supportedLocales,
-        child: NeonProvider<AccountsBloc>.value(
-          value: accountsBloc,
-          child: NeonProvider<TalkBloc>.value(
-            value: bloc,
-            child: const TalkMainPage(),
-          ),
-        ),
+        providers: [
+          NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          NeonProvider<TalkBloc>.value(value: bloc),
+        ],
+        child: const TalkMainPage(),
       ),
     );
 
@@ -88,13 +86,11 @@ void main() {
 
     await tester.pumpWidget(
       TestApp(
-        child: NeonProvider<AccountsBloc>.value(
-          value: accountsBloc,
-          child: NeonProvider<TalkBloc>.value(
-            value: bloc,
-            child: const TalkMainPage(),
-          ),
-        ),
+        providers: [
+          NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          NeonProvider<TalkBloc>.value(value: bloc),
+        ],
+        child: const TalkMainPage(),
       ),
     );
 
@@ -117,13 +113,11 @@ void main() {
         TestApp(
           localizationsDelegates: TalkLocalizations.localizationsDelegates,
           supportedLocales: TalkLocalizations.supportedLocales,
-          child: NeonProvider<AccountsBloc>.value(
-            value: accountsBloc,
-            child: NeonProvider<TalkBloc>.value(
-              value: bloc,
-              child: const TalkMainPage(),
-            ),
-          ),
+          providers: [
+            NeonProvider<AccountsBloc>.value(value: accountsBloc),
+            NeonProvider<TalkBloc>.value(value: bloc),
+          ],
+          child: const TalkMainPage(),
         ),
       );
 
@@ -153,13 +147,11 @@ void main() {
           TestApp(
             localizationsDelegates: TalkLocalizations.localizationsDelegates,
             supportedLocales: TalkLocalizations.supportedLocales,
-            child: NeonProvider<AccountsBloc>.value(
-              value: accountsBloc,
-              child: NeonProvider<TalkBloc>.value(
-                value: bloc,
-                child: const TalkMainPage(),
-              ),
-            ),
+            providers: [
+              NeonProvider<AccountsBloc>.value(value: accountsBloc),
+              NeonProvider<TalkBloc>.value(value: bloc),
+            ],
+            child: const TalkMainPage(),
           ),
         );
 
@@ -188,13 +180,11 @@ void main() {
           TestApp(
             localizationsDelegates: TalkLocalizations.localizationsDelegates,
             supportedLocales: TalkLocalizations.supportedLocales,
-            child: NeonProvider<AccountsBloc>.value(
-              value: accountsBloc,
-              child: NeonProvider<TalkBloc>.value(
-                value: bloc,
-                child: const TalkMainPage(),
-              ),
-            ),
+            providers: [
+              NeonProvider<AccountsBloc>.value(value: accountsBloc),
+              NeonProvider<TalkBloc>.value(value: bloc),
+            ],
+            child: const TalkMainPage(),
           ),
         );
 
@@ -217,13 +207,11 @@ void main() {
       TestApp(
         localizationsDelegates: TalkLocalizations.localizationsDelegates,
         supportedLocales: TalkLocalizations.supportedLocales,
-        child: NeonProvider<AccountsBloc>.value(
-          value: accountsBloc,
-          child: NeonProvider<TalkBloc>.value(
-            value: bloc,
-            child: const TalkMainPage(),
-          ),
-        ),
+        providers: [
+          NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          NeonProvider<TalkBloc>.value(value: bloc),
+        ],
+        child: const TalkMainPage(),
       ),
     );
 

--- a/packages/neon/neon_talk/test/message_test.dart
+++ b/packages/neon/neon_talk/test/message_test.dart
@@ -717,20 +717,20 @@ void main() {
 
               await tester.pumpWidget(
                 TestApp(
-                  child: NeonProvider<AccountsBloc>.value(
-                    value: accountsBloc,
-                    child: RichText(
-                      text: buildRichObjectParameter(
-                        parameter: spreed.RichObjectParameter(
-                          (b) => b
-                            ..type = type
-                            ..id = ''
-                            ..name = 'name'
-                            ..iconUrl = '',
-                        ),
-                        textStyle: null,
-                        isPreview: isPreview,
+                  providers: [
+                    NeonProvider<AccountsBloc>.value(value: accountsBloc),
+                  ],
+                  child: RichText(
+                    text: buildRichObjectParameter(
+                      parameter: spreed.RichObjectParameter(
+                        (b) => b
+                          ..type = type
+                          ..id = ''
+                          ..name = 'name'
+                          ..iconUrl = '',
                       ),
+                      textStyle: null,
+                      isPreview: isPreview,
                     ),
                   ),
                 ),

--- a/packages/neon/neon_talk/test/rich_object_test.dart
+++ b/packages/neon/neon_talk/test/rich_object_test.dart
@@ -69,17 +69,17 @@ void main() {
     testWidgets('user', (tester) async {
       await tester.pumpWidget(
         TestApp(
-          child: NeonProvider<AccountsBloc>.value(
-            value: accountsBloc,
-            child: TalkRichObjectMention(
-              parameter: spreed.RichObjectParameter(
-                (b) => b
-                  ..type = 'user'
-                  ..id = 'username'
-                  ..name = 'name',
-              ),
-              textStyle: null,
+          providers: [
+            NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          ],
+          child: TalkRichObjectMention(
+            parameter: spreed.RichObjectParameter(
+              (b) => b
+                ..type = 'user'
+                ..id = 'username'
+                ..name = 'name',
             ),
+            textStyle: null,
           ),
         ),
       );
@@ -92,17 +92,17 @@ void main() {
 
       await tester.pumpWidget(
         TestApp(
-          child: NeonProvider<AccountsBloc>.value(
-            value: accountsBloc,
-            child: TalkRichObjectMention(
-              parameter: spreed.RichObjectParameter(
-                (b) => b
-                  ..type = 'user'
-                  ..id = 'other'
-                  ..name = 'name',
-              ),
-              textStyle: null,
+          providers: [
+            NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          ],
+          child: TalkRichObjectMention(
+            parameter: spreed.RichObjectParameter(
+              (b) => b
+                ..type = 'user'
+                ..id = 'other'
+                ..name = 'name',
             ),
+            textStyle: null,
           ),
         ),
       );
@@ -117,18 +117,18 @@ void main() {
     testWidgets('call', (tester) async {
       await tester.pumpWidget(
         TestApp(
-          child: NeonProvider<AccountsBloc>.value(
-            value: accountsBloc,
-            child: TalkRichObjectMention(
-              parameter: spreed.RichObjectParameter(
-                (b) => b
-                  ..type = 'call'
-                  ..id = ''
-                  ..name = 'name'
-                  ..iconUrl = '',
-              ),
-              textStyle: null,
+          providers: [
+            NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          ],
+          child: TalkRichObjectMention(
+            parameter: spreed.RichObjectParameter(
+              (b) => b
+                ..type = 'call'
+                ..id = ''
+                ..name = 'name'
+                ..iconUrl = '',
             ),
+            textStyle: null,
           ),
         ),
       );
@@ -174,17 +174,17 @@ void main() {
 
         await tester.pumpWidget(
           TestApp(
-            child: NeonProvider<AccountsBloc>.value(
-              value: accountsBloc,
-              child: TalkRichObjectMention(
-                parameter: spreed.RichObjectParameter(
-                  (b) => b
-                    ..type = type
-                    ..id = 'group'
-                    ..name = 'name',
-                ),
-                textStyle: null,
+            providers: [
+              NeonProvider<AccountsBloc>.value(value: accountsBloc),
+            ],
+            child: TalkRichObjectMention(
+              parameter: spreed.RichObjectParameter(
+                (b) => b
+                  ..type = type
+                  ..id = 'group'
+                  ..name = 'name',
               ),
+              textStyle: null,
             ),
           ),
         );
@@ -197,17 +197,17 @@ void main() {
 
         await tester.pumpWidget(
           TestApp(
-            child: NeonProvider<AccountsBloc>.value(
-              value: accountsBloc,
-              child: TalkRichObjectMention(
-                parameter: spreed.RichObjectParameter(
-                  (b) => b
-                    ..type = type
-                    ..id = 'other'
-                    ..name = 'name',
-                ),
-                textStyle: null,
+            providers: [
+              NeonProvider<AccountsBloc>.value(value: accountsBloc),
+            ],
+            child: TalkRichObjectMention(
+              parameter: spreed.RichObjectParameter(
+                (b) => b
+                  ..type = type
+                  ..id = 'other'
+                  ..name = 'name',
               ),
+              textStyle: null,
             ),
           ),
         );
@@ -225,19 +225,19 @@ void main() {
     testWidgets('With preview', (tester) async {
       await tester.pumpWidget(
         TestApp(
-          child: NeonProvider<AccountsBloc>.value(
-            value: accountsBloc,
-            child: TalkRichObjectFile(
-              parameter: spreed.RichObjectParameter(
-                (b) => b
-                  ..type = ''
-                  ..id = '0'
-                  ..name = 'name'
-                  ..previewAvailable = spreed.RichObjectParameter_PreviewAvailable.yes
-                  ..path = '',
-              ),
-              textStyle: null,
+          providers: [
+            NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          ],
+          child: TalkRichObjectFile(
+            parameter: spreed.RichObjectParameter(
+              (b) => b
+                ..type = ''
+                ..id = '0'
+                ..name = 'name'
+                ..previewAvailable = spreed.RichObjectParameter_PreviewAvailable.yes
+                ..path = '',
             ),
+            textStyle: null,
           ),
         ),
       );
@@ -300,18 +300,18 @@ void main() {
     testWidgets('With icon', (tester) async {
       await tester.pumpWidget(
         TestApp(
-          child: NeonProvider<AccountsBloc>.value(
-            value: accountsBloc,
-            child: TalkRichObjectFallback(
-              parameter: spreed.RichObjectParameter(
-                (b) => b
-                  ..type = ''
-                  ..id = ''
-                  ..name = 'name'
-                  ..iconUrl = '',
-              ),
-              textStyle: null,
+          providers: [
+            NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          ],
+          child: TalkRichObjectFallback(
+            parameter: spreed.RichObjectParameter(
+              (b) => b
+                ..type = ''
+                ..id = ''
+                ..name = 'name'
+                ..iconUrl = '',
             ),
+            textStyle: null,
           ),
         ),
       );

--- a/packages/neon/neon_talk/test/room_avatar_test.dart
+++ b/packages/neon/neon_talk/test/room_avatar_test.dart
@@ -15,10 +15,10 @@ import 'package:rxdart/subjects.dart';
 import 'testing.dart';
 
 Widget wrapWidget(AccountsBloc accountsBloc, Widget child) => TestApp(
-      child: NeonProvider<AccountsBloc>.value(
-        value: accountsBloc,
-        child: child,
-      ),
+      providers: [
+        NeonProvider<AccountsBloc>.value(value: accountsBloc),
+      ],
+      child: child,
     );
 
 void main() {

--- a/packages/neon/neon_talk/test/room_page_test.dart
+++ b/packages/neon/neon_talk/test/room_page_test.dart
@@ -54,10 +54,10 @@ void main() {
         appThemes: const [
           TalkTheme(),
         ],
-        child: NeonProvider<TalkRoomBloc>.value(
-          value: bloc,
-          child: const TalkRoomPage(),
-        ),
+        providers: [
+          NeonProvider<TalkRoomBloc>.value(value: bloc),
+        ],
+        child: const TalkRoomPage(),
       ),
     );
 
@@ -75,10 +75,10 @@ void main() {
         appThemes: const [
           TalkTheme(),
         ],
-        child: NeonProvider<TalkRoomBloc>.value(
-          value: bloc,
-          child: const TalkRoomPage(),
-        ),
+        providers: [
+          NeonProvider<TalkRoomBloc>.value(value: bloc),
+        ],
+        child: const TalkRoomPage(),
       ),
     );
 
@@ -139,13 +139,11 @@ void main() {
         appThemes: const [
           TalkTheme(),
         ],
-        child: NeonProvider<AccountsBloc>.value(
-          value: accountsBloc,
-          child: NeonProvider<TalkRoomBloc>.value(
-            value: bloc,
-            child: const TalkRoomPage(),
-          ),
-        ),
+        providers: [
+          NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          NeonProvider<TalkRoomBloc>.value(value: bloc),
+        ],
+        child: const TalkRoomPage(),
       ),
     );
 
@@ -160,10 +158,10 @@ void main() {
       TestApp(
         localizationsDelegates: TalkLocalizations.localizationsDelegates,
         supportedLocales: TalkLocalizations.supportedLocales,
-        child: NeonProvider<TalkRoomBloc>.value(
-          value: bloc,
-          child: const TalkRoomPage(),
-        ),
+        providers: [
+          NeonProvider<TalkRoomBloc>.value(value: bloc),
+        ],
+        child: const TalkRoomPage(),
       ),
     );
 
@@ -181,10 +179,10 @@ void main() {
           TalkTheme(),
         ],
         platform: TargetPlatform.iOS,
-        child: NeonProvider<TalkRoomBloc>.value(
-          value: bloc,
-          child: const TalkRoomPage(),
-        ),
+        providers: [
+          NeonProvider<TalkRoomBloc>.value(value: bloc),
+        ],
+        child: const TalkRoomPage(),
       ),
     );
 
@@ -203,10 +201,10 @@ void main() {
         appThemes: const [
           TalkTheme(),
         ],
-        child: NeonProvider<TalkRoomBloc>.value(
-          value: bloc,
-          child: const TalkRoomPage(),
-        ),
+        providers: [
+          NeonProvider<TalkRoomBloc>.value(value: bloc),
+        ],
+        child: const TalkRoomPage(),
       ),
     );
 

--- a/packages/neon_framework/lib/src/testing/utils.dart
+++ b/packages/neon_framework/lib/src/testing/utils.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:neon_framework/src/theme/theme.dart';
 import 'package:neon_framework/utils.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
 
 /// An application used in testing that wraps it's children in a configured
 /// `MaterialApp`.
@@ -14,6 +16,7 @@ class TestApp extends StatelessWidget {
     this.appThemes,
     this.locale = const Locale('en'),
     this.wrapMaterial = true,
+    this.providers = const [],
     super.key,
   });
 
@@ -51,6 +54,9 @@ class TestApp extends StatelessWidget {
   /// {@macro flutter.widgets.widgetsApp.locale}
   final Locale locale;
 
+  /// Additional [Provider]s.
+  final List<SingleChildWidget> providers;
+
   @override
   Widget build(BuildContext context) {
     final theme = AppTheme.test(
@@ -63,7 +69,7 @@ class TestApp extends StatelessWidget {
       child = Material(child: child);
     }
 
-    return MaterialApp(
+    final app = MaterialApp(
       theme: theme.lightTheme,
       localizationsDelegates: [
         ...NeonLocalizations.localizationsDelegates,
@@ -76,5 +82,14 @@ class TestApp extends StatelessWidget {
       locale: locale,
       home: child,
     );
+
+    if (providers.isNotEmpty) {
+      return MultiProvider(
+        providers: providers,
+        child: app,
+      );
+    }
+
+    return app;
   }
 }

--- a/packages/neon_framework/test/dialog_test.dart
+++ b/packages/neon_framework/test/dialog_test.dart
@@ -273,12 +273,12 @@ void main() {
       await tester.pumpWidget(
         TestApp(
           wrapMaterial: false,
-          child: NeonProvider<AccountsBloc>.value(
-            value: accountsBloc,
-            child: NeonUserStatusDialog(
-              account: account,
-              now: now,
-            ),
+          providers: [
+            NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          ],
+          child: NeonUserStatusDialog(
+            account: account,
+            now: now,
           ),
         ),
       );

--- a/packages/neon_framework/test/drawer_test.dart
+++ b/packages/neon_framework/test/drawer_test.dart
@@ -54,10 +54,10 @@ void main() {
 
     await tester.pumpWidget(
       TestApp(
-        child: NeonProvider<AccountsBloc>.value(
-          value: accountsBloc,
-          child: const NeonDrawer(),
-        ),
+        providers: [
+          NeonProvider<AccountsBloc>.value(value: accountsBloc),
+        ],
+        child: const NeonDrawer(),
       ),
     );
     await tester.pumpAndSettle();

--- a/packages/neon_framework/test/user_avatar_test.dart
+++ b/packages/neon_framework/test/user_avatar_test.dart
@@ -47,11 +47,11 @@ void main() {
 
       await tester.pumpWidget(
         TestApp(
-          child: NeonProvider<AccountsBloc>.value(
-            value: accountsBloc,
-            child: NeonUserAvatar(
-              showStatus: withStatus,
-            ),
+          providers: [
+            NeonProvider<AccountsBloc>.value(value: accountsBloc),
+          ],
+          child: NeonUserAvatar(
+            showStatus: withStatus,
           ),
         ),
       );


### PR DESCRIPTION
Avoids nesting multiple providers in the tests or having to use MultiProvider manually.