### PR TITLE
test(neon_dashboard): Test for widget item without iconUrl

### DIFF
--- a/packages/neon/neon_dashboard/test/set_weather_location_dialog_test.dart
+++ b/packages/neon/neon_dashboard/test/set_weather_location_dialog_test.dart
@@ -41,7 +41,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField), 'Berlin');
 
-    await tester.tap(find.byType(ElevatedButton));
+    await tester.testTextInput.receiveAction(TextInputAction.done);
     await tester.pumpAndSettle();
 
     expect(await future, 'Berlin');

--- a/packages/neon/neon_dashboard/test/widget_test.dart
+++ b/packages/neon/neon_dashboard/test/widget_test.dart
@@ -143,6 +143,21 @@ void main() {
 
       expect(find.byType(NeonUriImage), findsOneWidget);
     });
+
+    testWidgets('Without iconUrl', (tester) async {
+      await tester.pumpWidget(
+        wrapWidget(
+          accountsBloc,
+          DashboardWidgetItem(
+            item: item.rebuild((b) => b..iconUrl = ''),
+            roundIcon: true,
+          ),
+        ),
+      );
+
+      expect(find.byType(NeonUriImage), findsOneWidget);
+      expect(find.byIcon(AdaptiveIcons.question_mark), findsOneWidget);
+    });
   });
 
   group('Widget button', () {


### PR DESCRIPTION
Simple wins to increase code coverage.