### PR TITLE
fix(neon_talk): Use automatic sizing for image file rich objects

### DIFF
--- a/packages/neon/neon_talk/lib/src/widgets/rich_object/file.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/rich_object/file.dart
@@ -40,7 +40,7 @@ class TalkRichObjectFile extends StatelessWidget {
         // Convert to logical pixels
         size /= devicePixelRatio;
 
-        // Constrain size to max height but keep aspect ration
+        // Constrain size to max height but keep aspect ratio
         if (size.height > maxHeight) {
           size = size * (maxHeight / size.height);
         }
@@ -51,6 +51,9 @@ class TalkRichObjectFile extends StatelessWidget {
         width = size.width.toInt();
         height = size.height.toInt();
       }
+
+      height ??= -1;
+      width ??= -1;
 
       child = ConstrainedBox(
         constraints: BoxConstraints(


### PR DESCRIPTION
If the photos app is not installed or the size metadata is somehow not available the desired size is not passed to the API call. Unintuitively this doesn't mean the image is returned in it's original size, but instead a very small square image is returned. The -1 value is not documented anywhere (I'll fix that in the upstream docs) but I found it while checking how the web frontend handles this problem.