### PR TITLE
fix(tool): search for bash in path

### DIFF
--- a/tool/build-app.sh
+++ b/tool/build-app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 source tool/common.sh

--- a/tool/build-dev-container.sh
+++ b/tool/build-dev-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 source tool/common.sh

--- a/tool/build/linux.sh
+++ b/tool/build/linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 if [ ! -f /.dockerenv ]; then

--- a/tool/cloc.sh
+++ b/tool/cloc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/common.sh
+++ b/tool/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 function image_tag() {

--- a/tool/dev.sh
+++ b/tool/dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 source tool/common.sh

--- a/tool/find-relative-markdown-links.sh
+++ b/tool/find-relative-markdown-links.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/find-untested-neon-apis.sh
+++ b/tool/find-untested-neon-apis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/generate-assets.sh
+++ b/tool/generate-assets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/generate-docs.sh
+++ b/tool/generate-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/generate-dynamite-e2e-test.sh
+++ b/tool/generate-dynamite-e2e-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/generate-dynamite-petstore-example.sh
+++ b/tool/generate-dynamite-petstore-example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/generate-file-icons.sh
+++ b/tool/generate-file-icons.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/generate-nextcloud-test-presets.sh
+++ b/tool/generate-nextcloud-test-presets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/generate-nextcloud.sh
+++ b/tool/generate-nextcloud.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/generate-specs.sh
+++ b/tool/generate-specs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/send-push-notification-test.sh
+++ b/tool/send-push-notification-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 source tool/common.sh

--- a/tool/setup.sh
+++ b/tool/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/update-cspell-dictionaries.sh
+++ b/tool/update-cspell-dictionaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
Not all linux distributions have bash installed at `/bin/bash`. Using the current path to search for the bash executable.
Another idea would be to directly use `/bin/sh` although I did not want to check whether all our scripts are compatible with plain posix shell (I doubt it).

I did succesfully test that this also works on OSX