### PR TITLE
chore: Suppress offscreen tap warnings

### DIFF
--- a/packages/neon/neon_talk/test/reactions_test.dart
+++ b/packages/neon/neon_talk/test/reactions_test.dart
@@ -73,7 +73,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('😀'));
+    await tester.tap(find.text('😀'), warnIfMissed: false);
 
     verify(() => bloc.addReaction(chatMessage, '😀')).called(1);
   });
@@ -90,7 +90,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('😊'));
+    await tester.tap(find.text('😊'), warnIfMissed: false);
 
     verify(() => bloc.removeReaction(chatMessage, '😊')).called(1);
   });
@@ -110,7 +110,7 @@ void main() {
     );
 
     await tester.runAsync(() async {
-      await tester.tap(find.byIcon(Icons.add_reaction_outlined));
+      await tester.tap(find.byIcon(Icons.add_reaction_outlined), warnIfMissed: false);
       await tester.pumpAndSettle();
       await tester.tap(find.byIcon(Icons.tag_faces));
       await tester.pumpAndSettle();

--- a/packages/neon_framework/test/autocomplete_test.dart
+++ b/packages/neon_framework/test/autocomplete_test.dart
@@ -103,7 +103,7 @@ void main() {
     await tester.enterText(find.byType(TextFormField), 't');
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('test'));
+    await tester.tap(find.text('test'), warnIfMissed: false);
     await tester.pumpAndSettle();
 
     await tester.testTextInput.receiveAction(TextInputAction.done);


### PR DESCRIPTION
Due to the way the widgets are rendered in tests these targets appear offscreen, but it is totally fine in the tests.