### PR TITLE
fix(neon_framework): Exclude computed fields from Account JSON

### DIFF
--- a/packages/neon_framework/lib/src/models/account.dart
+++ b/packages/neon_framework/lib/src/models/account.dart
@@ -82,15 +82,18 @@ class Account implements Credentials, Findable {
   int get hashCode => serverURL.hashCode + username.hashCode;
 
   /// An authenticated API client.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   late final NextcloudClient client;
 
   /// The unique ID of the account.
   ///
   /// Implemented in a primitive way hashing the [username] and [serverURL].
   @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   final String id;
 
   /// A human readable representation of [username] and [serverURL].
+  @JsonKey(includeFromJson: false, includeToJson: false)
   final String humanReadableID;
 
   /// Builds a human readable id for a user and server pair.


### PR DESCRIPTION
https://github.com/nextcloud/neon/pull/1907/commits/e82b46964cb4e76522e918f55dff3af86dafc428
The NextcloudClient is not even serializable, so json_serializable fails when build_runner is executed.