### PR TITLE
fix(dynamite)!: Handle nullable generics and serializers correctly

### DIFF
--- a/packages/dynamite/dynamite/lib/src/builder/resolve_enum.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_enum.dart
@@ -12,7 +12,9 @@ import 'package:source_helper/source_helper.dart';
 TypeResult resolveEnum(State state, json_schema.JsonSchema schema, TypeResult subResult) {
   final identifier = schema.identifier!;
 
-  if (state.resolvedTypes.add(TypeResultEnum(identifier, subResult))) {
+  final result = TypeResultEnum(identifier, subResult);
+  state.resolvedSerializers.addAll(result.serializers);
+  if (state.resolvedTypes.add(result)) {
     final values = <({String dartName, Object? value, String name})>[];
     for (final enumValue in schema.$enum!) {
       final name = enumValue.toString();

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_interface.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_interface.dart
@@ -168,6 +168,7 @@ void _generateProperties(
         generics: BuiltList([result]),
         nullable: result.nullable,
       );
+      state.resolvedSerializers.addAll(result.serializers);
       state.resolvedTypes.add(result);
     }
 

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_object.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_object.dart
@@ -14,6 +14,7 @@ TypeResultObject resolveObject(
     nullable: schema.nullable,
   );
 
+  state.resolvedSerializers.addAll(result.serializers);
   if (state.resolvedTypes.add(result)) {
     final $interface = buildInterface(
       state,

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_ofs.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_ofs.dart
@@ -45,19 +45,22 @@ TypeResult resolveSomeOf(State state, json_schema.JsonSchema schema) {
       throw StateError('allOf should be handled with inheritance');
   }
 
-  if (state.resolvedTypes.add(result) && !result.isSingleValue) {
-    final $typedef = TypeDef((b) {
-      b
-        ..docs.addAll(escapeDescription(schema.formattedDescription()))
-        ..name = result.className
-        ..definition = refer(result.dartType.name);
+  if (!result.isSingleValue) {
+    state.resolvedSerializers.addAll(result.serializers);
+    if (state.resolvedTypes.add(result)) {
+      final $typedef = TypeDef((b) {
+        b
+          ..docs.addAll(escapeDescription(schema.formattedDescription()))
+          ..name = result.className
+          ..definition = refer(result.dartType.name);
 
-      if (schema.deprecated) {
-        b.annotations.add(refer('Deprecated').call([refer("''")]));
-      }
-    });
+        if (schema.deprecated) {
+          b.annotations.add(refer('Deprecated').call([refer("''")]));
+        }
+      });
 
-    state.output.add($typedef);
+      state.output.add($typedef);
+    }
   }
 
   return result;

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_type.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_type.dart
@@ -15,6 +15,7 @@ TypeResult resolveType(State state, json_schema.JsonSchema schema) {
     schema,
   );
 
+  state.resolvedSerializers.addAll(result.serializers);
   state.resolvedTypes.add(result);
   return result;
 }

--- a/packages/dynamite/dynamite/lib/src/builder/serializer.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/serializer.dart
@@ -22,14 +22,12 @@ List<Spec> buildSerializer(State state) => [
           ..type = refer('Serializers', 'package:built_value/serializer.dart')
           ..name = r'_$serializers';
 
-        final serializers = state.resolvedTypes.map((type) => type.serializers).expand((element) => element).toSet();
-
-        if (serializers.isEmpty) {
+        if (state.resolvedSerializers.isEmpty) {
           b.assignment = const Code('Serializers()');
         } else {
           final bodyBuilder = StringBuffer()
             ..writeln('(Serializers().toBuilder()')
-            ..writeAll(serializers, '\n')
+            ..writeAll(state.resolvedSerializers, '\n')
             ..writeln(').build()');
 
           b.assignment = Code(bodyBuilder.toString());

--- a/packages/dynamite/dynamite/lib/src/builder/state.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/state.dart
@@ -41,6 +41,7 @@ class State {
 
   final output = <Spec>[];
   final resolvedTypes = <TypeResult>{};
+  final resolvedSerializers = <String>{};
   late final emitter = DartEmitter(
     allocator: _Allocator(partId: partId),
     orderDirectives: true,

--- a/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.dart
@@ -24,6 +24,7 @@ import 'package:meta/meta.dart' as _i2;
 part 'types.openapi.g.dart';
 
 typedef $Object = dynamic;
+typedef ObjectNullable = dynamic;
 typedef $String = dynamic;
 typedef $Uri = dynamic;
 typedef $Uint8List = dynamic;
@@ -253,6 +254,8 @@ abstract interface class $AdditionalPropertiesInterface {
   BuiltMap<String, BuiltMap<String, JsonObject>>? get nested;
   @BuiltValueField(wireName: 'Object')
   BuiltMap<String, JsonObject>? get object;
+  @BuiltValueField(wireName: 'ObjectNullable')
+  BuiltMap<String, JsonObject?>? get objectNullable;
   @BuiltValueField(wireName: 'bool')
   BuiltMap<String, bool>? get $bool;
   BuiltMap<String, int>? get integer;
@@ -262,7 +265,7 @@ abstract interface class $AdditionalPropertiesInterface {
   BuiltMap<String, num>? get $num;
   BuiltMap<String, String>? get string;
   @BuiltValueField(wireName: 'content-string')
-  BuiltMap<String, ContentString<int>>? get contentString;
+  BuiltMap<String, ContentString<int>?>? get contentString;
   @BuiltValueField(wireName: 'string-binary')
   BuiltMap<String, Uint8List>? get stringBinary;
   BuiltMap<String, BuiltList<JsonObject>>? get list;
@@ -338,6 +341,10 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ]),
         MapBuilder<String, BuiltMap<String, JsonObject>>.new,
       )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType.nullable(JsonObject)]),
+        MapBuilder<String, JsonObject?>.new,
+      )
       ..addBuilderFactory(const FullType(BuiltMap, [FullType(String), FullType(bool)]), MapBuilder<String, bool>.new)
       ..addBuilderFactory(const FullType(BuiltMap, [FullType(String), FullType(int)]), MapBuilder<String, int>.new)
       ..addBuilderFactory(
@@ -352,9 +359,9 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
         const FullType(BuiltMap, [
           FullType(String),
-          FullType(ContentString, [FullType(int)]),
+          FullType.nullable(ContentString, [FullType(int)]),
         ]),
-        MapBuilder<String, ContentString<int>>.new,
+        MapBuilder<String, ContentString<int>?>.new,
       )
       ..addBuilderFactory(
         const FullType(BuiltMap, [FullType(String), FullType(Uint8List)]),

--- a/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.g.dart
@@ -283,6 +283,13 @@ class _$AdditionalPropertiesSerializer implements StructuredSerializer<Additiona
         ..add(serializers.serialize(value,
             specifiedType: const FullType(BuiltMap, [FullType(String), FullType(JsonObject)])));
     }
+    value = object.objectNullable;
+    if (value != null) {
+      result
+        ..add('ObjectNullable')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltMap, [FullType(String), FullType.nullable(JsonObject)])));
+    }
     value = object.$bool;
     if (value != null) {
       result
@@ -323,7 +330,7 @@ class _$AdditionalPropertiesSerializer implements StructuredSerializer<Additiona
         ..add(serializers.serialize(value,
             specifiedType: const FullType(BuiltMap, [
               FullType(String),
-              FullType(ContentString, [FullType(int)])
+              FullType.nullable(ContentString, [FullType(int)])
             ])));
     }
     value = object.stringBinary;
@@ -396,6 +403,10 @@ class _$AdditionalPropertiesSerializer implements StructuredSerializer<Additiona
           result.object.replace(serializers.deserialize(value,
               specifiedType: const FullType(BuiltMap, [FullType(String), FullType(JsonObject)]))!);
           break;
+        case 'ObjectNullable':
+          result.objectNullable.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, [FullType(String), FullType.nullable(JsonObject)]))!);
+          break;
         case 'bool':
           result.$bool.replace(serializers.deserialize(value,
               specifiedType: const FullType(BuiltMap, [FullType(String), FullType(bool)]))!);
@@ -420,7 +431,7 @@ class _$AdditionalPropertiesSerializer implements StructuredSerializer<Additiona
           result.contentString.replace(serializers.deserialize(value,
               specifiedType: const FullType(BuiltMap, [
                 FullType(String),
-                FullType(ContentString, [FullType(int)])
+                FullType.nullable(ContentString, [FullType(int)])
               ]))!);
           break;
         case 'string-binary':
@@ -1016,6 +1027,9 @@ abstract mixin class $AdditionalPropertiesInterfaceBuilder {
   MapBuilder<String, JsonObject> get object;
   set object(MapBuilder<String, JsonObject>? object);
 
+  MapBuilder<String, JsonObject?> get objectNullable;
+  set objectNullable(MapBuilder<String, JsonObject?>? objectNullable);
+
   MapBuilder<String, bool> get $bool;
   set $bool(MapBuilder<String, bool>? $bool);
 
@@ -1031,8 +1045,8 @@ abstract mixin class $AdditionalPropertiesInterfaceBuilder {
   MapBuilder<String, String> get string;
   set string(MapBuilder<String, String>? string);
 
-  MapBuilder<String, ContentString<int>> get contentString;
-  set contentString(MapBuilder<String, ContentString<int>>? contentString);
+  MapBuilder<String, ContentString<int>?> get contentString;
+  set contentString(MapBuilder<String, ContentString<int>?>? contentString);
 
   MapBuilder<String, Uint8List> get stringBinary;
   set stringBinary(MapBuilder<String, Uint8List>? stringBinary);
@@ -1057,6 +1071,8 @@ class _$AdditionalProperties extends AdditionalProperties {
   @override
   final BuiltMap<String, JsonObject>? object;
   @override
+  final BuiltMap<String, JsonObject?>? objectNullable;
+  @override
   final BuiltMap<String, bool>? $bool;
   @override
   final BuiltMap<String, int>? integer;
@@ -1067,7 +1083,7 @@ class _$AdditionalProperties extends AdditionalProperties {
   @override
   final BuiltMap<String, String>? string;
   @override
-  final BuiltMap<String, ContentString<int>>? contentString;
+  final BuiltMap<String, ContentString<int>?>? contentString;
   @override
   final BuiltMap<String, Uint8List>? stringBinary;
   @override
@@ -1085,6 +1101,7 @@ class _$AdditionalProperties extends AdditionalProperties {
       this.emptySchema,
       this.nested,
       this.object,
+      this.objectNullable,
       this.$bool,
       this.integer,
       this.$double,
@@ -1112,6 +1129,7 @@ class _$AdditionalProperties extends AdditionalProperties {
         emptySchema == other.emptySchema &&
         nested == other.nested &&
         object == other.object &&
+        objectNullable == other.objectNullable &&
         $bool == other.$bool &&
         integer == other.integer &&
         $double == other.$double &&
@@ -1131,6 +1149,7 @@ class _$AdditionalProperties extends AdditionalProperties {
     _$hash = $jc(_$hash, emptySchema.hashCode);
     _$hash = $jc(_$hash, nested.hashCode);
     _$hash = $jc(_$hash, object.hashCode);
+    _$hash = $jc(_$hash, objectNullable.hashCode);
     _$hash = $jc(_$hash, $bool.hashCode);
     _$hash = $jc(_$hash, integer.hashCode);
     _$hash = $jc(_$hash, $double.hashCode);
@@ -1152,6 +1171,7 @@ class _$AdditionalProperties extends AdditionalProperties {
           ..add('emptySchema', emptySchema)
           ..add('nested', nested)
           ..add('object', object)
+          ..add('objectNullable', objectNullable)
           ..add('\$bool', $bool)
           ..add('integer', integer)
           ..add('\$double', $double)
@@ -1188,6 +1208,11 @@ class AdditionalPropertiesBuilder
   MapBuilder<String, JsonObject> get object => _$this._object ??= MapBuilder<String, JsonObject>();
   set object(covariant MapBuilder<String, JsonObject>? object) => _$this._object = object;
 
+  MapBuilder<String, JsonObject?>? _objectNullable;
+  MapBuilder<String, JsonObject?> get objectNullable => _$this._objectNullable ??= MapBuilder<String, JsonObject?>();
+  set objectNullable(covariant MapBuilder<String, JsonObject?>? objectNullable) =>
+      _$this._objectNullable = objectNullable;
+
   MapBuilder<String, bool>? _$bool;
   MapBuilder<String, bool> get $bool => _$this._$bool ??= MapBuilder<String, bool>();
   set $bool(covariant MapBuilder<String, bool>? $bool) => _$this._$bool = $bool;
@@ -1208,10 +1233,10 @@ class AdditionalPropertiesBuilder
   MapBuilder<String, String> get string => _$this._string ??= MapBuilder<String, String>();
   set string(covariant MapBuilder<String, String>? string) => _$this._string = string;
 
-  MapBuilder<String, ContentString<int>>? _contentString;
-  MapBuilder<String, ContentString<int>> get contentString =>
-      _$this._contentString ??= MapBuilder<String, ContentString<int>>();
-  set contentString(covariant MapBuilder<String, ContentString<int>>? contentString) =>
+  MapBuilder<String, ContentString<int>?>? _contentString;
+  MapBuilder<String, ContentString<int>?> get contentString =>
+      _$this._contentString ??= MapBuilder<String, ContentString<int>?>();
+  set contentString(covariant MapBuilder<String, ContentString<int>?>? contentString) =>
       _$this._contentString = contentString;
 
   MapBuilder<String, Uint8List>? _stringBinary;
@@ -1242,6 +1267,7 @@ class AdditionalPropertiesBuilder
       _emptySchema = $v.emptySchema?.toBuilder();
       _nested = $v.nested?.toBuilder();
       _object = $v.object?.toBuilder();
+      _objectNullable = $v.objectNullable?.toBuilder();
       _$bool = $v.$bool?.toBuilder();
       _integer = $v.integer?.toBuilder();
       _$double = $v.$double?.toBuilder();
@@ -1281,6 +1307,7 @@ class AdditionalPropertiesBuilder
               emptySchema: _emptySchema?.build(),
               nested: _nested?.build(),
               object: _object?.build(),
+              objectNullable: _objectNullable?.build(),
               $bool: _$bool?.build(),
               integer: _integer?.build(),
               $double: _$double?.build(),
@@ -1302,6 +1329,8 @@ class AdditionalPropertiesBuilder
         _nested?.build();
         _$failedField = 'object';
         _object?.build();
+        _$failedField = 'objectNullable';
+        _objectNullable?.build();
         _$failedField = '\$bool';
         _$bool?.build();
         _$failedField = 'integer';

--- a/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.json
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/types.openapi.json
@@ -141,6 +141,10 @@
             "Object": {
                 "type": "object"
             },
+            "ObjectNullable": {
+                "type": "object",
+                "nullable": true
+            },
             "AdditionalProperties": {
                 "type": "object",
                 "properties": {
@@ -163,6 +167,13 @@
                         "type": "object",
                         "additionalProperties": {
                             "type": "object"
+                        }
+                    },
+                    "ObjectNullable": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "nullable": true
                         }
                     },
                     "bool": {

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -6543,7 +6543,7 @@ abstract class AutoCompleteGetResponseApplicationJson
 @BuiltValue(instantiable: false)
 abstract interface class $AvatarAvatarGetAvatarDarkHeadersInterface {
   @BuiltValueField(wireName: 'x-nc-iscustomavatar')
-  Header<int>? get xNcIscustomavatar;
+  Header<int?>? get xNcIscustomavatar;
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -6594,7 +6594,7 @@ abstract class AvatarAvatarGetAvatarDarkHeaders
 @BuiltValue(instantiable: false)
 abstract interface class $AvatarAvatarGetAvatarHeadersInterface {
   @BuiltValueField(wireName: 'x-nc-iscustomavatar')
-  Header<int>? get xNcIscustomavatar;
+  Header<int?>? get xNcIscustomavatar;
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AvatarAvatarGetAvatarHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -8642,7 +8642,7 @@ class _$OcmOcmDiscoveryHeaders_XNextcloudOcmProvidersSerializer
 @BuiltValue(instantiable: false)
 abstract interface class $OcmOcmDiscoveryHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-ocm-providers')
-  Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? get xNextcloudOcmProviders;
+  Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?>? get xNextcloudOcmProviders;
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($OcmOcmDiscoveryHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -12908,7 +12908,7 @@ abstract class Reference implements $ReferenceInterface, Built<Reference, Refere
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiExtractResponseApplicationJson_Ocs_DataInterface {
-  BuiltMap<String, Reference> get references;
+  BuiltMap<String, Reference?> get references;
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13066,7 +13066,7 @@ abstract class ReferenceApiExtractResponseApplicationJson
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterface {
-  BuiltMap<String, Reference> get references;
+  BuiltMap<String, Reference?> get references;
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -13225,7 +13225,7 @@ abstract class ReferenceApiResolveOneResponseApplicationJson
 
 @BuiltValue(instantiable: false)
 abstract interface class $ReferenceApiResolveResponseApplicationJson_Ocs_DataInterface {
-  BuiltMap<String, Reference> get references;
+  BuiltMap<String, Reference?> get references;
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -18212,7 +18212,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..addBuilderFactory(const FullType(AvatarAvatarGetAvatarDarkHeaders), AvatarAvatarGetAvatarDarkHeadersBuilder.new)
       ..add(AvatarAvatarGetAvatarDarkHeaders.serializer)
-      ..addBuilderFactory(const FullType(Header, [FullType(int)]), HeaderBuilder<int>.new)
+      ..addBuilderFactory(const FullType(Header, [FullType.nullable(int)]), HeaderBuilder<int?>.new)
       ..add(Header.serializer)
       ..addBuilderFactory(const FullType(AvatarAvatarGetAvatarHeaders), AvatarAvatarGetAvatarHeadersBuilder.new)
       ..add(AvatarAvatarGetAvatarHeaders.serializer)
@@ -18378,8 +18378,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(OcmOcmDiscoveryHeaders.serializer)
       ..add(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders.serializer)
       ..addBuilderFactory(
-        const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)]),
-        HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>.new,
+        const FullType(Header, [FullType.nullable(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)]),
+        HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?>.new,
       )
       ..addBuilderFactory(
         const FullType(OcsGetCapabilitiesResponseApplicationJson),
@@ -18670,8 +18670,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(Reference), ReferenceBuilder.new)
       ..add(Reference.serializer)
       ..addBuilderFactory(
-        const FullType(BuiltMap, [FullType(String), FullType(Reference)]),
-        MapBuilder<String, Reference>.new,
+        const FullType(BuiltMap, [FullType(String), FullType.nullable(Reference)]),
+        MapBuilder<String, Reference?>.new,
       )
       ..addBuilderFactory(
         const FullType(ReferenceApiResolveOneResponseApplicationJson),

--- a/packages/nextcloud/lib/src/api/core.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.g.dart
@@ -1661,7 +1661,7 @@ class _$AvatarAvatarGetAvatarDarkHeadersSerializer implements StructuredSerializ
     if (value != null) {
       result
         ..add('x-nc-iscustomavatar')
-        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType(int)])));
+        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType.nullable(int)])));
     }
     return result;
   }
@@ -1678,8 +1678,8 @@ class _$AvatarAvatarGetAvatarDarkHeadersSerializer implements StructuredSerializ
       final Object? value = iterator.current;
       switch (key) {
         case 'x-nc-iscustomavatar':
-          result.xNcIscustomavatar.replace(
-              serializers.deserialize(value, specifiedType: const FullType(Header, [FullType(int)]))! as Header<int>);
+          result.xNcIscustomavatar.replace(serializers.deserialize(value,
+              specifiedType: const FullType(Header, [FullType.nullable(int)]))! as Header<int?>);
           break;
       }
     }
@@ -1703,7 +1703,7 @@ class _$AvatarAvatarGetAvatarHeadersSerializer implements StructuredSerializer<A
     if (value != null) {
       result
         ..add('x-nc-iscustomavatar')
-        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType(int)])));
+        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType.nullable(int)])));
     }
     return result;
   }
@@ -1720,8 +1720,8 @@ class _$AvatarAvatarGetAvatarHeadersSerializer implements StructuredSerializer<A
       final Object? value = iterator.current;
       switch (key) {
         case 'x-nc-iscustomavatar':
-          result.xNcIscustomavatar.replace(
-              serializers.deserialize(value, specifiedType: const FullType(Header, [FullType(int)]))! as Header<int>);
+          result.xNcIscustomavatar.replace(serializers.deserialize(value,
+              specifiedType: const FullType(Header, [FullType.nullable(int)]))! as Header<int?>);
           break;
       }
     }
@@ -3396,7 +3396,7 @@ class _$OcmOcmDiscoveryHeadersSerializer implements StructuredSerializer<OcmOcmD
       result
         ..add('x-nextcloud-ocm-providers')
         ..add(serializers.serialize(value,
-            specifiedType: const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)])));
+            specifiedType: const FullType(Header, [FullType.nullable(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)])));
     }
     return result;
   }
@@ -3414,8 +3414,9 @@ class _$OcmOcmDiscoveryHeadersSerializer implements StructuredSerializer<OcmOcmD
       switch (key) {
         case 'x-nextcloud-ocm-providers':
           result.xNextcloudOcmProviders.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(Header, [FullType(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)]))!
-              as Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>);
+                  specifiedType:
+                      const FullType(Header, [FullType.nullable(OcmOcmDiscoveryHeaders_XNextcloudOcmProviders)]))!
+              as Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?>);
           break;
       }
     }
@@ -7046,7 +7047,7 @@ class _$ReferenceApiExtractResponseApplicationJson_Ocs_DataSerializer
     final result = <Object?>[
       'references',
       serializers.serialize(object.references,
-          specifiedType: const FullType(BuiltMap, [FullType(String), FullType(Reference)])),
+          specifiedType: const FullType(BuiltMap, [FullType(String), FullType.nullable(Reference)])),
     ];
 
     return result;
@@ -7065,7 +7066,7 @@ class _$ReferenceApiExtractResponseApplicationJson_Ocs_DataSerializer
       switch (key) {
         case 'references':
           result.references.replace(serializers.deserialize(value,
-              specifiedType: const FullType(BuiltMap, [FullType(String), FullType(Reference)]))!);
+              specifiedType: const FullType(BuiltMap, [FullType(String), FullType.nullable(Reference)]))!);
           break;
       }
     }
@@ -7184,7 +7185,7 @@ class _$ReferenceApiResolveOneResponseApplicationJson_Ocs_DataSerializer
     final result = <Object?>[
       'references',
       serializers.serialize(object.references,
-          specifiedType: const FullType(BuiltMap, [FullType(String), FullType(Reference)])),
+          specifiedType: const FullType(BuiltMap, [FullType(String), FullType.nullable(Reference)])),
     ];
 
     return result;
@@ -7204,7 +7205,7 @@ class _$ReferenceApiResolveOneResponseApplicationJson_Ocs_DataSerializer
       switch (key) {
         case 'references':
           result.references.replace(serializers.deserialize(value,
-              specifiedType: const FullType(BuiltMap, [FullType(String), FullType(Reference)]))!);
+              specifiedType: const FullType(BuiltMap, [FullType(String), FullType.nullable(Reference)]))!);
           break;
       }
     }
@@ -7324,7 +7325,7 @@ class _$ReferenceApiResolveResponseApplicationJson_Ocs_DataSerializer
     final result = <Object?>[
       'references',
       serializers.serialize(object.references,
-          specifiedType: const FullType(BuiltMap, [FullType(String), FullType(Reference)])),
+          specifiedType: const FullType(BuiltMap, [FullType(String), FullType.nullable(Reference)])),
     ];
 
     return result;
@@ -7343,7 +7344,7 @@ class _$ReferenceApiResolveResponseApplicationJson_Ocs_DataSerializer
       switch (key) {
         case 'references':
           result.references.replace(serializers.deserialize(value,
-              specifiedType: const FullType(BuiltMap, [FullType(String), FullType(Reference)]))!);
+              specifiedType: const FullType(BuiltMap, [FullType(String), FullType.nullable(Reference)]))!);
           break;
       }
     }
@@ -13222,13 +13223,13 @@ class AutoCompleteGetResponseApplicationJsonBuilder
 abstract mixin class $AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder {
   void replace($AvatarAvatarGetAvatarDarkHeadersInterface other);
   void update(void Function($AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder) updates);
-  HeaderBuilder<int> get xNcIscustomavatar;
-  set xNcIscustomavatar(HeaderBuilder<int>? xNcIscustomavatar);
+  HeaderBuilder<int?> get xNcIscustomavatar;
+  set xNcIscustomavatar(HeaderBuilder<int?>? xNcIscustomavatar);
 }
 
 class _$AvatarAvatarGetAvatarDarkHeaders extends AvatarAvatarGetAvatarDarkHeaders {
   @override
-  final Header<int>? xNcIscustomavatar;
+  final Header<int?>? xNcIscustomavatar;
 
   factory _$AvatarAvatarGetAvatarDarkHeaders([void Function(AvatarAvatarGetAvatarDarkHeadersBuilder)? updates]) =>
       (AvatarAvatarGetAvatarDarkHeadersBuilder()..update(updates))._build();
@@ -13270,9 +13271,9 @@ class AvatarAvatarGetAvatarDarkHeadersBuilder
         $AvatarAvatarGetAvatarDarkHeadersInterfaceBuilder {
   _$AvatarAvatarGetAvatarDarkHeaders? _$v;
 
-  HeaderBuilder<int>? _xNcIscustomavatar;
-  HeaderBuilder<int> get xNcIscustomavatar => _$this._xNcIscustomavatar ??= HeaderBuilder<int>();
-  set xNcIscustomavatar(covariant HeaderBuilder<int>? xNcIscustomavatar) =>
+  HeaderBuilder<int?>? _xNcIscustomavatar;
+  HeaderBuilder<int?> get xNcIscustomavatar => _$this._xNcIscustomavatar ??= HeaderBuilder<int?>();
+  set xNcIscustomavatar(covariant HeaderBuilder<int?>? xNcIscustomavatar) =>
       _$this._xNcIscustomavatar = xNcIscustomavatar;
 
   AvatarAvatarGetAvatarDarkHeadersBuilder() {
@@ -13325,13 +13326,13 @@ class AvatarAvatarGetAvatarDarkHeadersBuilder
 abstract mixin class $AvatarAvatarGetAvatarHeadersInterfaceBuilder {
   void replace($AvatarAvatarGetAvatarHeadersInterface other);
   void update(void Function($AvatarAvatarGetAvatarHeadersInterfaceBuilder) updates);
-  HeaderBuilder<int> get xNcIscustomavatar;
-  set xNcIscustomavatar(HeaderBuilder<int>? xNcIscustomavatar);
+  HeaderBuilder<int?> get xNcIscustomavatar;
+  set xNcIscustomavatar(HeaderBuilder<int?>? xNcIscustomavatar);
 }
 
 class _$AvatarAvatarGetAvatarHeaders extends AvatarAvatarGetAvatarHeaders {
   @override
-  final Header<int>? xNcIscustomavatar;
+  final Header<int?>? xNcIscustomavatar;
 
   factory _$AvatarAvatarGetAvatarHeaders([void Function(AvatarAvatarGetAvatarHeadersBuilder)? updates]) =>
       (AvatarAvatarGetAvatarHeadersBuilder()..update(updates))._build();
@@ -13372,9 +13373,9 @@ class AvatarAvatarGetAvatarHeadersBuilder
         $AvatarAvatarGetAvatarHeadersInterfaceBuilder {
   _$AvatarAvatarGetAvatarHeaders? _$v;
 
-  HeaderBuilder<int>? _xNcIscustomavatar;
-  HeaderBuilder<int> get xNcIscustomavatar => _$this._xNcIscustomavatar ??= HeaderBuilder<int>();
-  set xNcIscustomavatar(covariant HeaderBuilder<int>? xNcIscustomavatar) =>
+  HeaderBuilder<int?>? _xNcIscustomavatar;
+  HeaderBuilder<int?> get xNcIscustomavatar => _$this._xNcIscustomavatar ??= HeaderBuilder<int?>();
+  set xNcIscustomavatar(covariant HeaderBuilder<int?>? xNcIscustomavatar) =>
       _$this._xNcIscustomavatar = xNcIscustomavatar;
 
   AvatarAvatarGetAvatarHeadersBuilder() {
@@ -17632,13 +17633,13 @@ class OcmDiscoveryResponseApplicationJsonBuilder
 abstract mixin class $OcmOcmDiscoveryHeadersInterfaceBuilder {
   void replace($OcmOcmDiscoveryHeadersInterface other);
   void update(void Function($OcmOcmDiscoveryHeadersInterfaceBuilder) updates);
-  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get xNextcloudOcmProviders;
-  set xNextcloudOcmProviders(HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders);
+  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?> get xNextcloudOcmProviders;
+  set xNextcloudOcmProviders(HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?>? xNextcloudOcmProviders);
 }
 
 class _$OcmOcmDiscoveryHeaders extends OcmOcmDiscoveryHeaders {
   @override
-  final Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders;
+  final Header<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?>? xNextcloudOcmProviders;
 
   factory _$OcmOcmDiscoveryHeaders([void Function(OcmOcmDiscoveryHeadersBuilder)? updates]) =>
       (OcmOcmDiscoveryHeadersBuilder()..update(updates))._build();
@@ -17678,11 +17679,11 @@ class OcmOcmDiscoveryHeadersBuilder
     implements Builder<OcmOcmDiscoveryHeaders, OcmOcmDiscoveryHeadersBuilder>, $OcmOcmDiscoveryHeadersInterfaceBuilder {
   _$OcmOcmDiscoveryHeaders? _$v;
 
-  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? _xNextcloudOcmProviders;
-  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders> get xNextcloudOcmProviders =>
-      _$this._xNextcloudOcmProviders ??= HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>();
+  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?>? _xNextcloudOcmProviders;
+  HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?> get xNextcloudOcmProviders =>
+      _$this._xNextcloudOcmProviders ??= HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?>();
   set xNextcloudOcmProviders(
-          covariant HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders>? xNextcloudOcmProviders) =>
+          covariant HeaderBuilder<OcmOcmDiscoveryHeaders_XNextcloudOcmProviders?>? xNextcloudOcmProviders) =>
       _$this._xNextcloudOcmProviders = xNextcloudOcmProviders;
 
   OcmOcmDiscoveryHeadersBuilder() {
@@ -26776,14 +26777,14 @@ class ReferenceBuilder implements Builder<Reference, ReferenceBuilder>, $Referen
 abstract mixin class $ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($ReferenceApiExtractResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
-  MapBuilder<String, Reference> get references;
-  set references(MapBuilder<String, Reference>? references);
+  MapBuilder<String, Reference?> get references;
+  set references(MapBuilder<String, Reference?>? references);
 }
 
 class _$ReferenceApiExtractResponseApplicationJson_Ocs_Data
     extends ReferenceApiExtractResponseApplicationJson_Ocs_Data {
   @override
-  final BuiltMap<String, Reference> references;
+  final BuiltMap<String, Reference?> references;
 
   factory _$ReferenceApiExtractResponseApplicationJson_Ocs_Data(
           [void Function(ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder)? updates]) =>
@@ -26832,9 +26833,9 @@ class ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder
         $ReferenceApiExtractResponseApplicationJson_Ocs_DataInterfaceBuilder {
   _$ReferenceApiExtractResponseApplicationJson_Ocs_Data? _$v;
 
-  MapBuilder<String, Reference>? _references;
-  MapBuilder<String, Reference> get references => _$this._references ??= MapBuilder<String, Reference>();
-  set references(covariant MapBuilder<String, Reference>? references) => _$this._references = references;
+  MapBuilder<String, Reference?>? _references;
+  MapBuilder<String, Reference?> get references => _$this._references ??= MapBuilder<String, Reference?>();
+  set references(covariant MapBuilder<String, Reference?>? references) => _$this._references = references;
 
   ReferenceApiExtractResponseApplicationJson_Ocs_DataBuilder() {
     ReferenceApiExtractResponseApplicationJson_Ocs_Data._defaults(this);
@@ -27117,14 +27118,14 @@ class ReferenceApiExtractResponseApplicationJsonBuilder
 abstract mixin class $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
-  MapBuilder<String, Reference> get references;
-  set references(MapBuilder<String, Reference>? references);
+  MapBuilder<String, Reference?> get references;
+  set references(MapBuilder<String, Reference?>? references);
 }
 
 class _$ReferenceApiResolveOneResponseApplicationJson_Ocs_Data
     extends ReferenceApiResolveOneResponseApplicationJson_Ocs_Data {
   @override
-  final BuiltMap<String, Reference> references;
+  final BuiltMap<String, Reference?> references;
 
   factory _$ReferenceApiResolveOneResponseApplicationJson_Ocs_Data(
           [void Function(ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder)? updates]) =>
@@ -27173,9 +27174,9 @@ class ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder
         $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder {
   _$ReferenceApiResolveOneResponseApplicationJson_Ocs_Data? _$v;
 
-  MapBuilder<String, Reference>? _references;
-  MapBuilder<String, Reference> get references => _$this._references ??= MapBuilder<String, Reference>();
-  set references(covariant MapBuilder<String, Reference>? references) => _$this._references = references;
+  MapBuilder<String, Reference?>? _references;
+  MapBuilder<String, Reference?> get references => _$this._references ??= MapBuilder<String, Reference?>();
+  set references(covariant MapBuilder<String, Reference?>? references) => _$this._references = references;
 
   ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder() {
     ReferenceApiResolveOneResponseApplicationJson_Ocs_Data._defaults(this);
@@ -27459,14 +27460,14 @@ class ReferenceApiResolveOneResponseApplicationJsonBuilder
 abstract mixin class $ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($ReferenceApiResolveResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
-  MapBuilder<String, Reference> get references;
-  set references(MapBuilder<String, Reference>? references);
+  MapBuilder<String, Reference?> get references;
+  set references(MapBuilder<String, Reference?>? references);
 }
 
 class _$ReferenceApiResolveResponseApplicationJson_Ocs_Data
     extends ReferenceApiResolveResponseApplicationJson_Ocs_Data {
   @override
-  final BuiltMap<String, Reference> references;
+  final BuiltMap<String, Reference?> references;
 
   factory _$ReferenceApiResolveResponseApplicationJson_Ocs_Data(
           [void Function(ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder)? updates]) =>
@@ -27515,9 +27516,9 @@ class ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder
         $ReferenceApiResolveResponseApplicationJson_Ocs_DataInterfaceBuilder {
   _$ReferenceApiResolveResponseApplicationJson_Ocs_Data? _$v;
 
-  MapBuilder<String, Reference>? _references;
-  MapBuilder<String, Reference> get references => _$this._references ??= MapBuilder<String, Reference>();
-  set references(covariant MapBuilder<String, Reference>? references) => _$this._references = references;
+  MapBuilder<String, Reference?>? _references;
+  MapBuilder<String, Reference?> get references => _$this._references ??= MapBuilder<String, Reference?>();
+  set references(covariant MapBuilder<String, Reference?>? references) => _$this._references = references;
 
   ReferenceApiResolveResponseApplicationJson_Ocs_DataBuilder() {
     ReferenceApiResolveResponseApplicationJson_Ocs_Data._defaults(this);

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -4792,7 +4792,7 @@ abstract class AppsGetAppsResponseApplicationJson
 @BuiltValue(instantiable: false)
 abstract interface class $AppsGetAppInfoResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
-  BuiltMap<String, JsonObject> get data;
+  BuiltMap<String, JsonObject?> get data;
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($AppsGetAppInfoResponseApplicationJson_OcsInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -10123,8 +10123,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(AppsGetAppInfoResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(
-        const FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
-        MapBuilder<String, JsonObject>.new,
+        const FullType(BuiltMap, [FullType(String), FullType.nullable(JsonObject)]),
+        MapBuilder<String, JsonObject?>.new,
       )
       ..addBuilderFactory(
         const FullType(AppsEnableResponseApplicationJson),

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
@@ -823,7 +823,7 @@ class _$AppsGetAppInfoResponseApplicationJson_OcsSerializer
       serializers.serialize(object.meta, specifiedType: const FullType(OCSMeta)),
       'data',
       serializers.serialize(object.data,
-          specifiedType: const FullType(BuiltMap, [FullType(String), FullType(JsonObject)])),
+          specifiedType: const FullType(BuiltMap, [FullType(String), FullType.nullable(JsonObject)])),
     ];
 
     return result;
@@ -845,7 +845,7 @@ class _$AppsGetAppInfoResponseApplicationJson_OcsSerializer
           break;
         case 'data':
           result.data.replace(serializers.deserialize(value,
-              specifiedType: const FullType(BuiltMap, [FullType(String), FullType(JsonObject)]))!);
+              specifiedType: const FullType(BuiltMap, [FullType(String), FullType.nullable(JsonObject)]))!);
           break;
       }
     }
@@ -6560,15 +6560,15 @@ abstract mixin class $AppsGetAppInfoResponseApplicationJson_OcsInterfaceBuilder 
   OCSMetaBuilder get meta;
   set meta(OCSMetaBuilder? meta);
 
-  MapBuilder<String, JsonObject> get data;
-  set data(MapBuilder<String, JsonObject>? data);
+  MapBuilder<String, JsonObject?> get data;
+  set data(MapBuilder<String, JsonObject?>? data);
 }
 
 class _$AppsGetAppInfoResponseApplicationJson_Ocs extends AppsGetAppInfoResponseApplicationJson_Ocs {
   @override
   final OCSMeta meta;
   @override
-  final BuiltMap<String, JsonObject> data;
+  final BuiltMap<String, JsonObject?> data;
 
   factory _$AppsGetAppInfoResponseApplicationJson_Ocs(
           [void Function(AppsGetAppInfoResponseApplicationJson_OcsBuilder)? updates]) =>
@@ -6622,9 +6622,9 @@ class AppsGetAppInfoResponseApplicationJson_OcsBuilder
   OCSMetaBuilder get meta => _$this._meta ??= OCSMetaBuilder();
   set meta(covariant OCSMetaBuilder? meta) => _$this._meta = meta;
 
-  MapBuilder<String, JsonObject>? _data;
-  MapBuilder<String, JsonObject> get data => _$this._data ??= MapBuilder<String, JsonObject>();
-  set data(covariant MapBuilder<String, JsonObject>? data) => _$this._data = data;
+  MapBuilder<String, JsonObject?>? _data;
+  MapBuilder<String, JsonObject?> get data => _$this._data ??= MapBuilder<String, JsonObject?>();
+  set data(covariant MapBuilder<String, JsonObject?>? data) => _$this._data = data;
 
   AppsGetAppInfoResponseApplicationJson_OcsBuilder() {
     AppsGetAppInfoResponseApplicationJson_Ocs._defaults(this);

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -34369,7 +34369,7 @@ abstract class RoomGetParticipantsResponseApplicationJson
 @BuiltValue(instantiable: false)
 abstract interface class $RoomRoomGetParticipantsHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-has-user-statuses')
-  Header<bool>? get xNextcloudHasUserStatuses;
+  Header<bool?>? get xNextcloudHasUserStatuses;
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRoomGetParticipantsHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -34965,7 +34965,7 @@ abstract class RoomGetBreakoutRoomParticipantsResponseApplicationJson
 @BuiltValue(instantiable: false)
 abstract interface class $RoomRoomGetBreakoutRoomParticipantsHeadersInterface {
   @BuiltValueField(wireName: 'x-nextcloud-has-user-statuses')
-  Header<bool>? get xNextcloudHasUserStatuses;
+  Header<bool?>? get xNextcloudHasUserStatuses;
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults($RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
@@ -44002,7 +44002,7 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(BuiltList, [FullType(Participant)]), ListBuilder<Participant>.new)
       ..addBuilderFactory(const FullType(RoomRoomGetParticipantsHeaders), RoomRoomGetParticipantsHeadersBuilder.new)
       ..add(RoomRoomGetParticipantsHeaders.serializer)
-      ..addBuilderFactory(const FullType(Header, [FullType(bool)]), HeaderBuilder<bool>.new)
+      ..addBuilderFactory(const FullType(Header, [FullType.nullable(bool)]), HeaderBuilder<bool?>.new)
       ..add(Header.serializer)
       ..add(RoomAddParticipantToRoomSource.serializer)
       ..add(RoomAddParticipantToRoomApiVersion.serializer)

--- a/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
@@ -14661,7 +14661,7 @@ class _$RoomRoomGetParticipantsHeadersSerializer implements StructuredSerializer
     if (value != null) {
       result
         ..add('x-nextcloud-has-user-statuses')
-        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType(bool)])));
+        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType.nullable(bool)])));
     }
     return result;
   }
@@ -14678,8 +14678,8 @@ class _$RoomRoomGetParticipantsHeadersSerializer implements StructuredSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'x-nextcloud-has-user-statuses':
-          result.xNextcloudHasUserStatuses.replace(
-              serializers.deserialize(value, specifiedType: const FullType(Header, [FullType(bool)]))! as Header<bool>);
+          result.xNextcloudHasUserStatuses.replace(serializers.deserialize(value,
+              specifiedType: const FullType(Header, [FullType.nullable(bool)]))! as Header<bool?>);
           break;
       }
     }
@@ -14941,7 +14941,7 @@ class _$RoomRoomGetBreakoutRoomParticipantsHeadersSerializer
     if (value != null) {
       result
         ..add('x-nextcloud-has-user-statuses')
-        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType(bool)])));
+        ..add(serializers.serialize(value, specifiedType: const FullType(Header, [FullType.nullable(bool)])));
     }
     return result;
   }
@@ -14958,8 +14958,8 @@ class _$RoomRoomGetBreakoutRoomParticipantsHeadersSerializer
       final Object? value = iterator.current;
       switch (key) {
         case 'x-nextcloud-has-user-statuses':
-          result.xNextcloudHasUserStatuses.replace(
-              serializers.deserialize(value, specifiedType: const FullType(Header, [FullType(bool)]))! as Header<bool>);
+          result.xNextcloudHasUserStatuses.replace(serializers.deserialize(value,
+              specifiedType: const FullType(Header, [FullType.nullable(bool)]))! as Header<bool?>);
           break;
       }
     }
@@ -46626,13 +46626,13 @@ class RoomGetParticipantsResponseApplicationJsonBuilder
 abstract mixin class $RoomRoomGetParticipantsHeadersInterfaceBuilder {
   void replace($RoomRoomGetParticipantsHeadersInterface other);
   void update(void Function($RoomRoomGetParticipantsHeadersInterfaceBuilder) updates);
-  HeaderBuilder<bool> get xNextcloudHasUserStatuses;
-  set xNextcloudHasUserStatuses(HeaderBuilder<bool>? xNextcloudHasUserStatuses);
+  HeaderBuilder<bool?> get xNextcloudHasUserStatuses;
+  set xNextcloudHasUserStatuses(HeaderBuilder<bool?>? xNextcloudHasUserStatuses);
 }
 
 class _$RoomRoomGetParticipantsHeaders extends RoomRoomGetParticipantsHeaders {
   @override
-  final Header<bool>? xNextcloudHasUserStatuses;
+  final Header<bool?>? xNextcloudHasUserStatuses;
 
   factory _$RoomRoomGetParticipantsHeaders([void Function(RoomRoomGetParticipantsHeadersBuilder)? updates]) =>
       (RoomRoomGetParticipantsHeadersBuilder()..update(updates))._build();
@@ -46674,9 +46674,9 @@ class RoomRoomGetParticipantsHeadersBuilder
         $RoomRoomGetParticipantsHeadersInterfaceBuilder {
   _$RoomRoomGetParticipantsHeaders? _$v;
 
-  HeaderBuilder<bool>? _xNextcloudHasUserStatuses;
-  HeaderBuilder<bool> get xNextcloudHasUserStatuses => _$this._xNextcloudHasUserStatuses ??= HeaderBuilder<bool>();
-  set xNextcloudHasUserStatuses(covariant HeaderBuilder<bool>? xNextcloudHasUserStatuses) =>
+  HeaderBuilder<bool?>? _xNextcloudHasUserStatuses;
+  HeaderBuilder<bool?> get xNextcloudHasUserStatuses => _$this._xNextcloudHasUserStatuses ??= HeaderBuilder<bool?>();
+  set xNextcloudHasUserStatuses(covariant HeaderBuilder<bool?>? xNextcloudHasUserStatuses) =>
       _$this._xNextcloudHasUserStatuses = xNextcloudHasUserStatuses;
 
   RoomRoomGetParticipantsHeadersBuilder() {
@@ -47307,13 +47307,13 @@ class RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder
 abstract mixin class $RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder {
   void replace($RoomRoomGetBreakoutRoomParticipantsHeadersInterface other);
   void update(void Function($RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder) updates);
-  HeaderBuilder<bool> get xNextcloudHasUserStatuses;
-  set xNextcloudHasUserStatuses(HeaderBuilder<bool>? xNextcloudHasUserStatuses);
+  HeaderBuilder<bool?> get xNextcloudHasUserStatuses;
+  set xNextcloudHasUserStatuses(HeaderBuilder<bool?>? xNextcloudHasUserStatuses);
 }
 
 class _$RoomRoomGetBreakoutRoomParticipantsHeaders extends RoomRoomGetBreakoutRoomParticipantsHeaders {
   @override
-  final Header<bool>? xNextcloudHasUserStatuses;
+  final Header<bool?>? xNextcloudHasUserStatuses;
 
   factory _$RoomRoomGetBreakoutRoomParticipantsHeaders(
           [void Function(RoomRoomGetBreakoutRoomParticipantsHeadersBuilder)? updates]) =>
@@ -47359,9 +47359,9 @@ class RoomRoomGetBreakoutRoomParticipantsHeadersBuilder
         $RoomRoomGetBreakoutRoomParticipantsHeadersInterfaceBuilder {
   _$RoomRoomGetBreakoutRoomParticipantsHeaders? _$v;
 
-  HeaderBuilder<bool>? _xNextcloudHasUserStatuses;
-  HeaderBuilder<bool> get xNextcloudHasUserStatuses => _$this._xNextcloudHasUserStatuses ??= HeaderBuilder<bool>();
-  set xNextcloudHasUserStatuses(covariant HeaderBuilder<bool>? xNextcloudHasUserStatuses) =>
+  HeaderBuilder<bool?>? _xNextcloudHasUserStatuses;
+  HeaderBuilder<bool?> get xNextcloudHasUserStatuses => _$this._xNextcloudHasUserStatuses ??= HeaderBuilder<bool?>();
+  set xNextcloudHasUserStatuses(covariant HeaderBuilder<bool?>? xNextcloudHasUserStatuses) =>
       _$this._xNextcloudHasUserStatuses = xNextcloudHasUserStatuses;
 
   RoomRoomGetBreakoutRoomParticipantsHeadersBuilder() {


### PR DESCRIPTION
Technically these are two separate fixes, but one doesn't work without the other, so I kept them together.

1. The serializers have to be handled separately, because the type equality check of TypeResult doesn't consider the the nullability, while it is important for the serializer. Making the check consider the nullability would result in duplicate types generated in the code as those don't care about the nullability in the end, so that is not possible.
2. The other part was simply allowing to generate types with nullable generics.