### PR TITLE
fix(tool): Filter out logs in build-app script when getting mounts

### DIFF
--- a/tool/build-app.sh
+++ b/tool/build-app.sh
@@ -5,13 +5,13 @@ source tool/common.sh
 
 function get_mount_paths_dir() {
   dir="$1"
-  mapfile -t packages < <(melos list --parsable --relative --dir-exists="$dir")
+  mapfile -t packages < <(melos list --parsable --relative --dir-exists="$dir" | grep "^packages/")
   echo "${packages[@]/%//$dir}"
 }
 
 function get_mount_paths_file() {
   file="$1"
-  mapfile -t packages < <(melos list --parsable --relative --file-exists="$file")
+  mapfile -t packages < <(melos list --parsable --relative --file-exists="$file" | grep "^packages/")
   echo "${packages[@]/%//$file}"
 }
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/2104
For some reasons the pub stdout started [containing messages like `'MSG : Logs written to /home/runner/.pub-cache/log/pub_log.txt./lib'`](https://github.com/nextcloud/neon/actions/runs/9313314365/job/25635538275) which were added as paths, but obviously they don't exist so this made the mounting fail.
This just filters all lines that are actually paths, so no other logs can sneak in there.