### PR TITLE
chore: update lints to dart 3.4.0

### DIFF
--- a/packages/dynamite/dynamite/lib/dynamite.dart
+++ b/packages/dynamite/dynamite/lib/dynamite.dart
@@ -6,6 +6,6 @@
 /// This library is **not** intended to be imported by typical end-users unless
 /// you are creating a custom compilation pipeline. See documentation for
 /// details, and `build.yaml` for how these builders are configured by default.
-library dynamite;
+library;
 
 export 'src/openapi_builder.dart';

--- a/packages/dynamite/dynamite_runtime/lib/built_value.dart
+++ b/packages/dynamite/dynamite_runtime/lib/built_value.dart
@@ -2,7 +2,7 @@
 ///
 /// Generated clients SHOULD NOT re export this library. It is only needed by
 /// the generated code itself.
-library built_value;
+library;
 
 export 'src/built_value/content_string_serializer.dart';
 export 'src/built_value/double_serializer.dart';

--- a/packages/dynamite/dynamite_runtime/lib/http_client.dart
+++ b/packages/dynamite/dynamite_runtime/lib/http_client.dart
@@ -1,7 +1,7 @@
 /// The dynamite client to handle http connections.
 ///
 /// Generated clients MAY re export this library.
-library http_client;
+library;
 
 export 'src/client/authentication.dart';
 export 'src/client/client.dart';

--- a/packages/dynamite/dynamite_runtime/lib/models.dart
+++ b/packages/dynamite/dynamite_runtime/lib/models.dart
@@ -1,7 +1,7 @@
 /// Common data models used in the generated code.
 ///
 /// Generated clients MAY re export this library.
-library models;
+library;
 
 export 'src/models/content_string.dart';
 export 'src/models/header.dart';

--- a/packages/dynamite/dynamite_runtime/lib/utils.dart
+++ b/packages/dynamite/dynamite_runtime/lib/utils.dart
@@ -2,7 +2,7 @@
 ///
 /// Generated clients SHOULD NOT re export this library. It is only needed by
 /// the client itself.
-library utils;
+library;
 
 export 'src/utils/byte_stream_extension.dart';
 export 'src/utils/codecs.dart';

--- a/packages/neon/neon_dashboard/lib/neon_dashboard.dart
+++ b/packages/neon/neon_dashboard/lib/neon_dashboard.dart
@@ -1,7 +1,7 @@
 /// The Neon client for the Dashboard app.
 ///
 /// Add `DashboardApp()` to your runNeon command to execute this app.
-library neon_dashboard;
+library;
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';

--- a/packages/neon/neon_files/lib/neon_files.dart
+++ b/packages/neon/neon_files/lib/neon_files.dart
@@ -1,7 +1,7 @@
 /// The Neon client for the Files app.
 ///
 /// Add `FilesApp()` to your runNeon command to execute this app.
-library neon_files;
+library;
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';

--- a/packages/neon/neon_news/lib/neon_news.dart
+++ b/packages/neon/neon_news/lib/neon_news.dart
@@ -1,7 +1,7 @@
 /// The Neon client for the News app.
 ///
 /// Add `NewsApp()` to your runNeon command to execute this app.
-library neon_news;
+library;
 
 import 'dart:async';
 

--- a/packages/neon/neon_notes/lib/neon_notes.dart
+++ b/packages/neon/neon_notes/lib/neon_notes.dart
@@ -1,7 +1,7 @@
 /// The Neon client for the Notes app.
 ///
 /// Add `NotesApp()` to your runNeon command to execute this app.
-library neon_notes;
+library;
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';

--- a/packages/neon/neon_notifications/lib/neon_notifications.dart
+++ b/packages/neon/neon_notifications/lib/neon_notifications.dart
@@ -1,7 +1,7 @@
 /// The Neon client for the Notifications app.
 ///
 /// Add `NotificationsApp()` to your runNeon command to execute this app.
-library neon_notifications;
+library;
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';

--- a/packages/neon/neon_talk/lib/neon_talk.dart
+++ b/packages/neon/neon_talk/lib/neon_talk.dart
@@ -1,7 +1,7 @@
 /// The Neon client for the Talk app.
 ///
 /// Add `TalkApp()` to your runNeon command to execute this app.
-library neon_talk;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';

--- a/packages/neon_framework/lib/models.dart
+++ b/packages/neon_framework/lib/models.dart
@@ -6,7 +6,7 @@
 /// client.
 ///
 /// {@canonicalFor label_builder.LabelBuilder}
-library models;
+library;
 
 export 'package:neon_framework/src/models/account.dart' hide Credentials, LoginQRcode;
 export 'package:neon_framework/src/models/app_implementation.dart';

--- a/packages/neon_lints/lib/src/base.yaml
+++ b/packages/neon_lints/lib/src/base.yaml
@@ -98,6 +98,7 @@ linter:
     lines_longer_than_80_chars: false
     literal_only_boolean_expressions: true
     matching_super_parameters: true
+    missing_code_block_language_in_doc_comment: true
     missing_whitespace_between_adjacent_strings: true
     no_adjacent_strings_in_list: true
     no_default_cases: false
@@ -189,6 +190,7 @@ linter:
     unnecessary_lambdas: true
     unnecessary_late: true
     unnecessary_library_directive: true
+    unnecessary_library_name: true
     unnecessary_new: true
     unnecessary_null_aware_assignments: true
     unnecessary_null_aware_operator_on_extension_on_nullable: true


### PR DESCRIPTION
fixes the `unnecessary_library_name` rule.

I initially thought that this might be breaking but according to the lint documentation:
> The only use of a library name is for a `part` file to refer back to its owning library, but part files should prefer to use a string URI to refer back to the library file, not a library name.
