### PR TITLE
fix(neon_notifications): Expose Bloc using public interface

### DIFF
--- a/packages/neon/neon_notifications/lib/neon_notifications.dart
+++ b/packages/neon/neon_notifications/lib/neon_notifications.dart
@@ -14,10 +14,10 @@ import 'package:neon_notifications/src/routes.dart';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:rxdart/rxdart.dart';
 
-class NotificationsApp extends AppImplementation<NotificationsBloc, NotificationsOptions>
+class NotificationsApp extends AppImplementation<NotificationsBlocInterface, NotificationsOptions>
     implements
         // ignore: avoid_implementing_value_types
-        NotificationsAppInterface<NotificationsBloc, NotificationsOptions> {
+        NotificationsAppInterface<NotificationsBlocInterface, NotificationsOptions> {
   NotificationsApp();
 
   @override
@@ -33,7 +33,7 @@ class NotificationsApp extends AppImplementation<NotificationsBloc, Notification
   late final NotificationsOptions options = NotificationsOptions(storage);
 
   @override
-  NotificationsBloc buildBloc(Account account) => NotificationsBloc(
+  NotificationsBlocInterface buildBloc(Account account) => NotificationsBloc(
         account: account,
       );
 
@@ -44,5 +44,5 @@ class NotificationsApp extends AppImplementation<NotificationsBloc, Notification
   final RouteBase route = $notificationsAppRoute;
 
   @override
-  BehaviorSubject<int> getUnreadCounter(NotificationsBloc bloc) => bloc.unreadCounter;
+  BehaviorSubject<int> getUnreadCounter(NotificationsBlocInterface bloc) => (bloc as NotificationsBloc).unreadCounter;
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/2125
Using the public interface is how it should be done as the framework and other apps might want to access it too, but the AppImplementation was only advertising it as the internal interface.