### PR TITLE
feat(cookie_store): add compliance oriented cookie_jar alternative

### DIFF
--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -1,6 +1,7 @@
 asctime
 Blist
 browsable
+canonicalized
 cleartext
 codegen
 deeplinking
@@ -11,7 +12,9 @@ persistences
 playstore
 postmarket
 provokateurin
+punycode
 subroutes
+testexample
 uncategorized
 upsert
 viewbox

--- a/commitlint.yaml
+++ b/commitlint.yaml
@@ -9,6 +9,7 @@ rules:
     - always
     - - app
       - ci
+      - cookie_store
       - deps
       - docs
       - dynamite

--- a/packages/cookie_store/BSD-3-Clause.txt
+++ b/packages/cookie_store/BSD-3-Clause.txt
@@ -1,0 +1,1 @@
+../../assets/BSD-3-Clause.txt

--- a/packages/cookie_store/analysis_options.yaml
+++ b/packages/cookie_store/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:neon_lints/dart.yaml

--- a/packages/cookie_store/lib/cookie_store.dart
+++ b/packages/cookie_store/lib/cookie_store.dart
@@ -1,0 +1,14 @@
+/// An [RFC6265](https://httpwg.org/specs/rfc6265.html) compliant cookie store.
+///
+/// Cookies are stored inside of `CookieStore`s parsing the received cookies
+/// into `StorableCookie`s that can be saved in a `CookiePersistence`.
+///
+/// This package has an implementation independent api and provides utilities
+/// that make it easy to extend and implemented into existing storage backends
+/// like SQLite databases.
+library;
+
+export 'src/cookie_persistence.dart';
+export 'src/cookie_store.dart';
+export 'src/storable_cookie.dart';
+export 'src/utils.dart';

--- a/packages/cookie_store/lib/src/cookie_persistence.dart
+++ b/packages/cookie_store/lib/src/cookie_persistence.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:cookie_store/src/storable_cookie.dart';
+import 'package:cookie_store/src/utils.dart';
+import 'package:timezone/timezone.dart' as tz;
+import 'package:universal_io/io.dart' show Cookie;
+
+/// Interface for a Storage backend persisting [StorableCookie]s.
+///
+/// ### Cookie value retrieval
+/// {@macro CookieStore.valueRetrieval}
+///
+/// ### Cookie management
+/// {@macro CookieStore.cookieManagement}
+///
+/// ### CookieStore limits, eviction policy
+/// {@macro CookieStore.limits}
+abstract interface class CookiePersistence {
+  /// Creates the default [MemoryCookiePersistence].
+  factory CookiePersistence() {
+    return MemoryCookiePersistence();
+  }
+
+  /// Load the cookies for specified [uri].
+  ///
+  /// Cookies SHOULD be sorted with the [sortCookies] function.
+  FutureOr<List<Cookie>> loadForRequest(Uri uri);
+
+  /// Saves the serialized [cookies].
+  ///
+  /// Returns whether the operation completed successfully.
+  FutureOr<bool> saveFromResponse(Set<StorableCookie> cookies, {required bool isHttpRequest});
+
+  /// Ends the current session deleting all session cookies.
+  ///
+  /// Returns whether the operation completed successfully.
+  FutureOr<bool> endSession();
+
+  /// Loads all cookies in the persistence.
+  ///
+  /// Implementing this method is optional. It must be documented if the
+  /// implementer does not support this operation.
+  FutureOr<List<Cookie>> loadAll();
+
+  /// Deletes all cookies in the persistence.
+  ///
+  /// Implementing this method is optional. It must be documented if the
+  /// implementer does not support this operation.
+  ///
+  /// Returns whether the operation completed successfully.
+  FutureOr<bool> deleteAll();
+
+  /// Removes all cookies in this persistence that satisfy the given [test].
+  ///
+  /// Implementing this method is optional. It must be documented if the
+  /// implementer does not support this operation.
+  ///
+  /// Returns whether the operation completed successfully.
+  FutureOr<bool> deleteWhere(bool Function(Cookie cookie) test);
+}
+
+/// Default cookie persistence.
+///
+/// Cookies are stored synchronously in memory and NOT persisted on disk.
+final class MemoryCookiePersistence implements CookiePersistence {
+  /// Created a new cookie persistence storing cookies in memory.
+  MemoryCookiePersistence();
+
+  final Set<StorableCookie> _cookieStore = {};
+
+  @override
+  bool endSession() {
+    _cookieStore.removeWhere((cookie) => !cookie.persistentFlag);
+
+    return true;
+  }
+
+  @override
+  List<Cookie> loadForRequest(Uri uri) {
+    final cookies = <StorableCookie>[];
+
+    final now = tz.TZDateTime.now(tz.UTC);
+    final isHttpRequest = isHttpUri(uri);
+    final isSecureRequest = isSecureUri(uri);
+
+    final requestHost = uri.host;
+    var requestPath = uri.path;
+    if (requestPath.isEmpty) {
+      requestPath = '/';
+    }
+
+    _cookieStore.removeWhere((cookie) => cookie.expiryTime.isBefore(now));
+
+    for (final cookie in _cookieStore) {
+      if (cookie.hostOnlyFlag && cookie.domain != requestHost) {
+        continue;
+      }
+
+      if (!cookie.hostOnlyFlag && !isDomainMatch(requestHost, cookie.domain)) {
+        continue;
+      }
+
+      if (!isPathMatch(requestPath, cookie.path)) {
+        continue;
+      }
+
+      if (cookie.secureOnlyFlag && !isSecureRequest) {
+        continue;
+      }
+
+      if (cookie.httpOnlyFlag && !isHttpRequest) {
+        continue;
+      }
+
+      cookies.add(cookie);
+    }
+
+    cookies.sort(sortCookies);
+    _cookieStore.addAll(cookies.map((cookie) => cookie.copyWith(lastAccessTime: now)));
+
+    return cookies.map((cookie) {
+      return Cookie(cookie.name, cookie.value)
+        ..httpOnly = false
+        ..secure = false;
+    }).toList();
+  }
+
+  @override
+  bool saveFromResponse(Set<StorableCookie> cookies, {required bool isHttpRequest}) {
+    for (var cookie in cookies) {
+      final stored = _cookieStore.lookup(cookie);
+      if (stored != null) {
+        if (stored.httpOnlyFlag && !isHttpRequest) {
+          continue;
+        }
+
+        _cookieStore.remove(stored);
+        cookie = cookie.copyWith(creationTime: stored.creationTime);
+      }
+
+      _cookieStore.add(cookie);
+    }
+
+    return true;
+  }
+
+  @override
+  bool deleteWhere(bool Function(Cookie cookie) test) {
+    _cookieStore.removeWhere((storableCookie) {
+      final cookie = _storableCookieToCookie(storableCookie);
+
+      return test(cookie);
+    });
+
+    return true;
+  }
+
+  @override
+  bool deleteAll() {
+    _cookieStore.clear();
+
+    return true;
+  }
+
+  @override
+  List<Cookie> loadAll() {
+    return _cookieStore.map(_storableCookieToCookie).toList();
+  }
+
+  static Cookie _storableCookieToCookie(StorableCookie storableCookie) {
+    return Cookie(storableCookie.name, storableCookie.value)
+      ..expires = storableCookie.expiryTime
+      ..domain = storableCookie.domain
+      ..path = storableCookie.path
+      ..secure = storableCookie.secureOnlyFlag
+      ..httpOnly = storableCookie.httpOnlyFlag;
+  }
+}

--- a/packages/cookie_store/lib/src/cookie_store.dart
+++ b/packages/cookie_store/lib/src/cookie_store.dart
@@ -1,0 +1,249 @@
+// ignore_for_file:   prefer_final_locals, omit_local_variable_types
+
+import 'dart:async';
+
+import 'package:cookie_store/src/cookie_persistence.dart';
+import 'package:cookie_store/src/storable_cookie.dart';
+import 'package:cookie_store/src/utils.dart';
+import 'package:timezone/timezone.dart' as tz;
+import 'package:universal_io/io.dart' show Cookie;
+
+// DateTimes can represent time values that are at a distance of at most 100,000,000
+// days from epoch (1970-01-01 UTC): -271821-04-20 to 275760-09-13.
+final tz.TZDateTime _maxDateTime = tz.TZDateTime.utc(275760, 09, 13);
+
+/// [CookieStore] is a cookie container and manager for HTTP requests implementing [RFC6265](https://httpwg.org/specs/rfc6265.html).
+///
+/// ## Implementation consideration
+/// In most cases it is not needed to implement this interface.
+/// To build a custom storage backend [CookiePersistence] can be used.
+///
+/// ### Cookie value retrieval
+/// {@template CookieStore.valueRetrieval}
+/// A cookie store does not need to retrieve cookies with all attributes present.
+/// Retrieved cookies only need to have a valid [Cookie.name] and [Cookie.value].
+/// It is up to the implementation to provide further information.
+/// {@endtemplate}
+///
+/// ### Cookie management
+/// {@template CookieStore.cookieManagement}
+/// According to [RFC6265 section 7.2](https://httpwg.org/specs/rfc6265.html#rfc.section.7.2)
+/// user agents SHOULD provide users with a mechanism for managing the cookies stored in the cookie store.
+/// It must be documented if an implementer does not provide any of the optional
+/// [loadAll], [deleteAll] and [deleteWhere] method.
+/// {@endtemplate}
+///
+/// ### Public suffix validation
+/// The default implementation does not validate the cookie domain against a public
+/// suffix list:
+/// {@template CookieStore.publicSuffix}
+/// > NOTE: A "public suffix" is a domain that is controlled by a public
+/// > registry, such as "com", "co.uk", and "pvt.k12.wy.us". This step is
+/// > essential for preventing attacker.com from disrupting the integrity of
+/// > example.com by setting a cookie with a Domain attribute of "com".
+/// > Unfortunately, the set of public suffixes (also known as "registry controlled domains")
+/// > changes over time. If feasible, user agents SHOULD use an up-to-date
+/// > public suffix list, such as the one maintained by the Mozilla project at <http://publicsuffix.org/>.
+/// {@endtemplate}
+///
+/// ### CookieStore limits, eviction policy
+/// {@template CookieStore.limits}
+/// If a cookie store has a limit to the number of cookies it can store,
+/// the removal policy outlined in [RFC6265 section 5.3](https://httpwg.org/specs/rfc6265.html#rfc.section.5.3)
+/// must be followed:
+/// > At any time, the user agent MAY "remove excess cookies" from the cookie store
+/// > if the number of cookies sharing a domain field exceeds some implementation-defined
+/// > upper bound (such as 50 cookies).
+/// >
+/// > At any time, the user agent MAY "remove excess cookies" from the cookie store
+/// > if the cookie store exceeds some predetermined upper bound (such as 3000 cookies).
+/// >
+/// > When the user agent removes excess cookies from the cookie store, the user agent MUST
+/// > evict cookies in the following priority order:
+/// >
+/// >    Expired cookies.
+/// >    Cookies that share a domain field with more than a predetermined number of other cookies.
+/// >    All cookies.
+/// >
+/// > If two cookies have the same removal priority, the user agent MUST evict the
+/// > cookie with the earliest last-access date first.
+///
+/// It is recommended to set an upper bound to the time a cookie is stored
+/// as described in [RFC6265 section 7.3](https://httpwg.org/specs/rfc6265.html#rfc.section.7.3):
+/// > Although servers can set the expiration date for cookies to the distant future,
+/// > most user agents do not actually retain cookies for multiple decades.
+/// > Rather than choosing gratuitously long expiration periods, servers SHOULD
+/// > promote user privacy by selecting reasonable cookie expiration periods based on the purpose of the cookie.
+/// > For example, a typical session identifier might reasonably be set to expire in two weeks.
+/// {@endtemplate}
+abstract interface class CookieStore {
+  /// Creates a [DefaultCookieStore] instance.
+  factory CookieStore() {
+    return DefaultCookieStore(
+      CookiePersistence(),
+    );
+  }
+
+  /// Save the [cookies] for specified [uri].
+  FutureOr<void> saveFromResponse(Uri uri, List<Cookie> cookies);
+
+  /// Load the cookies for specified [uri].
+  FutureOr<List<Cookie>> loadForRequest(Uri uri);
+
+  /// Ends the current session deleting all session cookies.
+  FutureOr<void> endSession();
+
+  /// Loads all cookies in the store.
+  ///
+  /// User agents SHOULD provide users with a mechanism for managing the cookies stored in the cookie store.
+  /// https://httpwg.org/specs/rfc6265.html#rfc.section.7.2
+  ///
+  /// Implementing this method is optional. It must be documented if the
+  /// implementer does not support this operation.
+  FutureOr<List<Cookie>> loadAll();
+
+  /// Deletes all cookies in the store.
+  ///
+  /// User agents SHOULD provide users with a mechanism for managing the cookies stored in the cookie store.
+  /// https://httpwg.org/specs/rfc6265.html#rfc.section.7.2
+  ///
+  /// Implementing this method is optional. It must be documented if the
+  /// implementer does not support this operation.
+  FutureOr<void> deleteAll();
+
+  /// Removes all cookies in this store that satisfy the given [test].
+  ///
+  /// User agents SHOULD provide users with a mechanism for managing the cookies stored in the cookie store.
+  /// https://httpwg.org/specs/rfc6265.html#rfc.section.7.2
+  ///
+  /// Implementing this method is optional. It must be documented if the
+  /// implementer does not support this operation.
+  FutureOr<void> deleteWhere(bool Function(Cookie cookie) test);
+}
+
+/// The default cookie store implementation.
+///
+/// This implementation does not validate the cookie domain against a public
+/// suffix list:
+/// {@macro CookieStore.publicSuffix}
+///
+/// Cookies are parsed into a set of [StorableCookie]s and persisted in the given [persistence].
+final class DefaultCookieStore implements CookieStore {
+  /// Creates a new cookie store backed by the provided [persistence].
+  DefaultCookieStore(this.persistence);
+
+  /// The persistence storing the serialized [StorableCookie].
+  final CookiePersistence persistence;
+
+  @override
+  FutureOr<void> saveFromResponse(Uri uri, List<Cookie> cookies) {
+    final now = tz.TZDateTime.now(tz.UTC);
+    final isHttpRequest = isHttpUri(uri);
+
+    Set<StorableCookie> persistentCookies = {};
+
+    for (final cookie in cookies) {
+      // declare all variables upfront and only assign them as needed.
+      // Easier for comparing to the rfc algorithm.
+      String name = cookie.name;
+      String value = cookie.value;
+      tz.TZDateTime creationTime = now;
+      tz.TZDateTime lastAccessTime = now;
+
+      tz.TZDateTime expiryTime;
+      String domain;
+      String path;
+      bool persistentFlag;
+      bool hostOnlyFlag;
+      bool secureOnlyFlag;
+      bool httpOnlyFlag;
+
+      final maxAge = cookie.maxAge;
+      tz.TZDateTime? expires;
+      if (cookie.expires != null) {
+        expires = tz.TZDateTime.from(cookie.expires!, tz.UTC);
+      }
+
+      if (maxAge != null) {
+        persistentFlag = true;
+        expiryTime = now.add(Duration(seconds: maxAge));
+      } else if (expires != null) {
+        persistentFlag = true;
+        expiryTime = expires;
+      } else {
+        persistentFlag = false;
+        expiryTime = _maxDateTime;
+      }
+
+      // perf: skip already expired cookies.
+      if (expiryTime.isBefore(now)) {
+        continue;
+      }
+
+      // Validating the public suffix is out of scope for this implementation.
+
+      if (cookie.domain == null || cookie.domain!.isEmpty) {
+        hostOnlyFlag = true;
+        domain = uri.host;
+      } else if (!isDomainMatch(uri.host, cookie.domain!)) {
+        continue;
+      } else {
+        hostOnlyFlag = false;
+        domain = cookie.domain!;
+      }
+
+      path = cookie.path ?? defaultPath(uri);
+      secureOnlyFlag = cookie.secure;
+      httpOnlyFlag = cookie.httpOnly;
+
+      if (httpOnlyFlag && !isHttpRequest) {
+        continue;
+      }
+
+      final persistentCookie = StorableCookie(
+        name: name,
+        value: value,
+        expiryTime: expiryTime,
+        domain: domain,
+        path: path,
+        creationTime: creationTime,
+        lastAccessTime: lastAccessTime,
+        persistentFlag: persistentFlag,
+        hostOnlyFlag: hostOnlyFlag,
+        secureOnlyFlag: secureOnlyFlag,
+        httpOnlyFlag: httpOnlyFlag,
+      );
+      persistentCookies.add(persistentCookie);
+    }
+
+    return persistence.saveFromResponse(
+      persistentCookies,
+      isHttpRequest: isHttpRequest,
+    );
+  }
+
+  @override
+  FutureOr<List<Cookie>> loadForRequest(Uri uri) {
+    return persistence.loadForRequest(uri);
+  }
+
+  @override
+  FutureOr<void> endSession() {
+    return persistence.endSession();
+  }
+
+  @override
+  FutureOr<List<Cookie>> loadAll() {
+    return persistence.loadAll();
+  }
+
+  @override
+  FutureOr<void> deleteAll() {
+    return persistence.deleteAll();
+  }
+
+  @override
+  FutureOr<void> deleteWhere(bool Function(Cookie cookie) test) {
+    return persistence.deleteWhere(test);
+  }
+}

--- a/packages/cookie_store/lib/src/storable_cookie.dart
+++ b/packages/cookie_store/lib/src/storable_cookie.dart
@@ -1,0 +1,112 @@
+import 'package:meta/meta.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+/// A storable cookie.
+///
+/// See:
+///   * https://httpwg.org/specs/rfc6265.html#storage-model
+@immutable
+final class StorableCookie {
+  /// Creates a new cookie in the rfc6265 storage model.
+  const StorableCookie({
+    required this.name,
+    required this.value,
+    required this.expiryTime,
+    required this.domain,
+    required this.path,
+    required this.creationTime,
+    required this.lastAccessTime,
+    required this.persistentFlag,
+    required this.hostOnlyFlag,
+    required this.secureOnlyFlag,
+    required this.httpOnlyFlag,
+  });
+
+  /// The name of the cookie.
+  ///
+  /// Must be a `token` as specified in RFC 6265.
+  ///
+  /// The allowed characters in a `token` are the visible ASCII characters,
+  /// U+0021 (`!`) through U+007E (`~`), except the separator characters:
+  /// `(`, `)`, `<`, `>`, `@`, `,`, `;`, `:`, `\`, `"`, `/`, `[`, `]`, `?`, `=`,
+  /// `{`, and `}`.
+  final String name;
+
+  /// The value of the cookie.
+  ///
+  /// Must be a `cookie-value` as specified in RFC 6265.
+  ///
+  /// The allowed characters in a cookie value are the visible ASCII characters,
+  /// U+0021 (`!`) through U+007E (`~`) except the characters:
+  /// `"`, `,`, `;` and `\`.
+  /// Cookie values may be wrapped in a single pair of double quotes
+  /// (U+0022, `"`).
+  final String value;
+
+  /// The time at which the cookie expires.
+  final tz.TZDateTime expiryTime;
+
+  /// The domain that the cookie applies to.
+  final String domain;
+
+  /// The path within the [domain] that the cookie applies to.
+  final String path;
+
+  /// The time at which the cookie has been created.
+  final tz.TZDateTime creationTime;
+
+  /// The time at which the cookie has been last accessed.
+  final tz.TZDateTime lastAccessTime;
+
+  /// Whether the cookie is persisted between session.
+  ///
+  /// Will be `false` for session cookies.
+  final bool persistentFlag;
+
+  /// Whether the cookie is only sent when the request `domain` is identical
+  /// to [domain].
+  final bool hostOnlyFlag;
+
+  /// Whether to only send this cookie on secure connections.
+  final bool secureOnlyFlag;
+
+  /// Whether the cookie is only sent in the HTTP request and is not made
+  /// available to client side scripts.
+  final bool httpOnlyFlag;
+
+  /// Creates a copy of this storable cookie with the given fields
+  /// replaced by the non-null parameter values.
+  StorableCookie copyWith({
+    String? value,
+    tz.TZDateTime? expiryTime,
+    tz.TZDateTime? creationTime,
+    tz.TZDateTime? lastAccessTime,
+    bool? persistentFlag,
+    bool? hostOnlyFlag,
+    bool? secureOnlyFlag,
+    bool? httpOnlyFlag,
+  }) {
+    return StorableCookie(
+      name: name,
+      value: value ?? this.value,
+      expiryTime: expiryTime ?? this.expiryTime,
+      domain: domain,
+      path: path,
+      creationTime: creationTime ?? this.creationTime,
+      lastAccessTime: lastAccessTime ?? this.lastAccessTime,
+      persistentFlag: persistentFlag ?? this.persistentFlag,
+      hostOnlyFlag: hostOnlyFlag ?? this.hostOnlyFlag,
+      secureOnlyFlag: secureOnlyFlag ?? this.secureOnlyFlag,
+      httpOnlyFlag: httpOnlyFlag ?? this.httpOnlyFlag,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return Object.hashAll([name, domain, path]);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is StorableCookie && name == other.name && domain == other.domain && path == other.path;
+}

--- a/packages/cookie_store/lib/src/utils.dart
+++ b/packages/cookie_store/lib/src/utils.dart
@@ -1,0 +1,133 @@
+// ignore_for_file: constant_identifier_names
+
+import 'package:cookie_store/src/storable_cookie.dart';
+
+const int _DOT = 0x2E;
+const int _SLASH = 0x2F;
+
+/// Computes the default cookie path for a [requestUri].
+///
+/// See:
+///   * https://httpwg.org/specs/rfc6265.html#cookie-path
+String defaultPath(Uri requestUri) {
+  // Let uri-path be the path portion of the request-uri if such a portion exists (and empty otherwise).
+  final path = requestUri.path;
+
+  // If the uri-path is empty or if the first character of the uri-path is not a %x2F ("/") character, output %x2F ("/") and skip the remaining steps.
+  if (path.isEmpty || path.codeUnitAt(0) != _SLASH) {
+    return '/';
+  }
+
+  // If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step.
+  if ('/'.allMatches(path).length <= 1) {
+    return '/';
+  }
+
+  // Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/").
+  if (path.endsWith('/')) {
+    return path.substring(0, path.length - 1);
+  }
+
+  return path;
+}
+
+/// Whether the [requestHost] domain matches the [cookieDomain].
+///
+/// It assumes that the given hosts are already canonicalized and punycode encoded.
+///
+/// See:
+///   * https://httpwg.org/specs/rfc6265.html#cookie-domain
+bool isDomainMatch(String requestHost, String cookieDomain) {
+  assert(
+    requestHost.toLowerCase() == requestHost && cookieDomain.toLowerCase() == cookieDomain,
+    'Both the requestHost and cookieDomain must be canonicalized to lower case.',
+  );
+
+  // The domain string and the string are identical.
+  if (requestHost == cookieDomain) {
+    return true;
+  }
+
+  // The domain string is a suffix of the string.
+  if (requestHost.endsWith(cookieDomain)) {
+    // The last character of the string that is not included in the domain string is a %x2E (".") character.
+    final lastChar = requestHost.length - cookieDomain.length;
+
+    if (requestHost.codeUnitAt(lastChar - 1) != _DOT) {
+      return false;
+    }
+
+    return !_isIPAdress(requestHost);
+  }
+
+  return false;
+}
+
+/// Whether the given [host] represents a valid IPv4 or IPv6 address.
+bool _isIPAdress(String host) {
+  try {
+    Uri.parseIPv4Address(host);
+    return true;
+
+    // ignore: empty_catches
+  } on FormatException {}
+
+  try {
+    Uri.parseIPv6Address(host);
+    return true;
+
+    // ignore: empty_catches
+  } on FormatException {}
+
+  return false;
+}
+
+/// Whether the [requestPath] path matches the [cookiePath].
+///
+/// See:
+///   * https://httpwg.org/specs/rfc6265.html#cookie-path
+bool isPathMatch(String requestPath, String cookiePath) {
+  // The cookie-path and the request-path are identical.
+  if (requestPath == cookiePath) {
+    return true;
+  }
+
+  if (requestPath.startsWith(cookiePath)) {
+    // The cookie-path is a prefix of the request-path, the last character of the cookie-path is %x2F ("/").
+    if (cookiePath.codeUnitAt(cookiePath.length - 1) == _SLASH) {
+      return true;
+    }
+
+    // The cookie-path is a prefix of the request-path, and the first character of the request-path that is not included in the cookie-path is a %x2F ("/") character.
+    return requestPath.codeUnitAt(cookiePath.length) == _SLASH;
+  }
+
+  return false;
+}
+
+/// Whether the given [uri] is using the `http` protocol.
+///
+/// Implementations MAY want to define a custom check.
+bool isHttpUri(Uri uri) {
+  return uri.isScheme('http') || uri.isScheme('https');
+}
+
+/// Whether the given [uri] is using a secure protocol.
+///
+/// Checks whether the request scheme ends with a `s`.
+///
+/// Implementations MAY want to define a custom check.
+bool isSecureUri(Uri uri) {
+  return uri.scheme.codeUnits.lastOrNull == 0x73;
+}
+
+/// Sorts cookies by path length and creation time.
+int sortCookies(StorableCookie a, StorableCookie b) {
+  if (a.path.length < b.path.length) {
+    return 1;
+  } else if (a.path.length > b.path.length) {
+    return -1;
+  } else {
+    return a.creationTime.compareTo(b.creationTime);
+  }
+}

--- a/packages/cookie_store/pubspec.yaml
+++ b/packages/cookie_store/pubspec.yaml
@@ -12,6 +12,10 @@ dependencies:
   universal_io: ^2.0.0
 
 dev_dependencies:
+  cookie_store_conformance_tests:
+    git:
+      url: https://github.com/nextcloud/neon
+      path: packages/cookie_store_conformance_tests
   neon_lints:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/cookie_store/pubspec.yaml
+++ b/packages/cookie_store/pubspec.yaml
@@ -1,0 +1,19 @@
+name: cookie_store
+description: A RFC compliant cookie_jar alternative
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  meta: ^1.0.0
+  timezone: ^0.9.0
+  universal_io: ^2.0.0
+
+dev_dependencies:
+  neon_lints:
+    git:
+      url: https://github.com/nextcloud/neon
+      path: packages/neon_lints
+  test: ^1.25.5

--- a/packages/cookie_store/pubspec_overrides.yaml
+++ b/packages/cookie_store/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: neon_lints
+dependency_overrides:
+  neon_lints:
+    path: ../neon_lints

--- a/packages/cookie_store/pubspec_overrides.yaml
+++ b/packages/cookie_store/pubspec_overrides.yaml
@@ -1,4 +1,6 @@
-# melos_managed_dependency_overrides: neon_lints
+# melos_managed_dependency_overrides: cookie_store_conformance_tests,neon_lints
 dependency_overrides:
+  cookie_store_conformance_tests:
+    path: ../cookie_store_conformance_tests
   neon_lints:
     path: ../neon_lints

--- a/packages/cookie_store/test/cookie_store_conformance_test.dart
+++ b/packages/cookie_store/test/cookie_store_conformance_test.dart
@@ -1,0 +1,6 @@
+import 'package:cookie_store/cookie_store.dart';
+import 'package:cookie_store_conformance_tests/cookie_store_conformance_tests.dart' as conformance_tests;
+
+void main() {
+  conformance_tests.testAll(CookieStore.new);
+}

--- a/packages/cookie_store/test/storable_cookie_test.dart
+++ b/packages/cookie_store/test/storable_cookie_test.dart
@@ -1,0 +1,152 @@
+import 'package:cookie_store/src/storable_cookie.dart';
+import 'package:test/test.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+void main() {
+  group('StorableCookie equality', () {
+    test('same values', () {
+      final now = tz.TZDateTime.now(tz.UTC);
+      final cookie1 = StorableCookie(
+        name: 'name',
+        value: 'value',
+        expiryTime: now,
+        domain: 'example.com',
+        path: '/path',
+        creationTime: now,
+        lastAccessTime: now,
+        persistentFlag: false,
+        hostOnlyFlag: false,
+        secureOnlyFlag: false,
+        httpOnlyFlag: false,
+      );
+
+      final cookie2 = StorableCookie(
+        name: 'name',
+        value: 'value',
+        expiryTime: now,
+        domain: 'example.com',
+        path: '/path',
+        creationTime: now,
+        lastAccessTime: now,
+        persistentFlag: false,
+        hostOnlyFlag: false,
+        secureOnlyFlag: false,
+        httpOnlyFlag: false,
+      );
+
+      expect(cookie1, equals(cookie2));
+      expect(cookie1.hashCode, equals(cookie2.hashCode));
+    });
+
+    test('matching name, domain and path', () {
+      var now = tz.TZDateTime.now(tz.UTC);
+      final cookie1 = StorableCookie(
+        name: 'name',
+        value: 'value',
+        expiryTime: now,
+        domain: 'example.com',
+        path: '/path',
+        creationTime: now,
+        lastAccessTime: now,
+        persistentFlag: false,
+        hostOnlyFlag: false,
+        secureOnlyFlag: false,
+        httpOnlyFlag: false,
+      );
+
+      now = now.subtract(const Duration(days: 3));
+      var cookie2 = StorableCookie(
+        name: 'name',
+        value: 'other-value',
+        expiryTime: now,
+        domain: 'example.com',
+        path: '/path',
+        creationTime: now,
+        lastAccessTime: now,
+        persistentFlag: true,
+        hostOnlyFlag: true,
+        secureOnlyFlag: true,
+        httpOnlyFlag: true,
+      );
+      expect(cookie1, equals(cookie2));
+      expect(cookie1.hashCode, equals(cookie2.hashCode));
+
+      cookie2 = StorableCookie(
+        name: 'name',
+        value: 'other-value',
+        expiryTime: now,
+        domain: 'example.com',
+        path: '/other-path',
+        creationTime: now,
+        lastAccessTime: now,
+        persistentFlag: true,
+        hostOnlyFlag: true,
+        secureOnlyFlag: true,
+        httpOnlyFlag: true,
+      );
+      expect(cookie1, isNot(equals(cookie2)));
+      expect(cookie1.hashCode, isNot(equals(cookie2.hashCode)));
+
+      cookie2 = StorableCookie(
+        name: 'name',
+        value: 'other-value',
+        expiryTime: now,
+        domain: 'other.example.com',
+        path: '/path',
+        creationTime: now,
+        lastAccessTime: now,
+        persistentFlag: true,
+        hostOnlyFlag: true,
+        secureOnlyFlag: true,
+        httpOnlyFlag: true,
+      );
+      expect(cookie1, isNot(equals(cookie2)));
+      expect(cookie1.hashCode, isNot(equals(cookie2.hashCode)));
+
+      cookie2 = StorableCookie(
+        name: 'other-name',
+        value: 'other-value',
+        expiryTime: now,
+        domain: 'example.com',
+        path: '/path',
+        creationTime: now,
+        lastAccessTime: now,
+        persistentFlag: true,
+        hostOnlyFlag: true,
+        secureOnlyFlag: true,
+        httpOnlyFlag: true,
+      );
+      expect(cookie1, isNot(equals(cookie2)));
+      expect(cookie1.hashCode, isNot(equals(cookie2.hashCode)));
+    });
+  });
+
+  test('StorableCookie copyWith', () {
+    final now = tz.TZDateTime.now(tz.UTC);
+    final cookie1 = StorableCookie(
+      name: 'name',
+      value: 'value',
+      expiryTime: now,
+      domain: 'example.com',
+      path: '/path',
+      creationTime: now,
+      lastAccessTime: now,
+      persistentFlag: false,
+      hostOnlyFlag: false,
+      secureOnlyFlag: false,
+      httpOnlyFlag: false,
+    );
+
+    var cookie2 = cookie1.copyWith(
+      value: 'different-value',
+    );
+    expect(cookie1, equals(cookie2));
+    expect(cookie1.hashCode, equals(cookie2.hashCode));
+
+    cookie2 = cookie1.copyWith(
+      lastAccessTime: now.subtract(const Duration(seconds: 2)),
+    );
+    expect(cookie1, equals(cookie2));
+    expect(cookie1.hashCode, equals(cookie2.hashCode));
+  });
+}

--- a/packages/cookie_store/test/utils_test.dart
+++ b/packages/cookie_store/test/utils_test.dart
@@ -1,0 +1,267 @@
+import 'package:cookie_store/src/storable_cookie.dart';
+import 'package:cookie_store/src/utils.dart';
+import 'package:test/test.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+void main() {
+  group('defaultPath', () {
+    test('empty uri', () {
+      final uri = Uri();
+      final result = defaultPath(uri);
+
+      expect(result, '/');
+    });
+
+    test('uri with query parameter or fragment', () {
+      var uri = Uri(scheme: 'http', host: 'example.com', query: 'query');
+      var result = defaultPath(uri);
+      expect(result, '/');
+
+      uri = Uri(scheme: 'http', host: 'example.com', fragment: 'fragment');
+      result = defaultPath(uri);
+      expect(result, '/');
+    });
+
+    test('relative path', () {
+      var uri = Uri(path: 'docs');
+      var result = defaultPath(uri);
+      expect(result, '/');
+
+      uri = Uri(path: 'docs/');
+      result = defaultPath(uri);
+      expect(result, '/');
+
+      uri = Uri(path: 'docs/Web');
+      result = defaultPath(uri);
+      expect(result, '/');
+
+      uri = Uri(path: 'docs/Web/');
+      result = defaultPath(uri);
+      expect(result, '/');
+    });
+
+    test('absolute path', () {
+      var uri = Uri(path: '/docs');
+      var result = defaultPath(uri);
+      expect(result, '/');
+
+      uri = Uri(path: '/docs/');
+      result = defaultPath(uri);
+      expect(result, '/docs');
+
+      uri = Uri(path: '/docs/Web');
+      result = defaultPath(uri);
+      expect(result, '/docs/Web');
+
+      uri = Uri(path: '/docs/Web/');
+      result = defaultPath(uri);
+      expect(result, '/docs/Web');
+    });
+  });
+
+  group('isDomainMatch', () {
+    test('identical domain', () {
+      const cookieDomain = 'example.com';
+      const requestDomain = 'example.com';
+
+      final result = isDomainMatch(requestDomain, cookieDomain);
+      expect(result, isTrue);
+    });
+
+    test('IP address', () {
+      const cookieDomain = '1';
+
+      var requestDomain = '127.0.0.1';
+      var result = isDomainMatch(requestDomain, cookieDomain);
+      expect(result, isFalse);
+
+      requestDomain = '::1';
+      result = isDomainMatch(requestDomain, cookieDomain);
+      expect(result, isFalse);
+    });
+
+    test('domain is suffix', () {
+      var cookieDomain = 'example.com';
+
+      var result = isDomainMatch('example.com', cookieDomain);
+      expect(result, isTrue);
+      result = isDomainMatch('.example.com', cookieDomain);
+      expect(result, isTrue);
+      result = isDomainMatch('test.example.com', cookieDomain);
+      expect(result, isTrue);
+      result = isDomainMatch('1example.com', cookieDomain);
+      expect(result, isFalse);
+      result = isDomainMatch('test.com', cookieDomain);
+      expect(result, isFalse);
+
+      cookieDomain = '.leading.dot.example.com';
+
+      result = isDomainMatch('.leading.dot.example.com', cookieDomain);
+      expect(result, isTrue);
+      result = isDomainMatch('..leading.dot.example.com', cookieDomain);
+      expect(result, isTrue);
+      result = isDomainMatch('sub..leading.dot.example.com', cookieDomain);
+      expect(result, isTrue);
+      result = isDomainMatch('sub.leading.dot.example.com', cookieDomain);
+      expect(result, isFalse);
+      result = isDomainMatch('dot.example.com', cookieDomain);
+      expect(result, isFalse);
+    });
+  });
+
+  group('isPathMatch', () {
+    test('identical path', () {
+      var cookiePath = '/';
+      var requestPath = '/';
+      var result = isPathMatch(requestPath, cookiePath);
+      expect(result, isTrue);
+
+      cookiePath = '/file';
+      requestPath = '/file';
+      result = isPathMatch(requestPath, cookiePath);
+      expect(result, isTrue);
+
+      cookiePath = '/directory/';
+      requestPath = '/directory/';
+      result = isPathMatch(requestPath, cookiePath);
+      expect(result, isTrue);
+    });
+
+    test('path is prefix', () {
+      const cookiePath = '/docs';
+
+      var result = isPathMatch('/docs', cookiePath);
+      expect(result, isTrue);
+      result = isPathMatch('/docs/', cookiePath);
+      expect(result, isTrue);
+      result = isPathMatch('/docs/Web/', cookiePath);
+      expect(result, isTrue);
+      result = isPathMatch('/docs/Web/HTTP', cookiePath);
+      expect(result, isTrue);
+
+      result = isPathMatch('/', cookiePath);
+      expect(result, isFalse);
+      result = isPathMatch('/docsTets', cookiePath);
+      expect(result, isFalse);
+      result = isPathMatch('/fr/docs', cookiePath);
+      expect(result, isFalse);
+    });
+  });
+
+  test('isHttpUri', () {
+    var uri = Uri.http('example.com');
+    var result = isHttpUri(uri);
+    expect(result, isTrue);
+
+    uri = Uri.https('example.com');
+    result = isHttpUri(uri);
+    expect(result, isTrue);
+
+    uri = Uri.file('example.com');
+    result = isHttpUri(uri);
+    expect(result, isFalse);
+
+    uri = Uri(host: 'example.com');
+    result = isHttpUri(uri);
+    expect(result, isFalse);
+  });
+
+  test('isSecureUri', () {
+    var uri = Uri.http('example.com');
+    var result = isSecureUri(uri);
+    expect(result, isFalse);
+
+    uri = Uri.https('example.com');
+    result = isSecureUri(uri);
+    expect(result, isTrue);
+
+    uri = Uri.file('example.com');
+    result = isSecureUri(uri);
+    expect(result, isFalse);
+
+    uri = Uri.parse('ftp://example.com');
+    result = isSecureUri(uri);
+    expect(result, isFalse);
+
+    uri = Uri.parse('ftps://example.com');
+    result = isSecureUri(uri);
+    expect(result, isTrue);
+  });
+
+  test('sortCookies', () {
+    var now = tz.TZDateTime.now(tz.UTC);
+    final shortPathCookie = StorableCookie(
+      name: 'short-path',
+      value: 'value',
+      expiryTime: now,
+      domain: 'example.com',
+      path: '/path',
+      creationTime: now,
+      lastAccessTime: now,
+      persistentFlag: false,
+      hostOnlyFlag: false,
+      secureOnlyFlag: false,
+      httpOnlyFlag: false,
+    );
+
+    final longerPathCookie = StorableCookie(
+      name: 'longer-path',
+      value: 'value',
+      expiryTime: now,
+      domain: 'example.com',
+      path: '/longerPath',
+      creationTime: now,
+      lastAccessTime: now,
+      persistentFlag: false,
+      hostOnlyFlag: false,
+      secureOnlyFlag: false,
+      httpOnlyFlag: false,
+    );
+
+    final earlyLongestPathCookie = StorableCookie(
+      name: 'longest-path-early',
+      value: 'value',
+      expiryTime: now,
+      domain: 'example.com',
+      path: '/longestPath',
+      creationTime: now,
+      lastAccessTime: now,
+      persistentFlag: false,
+      hostOnlyFlag: false,
+      secureOnlyFlag: false,
+      httpOnlyFlag: false,
+    );
+
+    now = now.add(const Duration(seconds: 1));
+    final laterLongestPathCookie = StorableCookie(
+      name: 'longest-path-later',
+      value: 'value',
+      expiryTime: now,
+      domain: 'example.com',
+      path: '/longestPath',
+      creationTime: now,
+      lastAccessTime: now,
+      persistentFlag: false,
+      hostOnlyFlag: false,
+      secureOnlyFlag: false,
+      httpOnlyFlag: false,
+    );
+
+    final list = [
+      laterLongestPathCookie,
+      longerPathCookie,
+      shortPathCookie,
+      earlyLongestPathCookie,
+    ];
+
+    expect(
+      list..sort(sortCookies),
+      orderedEquals([
+        earlyLongestPathCookie,
+        laterLongestPathCookie,
+        longerPathCookie,
+        shortPathCookie,
+      ]),
+    );
+  });
+}

--- a/packages/cookie_store_conformance_tests/BSD-3-Clause.txt
+++ b/packages/cookie_store_conformance_tests/BSD-3-Clause.txt
@@ -1,0 +1,1 @@
+../../assets/BSD-3-Clause.txt

--- a/packages/cookie_store_conformance_tests/analysis_options.yaml
+++ b/packages/cookie_store_conformance_tests/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:neon_lints/dart.yaml

--- a/packages/cookie_store_conformance_tests/lib/cookie_store_conformance_tests.dart
+++ b/packages/cookie_store_conformance_tests/lib/cookie_store_conformance_tests.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:cookie_store/cookie_store.dart' show CookieStore;
+import 'package:cookie_store_conformance_tests/src/deletion_tests.dart';
+import 'package:cookie_store_conformance_tests/src/domain_matching_tests.dart';
+import 'package:cookie_store_conformance_tests/src/expiration_tests.dart';
+import 'package:cookie_store_conformance_tests/src/http_only_cookie_tests.dart';
+import 'package:cookie_store_conformance_tests/src/path_matching_tests.dart';
+import 'package:cookie_store_conformance_tests/src/persist_cookies_tests.dart';
+import 'package:cookie_store_conformance_tests/src/secure_cookie_tests.dart';
+import 'package:cookie_store_conformance_tests/src/sorting_tests.dart';
+import 'package:meta/meta.dart';
+
+export 'package:cookie_store_conformance_tests/src/deletion_tests.dart' show deletionTests;
+export 'package:cookie_store_conformance_tests/src/domain_matching_tests.dart' show domainMatching;
+export 'package:cookie_store_conformance_tests/src/expiration_tests.dart' show expiration;
+export 'package:cookie_store_conformance_tests/src/http_only_cookie_tests.dart' show httpOnly;
+export 'package:cookie_store_conformance_tests/src/path_matching_tests.dart' show pathMatching;
+export 'package:cookie_store_conformance_tests/src/persist_cookies_tests.dart' show persistCookies;
+export 'package:cookie_store_conformance_tests/src/secure_cookie_tests.dart' show secure;
+export 'package:cookie_store_conformance_tests/src/sorting_tests.dart' show sortTests;
+
+/// Runs the entire test suite against the given [CookieStore].
+///
+/// These tests require the otherwise optional method [CookieStore.loadAll] to
+/// be implemented.
+///
+/// If [canDeleteAll] is `false` then tests for [CookieStore.deleteAll] will
+/// be skipped.
+///
+/// If [canDeleteByTest] is `false` then tests for [CookieStore.deleteWhere] will
+/// be skipped.
+///
+/// If [canSortByPath] is `false` then tests for sorting the cookies loaded for
+/// a request against the `Cookie.path` attribute will be skipped.
+///
+/// If [canSortByCreationTime] is `false` then tests for sorting the cookies
+/// loaded for a request against the creation time will be skipped.
+/// Requires [canSortByPath] to be also `true`.
+@isTestGroup
+void testAll(
+  FutureOr<CookieStore> Function() cookieStoreFactory, {
+  bool canDeleteAll = true,
+  bool canDeleteByTest = true,
+  bool canSortByPath = true,
+  bool canSortByCreationTime = true,
+}) {
+  persistCookies(cookieStoreFactory);
+  domainMatching(cookieStoreFactory);
+  pathMatching(cookieStoreFactory);
+  httpOnly(cookieStoreFactory);
+  secure(cookieStoreFactory);
+  expiration(cookieStoreFactory);
+  sortTests(
+    cookieStoreFactory,
+    canSortByPath: canSortByPath,
+    canSortByCreationTime: canSortByCreationTime,
+  );
+  deletionTests(
+    cookieStoreFactory,
+    canDeleteAll: canDeleteAll,
+    canDeleteByTest: canDeleteByTest,
+  );
+}

--- a/packages/cookie_store_conformance_tests/lib/src/deletion_tests.dart
+++ b/packages/cookie_store_conformance_tests/lib/src/deletion_tests.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:cookie_store/cookie_store.dart';
+import 'package:cookie_store_conformance_tests/src/utils.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+/// Tests that the store correctly implements the optional cookie management interface.
+@isTestGroup
+void deletionTests(
+  FutureOr<CookieStore> Function() cookieStoreFactory, {
+  bool canDeleteAll = true,
+  bool canDeleteByTest = true,
+}) {
+  late CookieStore cookieStore;
+
+  setUp(() async {
+    cookieStore = await cookieStoreFactory();
+  });
+
+  group('delete cookies,', () {
+    test(
+      'delete all',
+      () async {
+        final uri = Uri();
+
+        final cookies = [
+          TestCookie('name0', 'value'),
+          TestCookie('name1', 'other-value'),
+          TestCookie('name2', 'value'),
+          TestCookie('name3', ''),
+        ];
+
+        await cookieStore.saveFromResponse(uri, cookies);
+        var stored = await cookieStore.loadAll();
+        expect(
+          toSortedStringList(stored),
+          equals([
+            'name0=value',
+            'name1=other-value',
+            'name2=value',
+            'name3=',
+          ]),
+        );
+
+        await cookieStore.deleteAll();
+        stored = await cookieStore.loadAll();
+        expect(
+          toSortedStringList(stored),
+          equals([]),
+        );
+      },
+      skip: canDeleteAll ? false : 'does not support deleting all cookies',
+    );
+
+    test(
+      'delete by test',
+      () async {
+        final uri = Uri();
+
+        final cookies = [
+          TestCookie('name0', 'value'),
+          TestCookie('name1', 'other-value'),
+          TestCookie('name2', 'value'),
+          TestCookie('name3', ''),
+        ];
+
+        await cookieStore.saveFromResponse(uri, cookies);
+        var stored = await cookieStore.loadAll();
+        expect(
+          toSortedStringList(stored),
+          equals([
+            'name0=value',
+            'name1=other-value',
+            'name2=value',
+            'name3=',
+          ]),
+        );
+
+        await cookieStore.deleteWhere((cookie) {
+          return cookie.name == 'name1' || cookie.value.isEmpty;
+        });
+        stored = await cookieStore.loadAll();
+        expect(
+          toSortedStringList(stored),
+          equals([
+            'name0=value',
+            'name2=value',
+          ]),
+        );
+      },
+      skip: canDeleteByTest ? false : 'does not support deleting by test',
+    );
+  });
+}

--- a/packages/cookie_store_conformance_tests/lib/src/domain_matching_tests.dart
+++ b/packages/cookie_store_conformance_tests/lib/src/domain_matching_tests.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+
+import 'package:cookie_store/cookie_store.dart';
+import 'package:cookie_store_conformance_tests/src/utils.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+/// Tests that the store correctly implements the domain-matching algorithm as
+/// defined by [RFC6265 section 5.1.3](https://httpwg.org/specs/rfc6265.html#cookie-domain).
+@isTestGroup
+void domainMatching(FutureOr<CookieStore> Function() cookieStoreFactory) {
+  late CookieStore cookieStore;
+
+  setUp(() async {
+    cookieStore = await cookieStoreFactory();
+  });
+
+  group('domain matching,', () {
+    test('do not store not matching domain', () async {
+      final cookies = [
+        TestCookie('null', 'value')..domain = null,
+        TestCookie('example.com', 'value')..domain = 'example.com',
+        TestCookie('.example.com', 'value')..domain = '.example.com',
+        TestCookie('test.example.com', 'value')..domain = 'test.example.com',
+        TestCookie('testexample.com', 'value')..domain = 'testexample.com',
+        TestCookie('test.com', 'value')..domain = 'test.com',
+      ];
+
+      await cookieStore.saveFromResponse(Uri(host: 'test.example.com'), cookies);
+      final stored = await cookieStore.loadAll();
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'example.com=value',
+          'null=value',
+          'test.example.com=value',
+        ]),
+      );
+    });
+
+    test('do not load not matching domain', () async {
+      var cookies = [
+        TestCookie('null', 'value')..domain = null,
+        TestCookie('example.com', 'value')..domain = 'example.com',
+        TestCookie('test.example.com', 'value')..domain = 'test.example.com',
+      ];
+      await cookieStore.saveFromResponse(Uri(host: 'test.example.com'), cookies);
+
+      cookies = [
+        TestCookie('.example.com', 'value')..domain = '.example.com',
+      ];
+      await cookieStore.saveFromResponse(Uri(host: '.example.com'), cookies);
+
+      cookies = [
+        TestCookie('testexample.com', 'value')..domain = 'testexample.com',
+      ];
+      await cookieStore.saveFromResponse(Uri(host: 'testexample.com'), cookies);
+
+      cookies = [
+        TestCookie('test.com', 'value')..domain = 'test.com',
+      ];
+      await cookieStore.saveFromResponse(Uri(host: 'test.com'), cookies);
+
+      var stored = await cookieStore.loadAll();
+      expect(
+        toSortedStringList(stored),
+        equals([
+          '.example.com=value',
+          'example.com=value',
+          'null=value',
+          'test.com=value',
+          'test.example.com=value',
+          'testexample.com=value',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(Uri(host: 'example.com'));
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'example.com=value',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(Uri(host: 'test.example.com'));
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'example.com=value',
+          'null=value',
+          'test.example.com=value',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(Uri(host: 'testexample.com'));
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'testexample.com=value',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(Uri(host: 'test..example.com'));
+      expect(
+        toSortedStringList(stored),
+        equals([
+          '.example.com=value',
+          'example.com=value',
+        ]),
+      );
+    });
+
+    group('ip address matching', () {
+      test('storing', () async {
+        final uri = Uri(host: '1');
+
+        final cookies = [
+          TestCookie('IPv4-address', 'value')..domain = '127.0.0.1',
+          TestCookie('IPv6-address', 'value')..domain = '::1',
+        ];
+
+        await cookieStore.saveFromResponse(uri, cookies);
+        final stored = await cookieStore.loadAll();
+        expect(
+          toSortedStringList(stored),
+          equals([]),
+        );
+      });
+
+      test('do not load from similar domain', () async {
+        var cookies = [
+          TestCookie('IPv4-address', 'value')..domain = '127.0.0.1',
+        ];
+        await cookieStore.saveFromResponse(Uri(host: '127.0.0.1'), cookies);
+
+        cookies = [
+          TestCookie('IPv6-address', 'value')..domain = '::1',
+        ];
+        await cookieStore.saveFromResponse(Uri(host: '::1'), cookies);
+
+        var stored = await cookieStore.loadAll();
+        expect(
+          toSortedStringList(stored),
+          equals([
+            'IPv4-address=value',
+            'IPv6-address=value',
+          ]),
+        );
+
+        final uri = Uri(host: '1');
+        stored = await cookieStore.loadForRequest(uri);
+        expect(
+          toSortedStringList(stored),
+          equals([]),
+        );
+      });
+
+      test('load when identical', () async {
+        var uri = Uri(host: '127.0.0.1');
+        var cookies = [
+          TestCookie('IPv4-address', 'value')..domain = '127.0.0.1',
+        ];
+        await cookieStore.saveFromResponse(uri, cookies);
+        var stored = await cookieStore.loadForRequest(uri);
+        expect(
+          toSortedStringList(stored),
+          equals([
+            'IPv4-address=value',
+          ]),
+        );
+
+        uri = Uri(host: '::1');
+        cookies = [
+          TestCookie('IPv6-address', 'value')..domain = '::1',
+        ];
+        await cookieStore.saveFromResponse(uri, cookies);
+        stored = await cookieStore.loadForRequest(uri);
+        expect(
+          toSortedStringList(stored),
+          equals([
+            'IPv6-address=value',
+          ]),
+        );
+      });
+    });
+  });
+}

--- a/packages/cookie_store_conformance_tests/lib/src/expiration_tests.dart
+++ b/packages/cookie_store_conformance_tests/lib/src/expiration_tests.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import 'package:cookie_store/cookie_store.dart';
+import 'package:cookie_store_conformance_tests/src/utils.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+/// Tests that the store does correctly handle cookie expiration.
+///
+/// This also tests the eviction of session-cookies after calling
+/// [CookieStore.endSession].
+@isTestGroup
+void expiration(FutureOr<CookieStore> Function() cookieStoreFactory) {
+  late CookieStore cookieStore;
+
+  setUp(() async {
+    cookieStore = await cookieStoreFactory();
+  });
+
+  group('expiration,', () {
+    test('do not store already expired', () async {
+      final uri = Uri();
+
+      const duration = Duration(seconds: 1);
+      final expiration = DateTime.timestamp().subtract(duration);
+      final cookies = [
+        TestCookie('expired0', 'value')..expires = expiration,
+        TestCookie('expired1', 'value')..maxAge = -duration.inSeconds,
+        TestCookie('not-expired0', 'value'),
+        TestCookie('not-expired1', 'value'),
+      ];
+
+      await cookieStore.saveFromResponse(uri, cookies);
+      final stored = await cookieStore.loadAll();
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'not-expired0=value',
+          'not-expired1=value',
+        ]),
+      );
+    });
+
+    test('expiration at a later point', () async {
+      final uri = Uri();
+
+      const duration = Duration(seconds: 2);
+      final expiration = DateTime.timestamp().add(duration);
+      final cookies = [
+        TestCookie('will-expire0', 'value')..expires = expiration,
+        TestCookie('will-expire1', 'value')..maxAge = duration.inSeconds,
+        TestCookie('not-expired0', 'value'),
+        TestCookie('not-expired1', 'value'),
+      ];
+
+      await cookieStore.saveFromResponse(uri, cookies);
+      var stored = await cookieStore.loadForRequest(uri);
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'not-expired0=value',
+          'not-expired1=value',
+          'will-expire0=value',
+          'will-expire1=value',
+        ]),
+      );
+
+      await Future<void>.delayed(duration * 2);
+      stored = await cookieStore.loadForRequest(uri);
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'not-expired0=value',
+          'not-expired1=value',
+        ]),
+      );
+    });
+
+    test('session cookies', () async {
+      final uri = Uri();
+
+      const duration = Duration(days: 1);
+      final expiration = DateTime.timestamp().add(duration);
+      final cookies = [
+        TestCookie('will-expire0', 'value')..expires = expiration,
+        TestCookie('will-expire1', 'value')..maxAge = duration.inSeconds,
+        TestCookie('session-cookie1', 'value'),
+        TestCookie('session-cookie2', 'value'),
+      ];
+
+      await cookieStore.saveFromResponse(uri, cookies);
+      var stored = await cookieStore.loadForRequest(uri);
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'session-cookie1=value',
+          'session-cookie2=value',
+          'will-expire0=value',
+          'will-expire1=value',
+        ]),
+      );
+
+      await cookieStore.endSession();
+      stored = await cookieStore.loadForRequest(uri);
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'will-expire0=value',
+          'will-expire1=value',
+        ]),
+      );
+    });
+  });
+}

--- a/packages/cookie_store_conformance_tests/lib/src/http_only_cookie_tests.dart
+++ b/packages/cookie_store_conformance_tests/lib/src/http_only_cookie_tests.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+
+import 'package:cookie_store/cookie_store.dart';
+import 'package:cookie_store_conformance_tests/src/utils.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+/// Tests that the store does not load cookies with the httpOnly flag on non http
+/// requests.
+///
+/// Tested with the following Uris.
+/// ```dart
+///   var nonHttp = Uri(host: 'example.com');
+///   var http = Uri.http('example.com');
+/// ```
+///
+/// An implementation might not share the same definition of what protocols are `http`.
+@isTestGroup
+void httpOnly(FutureOr<CookieStore> Function() cookieStoreFactory) {
+  late CookieStore cookieStore;
+
+  setUp(() async {
+    cookieStore = await cookieStoreFactory();
+  });
+
+  group('http only cookies,', () {
+    test('do not save when requestUri is not http', () async {
+      final uri = Uri(host: 'example.com');
+      final httpUri = Uri.http('example.com');
+
+      final cookies = [
+        TestCookie('httpOnly0', 'value')..httpOnly = true,
+        TestCookie('httpOnly1', 'value')..httpOnly = true,
+        TestCookie('not-httpOnly0', 'value'),
+        TestCookie('not-httpOnly1', 'value'),
+      ];
+
+      await cookieStore.saveFromResponse(uri, cookies);
+      var stored = await cookieStore.loadAll();
+
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'not-httpOnly0=value',
+          'not-httpOnly1=value',
+        ]),
+      );
+
+      await cookieStore.saveFromResponse(httpUri, cookies);
+      stored = await cookieStore.loadAll();
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'httpOnly0=value',
+          'httpOnly1=value',
+          'not-httpOnly0=value',
+          'not-httpOnly1=value',
+        ]),
+      );
+    });
+
+    test('do not retrieve when requestUri is not http', () async {
+      final uri = Uri(host: 'example.com');
+      final httpUri = Uri.http('example.com');
+
+      final cookies = [
+        TestCookie('httpOnly0', 'value')..httpOnly = true,
+        TestCookie('httpOnly1', 'value')..httpOnly = true,
+        TestCookie('not-httpOnly0', 'value'),
+        TestCookie('not-httpOnly1', 'value'),
+      ];
+
+      await cookieStore.saveFromResponse(httpUri, cookies);
+      var stored = await cookieStore.loadAll();
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'httpOnly0=value',
+          'httpOnly1=value',
+          'not-httpOnly0=value',
+          'not-httpOnly1=value',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(uri);
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'not-httpOnly0=value',
+          'not-httpOnly1=value',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(httpUri);
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'httpOnly0=value',
+          'httpOnly1=value',
+          'not-httpOnly0=value',
+          'not-httpOnly1=value',
+        ]),
+      );
+    });
+  });
+}

--- a/packages/cookie_store_conformance_tests/lib/src/path_matching_tests.dart
+++ b/packages/cookie_store_conformance_tests/lib/src/path_matching_tests.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+
+import 'package:cookie_store/cookie_store.dart';
+import 'package:cookie_store_conformance_tests/src/utils.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+/// Tests that the store correctly implements path and path-matching algorithms
+/// as defined by [RFC6265 section 5.1.4](https://httpwg.org/specs/rfc6265.html#cookie-path).
+@isTestGroup
+void pathMatching(FutureOr<CookieStore> Function() cookieStoreFactory) {
+  late CookieStore cookieStore;
+
+  setUp(() async {
+    cookieStore = await cookieStoreFactory();
+  });
+
+  group('path matching,', () {
+    test('with path attribute', () async {
+      final cookies = [
+        TestCookie('docs', 'value')..path = '/docs',
+      ];
+
+      await cookieStore.saveFromResponse(Uri(), cookies);
+      var stored = await cookieStore.loadAll();
+      expect(toStringList(stored), equals(['docs=value']));
+
+      // Not matching
+      stored = await cookieStore.loadForRequest(Uri());
+      expect(stored, isEmpty);
+      stored = await cookieStore.loadForRequest(Uri(path: '/'));
+      expect(stored, isEmpty);
+      stored = await cookieStore.loadForRequest(Uri(path: '/docsTets'));
+      expect(stored, isEmpty);
+      stored = await cookieStore.loadForRequest(Uri(path: '/fr/docs'));
+      expect(stored, isEmpty);
+
+      // Matching
+      stored = await cookieStore.loadForRequest(Uri(path: '/docs'));
+      expect(toStringList(stored), equals(['docs=value']));
+      stored = await cookieStore.loadForRequest(Uri(path: '/docs/'));
+      expect(toStringList(stored), equals(['docs=value']));
+      stored = await cookieStore.loadForRequest(Uri(path: '/docs/Web/'));
+      expect(toStringList(stored), equals(['docs=value']));
+      stored = await cookieStore.loadForRequest(Uri(path: '/docs/Web/HTTP'));
+      expect(toStringList(stored), equals(['docs=value']));
+      stored = await cookieStore.loadForRequest(Uri(path: '/docs', query: 'queryParam'));
+      expect(toStringList(stored), equals(['docs=value']));
+      stored = await cookieStore.loadForRequest(Uri(path: '/docs', fragment: 'fragment'));
+      expect(toStringList(stored), equals(['docs=value']));
+    });
+
+    test('default path check', () async {
+      var cookies = [
+        TestCookie('no-path', '/'),
+      ];
+      await cookieStore.saveFromResponse(Uri(), cookies);
+
+      cookies = [
+        TestCookie('no-path-query', '/'),
+      ];
+      await cookieStore.saveFromResponse(Uri(query: 'queryParam'), cookies);
+
+      cookies = [
+        TestCookie('no-path-fragment', '/'),
+      ];
+      await cookieStore.saveFromResponse(Uri(fragment: 'fragment'), cookies);
+
+      cookies = [
+        TestCookie('relative', '/'),
+      ];
+      await cookieStore.saveFromResponse(Uri(path: 'docs'), cookies);
+
+      cookies = [
+        TestCookie('relative-one-slash', '/'),
+      ];
+      await cookieStore.saveFromResponse(Uri(path: 'docs/Web'), cookies);
+
+      cookies = [
+        TestCookie('relative-multiple-slash', '/'),
+      ];
+      await cookieStore.saveFromResponse(Uri(path: 'docs/Web/'), cookies);
+
+      cookies = [
+        TestCookie('absolute-path', '/'),
+      ];
+      await cookieStore.saveFromResponse(Uri(path: '/docs'), cookies);
+
+      cookies = [
+        TestCookie('absolute-path-trailing-slash', '/docs'),
+      ];
+      await cookieStore.saveFromResponse(Uri(path: '/docs/'), cookies);
+
+      var stored = await cookieStore.loadAll();
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'absolute-path-trailing-slash=/docs',
+          'absolute-path=/',
+          'no-path-fragment=/',
+          'no-path-query=/',
+          'no-path=/',
+          'relative-multiple-slash=/',
+          'relative-one-slash=/',
+          'relative=/',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(Uri());
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'absolute-path=/',
+          'no-path-fragment=/',
+          'no-path-query=/',
+          'no-path=/',
+          'relative-multiple-slash=/',
+          'relative-one-slash=/',
+          'relative=/',
+        ]),
+      );
+      stored = await cookieStore.loadForRequest(Uri(path: '/'));
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'absolute-path=/',
+          'no-path-fragment=/',
+          'no-path-query=/',
+          'no-path=/',
+          'relative-multiple-slash=/',
+          'relative-one-slash=/',
+          'relative=/',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(Uri(path: '/docs'));
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'absolute-path-trailing-slash=/docs',
+          'absolute-path=/',
+          'no-path-fragment=/',
+          'no-path-query=/',
+          'no-path=/',
+          'relative-multiple-slash=/',
+          'relative-one-slash=/',
+          'relative=/',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(Uri(path: '/docs/'));
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'absolute-path-trailing-slash=/docs',
+          'absolute-path=/',
+          'no-path-fragment=/',
+          'no-path-query=/',
+          'no-path=/',
+          'relative-multiple-slash=/',
+          'relative-one-slash=/',
+          'relative=/',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(Uri(path: '/docs/Web'));
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'absolute-path-trailing-slash=/docs',
+          'absolute-path=/',
+          'no-path-fragment=/',
+          'no-path-query=/',
+          'no-path=/',
+          'relative-multiple-slash=/',
+          'relative-one-slash=/',
+          'relative=/',
+        ]),
+      );
+    });
+  });
+}

--- a/packages/cookie_store_conformance_tests/lib/src/persist_cookies_tests.dart
+++ b/packages/cookie_store_conformance_tests/lib/src/persist_cookies_tests.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:cookie_store/cookie_store.dart';
+import 'package:cookie_store_conformance_tests/src/utils.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+/// Tests that the store can store and update cookies.
+@isTestGroup
+void persistCookies(FutureOr<CookieStore> Function() cookieStoreFactory) {
+  late CookieStore cookieStore;
+
+  setUp(() async {
+    cookieStore = await cookieStoreFactory();
+  });
+
+  group('persist cookie,', () {
+    test('plain cookie', () async {
+      final uri = Uri();
+
+      final cookies = [
+        TestCookie('name0', 'value'),
+        TestCookie('name1', 'other-value'),
+        TestCookie('name2', 'value'),
+        TestCookie('name3', ''),
+      ];
+
+      await cookieStore.saveFromResponse(uri, cookies);
+      final stored = await cookieStore.loadAll();
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'name0=value',
+          'name1=other-value',
+          'name2=value',
+          'name3=',
+        ]),
+      );
+    });
+
+    test('update cookie', () async {
+      final uri = Uri();
+
+      var cookies = [
+        TestCookie('name0', 'value'),
+        TestCookie('name1', 'value'),
+        TestCookie('name2', 'value'),
+        TestCookie('name3', 'value'),
+      ];
+
+      await cookieStore.saveFromResponse(uri, cookies);
+      var stored = await cookieStore.loadAll();
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'name0=value',
+          'name1=value',
+          'name2=value',
+          'name3=value',
+        ]),
+      );
+
+      cookies = [
+        TestCookie('name0', 'value2'),
+      ];
+
+      await cookieStore.saveFromResponse(uri, cookies);
+      stored = await cookieStore.loadAll();
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'name0=value2',
+          'name1=value',
+          'name2=value',
+          'name3=value',
+        ]),
+      );
+    });
+  });
+}

--- a/packages/cookie_store_conformance_tests/lib/src/secure_cookie_tests.dart
+++ b/packages/cookie_store_conformance_tests/lib/src/secure_cookie_tests.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:cookie_store/cookie_store.dart';
+import 'package:cookie_store_conformance_tests/src/utils.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+/// Tests that the store does not load cookies with the secure flag on insecure
+/// requests.
+///
+/// Tested with the following Uris.
+/// ```dart
+///   var insecure = Uri(host: 'example.com');
+///   var secure = Uri(scheme: 'ftps', host: 'example.com');
+/// ```
+///
+/// An implementation might not consider the `ftps` uri as secure.
+@isTestGroup
+void secure(FutureOr<CookieStore> Function() cookieStoreFactory) {
+  late CookieStore cookieStore;
+
+  setUp(() async {
+    cookieStore = await cookieStoreFactory();
+  });
+
+  group('secure cookies,', () {
+    test('do not load secure cookies in insecure requests', () async {
+      final uri = Uri(host: 'example.com');
+
+      final cookies = [
+        TestCookie('not-secure0', 'value'),
+        TestCookie('secure0', 'value')..secure = true,
+        TestCookie('not-secure1', 'value'),
+        TestCookie('secure1', 'value')..secure = true,
+      ];
+
+      await cookieStore.saveFromResponse(uri, cookies);
+      var stored = await cookieStore.loadAll();
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'not-secure0=value',
+          'not-secure1=value',
+          'secure0=value',
+          'secure1=value',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(uri);
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'not-secure0=value',
+          'not-secure1=value',
+        ]),
+      );
+
+      stored = await cookieStore.loadForRequest(Uri(scheme: 'ftps', host: 'example.com'));
+      expect(
+        toSortedStringList(stored),
+        equals([
+          'not-secure0=value',
+          'not-secure1=value',
+          'secure0=value',
+          'secure1=value',
+        ]),
+      );
+    });
+  });
+}

--- a/packages/cookie_store_conformance_tests/lib/src/sorting_tests.dart
+++ b/packages/cookie_store_conformance_tests/lib/src/sorting_tests.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+
+import 'package:cookie_store/cookie_store.dart';
+import 'package:cookie_store_conformance_tests/src/utils.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+/// Tests that the store correctly sorts cookies on retrieval (optional).
+///
+/// The user agent SHOULD sort the cookie-list in the following order:
+///   * Cookies with longer paths are listed before cookies with shorter paths.
+///   * Among cookies that have equal-length path fields, cookies with earlier
+///     creation-times are listed before cookies with later creation-times.
+@isTestGroup
+void sortTests(
+  FutureOr<CookieStore> Function() cookieStoreFactory, {
+  bool canSortByPath = true,
+  bool canSortByCreationTime = true,
+}) {
+  late CookieStore cookieStore;
+
+  setUp(() async {
+    cookieStore = await cookieStoreFactory();
+  });
+
+  group('sort cookies,', () {
+    test(
+      'by path length',
+      () async {
+        final cookies = [
+          TestCookie('root', 'value')..path = '/',
+          TestCookie('docs', 'value')..path = '/docs/',
+          TestCookie('docs-Web', 'value')..path = '/docs/Web/',
+          TestCookie('docs-Web-HTTP', 'value')..path = '/docs/Web/HTTP',
+        ];
+
+        await cookieStore.saveFromResponse(Uri(path: '/'), cookies);
+        final stored = await cookieStore.loadForRequest(Uri(path: '/docs/Web/HTTP'));
+        expect(
+          toStringList(stored),
+          equals([
+            'docs-Web-HTTP=value',
+            'docs-Web=value',
+            'docs=value',
+            'root=value',
+          ]),
+        );
+      },
+      skip: canSortByPath ? false : 'does not support sorting by path length',
+    );
+
+    test(
+      'by access time',
+      () async {
+        var cookies = [
+          TestCookie('root', 'value')..path = '/',
+          TestCookie('docs', 'value')..path = '/docs/',
+          TestCookie('docs-Web', 'value')..path = '/docs/Web/',
+          TestCookie('docs-Web-HTTP', 'value')..path = '/docs/Web/HTTP',
+        ];
+
+        await cookieStore.saveFromResponse(Uri(path: '/'), cookies);
+        var stored = await cookieStore.loadForRequest(Uri(path: '/docs/Web/HTTP'));
+        expect(
+          toStringList(stored),
+          equals([
+            'docs-Web-HTTP=value',
+            'docs-Web=value',
+            'docs=value',
+            'root=value',
+          ]),
+        );
+
+        cookies = [
+          TestCookie('later-written', 'value')..path = '/docs/Web/',
+        ];
+        await cookieStore.saveFromResponse(Uri(path: '/'), cookies);
+        stored = await cookieStore.loadForRequest(Uri(path: '/docs/Web/HTTP'));
+        expect(
+          toStringList(stored),
+          equals([
+            'docs-Web-HTTP=value',
+            'docs-Web=value',
+            'later-written=value',
+            'docs=value',
+            'root=value',
+          ]),
+        );
+      },
+      skip: (canSortByPath && canSortByCreationTime) ? false : 'does not support sorting by creating time',
+    );
+  });
+}

--- a/packages/cookie_store_conformance_tests/lib/src/utils.dart
+++ b/packages/cookie_store_conformance_tests/lib/src/utils.dart
@@ -1,0 +1,49 @@
+import 'package:meta/meta.dart';
+import 'package:universal_io/io.dart';
+
+/// Converts the given cookies to strings containing only the [Cookie.name] and
+/// `Cookie.vale` and sorts the resulting list.
+@internal
+List<String> toSortedStringList(List<Cookie> cookies) {
+  return toStringList(cookies)..sort();
+}
+
+/// Converts the given cookies to strings containing only the [Cookie.name] and
+/// `Cookie.vale`.
+@internal
+List<String> toStringList(List<Cookie> cookies) {
+  return cookies.map((cookie) => '${cookie.name}=${cookie.value}').toList();
+}
+
+/// Cookie that sets the [secure] and [httpOnly] flag to false by default.
+@internal
+class TestCookie implements Cookie {
+  TestCookie(this.name, this.value);
+
+  @override
+  String name;
+
+  @override
+  String value;
+
+  @override
+  String? domain;
+
+  @override
+  DateTime? expires;
+
+  @override
+  bool httpOnly = false;
+
+  @override
+  int? maxAge;
+
+  @override
+  String? path;
+
+  @override
+  SameSite? sameSite;
+
+  @override
+  bool secure = false;
+}

--- a/packages/cookie_store_conformance_tests/pubspec.yaml
+++ b/packages/cookie_store_conformance_tests/pubspec.yaml
@@ -1,0 +1,23 @@
+name: cookie_store_conformance_tests
+description: >-
+  A library that tests whether implementations of package:cookie_store's `CookieStore`
+  class behave as expected.
+publish_to: none
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  cookie_store:
+    git:
+      url: https://github.com/nextcloud/neon
+      path: packages/cookie_store
+  meta: ^1.0.0
+  test: ^1.21.2
+  timezone: ^0.9.2
+  universal_io: ^2.0.0
+
+dev_dependencies:
+  neon_lints:
+    git:
+      url: https://github.com/nextcloud/neon
+      path: packages/neon_lints

--- a/packages/cookie_store_conformance_tests/pubspec_overrides.yaml
+++ b/packages/cookie_store_conformance_tests/pubspec_overrides.yaml
@@ -1,0 +1,6 @@
+# melos_managed_dependency_overrides: cookie_store,neon_lints
+dependency_overrides:
+  cookie_store:
+    path: ../cookie_store
+  neon_lints:
+    path: ../neon_lints


### PR DESCRIPTION
extracted from: #1907
Just a cherry pick with the `CookieJarAdapter` removed and the fixed typo